### PR TITLE
Mise à jour du suivi des recrutements

### DIFF
--- a/itou/metabase/management/commands/sql/009_recrutements.sql
+++ b/itou/metabase/management/commands/sql/009_recrutements.sql
@@ -1,7 +1,5 @@
 /*
-
 L'objectif est d'avoir un suivi annuel des recrutements en se basant sur les déclarations mensuelles des structures dans l'extranet asp
-
 */
 
 select 
@@ -18,12 +16,13 @@ select
     structure_denomination,
     commune_structure, 
     code_insee_structure, 
-    nom_departement_structure, 
-    nom_region_structure,
+    nom_departement_af,
+    nom_region_af,
     af_numero_convention,
     af_numero_annexe_financiere
 from 
     saisies_mensuelles_IAE
+where date_part('year', date_recrutement) >= (date_part('year', current_date) - 2)
 group by 
     annee_recrutement,
     etablissement_Public_Territorial, 
@@ -36,7 +35,7 @@ group by
     structure_denomination,
     commune_structure, 
     code_insee_structure, 
-    nom_departement_structure, 
-    nom_region_structure,
+    nom_departement_af,
+    nom_region_af,
     af_numero_convention,
     af_numero_annexe_financiere


### PR DESCRIPTION
### Quoi ?

- Utiliser le département de conventionnement au lieu du département de la structure
- Se contenter de 2 ans d'historique en plus de l'année en cours
- Changer le nom de la table générée en "recrutements"

### Pourquoi ?

A la demande des DDETS des 4 départements d'expérimentation on filtrera les tableaux de bord par département de conventionnement au lieu du département de la structure
