### PR TITLE
Metabase : Ajout de la colonne `organisations.siret`

### DIFF
--- a/itou/metabase/tables/organizations.py
+++ b/itou/metabase/tables/organizations.py
@@ -78,6 +78,7 @@ TABLE = MetabaseTable(name="organisations")
 TABLE.add_columns(
     [
         {"name": "id", "type": "integer", "comment": "ID organisation", "fn": lambda o: o.id},
+        {"name": "siret", "type": "varchar", "comment": "SIRET organisation", "fn": lambda o: o.siret},
         {"name": "nom", "type": "varchar", "comment": "Nom organisation", "fn": lambda o: o.display_name},
         {
             "name": "type",


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Ajout-de-la-colonne-SIRET-sur-la-table-organisations-c8166d9672854fcf9300b004cbaf9cc9**

Trivial - pas de revue.