### PR TITLE
Ne pas mettre en cache les réponses

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -120,6 +120,7 @@ THIRD_PARTY_MIDDLEWARES = [
 ITOU_MIDDLEWARES = [
     "itou.utils.new_dns.middleware.NewDnsRedirectMiddleware",
     "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
+    "itou.www.middleware.never_cache",
 ]
 
 MIDDLEWARE = DJANGO_MIDDLEWARES + THIRD_PARTY_MIDDLEWARES + ITOU_MIDDLEWARES

--- a/itou/www/api/views.py
+++ b/itou/www/api/views.py
@@ -1,8 +1,6 @@
 from django.shortcuts import render
-from django.views.decorators.cache import cache_page
 
 
-@cache_page(60 * 60)  # 1 hour
 def index(request, template_name="api/index.html"):
     """
     Render the home page for the API

--- a/itou/www/middleware.py
+++ b/itou/www/middleware.py
@@ -1,0 +1,11 @@
+from django.utils.cache import add_never_cache_headers
+
+
+def never_cache(get_response):
+    def middleware(request):
+        response = get_response(request)
+        if request.user.is_authenticated:
+            add_never_cache_headers(response)
+        return response
+
+    return middleware

--- a/itou/www/releases/views.py
+++ b/itou/www/releases/views.py
@@ -4,10 +4,8 @@ import markdown
 from django.conf import settings
 from django.shortcuts import render
 from django.utils.html import mark_safe
-from django.views.decorators.cache import cache_page
 
 
-@cache_page(60 * 60)  # 1 hour
 def releases(request, template_name="releases/list.html"):
     """
     Render our CHANGELOG.md file in HTML


### PR DESCRIPTION
### Quoi ?

Ne pas mettre en cache les réponses

### Pourquoi ?

La plupart des actions sur le site demandent d’être authentifié. Une page qui reste en cache va probablement dévoiler des données de manière non intentionnelle.

Par exemple :
1. Login | /Tableau de bord se charge/
2. Logout | /Page de recherche d’emploi se charge/ (page publique)
3. Utilisation du bouton précédent dans le navigateur | /Tableau de bord est affiché/, alors que l’utilisateur s’est déconnecté.

### Comment ?

Deux pages utilisaient un cache :
1. Les notes de versions. Cette page ne reçoit certainement pas un gros trafic et ne mérite pas un cache.
2. La page d’accueil de l’API. C’est un rendu de template statique qui effectue une seule requête SQL. Difficile de justifier un cache…