### PR TITLE
Permettre de mettre en liste d'attente des candidatures à l'étude nécessitant un diagnostic d'éligibilité

### DIFF
--- a/itou/templates/apply/includes/siae_hiring_actions.html
+++ b/itou/templates/apply/includes/siae_hiring_actions.html
@@ -19,8 +19,8 @@
             {% include "apply/includes/buttons/new_diagnosis.html" %}
         {% else %}
             {% include "apply/includes/buttons/accept.html" %}
-            {% include "apply/includes/buttons/postpone.html" %}
         {% endif %}
+        {% include "apply/includes/buttons/postpone.html" %}
         {% include "apply/includes/buttons/refuse.html" %}
     {% endif %}
 

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1399,7 +1399,7 @@ class ProcessTemplatesTest(TestCase):
         self.assertNotContains(response, self.url_process)
         self.assertContains(response, self.url_eligibility)
         self.assertContains(response, self.url_refuse)
-        self.assertNotContains(response, self.url_postpone)
+        self.assertContains(response, self.url_postpone)
         self.assertNotContains(response, self.url_accept)
 
     def test_details_template_for_state_prior_to_hire(self):
@@ -1412,7 +1412,7 @@ class ProcessTemplatesTest(TestCase):
         self.assertNotContains(response, self.url_process)
         self.assertContains(response, self.url_eligibility)
         self.assertContains(response, self.url_refuse)
-        self.assertNotContains(response, self.url_postpone)
+        self.assertContains(response, self.url_postpone)
         self.assertNotContains(response, self.url_accept)
 
     def test_details_template_for_state_processing_but_suspended_siae(self):
@@ -1436,7 +1436,7 @@ class ProcessTemplatesTest(TestCase):
             ),
         )
         self.assertContains(response, self.url_refuse)
-        self.assertNotContains(response, self.url_postpone)
+        self.assertContains(response, self.url_postpone)
         self.assertNotContains(response, self.url_accept)
 
     def test_details_template_for_state_postponed(self):


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/BUG-Disparition-du-bouton-Mettre-en-attente-sur-certaines-candidatures-a12459018b48468487a07214d13ea48a

<!-- Pensez à mettre le label "no-changelog" si nécessaire. -->

### Pourquoi ?

Pour que le comportement soit plus simple (c'est un cas de figure qui n'a pas besoin de cas particulier)

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

