### PR TITLE
Fiches Salarié : Suppression du champs notification_type 2/2

### DIFF
--- a/itou/employee_record/migrations/0006_remove_employeerecordupdatenotification_notification_type.py
+++ b/itou/employee_record/migrations/0006_remove_employeerecordupdatenotification_notification_type.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("employee_record", "0005_stop_using_notification_type_field"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="employeerecordupdatenotification",
+            name="notification_type",
+        ),
+    ]

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -738,13 +738,6 @@ class EmployeeRecordUpdateNotification(ASPExchangeInformation):
         default=NotificationStatus.NEW,
     )
 
-    notification_type = models.CharField(
-        verbose_name="Type de notification",
-        max_length=20,
-        null=True,
-        blank=True,
-    )
-
     employee_record = models.ForeignKey(
         EmployeeRecord,
         related_name="update_notifications",


### PR DESCRIPTION
### Pourquoi ?

Suite et fin de #2537.