### PR TITLE
Fiches salarié : Amélioration de performance pour le nettoyage des FS orphelines

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -50,7 +50,8 @@ class Command(BaseCommand):
     def _check_orphans(self, dry_run):
         # Report all orphans employee records (bad asp_id)
 
-        orphans = EmployeeRecord.objects.orphans()
+        # Exclude the one that are already DISABLED, and also the ARCHIVED ones as they are now unusable
+        orphans = EmployeeRecord.objects.orphans().exclude(status__in=[Status.DISABLED, Status.ARCHIVED])
 
         self.stdout.write("* Checking orphans employee records:")
 


### PR DESCRIPTION
### Pourquoi ?

Pour ne pas gâcher du temps pour rien.
Je ne fait pas un `filter()` avec seulement les états qui font que `can_be_disabled is True` pour éventuellement choper les cas anormaux plus tard en mode "C'est bizarre d'avoir autant de FS toujours orphelines" (#monderéel).