### PR TITLE
Stats : résolution d'une erreur CSP qui empêchait le téléchargement des graphiques Metabase sur certains navigateurs uniquement (Firefox, Edge, Safari)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -586,6 +586,8 @@ CSP_FRAME_SRC = [
     "https://pilotage.inclusion.beta.gouv.fr",
     "https://communaute.inclusion.beta.gouv.fr",
     "https://inclusion.beta.gouv.fr",
+    "blob:",  # For downloading Metabase questions as CSV/XSLX/JSON on Firefox etc
+    "data:",  # For downloading Metabase questions as PNG on Firefox etc
 ]
 CSP_FRAME_ANCESTORS = [
     "https://pilotage.inclusion.beta.gouv.fr",


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/ETQ-utilisateur-je-souhaite-utiliser-la-fonctionnalit-t-l-charger-de-metabase-sur-n-importe-quel-n-97d3b0374ebf4fb79e6ad43206694e20**

### Pourquoi ?

Jusqu'ici les utilisateurs pouvaient télécharger les graphiques Metabase comme ci-dessous sur Chrome mais cela échouait silencieusement sur Firefox, Edge et Safari.

![image](https://github.com/betagouv/itou/assets/10533583/31e1a876-fcdd-4490-94a5-a7f1db2d5c59)

Les erreurs rencontrées sont :
- pour PNG : `Content Security Policy: The page’s settings blocked the loading of a resource at data:image/octet-stream;base64,XxXxXxX… (“frame-src”).`
- pour CSV/XSLX/JSON : `Content Security Policy: The page’s settings blocked the loading of a resource at blob:https://stats.inclusion.beta.gouv.fr/[SOME_OBSCURE_UUID_HERE] (“frame-src”).`

### Comment

En rajoutant deux nouvelles CSP `blob:` et `data:`. Malheureusement je n'ai pas réussi à spécifier le domaine stats.inclusion.beta.gouv.fr pour ces nouvelles CSP mais si j'ai bien compris la doc ci-dessous c'est normal :

![image](https://github.com/betagouv/itou/assets/10533583/c600ffe2-ed31-49f2-9817-828b02d8e539)

