### PR TITLE
Ajout d'un journal des changements techniques majeurs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.
 
-### Comment <!-- optionnel -->
+### Comment ? <!-- optionnel -->
 
 Attirer l'attention sur les décisions d'architecture ou de conception importantes.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 **Carte Notion : **
 
-<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->
-
 ### Pourquoi ?
 
 Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.
@@ -12,3 +10,7 @@ Attirer l'attention sur les décisions d'architecture ou de conception important
 
 ### Captures d'écran <!-- optionnel -->
 
+### Actions facultatives
+
+- [ ] Ajouter l'étiquette « no-changelog » ?
+- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Attirer l'attention sur les décisions d'architecture ou de conception important
 
 ### Captures d'écran <!-- optionnel -->
 
-### Actions facultatives
+### À vérifier
 
 - [ ] Ajouter l'étiquette « no-changelog » ?
 - [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -1,5 +1,5 @@
 # Journal des changements techniques majeurs
 
 <!-- This is just a placeholder to be discussed. Replace me by real-world information. -->
-## [numéro de sprint] - YYYY-MM-DD
-- …
+## YYYY-MM-DD
+- Courte description du changement. Si besoin, ajoutez plus d'informations : actions à faire pour mettre à jour, etc …

--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -1,0 +1,5 @@
+# Journal des changements techniques majeurs
+
+<!-- This is just a placeholder to be discussed. Replace me by real-world information. -->
+## [numéro de sprint] - YYYY-MM-DD
+- …


### PR DESCRIPTION
### Pourquoi ?

Pour permettre aux développeurs intervenant occasionnellement sur notre projet de conserver un environnement de travail stable (ou de le réparer plus rapidement).
