### PR TITLE
[STATS] analyser l'usage des liens d'aide

### DIFF
--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -31,6 +31,7 @@
                     <ul>
                         <li>
                             <a href="{{ ITOU_HELP_CENTER_URL }}"
+                               rel="noopener"
                                target="_blank"
                                aria-label="Accéder à l'espace de documentation (nouvel onglet)"
                                class="matomo-event"
@@ -40,6 +41,7 @@
                         </li>
                         <li>
                             <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
+                               rel="noopener"
                                target="_blank"
                                aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)"
                                class="matomo-event"

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -30,10 +30,22 @@
                     <strong>Besoin d'aide ?</strong>
                     <ul>
                         <li>
-                            <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">Documentation</a>
+                            <a href="{{ ITOU_HELP_CENTER_URL }}"
+                               target="_blank"
+                               aria-label="Accéder à l'espace de documentation (nouvel onglet)"
+                               class="matomo-event"
+                               data-matomo-category="help"
+                               data-matomo-action="clic"
+                               data-matomo-option="footer_documentation">Documentation</a>
                         </li>
                         <li>
-                            <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE" target="_blank" aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
+                            <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
+                               target="_blank"
+                               aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)"
+                               class="matomo-event"
+                               data-matomo-category="help"
+                               data-matomo-action="clic"
+                               data-matomo-option="footer_comprendre-liae">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
                         </li>
                         <li>
                             <a href="https://updown.io/p/vjjst" target="_blank" aria-label="Disponibilité (ouverture dans un nouvel onglet)">Disponibilité</a>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -11,13 +11,22 @@
         <div class="dropdown-menu" id="helpDropdown{% if is_mobile %}Mobile{% endif %}">
             <ul class="list-unstyled">
                 <li>
-                    <a href="{{ ITOU_HELP_CENTER_URL }}" class="dropdown-item has-external-link" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)">Documentation</a>
+                    <a href="{{ ITOU_HELP_CENTER_URL }}"
+                       class="dropdown-item has-external-link matomo-event"
+                       target="_blank"
+                       aria-label="Accéder à l'espace de documentation (nouvel onglet)"
+                       data-matomo-category="help"
+                       data-matomo-action="clic"
+                       data-matomo-option="header_documentation">Documentation</a>
                 </li>
                 <li>
                     <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
-                       class="dropdown-item has-external-link"
+                       class="dropdown-item has-external-link matomo-event"
                        target="_blank"
-                       aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
+                       aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)"
+                       data-matomo-category="help"
+                       data-matomo-action="clic"
+                       data-matomo-option="header_comprendre-liae">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
                 </li>
             </ul>
         </div>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -12,6 +12,7 @@
             <ul class="list-unstyled">
                 <li>
                     <a href="{{ ITOU_HELP_CENTER_URL }}"
+                       rel="noopener"
                        class="dropdown-item has-external-link matomo-event"
                        target="_blank"
                        aria-label="Accéder à l'espace de documentation (nouvel onglet)"
@@ -21,6 +22,7 @@
                 </li>
                 <li>
                     <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
+                       rel="noopener"
                        class="dropdown-item has-external-link matomo-event"
                        target="_blank"
                        aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)"

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -285,9 +285,14 @@
         {% else %}
             {# Sticky FAQ link is not displayed on HP and on small devices #}
             <div class="rounded-pill bg-white shadow fixed-sm-bottom d-none d-sm-inline-block m-3 py-2 px-3 text-center text-md-right">
-                <a href="{{ ITOU_HELP_CENTER_URL }}" rel="noopener" target="_blank" class="has-external-link text-decoration-none" aria-label="Besoin d'aide ? (ouverture dans un nouvel onglet)">
-                    Besoin d'aide ?
-                </a>
+                <a href="{{ ITOU_HELP_CENTER_URL }}"
+                   rel="noopener"
+                   target="_blank"
+                   class="has-external-link text-decoration-none matomo-event"
+                   aria-label="Besoin d'aide ? (ouverture dans un nouvel onglet)"
+                   data-matomo-category="help"
+                   data-matomo-action="clic"
+                   data-matomo-option="sticky_documentation">Besoin d'aide ?</a>
             </div>
         {% endif %}
     </body>


### PR DESCRIPTION
### Pourquoi ?

Des liens d'aide sont présents : dans le header, dans le footer et dans un sticky widget. 
L'objectif est d'analyser leurs utilisation

### Comment <!-- optionnel -->

Ajout d'evenements Matomo 

```
data-matomo-category="help"
data-matomo-action="clic"
```

puis, selon le lien et sa postion : `{position}_{destination}`
où `position` =  `header` ou `footer` ou `sticky`
et `destination` = `documentation` ou `comprendre_lieae`

exemple : `data-matomo-option="header_documentation"`
