### PR TITLE
Fiches salarié : Parcours de création autonome

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -140,7 +140,9 @@ class JobApplicationQuerySet(models.QuerySet):
         Get unique foreign key objects in a single query.
         TODO: move this method in a custom manager since it's not chainable.
         """
+        # FIXME: Replace that static list by a dynamic one
         if fk_field not in [
+            "approval",
             "job_seeker",
             "sender",
             "sender_company",
@@ -149,7 +151,8 @@ class JobApplicationQuerySet(models.QuerySet):
         ]:
             raise RuntimeError("Unauthorized fk_field")
 
-        job_applications = self.order_by(fk_field).distinct(fk_field).select_related(fk_field)
+        # Use the `_id` field because ordering by a ForeignKey will follow the Meta.ordering but the distinct will not.
+        job_applications = self.order_by(f"{fk_field}_id").distinct(f"{fk_field}_id").select_related(fk_field)
         return [
             getattr(job_application, fk_field)
             for job_application in job_applications

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -1,0 +1,70 @@
+{% extends "layout/base.html" %}
+{% load django_bootstrap5 %}
+{% load format_filters %}
+{% load str_filters %}
+{% load theme_inclusion %}
+{% load matomo %}
+
+{% block title %}Créer une fiche salarié {{ block.super }}{% endblock %}
+{% block content_title %}
+    <h1>Créer une fiche salarié - {{ request.current_organization.display_name }}</h1>
+{% endblock %}
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="row">
+                <div class="col-12 col-md-9">
+                    <div class="c-stepper mb-3 mb-lg-5">
+                        <div class="progress progress--emploi">
+                            <div class="progress-bar progress-bar-{{ wizard|stepper_progress }}" role="progressbar" aria-valuenow="{{ wizard|stepper_progress }}" aria-valuemin="0" aria-valuemax="100">
+                            </div>
+                        </div>
+                        <p>
+                            <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }}
+                        </p>
+                    </div>
+                    <div class="c-form mb-3 mb-lg-5">
+                        <form method="post">
+                            {% csrf_token %}
+                            {{ wizard.management_form }}
+
+                            {% bootstrap_form form alert_error_type="non_fields" %}
+
+                            {% if not wizard.steps.next %}
+                                <p>
+                                    Après avoir sélectionné le PASS IAE concerné et cliqué sur <i>"Confirmer"</i>, 2 cas de figure sont possibles :
+                                </p>
+                                <ul>
+                                    <li>
+                                        <p class="m-0">
+                                            <b>Une fiche salarié existe déjà pour ce salarié et ce PASS IAE :</b> dans ce cas vous serez automatiquement redirigé sur la page de détail de cette fiche salarié.
+                                        </p>
+                                        <p>
+                                            Si la fiche salarié est déjà intégrée et que vous avez besoin de la renvoyer dans l’Extranet IAE 2.0 de l’ASP, vous devez la <b>désactiver</b> puis la <b>réactiver</b>.
+                                        </p>
+                                    </li>
+                                    <li>
+                                        <b>Aucune fiche salarié n’existe pour ce salarié et ce PASS IAE :</b> dans ce cas vous serez redirigé vers le formulaire de création et d’envoi de la fiche salarié.
+                                    </li>
+                                </ul>
+                            {% endif %}
+
+                            <hr>
+                            <p class="fs-xs">* champ obligatoire</p>
+                            <div class="form-group text-end">
+                                {% if wizard.steps.prev %}
+                                    {% bootstrap_button "Retour" button_type="submit" button_class="btn btn-outline-primary" name="wizard_goto_step" value=wizard.steps.prev %}
+                                {% else %}
+                                    <a class="btn btn-link btn-outline-primary" href="{% url "employee_record_views:list" %}?status=NEW">Annuler</a>
+                                {% endif %}
+                                <button class="btn btn-primary" {% if not wizard.steps.next %}{% matomo_event "fiches-salarié" "submit" "création" %}{% endif %}>
+                                    {{ wizard.steps.next|yesno:"Suivant,Confirmer" }}
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/employee_record/includes/_status.html
+++ b/itou/templates/employee_record/includes/_status.html
@@ -1,0 +1,21 @@
+{% if employee_record.status == "SENT" %}
+    <span class="badge rounded-pill badge-sm bg-warning">
+        Transmise à l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+    </span>
+{% elif employee_record.status == "REJECTED" %}
+    <span class="badge rounded-pill badge-sm bg-danger">
+        Retour en erreur le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+    </span>
+{% elif employee_record.status == "PROCESSED" %}
+    <span class="badge rounded-pill badge-sm bg-success">
+        Intégrée par l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+    </span>
+{% elif employee_record.status == "READY" %}
+    <span class="badge rounded-pill badge-sm bg-secondary">
+        Complétée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+    </span>
+{% elif employee_record.status == "DISABLED" %}
+    <span class="badge rounded-pill badge-sm bg-emploi-lightest text-primary">
+        Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+    </span>
+{% endif %}

--- a/itou/templates/employee_record/includes/_status.html
+++ b/itou/templates/employee_record/includes/_status.html
@@ -18,4 +18,8 @@
     <span class="badge rounded-pill badge-sm bg-emploi-lightest text-primary">
         Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
+{% elif employee_record.status == "ARCHIVED" %}
+    <span class="badge rounded-pill badge-sm bg-emploi-lightest text-primary">
+        Archivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
+    </span>
 {% endif %}

--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -30,7 +30,7 @@
                     <div class="col-12">
                         <div class="form-row align-items-center justify-content-lg-between">
                             <div class="form-group col-12 col-md-6 col-lg-auto order-2 order-md-1">
-                                <a href="{% url "employee_record_views:list" %}?status={{ request.GET.from_status }}" class="btn btn-block btn-ico btn-link ps-lg-0 justify-content-center">
+                                <a href="{% url "employee_record_views:list" %}?status={{ request.GET.from_status|default:"NEW" }}" class="btn btn-block btn-ico btn-link ps-lg-0 justify-content-center">
                                     <i class="ri-arrow-go-back-line ri-lg"></i>
                                     <span>Retour à la liste</span>
                                 </a>

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -149,7 +149,7 @@
                     {% if item.employee_record_new %}
                         <a href="{% url "employee_record_views:disable" item.employee_record_new.id %}" class="btn btn-sm btn-outline-primary mt-2">Désactiver la fiche salarié</a>
                     {% endif %}
-                    <a href="{% url "employee_record_views:create" item.id %}?from_status=NEW" class="btn btn-sm btn-outline-primary mt-2">Créer la fiche salarié</a>
+                    <a href="{% url "employee_record_views:create" item.id %}?from_status=NEW" class="btn btn-sm btn-outline-primary mt-2">Compléter la fiche salarié</a>
                 </div>
             {% endif %}
         {% else %}

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -8,27 +8,7 @@
             </div>
             {# Statuses #}
             <div class="col-12 col-md-auto">
-                {% if form.status.value == "SENT" %}
-                    <span class="badge rounded-pill badge-sm bg-warning">
-                        Transmise à l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                    </span>
-                {% elif form.status.value == "REJECTED" %}
-                    <span class="badge rounded-pill badge-sm bg-danger">
-                        Retour en erreur le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                    </span>
-                {% elif form.status.value == "PROCESSED" %}
-                    <span class="badge rounded-pill badge-sm bg-success">
-                        Intégrée ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                    </span>
-                {% elif form.status.value == "READY" %}
-                    <span class="badge rounded-pill badge-sm bg-secondary">
-                        Complétée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                    </span>
-                {% elif form.status.value == "DISABLED" %}
-                    <span class="badge rounded-pill badge-sm bg-emploi-lightest text-primary">
-                        Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
-                    </span>
-                {% endif %}
+                {% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}
             </div>
         </div>
 

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -80,6 +80,14 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
+            <div class="row my-3 my-md-5">
+                <div class="col-12">
+                    <div class="c-box p-3 p-md-4 d-flex align-items-center">
+                        <div class="p-0 flex-grow-1 h5 m-0">Vous ne trouvez pas la fiche salarié d’un de vos salariés ?</div>
+                        <a class="btn btn-primary" href="{% url "employee_record_views:add" %}">Créer une fiche salarié</a>
+                    </div>
+                </div>
+            </div>
             <div class="row">
                 <div class="col-12 col-md-3">
                     <aside class="c-aside-filters">

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -143,14 +143,12 @@
                         <div class="employee-records-list">
                             {% if employee_records_list %}
                                 {% for employee_record in navigation_pages %}
-                                    {% with item=employee_record.job_application %}
-                                        {% include "employee_record/includes/list_item.html" %}
-                                    {% endwith %}
+                                    {% include "employee_record/includes/list_item.html" with employee_record=employee_record item=employee_record.job_application form=form only %}
                                 {% endfor %}
                                 {# New employee records i.e. job applications #}
                             {% else %}
-                                {% for item in navigation_pages %}
-                                    {% include "employee_record/includes/list_item.html" %}
+                                {% for job_application in navigation_pages %}
+                                    {% include "employee_record/includes/list_item.html" with employee_record=None item=job_application form=form %}
                                 {% endfor %}
                             {% endif %}
                         </div>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -9,6 +9,9 @@
 
 {% block content_title %}
     <h1>Détail fiche salarié ASP: {{ employee_record.job_seeker.get_full_name }}</h1>
+    <p>
+        {% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}
+    </p>
 {% endblock %}
 
 {% block content %}
@@ -31,8 +34,6 @@
                 </div>
                 <div class="col-12 col-lg-4 order-1 order-lg-2 mb-3">
                     <div class="c-box">
-                        <p>{{ employee_record.get_status_display }} le {{ employee_record.updated_at }}</p>
-                        <hr class="my-3">
                         {% with job_application=employee_record.job_application %}
                             <p>
                                 <b>PASS IAE :</b>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -9,9 +9,7 @@
 
 {% block content_title %}
     <h1>Détail fiche salarié ASP: {{ employee_record.job_seeker.get_full_name }}</h1>
-    <p>
-        {% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}
-    </p>
+    <p>{% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}</p>
 {% endblock %}
 
 {% block content %}
@@ -21,19 +19,21 @@
                 <div class="col-12 col-lg-8 order-2 order-lg-1">
                     <div class="c-box">
                         {% include "employee_record/includes/employee_record_summary.html" %}
-                        <hr class="mb-3">
-                        <div class="row mt-3">
-                            <div class="col-12 col-md-auto">
-                                <a href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}" class="btn btn-block btn-link ps-lg-0">
-                                    <i class="ri-arrow-go-back-line ri-lg"></i>
-                                    <span>Retour à la liste</span>
-                                </a>
+                        {% if employee_record.status != "ARCHIVED" %}
+                            <hr class="mb-3">
+                            <div class="row mt-3">
+                                <div class="col-12 col-md-auto">
+                                    <a href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}" class="btn btn-block btn-link ps-lg-0">
+                                        <i class="ri-arrow-go-back-line ri-lg"></i>
+                                        <span>Retour à la liste</span>
+                                    </a>
+                                </div>
                             </div>
-                        </div>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="col-12 col-lg-4 order-1 order-lg-2 mb-3">
-                    {% if employee_record.status != "READY" and employee_record.status != "SENT" %}
+                    {% if employee_record.status != "READY" and employee_record.status != "SENT" and employee_record.status != "ARCHIVED" %}
                         <div class="c-box mb-4">
                             {% if employee_record.status == "NEW" %}
                                 <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=NEW" class="btn btn-block btn-primary my-2">Compléter la fiche salarié</a>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -33,6 +33,20 @@
                     </div>
                 </div>
                 <div class="col-12 col-lg-4 order-1 order-lg-2 mb-3">
+                    {% if employee_record.status != "READY" and employee_record.status != "SENT" %}
+                        <div class="c-box mb-4">
+                            {% if employee_record.status == "NEW" %}
+                                <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=NEW" class="btn btn-block btn-primary my-2">Compléter la fiche salarié</a>
+                            {% elif employee_record.status == "REJECTED" %}
+                                <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=REJECTED" class="btn btn-block btn-primary my-2">Modifier la fiche salarié</a>
+                            {% elif employee_record.status == "DISABLED" %}
+                                <a href="{% url "employee_record_views:reactivate" employee_record.pk %}" class="btn btn-block btn-outline-primary my-2">Réactiver la fiche salarié</a>
+                            {% endif %}
+                            {% if employee_record.status == "REJECTED" or employee_record.status == "PROCESSED" %}
+                                <a href="{% url "employee_record_views:disable" employee_record.pk %}" class="btn btn-block btn-outline-primary my-2">Désactiver la fiche salarié</a>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                     <div class="c-box">
                         {% with job_application=employee_record.job_application %}
                             <p>

--- a/itou/www/employee_record_views/urls.py
+++ b/itou/www/employee_record_views/urls.py
@@ -6,6 +6,16 @@ from itou.www.employee_record_views import views
 app_name = "employee_record_views"
 
 urlpatterns = [
+    path(
+        "add/",
+        views.AddView.as_view(url_name="employee_record_views:add"),
+        name="add",
+    ),
+    path(
+        "add/<slug:step>",
+        views.AddView.as_view(url_name="employee_record_views:add"),
+        name="add",
+    ),
     path("list", views.list_employee_records, name="list"),
     path("create/<uuid:job_application_id>", views.create, name="create"),
     path("create_step_2/<uuid:job_application_id>", views.create_step_2, name="create_step_2"),

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -1,0 +1,112 @@
+# serializer version: 1
+# name: test_wizard[choose-approval]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-md-9">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="progress-bar progress-bar-100" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              <strong>Étape 2</strong>/2
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <form method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <input id="id_add_view-current_step" name="add_view-current_step" type="hidden" value="choose-approval"/>
+  
+                              <div class="form-group form-group-required"><label class="form-label" for="id_choose-approval-approval">PASS IAE de John DOE</label><select class="form-select" id="id_choose-approval-approval" name="choose-approval-approval">
+    <option value="1">999999999999 — Du 01/01/2000 au 01/01/3000</option>
+  
+  </select><div class="form-text">Le PASS IAE concerné par le transfert de données vers l'Extranet IAE 2.0 de l'ASP</div>
+  </div>
+  
+                              
+                                  <p>
+                                      Après avoir sélectionné le PASS IAE concerné et cliqué sur <i>"Confirmer"</i>, 2 cas de figure sont possibles :
+                                  </p>
+                                  <ul>
+                                      <li>
+                                          <p class="m-0">
+                                              <b>Une fiche salarié existe déjà pour ce salarié et ce PASS IAE :</b> dans ce cas vous serez automatiquement redirigé sur la page de détail de cette fiche salarié.
+                                          </p>
+                                          <p>
+                                              Si la fiche salarié est déjà intégrée et que vous avez besoin de la renvoyer dans l’Extranet IAE 2.0 de l’ASP, vous devez la <b>désactiver</b> puis la <b>réactiver</b>.
+                                          </p>
+                                      </li>
+                                      <li>
+                                          <b>Aucune fiche salarié n’existe pour ce salarié et ce PASS IAE :</b> dans ce cas vous serez redirigé vers le formulaire de création et d’envoi de la fiche salarié.
+                                      </li>
+                                  </ul>
+                              
+  
+                              <hr/>
+                              <p class="fs-xs">* champ obligatoire</p>
+                              <div class="form-group text-end">
+                                  
+                                      <button class="btn btn-outline-primary" name="wizard_goto_step" type="submit" value="choose-employee">Retour</button>
+                                  
+                                  <button class="btn btn-primary" data-matomo-action="submit" data-matomo-category="fiches-salarié" data-matomo-event="true" data-matomo-option="création">
+                                      Confirmer
+                                  </button>
+                              </div>
+                          </form>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_wizard[choose-employee]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-md-9">
+                      <div class="c-stepper mb-3 mb-lg-5">
+                          <div class="progress progress--emploi">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="progress-bar progress-bar-50" role="progressbar">
+                              </div>
+                          </div>
+                          <p>
+                              <strong>Étape 1</strong>/2
+                          </p>
+                      </div>
+                      <div class="c-form mb-3 mb-lg-5">
+                          <form method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <input id="id_add_view-current_step" name="add_view-current_step" type="hidden" value="choose-employee"/>
+  
+                              <div class="form-group form-group-required"><label class="form-label" for="id_choose-employee-employee">Nom du salarié</label><select class="form-select django-select2" data-allow-clear="false" data-minimum-input-length="0" data-theme="bootstrap-5" id="id_choose-employee-employee" lang="fr" name="choose-employee-employee" required="">
+    <option selected="" value="">Sélectionnez le salarié</option>
+  
+    <option value="1">John Doe</option>
+  
+  </select><div class="form-text">Le salarié concerné par le transfert de données vers l'Extranet IAE 2.0 de l'ASP</div>
+  </div>
+  
+                              
+  
+                              <hr/>
+                              <p class="fs-xs">* champ obligatoire</p>
+                              <div class="form-group text-end">
+                                  
+                                      <a class="btn btn-link btn-outline-primary" href="/employee_record/list?status=NEW">Annuler</a>
+                                  
+                                  <button class="btn btn-primary">
+                                      Suivant
+                                  </button>
+                              </div>
+                          </form>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---

--- a/tests/www/employee_record_views/test_add.py
+++ b/tests/www/employee_record_views/test_add.py
@@ -1,0 +1,154 @@
+from django.urls import reverse
+from pytest_django.asserts import assertRedirects
+
+from itou.employee_record.enums import Status
+from tests.approvals.factories import ApprovalFactory
+from tests.companies.factories import CompanyFactory
+from tests.employee_record.factories import EmployeeRecordFactory
+from tests.job_applications.factories import JobApplicationFactory
+from tests.utils.test import parse_response_to_soup
+
+
+def test_wizard(snapshot, client):
+    company = CompanyFactory(with_membership=True)
+    approval = ApprovalFactory(for_snapshot=True, pk=1, user__pk=1)
+    job_application = JobApplicationFactory(
+        to_company=company,
+        job_seeker=approval.user,
+        with_approval=True,
+        approval=approval,
+    )
+    client.force_login(company.members.first())
+
+    start_url = reverse("employee_record_views:add")
+    choose_employee_url = reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
+    choose_approval_url = reverse("employee_record_views:add", kwargs={"step": "choose-approval"})
+    end_url = reverse("employee_record_views:add", kwargs={"step": "done"})
+
+    # Starting the tunnel should redirect to the first step
+    assertRedirects(client.get(start_url), choose_employee_url)
+
+    # Submit data for the "choose-employee" step
+    assert str(parse_response_to_soup(client.get(choose_employee_url), selector="#main .s-section")) == snapshot(
+        name="choose-employee"
+    )
+    response = client.post(
+        choose_employee_url,
+        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+    )
+    assertRedirects(response, choose_approval_url)
+
+    # Submit data for the "choose-approval" step
+    assert str(parse_response_to_soup(client.get(choose_approval_url), selector="#main .s-section")) == snapshot(
+        name="choose-approval"
+    )
+    response = client.post(
+        choose_approval_url,
+        {
+            "choose-approval-approval": job_application.approval.pk,
+            "add_view-current_step": "choose-approval",
+        },
+    )
+
+    assertRedirects(response, end_url, fetch_redirect_response=False)
+
+
+def test_done_step_when_the_employee_record_need_to_be_created(client):
+    company = CompanyFactory(with_membership=True)
+    approval = ApprovalFactory(for_snapshot=True, pk=1, user__pk=1)
+    job_application = JobApplicationFactory(
+        to_company=company,
+        job_seeker=approval.user,
+        with_approval=True,
+        approval=approval,
+    )
+    client.force_login(company.members.first())
+
+    choose_employee_url = reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
+    choose_approval_url = reverse("employee_record_views:add", kwargs={"step": "choose-approval"})
+    end_url = reverse("employee_record_views:create", kwargs={"job_application_id": job_application.pk})
+
+    client.post(
+        choose_employee_url,
+        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+    )
+    response = client.post(
+        choose_approval_url,
+        {
+            "choose-approval-approval": job_application.approval.pk,
+            "add_view-current_step": "choose-approval",
+        },
+        follow=True,  # Don't stop to the `done` step
+    )
+
+    assertRedirects(response, end_url)
+
+
+def test_done_step_when_a_new_employee_record_already_exists(client):
+    company = CompanyFactory(with_membership=True)
+    approval = ApprovalFactory(for_snapshot=True, pk=1, user__pk=1)
+    job_application = JobApplicationFactory(
+        to_company=company,
+        to_company__use_employee_record=True,
+        job_seeker=approval.user,
+        with_approval=True,
+        approval=approval,
+    )
+    EmployeeRecordFactory(job_application=job_application, status=Status.NEW)
+
+    client.force_login(company.members.first())
+
+    choose_employee_url = reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
+    choose_approval_url = reverse("employee_record_views:add", kwargs={"step": "choose-approval"})
+    end_url = reverse("employee_record_views:create", kwargs={"job_application_id": job_application.pk})
+
+    client.post(
+        choose_employee_url,
+        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+    )
+
+    response = client.post(
+        choose_approval_url,
+        {
+            "choose-approval-approval": job_application.approval.pk,
+            "add_view-current_step": "choose-approval",
+        },
+        follow=True,  # Don't stop to the `done` step
+    )
+
+    assertRedirects(response, end_url)
+
+
+def test_done_step_when_a_other_than_new_employee_record_already_exists(client):
+    company = CompanyFactory(with_membership=True)
+    approval = ApprovalFactory(for_snapshot=True, pk=1, user__pk=1)
+    job_application = JobApplicationFactory(
+        to_company=company,
+        to_company__use_employee_record=True,
+        job_seeker=approval.user,
+        with_approval=True,
+        approval=approval,
+    )
+    employee_record = EmployeeRecordFactory(job_application=job_application, status=Status.PROCESSED)
+
+    client.force_login(company.members.first())
+
+    choose_employee_url = reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
+    choose_approval_url = reverse("employee_record_views:add", kwargs={"step": "choose-approval"})
+    end_url = reverse("employee_record_views:summary", kwargs={"employee_record_id": employee_record.pk})
+
+    client.post(
+        choose_employee_url,
+        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+    )
+
+    response = client.post(
+        choose_approval_url,
+        {
+            "choose-approval-approval": job_application.approval.pk,
+            "add_view-current_step": "choose-approval",
+        },
+        follow=True,  # Don't stop to the `done` step
+    )
+
+    assertRedirects(response, end_url)

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -140,7 +140,7 @@ class ListEmployeeRecordsTest(TestCase):
         response = self.client.get(self.url + "?status=NEW")
 
         self.assertContains(response, "Désactiver la fiche salarié")
-        self.assertContains(response, "Créer la fiche salarié")
+        self.assertContains(response, "Compléter la fiche salarié")
 
     @override_settings(TALLY_URL="https://tally.so")
     def test_employee_records_with_nir_associated_to_other(self):
@@ -174,7 +174,7 @@ class ListEmployeeRecordsTest(TestCase):
         self.assertContains(response, "demander la régularisation du numéro de sécurité sociale")
         self.assertContains(response, f'href="https://tally.so/r/wzxQlg?employeerecord={ new_er.pk }"')
         self.assertNotContains(response, "Désactiver la fiche salarié")
-        self.assertNotContains(response, "Créer la fiche salarié")
+        self.assertNotContains(response, "Compléter la fiche salarié")
 
     def test_rejected_without_custom_message(self):
         self.client.force_login(self.user)


### PR DESCRIPTION
**Carte notion :** https://www.notion.so/plateforme-inclusion/Fiche-salari-En-tant-qu-employeur-je-peux-cr-er-une-fiche-salari-sans-que-celle-ci-soit-dans-Nou-85e0190b04754325a8e1106e8f6eefad?pvs=4

### Pourquoi ?

Permettre la création d’une FS par l’employeur sans quelle soit obligatoirement dans “Nouvelle”
⇒ Philosophie : Les emplois transfert ses données vers l’ASP, ce n’est pas au système mais à l’employeur de choisir ce qu’il veux envoyer vers l’ASP. Les FS sont de la périphérie et pas centrale pour les emplois
⇒ Autonomise l’employeur pour toute les opérations de création de FS : changement de SIRET, embauche avant l'interopérabilité, drapeau "Création de fiche salarié" pour le stock AI, etc
⇒ Moins de logique métier chez nous, ce qui devrais permettre de plus facilement renvoyer la balle vers le support ASP, nous ne somme qu’un conduit entre les données rentrées par l’utilisateur et l’Extranet ASP
⇒ Devrait nous permettre à terme de supprimer les FS hologrammes et donc d'avoir une meilleure visualisation des données