### PR TITLE
Ajout d’information dans le PASS IAE pour une Prolongation en cours

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -55,7 +55,7 @@ Arguments:
         <ul class="list-unstyled">
             <li class="h4 mt-4 mb-2">
                 Nombre de jours restants sur le PASS IAE : {{ common_approval.remainder.days }} jour{{ common_approval.remainder.days|pluralizefr }}
-                <i class="ri-information-line ri-xl"
+                <i class="ri-information-line ri-xl text-info"
                    data-bs-toggle="tooltip"
                    title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
             </li>
@@ -69,7 +69,7 @@ Arguments:
             {% if not hiring_pending %}
                 <li class="pb-2">
                     Date de fin prévisionnelle : {{ common_approval.end_at|date:"d/m/Y" }}
-                    <i class="ri-information-line ri-xl" data-bs-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
+                    <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
                 </li>
             {% endif %}
         </ul>
@@ -95,14 +95,13 @@ Arguments:
             {% endif %}
         {% endif %}
     {% endif %}
-    {% if common_approval.pending_prolongation_request %}<p>Une demande de prolongation est en cours</p>{% endif %}
 </div>
 
 {% if common_approval.is_valid and common_approval.is_pass_iae %}
     {# Suspensions history. #}
     {% with common_approval.suspensions_for_status_card as suspensions %}
         {% if suspensions.last_in_progress or suspensions.older %}
-            <div id="suspensions-list" class="ps-2 border-start approval-left-border">
+            <div id="suspensions-list" class="ps-3 border-start approval-left-border">
                 {% if suspensions.last_in_progress %}
                     <p class="mb-1">Suspension en cours :</p>
                     <ul class="list-unstyled">
@@ -137,7 +136,7 @@ Arguments:
     {# Prolongations history. #}
     {% with prolongations=common_approval.prolongations_for_status_card prolongation_requests=common_approval.prolongation_requests_for_status_card %}
         {% if prolongations or prolongation_requests %}
-            <div id="prolongations-list" class="ps-2 border-start approval-left-border">
+            <div id="prolongations-list" class="ps-3 border-start approval-left-border">
                 {% if prolongations.in_progress %}
                     <p class="mb-1">Prolongation en cours :</p>
                     {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.in_progress %}
@@ -149,7 +148,7 @@ Arguments:
                     {% include "approvals/includes/prolongations_list.html" with prolongations=prolongations.not_in_progress %}
                 {% endif %}
                 {% if prolongation_requests %}
-                    <p class="mb-1">Demande{{ prolongation_requests|pluralizefr }} de prolongation</p>
+                    <p class="mb-1">Demande{{ prolongation_requests|pluralizefr }} de prolongation en cours :</p>
                     <ul class="list-unstyled">
                         {% for prolongation_request in prolongation_requests %}
                             <li>
@@ -157,7 +156,7 @@ Arguments:
                                 <small class="ms-3">{{ prolongation_request.get_reason_display }}</small>
                                 <small class="d-block mb-2">
                                     {% if prolongation_request.status == ProlongationRequestStatus.PENDING %}
-                                        En cours
+                                        Demandée le {{ prolongation_request.created_at|date:"d/m/Y" }} par <i>{{ prolongation_request.declared_by.get_full_name }}</i> à <i>{{ prolongation_request.validated_by.get_full_name }}</i> ({{ prolongation_request.prescriber_organization.display_name }} - {{ prolongation_request.prescriber_organization.department }})
                                     {% elif prolongation_request.status == ProlongationRequestStatus.DENIED %}
                                         Refusée par <i>{{ prolongation_request.processed_by.get_full_name }}</i> ({{ prolongation_request.prescriber_organization.display_name }})
                                     {% endif %}

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestApprovalDetailView.test_approval_status_includes[Approval prolongations list]
   '''
-  <div class="ps-2 border-start approval-left-border" id="prolongations-list">
+  <div class="ps-3 border-start approval-left-border" id="prolongations-list">
                   
                       <p class="mb-1">Prolongation en cours :</p>
                       <ul class="list-unstyled">
@@ -43,12 +43,27 @@
   
                   
                   
+                      <p class="mb-1">Demande de prolongation en cours :</p>
+                      <ul class="list-unstyled">
+                          
+                              <li>
+                                  du 26/04/2023 au 26/05/2023
+                                  <small class="ms-3">Fin d'une formation</small>
+                                  <small class="d-block mb-2">
+                                      
+                                          Demandée le 26/04/2023 par <i>Milady DE WINTER</i> à <i>First LAST</i> (Organization - 72)
+                                      
+                                  </small>
+                              </li>
+                          
+                      </ul>
+                  
               </div>
   '''
 # ---
 # name: TestApprovalDetailView.test_approval_status_includes[Approval suspensions list]
   '''
-  <div class="ps-2 border-start approval-left-border" id="suspensions-list">
+  <div class="ps-3 border-start approval-left-border" id="suspensions-list">
                   
                       <p class="mb-1">Suspension en cours :</p>
                       <ul class="list-unstyled">


### PR DESCRIPTION
### Carte Notion

https://www.notion.so/plateforme-inclusion/Ajout-d-information-dans-le-PASS-IAE-pour-une-Prolongation-en-cours-7a4757d5d430431f931cab25177ea355

### Pourquoi ?

Les utilisateurs ont besoin de voir les informations ajoutées pour suivre correctement leur demande de prolongation.

### Comment

Ajouter des informations dans l’encart du PASS IAE, visible par tous (SIAE, PH, Candidat).
On on profite pour réaligner les textes qui étaient décalés via l'usage de la classe `ps-3`.

### Captures d'écran
![Screenshot from 2023-11-13 08-44-08](https://github.com/betagouv/itou/assets/154904/fc25768e-ec21-4aee-b2a1-1e7bb963274e)

