### PR TITLE
Admin - SIAE : Historique des SIRET

### DIFF
--- a/itou/siaes/admin.py
+++ b/itou/siaes/admin.py
@@ -143,6 +143,7 @@ class SiaeAdmin(ItouGISMixin, ExportActionMixin, OrganizationAdmin):
                 "fields": (
                     "pk",
                     "siret",
+                    "siret_history",
                     "naf",
                     "kind",
                     "name",
@@ -188,6 +189,7 @@ class SiaeAdmin(ItouGISMixin, ExportActionMixin, OrganizationAdmin):
     def get_readonly_fields(self, request, obj=None):
         readonly_fields = [
             "pk",
+            "siret_history",
             "source",
             "created_by",
             "created_at",
@@ -217,6 +219,9 @@ class SiaeAdmin(ItouGISMixin, ExportActionMixin, OrganizationAdmin):
                 obj.set_coords(obj.geocoding_address, post_code=obj.post_code)
             except GeocodingDataError:
                 messages.error(request, "L'adresse semble erronée car le geocoding n'a pas pu être recalculé.")
+
+        if change and (not obj.siret_history or obj.siret != obj.siret_history[-1]):
+            obj.siret_history.append(obj.siret)
 
         # Pulled-up the save action:
         # many-to-many relationships / cross-tables references

--- a/itou/siaes/management/commands/import_siae.py
+++ b/itou/siaes/management/commands/import_siae.py
@@ -127,6 +127,8 @@ class Command(BaseCommand):
     def update_siae_siret(self, siae, new_siret):
         assert siae.siret != new_siret
         self.stdout.write(f"siae.id={siae.id} has changed siret from {siae.siret} to {new_siret} (will be updated)")
+        if not siae.siret_history or siae.siret != siae.siret_history[-1]:
+            siae.siret_history.append(siae.siret)
         siae.siret = new_siret
         siae.save()
 

--- a/itou/siaes/migrations/0005_siae_siret_history.py
+++ b/itou/siaes/migrations/0005_siae_siret_history.py
@@ -1,0 +1,23 @@
+import django.contrib.postgres.fields
+from django.db import migrations, models
+
+import itou.utils.validators
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("siaes", "0004_siaejobdescription_field_history"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="siae",
+            name="siret_history",
+            field=django.contrib.postgres.fields.ArrayField(
+                base_field=models.CharField(max_length=14, validators=[itou.utils.validators.validate_siret]),
+                default=list,
+                size=None,
+                verbose_name="historique des siret",
+            ),
+        ),
+    ]

--- a/itou/siaes/models.py
+++ b/itou/siaes/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.gis.measure import D
+from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator
@@ -208,6 +209,9 @@ class Siae(AddressMixin, OrganizationAbstract):
     # almost never changes.
     # Both SIRET numbers are kept up to date by the weekly `import_siae.py` script.
     siret = models.CharField(verbose_name="siret", max_length=14, validators=[validate_siret], db_index=True)
+    siret_history = ArrayField(
+        models.CharField(max_length=14, validators=[validate_siret]), verbose_name="historique des siret", default=list
+    )
     naf = models.CharField(verbose_name="naf", max_length=5, validators=[validate_naf], blank=True)
     kind = models.CharField(verbose_name="type", max_length=8, choices=SiaeKind.choices, default=SiaeKind.EI)
     # `brand` (or `enseigne` in French) is used to override `name` if needed.

--- a/tests/siaes/test_import_siae_command.py
+++ b/tests/siaes/test_import_siae_command.py
@@ -226,6 +226,34 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
             for (kind, name) in Siae.objects.values_list("kind", "name")
         ]
 
+    def test_update_siret_and_auth_email_of_existing_siaes_fill_siret_history_without_history(self):
+        siae = SiaeFactory(siret_history=[], siret="34950857200000", kind=SiaeKind.AI, convention__asp_id=768)
+        instance = lazy_import_siae_command()
+
+        instance.update_siret_and_auth_email_of_existing_siaes()
+        siae.refresh_from_db()
+        assert siae.siret_history == ["34950857200000"]
+
+    def test_update_siret_and_auth_email_of_existing_siaes_fill_siret_history_with_history(self):
+        siae = SiaeFactory(
+            siret_history=["00000000000000"], siret="34950857200000", kind=SiaeKind.AI, convention__asp_id=768
+        )
+        instance = lazy_import_siae_command()
+
+        instance.update_siret_and_auth_email_of_existing_siaes()
+        siae.refresh_from_db()
+        assert siae.siret_history == ["00000000000000", "34950857200000"]
+
+    def test_update_siret_and_auth_email_of_existing_siaes_fill_siret_history_if_the_last_one_is_not_the_same(self):
+        siae = SiaeFactory(
+            siret_history=["34950857200000"], siret="34950857200000", kind=SiaeKind.AI, convention__asp_id=768
+        )
+        instance = lazy_import_siae_command()
+
+        instance.update_siret_and_auth_email_of_existing_siaes()
+        siae.refresh_from_db()
+        assert siae.siret_history == ["34950857200000"]
+
 
 @override_settings(METABASE_HASH_SALT="foobar2000")
 def test_hashed_approval_number():


### PR DESCRIPTION
### Pourquoi ?

Car c'est mieux, pour nous et le support, que de lire dans les feuilles de thés (`updated_at`, objet `Convention()`, log du script `import_siae`) pour voir si le SIRET a changé ou pour retrouver les anciennes valeurs, en particulier pour les FS car elles sont liés au SIRET du coté de l'ASP.

### Comment <!-- optionnel -->

`ArrayField()` remplis à 2 endroits (je pense n'en avoir pas oublié) :
1. Dans `import_siae` quand un changement de SIRET est détecté
2. Dans l'admin quand un changement de SIRET est détecté
