### PR TITLE
Hotfix - problème de navigation

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -354,7 +354,7 @@
                     {% if can_show_employee_records %}
                         <p class="card-text">
                             {% include "includes/icon.html" with icon="file" %}
-                            <a href="{% url 'employee_record_views:list' %}">Gérer mes fiches salarié (ASP)</a>
+                            <a href="{% url 'employee_record_views:list' %}?status=NEW">Gérer mes fiches salarié (ASP)</a>
                             <span class="badge badge-info">Nouveau</span>
                         </p>
                     {% endif %}


### PR DESCRIPTION
### Quoi ?

Au delà de la première page de la liste de dixhla saisie de fiche est bloquée.

### Pourquoi ?

Le pager ne garde pas l'état initial de la fiche salarié.

## Comment ?

En urgence