### PR TITLE
docker: Utiliser le bon `DJANGO_SETTINGS_MODULE` pour les tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - PGUSER=postgres
       - PGPASSWORD=password
       - PYTHONPATH=.
-      - DJANGO_SETTINGS_MODULE=config.settings.dev
       - ITOU_LOG_LEVEL=DEBUG
     depends_on:
       - postgres

--- a/docker/dev/django/entrypoint.sh
+++ b/docker/dev/django/entrypoint.sh
@@ -12,8 +12,8 @@ done
 # trap : TERM INT
 # tail -f /dev/null & wait
 
-django-admin migrate
+./manage.py migrate
 
-django-admin runserver 0.0.0.0:8000
+./manage.py runserver 0.0.0.0:8000
 
 exec "$@"


### PR DESCRIPTION

### Pourquoi ?

Lancer `pytest` dans le docker utilise toujours `settings.dev` au lieu de `settings.test`.

Voir 5ba03c44d5d45c268cb5e15b1a1e1a2c3cfde2e2 (#2750).

### Comment ?

Je supprime la variable d'env `DJANGO_SETTINGS_MODULE` du docker donc il est possible que certaine commande (`django-admin` par exemple) liée à Django ne fonctionne plus par défaut.
