### PR TITLE
BOOST : Liste des candidatures : affichage dynamique du badge "auto-prescription"

### DIFF
--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -38,7 +38,15 @@
                 <b>{{ job_application.sender_siae.display_name }}</b>
                 {% if request.user.is_siae_staff %}
                     <br>
-                    <small><span class="badge badge-pill badge-info">Auto-prescription</span></small>
+                    <small>
+                        <span class="badge badge-info">
+                            {% if job_application.created_from_pe_approval %}
+                                Import agrément Pôle emploi
+                            {% else %}
+                                Auto-prescription
+                            {% endif %}
+                        </span>
+                    </small>
                 {% endif %}
             {% endif %}
 

--- a/itou/www/apply/tests/tests_templates.py
+++ b/itou/www/apply/tests/tests_templates.py
@@ -1,0 +1,47 @@
+from django.conf import Path
+from django.template import Context, Template
+from django.test.client import RequestFactory
+
+from itou.job_applications.factories import JobApplicationSentBySiaeFactory
+from itou.users.factories import UserFactory
+
+
+def load_template(path):
+    return Template((Path("itou/templates") / path).read_text())
+
+
+def get_request():
+    request = RequestFactory()
+    request.user = UserFactory(is_siae_staff=True)
+    return request
+
+
+# Job applications list (SIAE)
+
+
+def test_job_application_auto_prescription_badge_in_list():
+    tmpl = load_template("apply/includes/list_card_body.html")
+    rendered = tmpl.render(
+        Context(
+            {
+                "job_application": JobApplicationSentBySiaeFactory(),
+                "request": get_request(),
+            }
+        )
+    )
+
+    assert "Auto-prescription" in rendered
+
+
+def test_job_application_imported_from_pe_in_list():
+    tmpl = load_template("apply/includes/list_card_body.html")
+    rendered = tmpl.render(
+        Context(
+            {
+                "job_application": JobApplicationSentBySiaeFactory(created_from_pe_approval=True),
+                "request": get_request(),
+            }
+        )
+    )
+
+    assert "Import agrément Pôle emploi" in rendered


### PR DESCRIPTION
### Quoi ?

Remplace le badge "Auto-prescription" par "Import agrément P6ole emploi" dans la liste des candidatures pour les SIAE, si la candidature est associée à un ancien agrément PE transformé en PASS IAE.

### Pourquoi ?

Cela donne l’impression aux employeurs qu’ils risquent d’être contrôlé pour ces PASS IAE/ agrément alors que non.

### Comment ?

Modification du template 

### Captures d'écran (optionnel)

- auto-prescription :  

![image](https://user-images.githubusercontent.com/147232/204850876-2dc85fa6-4eaf-4a1f-b835-0fa10fc3863b.png)

- import PE : 

![image](https://user-images.githubusercontent.com/147232/204851069-dbe0e326-751b-4d99-9b05-deccb26ab481.png)




