### PR TITLE
[MATOMO] ajout d'un templatetag et utilisation sur les candidatures

### DIFF
--- a/itou/static/js/matomo.js
+++ b/itou/static/js/matomo.js
@@ -2,11 +2,17 @@ htmx.onLoad((target) => {
 
     /********************************************************************
        Send an event to Matomo on click.
-       Usage:
+       Legacy usage:
        <a href="#" class="matomo-event" data-matomo-category="MyCategory"
        data-matomo-action="MyAction" data-matomo-option="MyOption" >
+       New usage:
+         <a href="#" data-matomo-event="true" data-matomo-category="MyCategory"
+            data-matomo-action="MyAction" data-matomo-option="MyOption" >
+        With matomo-attributes tag:
+         {% load matomo %}
+            <a href="#" {% matomo_event "MyCategory" "MyAction" "MyOption" %} >
     ********************************************************************/
-    $(".matomo-event", target).on("click", function() {
+    $('[data-matomo-event="true"], .matomo-event', target).on("click", function() {
         var category = $(this).data("matomo-category");
         var action = $(this).data("matomo-action");
         var option = $(this).data("matomo-option");

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load i18n %}
+{% load matomo %}
 
 {% block title %}Export des candidatures {{ block.super }}{% endblock %}
 
@@ -64,22 +65,12 @@
                                             <td>{{ total_job_applications }}</td>
                                             <td>
                                                 {% if export_for == "siae" %}
-                                                    <a class="matomo-event btn-link"
-                                                       data-matomo-category="candidatures"
-                                                       data-matomo-action="exports"
-                                                       data-matomo-option="export-siae"
-                                                       aria-label="Télécharger cet export SIAE"
-                                                       href="{% url 'apply:list_for_siae_exports_download' %}">
+                                                    <a class="btn-link" {% matomo_event "candidature" "exports" "export-siae" %} aria-label="Télécharger cet export SIAE" href="{% url 'apply:list_for_siae_exports_download' %}">
                                                         <i class="ri-download-line me-1" aria-hidden="true"></i>
                                                         Télécharger
                                                     </a>
                                                 {% else %}
-                                                    <a class="matomo-event btn-link"
-                                                       data-matomo-category="candidatures"
-                                                       data-matomo-action="exports"
-                                                       data-matomo-option="export-prescripteur"
-                                                       aria-label="Télécharger cet export prescripteur"
-                                                       href="{% url 'apply:list_for_prescriber_exports_download' %}">
+                                                    <a class="btn-link" {% matomo_event "candidature" "exports" "export-prescripteur" %} aria-label="Télécharger cet export prescripteur" href="{% url 'apply:list_for_prescriber_exports_download' %}">
                                                         <i class="ri-download-line me-1" aria-hidden="true"></i>
                                                         Télécharger
                                                     </a>
@@ -92,20 +83,16 @@
                                                 <td>{{ month.c }}</td>
                                                 <td>
                                                     {% if export_for == "siae" %}
-                                                        <a class="matomo-event btn-link"
-                                                           data-matomo-category="candidatures"
-                                                           data-matomo-action="exports"
-                                                           data-matomo-option="export-siae"
+                                                        <a class="btn-link"
+                                                           {% matomo_event "candidature" "exports" "export-siae" %}
                                                            aria-label="Télécharger cet export SIAE"
                                                            href="{% url 'apply:list_for_siae_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                                             <i class="ri-download-line me-1" aria-hidden="true"></i>
                                                             Télécharger
                                                         </a>
                                                     {% else %}
-                                                        <a class="matomo-event btn-link"
-                                                           data-matomo-category="candidatures"
-                                                           data-matomo-action="exports"
-                                                           data-matomo-option="export-prescripteur"
+                                                        <a class="btn-link"
+                                                           {% matomo_event "candidature" "exports" "export-prescripteur" %}
                                                            aria-label="Télécharger cet export prescripteur"
                                                            href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                                             <i class="ri-download-line me-1" aria-hidden="true"></i>

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -1,6 +1,7 @@
 {% extends "apply/submit/application/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load matomo %}
 
 {% block progress_title %}{{ block.super }} - Message & CV{% endblock %}
 {% block step_title %}Finaliser la candidature{% endblock %}
@@ -215,10 +216,12 @@
 
 {% block form_submit_button %}
     <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-        {% if request.user.is_employer %}
-            <button class="btn btn-primary btn-block">Enregistrer</button>
-        {% else %}
-            <button class="btn btn-primary btn-block">Envoyer la candidature</button>
-        {% endif %}
+        <button class="btn btn-primary btn-block" {% matomo_event "candidature" "submit" "candidature_"|add:request.user.get_kind_display %}>
+            {% if request.user.is_employer %}
+                Enregistrer
+            {% else %}
+                Envoyer la candidature
+            {% endif %}
+        </button>
     </div>
 {% endblock %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load str_filters %}
+{% load matomo %}
 {% load static %}
 
 {% block title_messages %}
@@ -18,9 +19,9 @@
                         Cet espace vous permet maintenant de déclarer directement une embauche sans avoir à créer une candidature au préalable.
                         {% if siae.kind == CompanyKind.GEIQ %}
                             Si vous souhaitez créer une candidature à traiter plus tard (avec la possibilité d’enregistrer une action préalable au recrutement), veuillez vous rendre
-                            sur <a href="{% url 'apply:start' company_pk=siae.pk %}">Enregistrer une candidature</a> depuis le tableau de bord.
+                            sur <a href="{% url 'apply:start' company_pk=siae.pk %} {% matomo_event "candidature" "clic" "start_application" %}">Enregistrer une candidature</a> depuis le tableau de bord.
                         {% else %}
-                            Pour la création d’une candidature, veuillez vous rendre sur <a href="{% url 'apply:start' company_pk=siae.pk %}">Enregistrer une candidature</a> depuis le tableau de bord.
+                            Pour la création d’une candidature, veuillez vous rendre sur <a href="{% url 'apply:start' company_pk=siae.pk %} {% matomo_event "candidature" "clic" "start_application" %}">Enregistrer une candidature</a> depuis le tableau de bord.
                         {% endif %}
                     {% else %}
                         {% if siae.kind == CompanyKind.GEIQ %}

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load matomo %}
 
 {% block title %}Prolonger ou suspendre un agrément émis par Pôle emploi {{ block.super }}{% endblock %}
 
@@ -30,7 +31,7 @@
                                 {% endif %}
                             </div>
                             <p>
-                                Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' company_pk=request.current_organization.pk %}">réaliser une auto-prescription</a>.
+                                Afin de le prolonger ou de le suspendre, nous vous invitons à <a href="{% url 'apply:start' company_pk=request.current_organization.pk %} {% matomo_event "candidature" "clic" "start_application" %}">réaliser une auto-prescription</a>.
                             </p>
                             <a class="btn btn-link btn-ico ps-lg-0 " href="{{ back_url }}" aria-label="Retourner à l'étape précédente">
                                 <i class="ri-arrow-go-back-line ri-lg"></i>

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -2,6 +2,7 @@
 {% load format_filters %}
 {% load str_filters %}
 {% load static %}
+{% load matomo %}
 
 {% block title %}{{ siae.display_name }} {{ block.super }}{% endblock %}
 
@@ -51,7 +52,10 @@
                         {% if not siae.has_active_members %}
                             <p class="mb-0">Cet employeur n'est pas inscrit, vous ne pouvez pas déposer de candidatures en ligne.</p>
                         {% elif not siae.block_job_applications %}
-                            <a class="btn btn-primary btn-block btn-ico justify-content-center" href="{% url 'apply:start' company_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                            <a class="btn btn-primary btn-block btn-ico justify-content-center"
+                               href="{% url 'apply:start' company_pk=siae.pk %}"
+                               {% matomo_event "candidature" "clic" "start_application" %}
+                               aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                 <i class="ri-draft-line"></i>
                                 <span>Postuler</span>
                             </a>
@@ -145,7 +149,10 @@
                         {% endif %}
                         {% if not siae.block_job_applications and siae.has_active_members %}
                             <div class="d-flex justify-content-end mt-3">
-                                <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" href="{% url 'apply:start' company_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                                <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
+                                   href="{% url 'apply:start' company_pk=siae.pk %}"
+                                   {% matomo_event "candidature" "clic" "start_application" %}
+                                   aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                     <i class="ri-draft-line"></i>
                                     <span>Postuler</span>
                                 </a>

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -3,6 +3,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load theme_inclusion %}
+{% load matomo %}
 
 {% block title %}Modifier les coordonnées de votre structure {{ block.super }}{% endblock %}
 
@@ -116,7 +117,7 @@
                                     </a>
                                 </div>
                                 <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Publier le formulaire" data-matomo-category="employeurs" data-matomo-action="submit" data-matomo-option="publier-infos-structure">
+                                    <button class="btn btn-primary btn-block" aria-label="Publier le formulaire" {% matomo_event "employeurs" "submit" "publier-infos-structure" %}>
                                         Publier
                                     </button>
                                 </div>

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -1,3 +1,5 @@
+{% load matomo %}
+
 {% comment %} takes argument siae <Siae>{% endcomment %}
 <div class="card c-card has-links-inside mb-3 mb-md-4">
     <div class="card-header bg-light pb-3">
@@ -59,9 +61,10 @@
             {% else %}
                 <div class="d-flex justify-content-between align-items-center">
                     <span>Cette structure vous intéresse ?</span>
-                    <a class="btn btn-sm btn-primary" href="{% url 'apply:start' company_pk=siae.pk %}" aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
-                        Postuler
-                    </a>
+                    <a class="btn btn-sm btn-primary"
+                       href="{% url 'apply:start' company_pk=siae.pk %}"
+                       {% matomo_event "candidature" "clic" "start_application" %}
+                       aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">Postuler</a>
                 </div>
             {% endif %}
         {% endif %}

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load format_filters %}
 {% load str_filters %}
+{% load matomo %}
 
 {% block title %}{{ job.display_name }} - {{ siae.display_name }} {{ block.super }}{% endblock %}
 
@@ -43,10 +44,8 @@
                                     {% if job.is_active and not siae.block_job_applications %}
                                         <div class="col-auto text-end">
                                             <a href="{% url "apply:start" company_pk=siae.pk %}?job_description_id={{ job.pk }}"
-                                               class="matomo-event btn btn-sm btn-primary"
-                                               data-matomo-category="candidature"
-                                               data-matomo-action="clic"
-                                               data-matomo-option="clic-metiers"
+                                               class="btn btn-sm btn-primary"
+                                               {% matomo_event "candidature" "clic" "start_application" %}
                                                aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
                                                 Postuler
                                             </a>

--- a/itou/templates/dashboard/includes/siae_job_applications_card.html
+++ b/itou/templates/dashboard/includes/siae_job_applications_card.html
@@ -1,3 +1,5 @@
+{% load matomo %}
+
 <div class="col mb-3 mb-md-5">
     <div class="c-box p-0 h-100">
         <div class="p-3 p-lg-4">
@@ -39,7 +41,7 @@
                         </span>
                     {% else %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'apply:start' company_pk=request.current_organization.pk %}" class="btn-link btn-ico">
+                            <a href="{% url 'apply:start' company_pk=request.current_organization.pk %}" class="btn-link btn-ico" {% matomo_event "candidature" "clic" "start_application" %}>
                                 <i class="ri-draft-line ri-lg font-weight-normal"></i>
                                 <span>Enregistrer une candidature</span>
                             </a>

--- a/itou/utils/templatetags/matomo.py
+++ b/itou/utils/templatetags/matomo.py
@@ -1,0 +1,15 @@
+from django import template
+from django.utils.html import format_html
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def matomo_event(category, action, option):
+    return format_html(
+        'data-matomo-event="true" data-matomo-category="{}" data-matomo-action="{}" data-matomo-option="{}"',
+        category,
+        action,
+        option,
+    )

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -1,0 +1,11 @@
+import pytest  # noqa
+from django.template import Context, Template
+
+
+def test_matomo_event():
+    template = Template('{% load matomo %}<a href="#" {% matomo_event "category" "action" "option" %} >')
+    expected_render = (
+        '<a href="#" data-matomo-event="true" data-matomo-category="category" '
+        'data-matomo-action="action" data-matomo-option="option" >'
+    )
+    assert template.render(Context({})) == expected_render

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -156,6 +156,8 @@ class CardViewTest(TestCase):
              <div class="d-flex justify-content-end mt-3">
               <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                  href="/apply/{company.pk}/start"
+                 data-matomo-event=true data-matomo-category=candidature data-matomo-action=clic
+                 data-matomo-option=start_application
                  aria-label="Postuler aupr&egrave;s de l'employeur solidaire Les petits jardins">
                <i class="ri-draft-line">
                </i>
@@ -256,6 +258,8 @@ class CardViewTest(TestCase):
              <div class="d-flex justify-content-end mt-3">
               <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                  href="/apply/{company.pk}/start"
+                 data-matomo-event=true data-matomo-category=candidature data-matomo-action=clic
+                 data-matomo-option=start_application
                  aria-label="Postuler aupr&egrave;s de l'employeur solidaire Les petits jardins">
                <i class="ri-draft-line">
                </i>
@@ -410,6 +414,8 @@ class CardViewTest(TestCase):
              <div class="d-flex justify-content-end mt-3">
               <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
                  href="/apply/{company.pk}/start"
+                 data-matomo-event=true data-matomo-category=candidature data-matomo-action=clic
+                 data-matomo-option=start_application
                  aria-label="Postuler aupr&egrave;s de l'employeur solidaire Les petits jardins">
                <i class="ri-draft-line">
                </i>


### PR DESCRIPTION
+ quelques fixes au passage isolés dans leur propres commits

### Pourquoi ?

* réduire la longueur de code à ajouter dans les gabarits pour les nouveaux evenements matomo
* enregistrer les evenements liés aux candidatures

### Comment <!-- optionnel -->

🦺 ajout du templateag `matomo-attributes`
🦺 modification de `matomo-js` pour considerer soit les liens contenant la class `matomo-event` (legacy mode), soit l'attribut `data-matomo-event=true`

