### PR TITLE
Ajout d'une action dans l'admin Django (fiches salarié)

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -7,7 +7,7 @@ import itou.employee_record.models as models
 class EmployeeRecordAdmin(admin.ModelAdmin):
     @admin.action(description="Marquer les fiches salarié selectionnées comme COMPLETÉES")
     def update_employee_record_as_ready(self, _request, queryset):
-        queryset.update(status="READY")
+        queryset.update(status=models.EmployeeRecord.Status.READY)
 
     actions = [
         update_employee_record_as_ready,


### PR DESCRIPTION
### Quoi ?

Ajout d'une action dans le formulaire d'admin des fiches salarié.

### Pourquoi ?

Pour résoudre certains problèmes de transmission récents, il est pratique de pouvoir changer l'état de fiches salarié en lot. 

### Comment ?

Via l'admin Django
En changeant l'état des fiches selectionnées en `READY` (ce qui permet un nouveau traitement de la selection par l'ASP)