### PR TITLE
boost: ajouter le type de SIAE dans l’encart candidature affiché dans la page d'admin du PASS IAE

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -47,7 +47,8 @@ class JobApplicationInline(admin.StackedInline):
     @admin.display(description="SIAE destinataire")
     def to_siae_link(self, obj):
         return mark_safe(
-            get_admin_view_link(obj.to_siae, content=obj.to_siae.display_name) + f" — SIRET : {obj.to_siae.siret}"
+            get_admin_view_link(obj.to_siae, content=obj.to_siae.display_name)
+            + f" — SIRET : {obj.to_siae.siret} ({obj.to_siae.kind})"
         )
 
     # Custom read-only fields as workaround :


### PR DESCRIPTION
**Carte Notion : **

https://www.notion.so/plateforme-inclusion/ADMIN-ajouter-le-type-de-siae-dans-l-encart-candidature-affich-dans-la-page-du-pass-66c72dd9915d4cc4881c69f142b6c205

### Pourquoi ?

Permet de discerner d'un coup d'oeil a quelle structure on a affaire (dans le cas de structures multiples avec le même SIRET)

### Captures d'écran 

![image](https://github.com/betagouv/itou/assets/147232/274b13ac-d73d-4289-a237-136729120145)


