### PR TITLE
Possibilité de passer des classe CSS arbitraires à `DuetDatePickerWidget`

### DIFF
--- a/itou/templates/utils/widgets/duet_date_picker_widget.html
+++ b/itou/templates/utils/widgets/duet_date_picker_widget.html
@@ -10,5 +10,5 @@
         See also `itou.css`.
         https://getbootstrap.com/docs/4.6/components/forms/#server-side
     {% endcomment %}
-    {% if "is-invalid" in widget.attrs.class %}class="is-invalid"{% endif %}
+    {% if widget.attrs.class %}class="{{ widget.attrs.class }}"{% endif %}
     ></duet-date-picker>

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -63,6 +63,9 @@ class DuetDatePickerWidget(forms.DateInput):
         max_attr = attrs.get("max")
         if max_attr:
             attrs["max"] = self.format_value(max_attr)
+        # Remove the `form-control` class inserted by `django-bootstrap4` to avoid
+        # breaking the layout.
+        attrs["class"] = attrs.get("class", "").replace("form-control", "").strip()
         return attrs
 
     @classmethod


### PR DESCRIPTION
### Quoi ?

Possibilité de passer des classe CSS arbitraires à `DuetDatePickerWidget`.

### Pourquoi ?

Pour pouvoir cibler facilement le _date-picker_ quand on a besoin de le manipuler avec JavaScript.

C.f. :

> https://github.com/betagouv/itou/pull/921/files#r731596008

### Comment ?

Comme tous les champs de formulaire Django :

```python
self.fields["birthdate"].widget = DuetDatePickerWidget(
    attrs={
        "min": DuetDatePickerWidget.min_birthdate(),
        "max": DuetDatePickerWidget.max_birthdate(),
        "class": "foo bar",
    }
)
```

### Captures d'écran

![foo](https://user-images.githubusercontent.com/281139/138287683-05c0c984-7589-4427-9b03-3ed582bdfe15.png)
