### PR TITLE
Fix: Anomalie d’affichage du PASS pour les prescripteurs

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -64,6 +64,8 @@
                 {# Approval status. #}
                 {% if job_application.approval %}
                     {% include "approvals/includes/status.html" with common_approval=job_application.approval %}
+                {% elif job_application.job_seeker.has_valid_common_approval %}
+                    {% include "approvals/includes/status.html" with common_approval=job_application.job_seeker.latest_common_approval %}
                 {% elif job_application.hiring_without_approval %}
                     Vous n'avez pas demandé de PASS IAE (agrément).
                 {% elif job_application.approval_manually_refused_at %}


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/Anomalie-d-affichage-du-PASS-pour-les-prescripteurs-boost-1f45cea3a1a24b3586fbe6e673141126

### Pourquoi ?

La page de détails d'une candidature n'affiche pas les informations d'un PASS IAE du demandeur d'emploi qui n'est pas rattaché à la candidature en cours. 

