### PR TITLE
Tentative de correctif pour un test flaky

### DIFF
--- a/itou/users/factories.py
+++ b/itou/users/factories.py
@@ -49,7 +49,7 @@ class JobSeekerFactory(UserFactory):
         random_2 = str(random.randint(0, 399)).zfill(3)
         incomplete_nir = f"{gender}{year}{month}{department}{random_1}{random_2}"
         assert len(incomplete_nir) == 13
-        control_key = 97 - int(incomplete_nir) % 97
+        control_key = str(97 - int(incomplete_nir) % 97).zfill(2)
         nir = f"{incomplete_nir}{control_key}"
         validate_nir(nir)
         return nir


### PR DESCRIPTION
### Quoi ?

Tentative de correctif pour le test _flaky_ `test_apply_as_authorized_prescriber_to_siae_for_approval_in_waiting_period`.

### Pourquoi ?

Le test échoue dans plusieurs PR récentes avec pour conséquence un résultat de la CI en erreur.

Exemple ici : https://github.com/betagouv/itou/runs/4031417265?check_suite_focus=true

### Comment ?

La seule façon de reproduire l'erreur en local est d'insérer un NIR invalide dans `JobSeekerFactory` :

```python
job_seeker = JobSeekerFactory(nir='200000000218074')
```

Avec pour résultat :

```python
test_apply_as_authorized_prescriber_to_siae_for_approval_in_waiting_period
    last_url = response.redirect_chain[-1][0]
IndexError: list index out of range
```

J'en arrive à la conclusion suivante : peut-être que la génération aléatoire du NIR pour les objets est _flaky_.

Du coup je tente de reprendre une année et un mois qui sont déjà ceux de l'instance en cours de construction et j'ajoute `validate_nir` pour voir si des numéros invalides peuvent être générés.
