### PR TITLE
Modification d'un ancien DAG + nouveau DAG pilotage

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -37,7 +37,7 @@ if [[ "$1" == "--daily" ]]; then
     django-admin populate_metabase_emplois --mode=evaluated_criteria |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=users |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=memberships |& tee -a "$OUTPUT_LOG"
-    django-admin populate_metabase_emplois --mode=final_tables |& tee -a "$OUTPUT_LOG"
+    django-admin populate_metabase_emplois --mode=dbt_daily |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=data_inconsistencies |& tee -a "$OUTPUT_LOG"
     django-admin send_slack_message ":white_check_mark: succès mise à jour de données C1 -> Metabase"
 elif [[ "$1" == "--monthly" ]]; then
@@ -47,7 +47,7 @@ elif [[ "$1" == "--monthly" ]]; then
     django-admin populate_metabase_emplois --mode=insee_codes_vs_post_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=departments |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=enums |& tee -a "$OUTPUT_LOG"
-    django-admin populate_metabase_emplois --mode=final_tables |& tee -a "$OUTPUT_LOG"
+    django-admin populate_metabase_emplois --mode=dbt_daily |& tee -a "$OUTPUT_LOG"
     django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
 else
     echo "populate_metabase_emplois shell script: unknown mode='$1' selected"

--- a/clevercloud/crons/populate_metabase_matomo.sh
+++ b/clevercloud/crons/populate_metabase_matomo.sh
@@ -16,5 +16,5 @@ OUTPUT_LOG="$OUTPUT_PATH/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 
 django-admin send_slack_message ":rocket: Démarrage de la mise à jour des données Matomo"
 django-admin populate_metabase_matomo --wet-run |& tee -a "$OUTPUT_LOG"
-django-admin populate_metabase_emplois --mode final_tables |& tee -a "$OUTPUT_LOG"
+django-admin populate_metabase_emplois --mode dbt_daily |& tee -a "$OUTPUT_LOG"
 django-admin send_slack_message  ":white_check_mark: Mise à jour des données Matomo terminée"

--- a/itou/metabase/db.py
+++ b/itou/metabase/db.py
@@ -61,7 +61,7 @@ def rename_table_atomically(from_table_name, to_table_name):
     to_table_name to z_old_<to_table_name>.
     This allows us to take our time filling the new table without locking the current one.
     Note that when the old table z_old_<to_table_name> is deleted, all its obsolete airflow staging views
-    are deleted as well, they will be rebuilt by the next run of the airflow DAG `final_tables`.
+    are deleted as well, they will be rebuilt by the next run of the airflow DAG `dbt_daily`.
     """
 
     with MetabaseDatabaseCursor() as (cur, conn):
@@ -105,11 +105,21 @@ def create_table(table_name: str, columns: list[str, str], reset=False):
         conn.commit()
 
 
-def build_final_tables():
+def build_dbt_daily():
     # FIXME(vperron): this has to be moved to DBT seeds.
     create_unversioned_tables_if_needed()
     response = httpx.post(
-        urllib.parse.urljoin(settings.AIRFLOW_BASE_URL, "api/v1/dags/final_tables/dagRuns"),
+        urllib.parse.urljoin(settings.AIRFLOW_BASE_URL, "api/v1/dags/dbt_daily/dagRuns"),
+        json={"conf": {}},
+    )
+    response.raise_for_status()
+
+
+def build_dbt_weekly():
+    # FIXME(vperron): this has to be moved to DBT seeds.
+    create_unversioned_tables_if_needed()
+    response = httpx.post(
+        urllib.parse.urljoin(settings.AIRFLOW_BASE_URL, "api/v1/dags/dbt_weekly/dagRuns"),
         json={"conf": {}},
     )
     response.raise_for_status()

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -42,7 +42,7 @@ from itou.job_applications.enums import Origin, SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.jobs.models import Rome
 from itou.metabase.dataframes import get_df_from_rows, store_df
-from itou.metabase.db import build_final_tables, populate_table
+from itou.metabase.db import build_dbt_daily, populate_table
 from itou.metabase.tables import (
     analytics,
     approvals,
@@ -111,7 +111,7 @@ class Command(BaseCommand):
             "insee_codes_vs_post_codes": self.populate_insee_codes_vs_post_codes,
             "departments": self.populate_departments,
             "enums": self.populate_enums,
-            "final_tables": self.build_final_tables,
+            "dbt_daily": self.build_dbt_daily,
             "data_inconsistencies": self.report_data_inconsistencies,
         }
 
@@ -502,8 +502,8 @@ class Command(BaseCommand):
             )
 
     @timeit
-    def build_final_tables(self):
-        build_final_tables()
+    def build_dbt_daily(self):
+        build_dbt_daily()
 
     @timeit
     @monitor(monitor_slug="populate-metabase-emplois")

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -66,7 +66,7 @@ from django.core.management.base import BaseCommand
 # Another way to do it would be to rationalize our import (to Itou) & export (to Metabase) logic.
 from itou.companies.management.commands._import_siae.utils import get_fluxiae_df, get_fluxiae_referential_filenames
 from itou.metabase.dataframes import store_df
-from itou.metabase.db import build_final_tables
+from itou.metabase.db import build_dbt_weekly
 from itou.utils.python import timeit
 from itou.utils.slack import send_slack_message
 
@@ -105,7 +105,7 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_Salarie", skip_first_row=False)
         self.populate_fluxiae_view(vue_name="fluxIAE_Structure")
 
-        build_final_tables()
+        build_dbt_weekly()
 
         send_slack_message(
             ":white_check_mark: Fin de la mise à jour hebdomadaire de Metabase avec les"


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Les DAGS du pilotage mettant à jour les tables sont lancés via les emplois. [Dans cette PR](https://github.com/gip-inclusion/pilotage-airflow/pull/198) nous avons divisé en deux dags les mises à jours qui doivent être faites quotidiennement (données issues des emplois) et les maj qui doivent être faites de façon hebdomadaire (flux IAE).

Les modifications de cette PR ont pour but de prendre cela en compte côté C1

### Comment <!-- optionnel -->

Attirer l'attention sur les décisions d'architecture ou de conception importantes.

### Captures d'écran <!-- optionnel -->

