### PR TITLE
Session de test sur staging : groupe Vitamine T

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -632,5 +632,5 @@ EMPLOYEE_RECORD_PROGRESSIVE_OPENING_ENABLED = os.environ.get("EMPLOYEE_RECORD_PR
 # Will be updated throughout the process via environment vars on production instance.
 EMPLOYEE_RECORD_OPENING_PERCENTAGE = int(os.environ.get("EMPLOYEE_RECORD_OPENING_PERCENTAGE", 1))
 # Allows a manual / custom selection of some SIAEs as "VIP users":
-# Add selected SIAE ASP_IDs in list below:
-EMPLOYEE_RECORD_CUSTOM_SIAE_ID_LIST = []
+# Add selected SIAE IDs in list below:
+EMPLOYEE_RECORD_CUSTOM_SIAE_ID_LIST = [41, 4847, 4848]


### PR DESCRIPTION
### Quoi ?

Modifications des `settings`pour effectuer une session de test de saisie des fiches salarié et de l'API par le groupe Vitamine-T.

### Pourquoi ?

- vérifier que le mécanisme d'ouverture est ok,
- donner accès live à des utilisateurs,
- intégrer du retour avant la MEP.

### Comment ?

Donner accès à un environnement `staging` mis à jour avec des données récentes et les fonctionnalités des fiches salarié activées.

Ne nécessite pas de revue particulière.

