### PR TITLE
Stats : Renommage des stats employeur

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -17,7 +17,7 @@
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_siae_hiring' %}" class="btn-link btn-ico">
                             <i class="ri-line-chart-line ri-lg font-weight-normal align-self-start mt-1"></i>
-                            <span>Voir les données de recrutement de mes structures (Plateforme de l'inclusion)</span>
+                            <span>Voir les données de candidatures de mes structures</span>
                         </a>
                     </li>
                 {% endif %}

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -207,7 +207,7 @@ def stats_siae_hiring(request):
     """
     current_org = get_stats_siae_hiring_current_org(request)
     context = {
-        "page_title": "Données de recrutement de mes structures (Plateforme de l'inclusion)",
+        "page_title": "Données de candidatures de mes structures",
         "department": current_org.department,
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(current_org.department),
     }


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/TB185-Renommer-l-intitul-du-TB-priv-SIAE-5cfb18861c7b4e5b9f3055db0fbe70ac**

### Pourquoi ?

A la demande de Annie.

### Comment

- Avant : Voir les données de recrutement de mes structures (Plateforme de l'inclusion)
- Après : Voir les données de candidatures de mes structures

### Revue

Pas de revue car trivial.