### PR TITLE
Contrôle a posteriori : cache les candidatures des campagnes précédentes

### DIFF
--- a/itou/siae_evaluations/factories.py
+++ b/itou/siae_evaluations/factories.py
@@ -5,8 +5,18 @@ from django.utils import timezone
 from itou.eligibility.models import AdministrativeCriteria
 from itou.institutions.factories import InstitutionFactory
 from itou.job_applications.factories import JobApplicationWithApprovalFactory
-from itou.siae_evaluations import models
+from itou.siae_evaluations import enums as evaluation_enums, models
 from itou.siaes.factories import SiaeFactory
+
+
+def before_ended_at(**kwargs):
+    def inner(obj):
+        date = getattr(obj, "ended_at", None)
+        if date is None:
+            date = timezone.localdate()
+        return date - relativedelta(**kwargs)
+
+    return inner
 
 
 class EvaluationCampaignFactory(factory.django.DjangoModelFactory):
@@ -15,13 +25,29 @@ class EvaluationCampaignFactory(factory.django.DjangoModelFactory):
 
     name = factory.fuzzy.FuzzyText(length=10)
     institution = factory.SubFactory(InstitutionFactory, department="14")
-    evaluated_period_start_at = (timezone.now() - relativedelta(months=3)).date()
-    evaluated_period_end_at = timezone.now().date()
+    evaluated_period_start_at = factory.LazyAttribute(before_ended_at(months=3))
+    evaluated_period_end_at = factory.LazyAttribute(before_ended_at(months=1))
 
 
 class EvaluatedSiaeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EvaluatedSiae
+
+    class Params:
+        accepted = factory.Trait(
+            evaluation_campaign=factory.SubFactory(
+                EvaluationCampaignFactory,
+                evaluations_asked_at=factory.LazyFunction(lambda: timezone.now() - relativedelta(weeks=12)),
+                ended_at=factory.LazyFunction(lambda: timezone.now() - relativedelta(days=1)),
+            ),
+            job_app=factory.RelatedFactory(
+                "itou.siae_evaluations.factories.EvaluatedJobApplicationFactory",
+                factory_related_name="evaluated_siae",
+                accepted=True,
+            ),
+            reviewed_at=factory.LazyFunction(timezone.now),
+            final_reviewed_at=factory.LazyFunction(timezone.now),
+        )
 
     evaluation_campaign = factory.SubFactory(EvaluationCampaignFactory)
     siae = factory.SubFactory(SiaeFactory, department="14")
@@ -30,6 +56,23 @@ class EvaluatedSiaeFactory(factory.django.DjangoModelFactory):
 class EvaluatedJobApplicationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EvaluatedJobApplication
+
+    class Params:
+        accepted = factory.Trait(
+            criteria=factory.RelatedFactory(
+                "itou.siae_evaluations.factories.EvaluatedAdministrativeCriteriaFactory",
+                factory_related_name="evaluated_job_application",
+                uploaded_at=factory.LazyAttribute(
+                    lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.ended_at
+                    - relativedelta(days=10)
+                ),
+                submitted_at=factory.LazyAttribute(
+                    lambda siae: siae.factory_parent.evaluated_siae.evaluation_campaign.ended_at
+                    - relativedelta(days=5)
+                ),
+                review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
+            )
+        )
 
     evaluated_siae = factory.SubFactory(EvaluatedSiaeFactory)
     job_application = factory.SubFactory(JobApplicationWithApprovalFactory)

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -156,6 +156,7 @@ def institution_evaluated_job_application(
         pk=evaluated_job_application_pk,
         evaluated_siae__evaluation_campaign__institution=institution,
         evaluated_siae__evaluation_campaign__evaluations_asked_at__isnull=False,
+        evaluated_siae__evaluation_campaign__ended_at=None,
     )
 
     back_url = (


### PR DESCRIPTION
### Quoi ?

Contrôle a posteriori : cache les candidatures des campagnes précédentes

### Pourquoi ?

Seules les candidatures de la campagnes actuelles sont visibles et modifiables.