### PR TITLE
Résolution d'un souci dans l'interface "Mes AF"

### DIFF
--- a/itou/www/siaes_views/views.py
+++ b/itou/www/siaes_views/views.py
@@ -137,7 +137,7 @@ def configure_jobs(request, template_name="siaes/configure_jobs.html"):
 def show_financial_annexes(request, template_name="siaes/show_financial_annexes.html"):
     """
     Show a summary of the financial annexes of the convention to the siae admin user.
-    Financial annexes are grouped by suffix, and only the most relevant one is shown for each suffix.
+    Financial annexes are grouped by suffix, and only the most relevant one (active if any, or most recent if not) is shown for each suffix.
     """
     current_siae = get_current_siae_or_404(request)
     if not current_siae.convention_can_be_accessed_by(request.user):
@@ -147,7 +147,7 @@ def show_financial_annexes(request, template_name="siaes/show_financial_annexes.
     if current_siae.convention:
         financial_annexes = current_siae.convention.financial_annexes.all()
 
-    # For each group of AFs sharing the same number prefix, show only the most relevant AF.
+    # For each group of AFs sharing the same number prefix, show only the most relevant AF (active if any, or most recent if not).
     # We do this to avoid showing too many AFs and confusing the user.
     prefix_to_af = {}
     for af in financial_annexes:
@@ -158,7 +158,7 @@ def show_financial_annexes(request, template_name="siaes/show_financial_annexes.
             continue
         old_suffix = prefix_to_af[prefix].number_suffix
         new_suffix = af.number_suffix
-        if new_suffix > old_suffix:
+        if not prefix_to_af[prefix].is_active and new_suffix > old_suffix:
             # Show the AF with the latest suffix when there is no active one.
             prefix_to_af[prefix] = af
             continue


### PR DESCRIPTION
### Quoi ?

Résolution d'un souci dans l'interface "Mes AF".

On montre une AF par groupe d'AF avec le même préfixe. Pour chaque groupe, on montre la plus pertinente (soit une AF active, soit une AF récente).

Avant le fix :

![image](https://user-images.githubusercontent.com/10533583/137324551-29c3f5b7-76de-4ea2-81c4-048c8a80ff7f.png)

Après le fix :

![image](https://user-images.githubusercontent.com/10533583/137324476-1dc60350-8486-4af8-9e9b-f806404eee11.png)

Pour plus de détails voir [ce thread](https://itou-inclusion.slack.com/archives/C01181Y04LT/p1634049367047600)

### Comment ?

En corrigeant un bête oubli dans le code.

