### PR TITLE
Forcage de Python 3.9 sur les machines créées à la volée

### DIFF
--- a/.github/workflows/imports-asp.yml
+++ b/.github/workflows/imports-asp.yml
@@ -24,6 +24,7 @@ env:
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
   ITOU_ORGANIZATION_NAME: ${{ secrets.CLEVER_ORGANIZATION_NAME }}
   DEPLOY_BRANCH: master_clever
+  PYTHON_VERSION: 3.9
 
 jobs:
   imports_asp:
@@ -49,6 +50,12 @@ jobs:
     - name: 🏷 Setup post-deployment hook
       run:
         echo 'CC_RUN_SUCCEEDED_HOOK=./scripts/imports-asp.sh' >> $GITHUB_ENV
+
+    # Clever cloud seem to inject CC_PYTHON_VERSION=3, whicĥ breaks some of our machines
+    # that use 3.9 and may not support python 3.10
+    - name: 🏷 Fix Python version
+      run:
+        echo 'CC_PYTHON_VERSION=${{ env.DEPLOY_BRANCH }}'
 
     - name: 🧫 Create a cron app on Clever Cloud on a strong machine
       run: |

--- a/.github/workflows/populate-metabase.yml
+++ b/.github/workflows/populate-metabase.yml
@@ -27,6 +27,7 @@ env:
   CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
   CRON_APPS_ORGANIZATION_NAME: ${{ secrets.CLEVER_CRON_APPS_ORGANIZATION_NAME }}
   DEPLOY_BRANCH: master_clever
+  PYTHON_VERSION: 3.9
 
 jobs:
   populate_metabase:
@@ -44,6 +45,12 @@ jobs:
     - name: 🏷 Setup app name
       run:
         echo "CRON_TASK_APP_NAME=`echo \"c1-cron-populate-$(date +%y-%m-%d-%Hh-%M)"`" >> $GITHUB_ENV
+
+    # Clever cloud seem to inject CC_PYTHON_VERSION=3, whicĥ breaks some of our machines
+    # that use 3.9 and may not support python 3.10
+    - name: 🏷 Fix Python version
+      run:
+        echo 'CC_PYTHON_VERSION=${{ env.DEPLOY_BRANCH }}'
 
     # CC_RUN_SUCCEEDED_HOOK is a clever-cloud-specific environment variable.
     # We set the command we want to run once the app is started

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -18,6 +18,7 @@ env:
   CONFIGURATION_ADDON: ${{ secrets.CLEVER_REVIEW_APPS_CONFIGURATION_ADDON }}
   S3_ADDON: ${{ secrets.CLEVER_REVIEW_APPS_S3_ADDON }}
   BRANCH: ${{ github.head_ref }}
+  PYTHON_VERSION: 3.9
 
 jobs:
   create:
@@ -37,7 +38,11 @@ jobs:
     - name: 🏷 Set review app name
       run:
         echo "REVIEW_APP_NAME=`echo \"c1-review-$BRANCH\" | sed -r 's/[-;\\/._]+/-/g'`" >> $GITHUB_ENV
-
+    # Clever cloud seem to inject CC_PYTHON_VERSION=3, whicĥ breaks some of our machines
+    # that use 3.9 and may not support python 3.10
+    - name: 🏷 Fix Python version
+      run:
+        echo 'CC_PYTHON_VERSION=${{ env.DEPLOY_BRANCH }}'
     - name: 🏷 Set database addon name
       run:
         echo "REVIEW_APP_DB_NAME=`echo $REVIEW_APP_NAME | sed -r 's/-/_/g'`" >> $GITHUB_ENV


### PR DESCRIPTION
### Quoi ?

Python version 3.9 en dur sur les machines créées à la volée (review apps, imports de BDD)

### Pourquoi ?

 - on ne supporte pas encore python 3.10, et on ne souhaite pas se jeter sur une montée de version
 - la présence de CC_PYTHON_VERSION dans les variables d’environnement, qui semble injectée depuis peu par clever à une valeur par défaut, remplace la version qu’on spécifie dans le configuration provider

### Comment ?

 - spécification en dur de la version à utiliser dans les variables d’environnement. L’info est en doublon, je n’ai pas mieux à court terme.
