### PR TITLE
Fiche de poste: correction de l'affichage de la ville d'une fiche de poste en l'absence de l'information

### DIFF
--- a/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
@@ -21,7 +21,7 @@
                 {% if job.location %}
                     {{ job.location }}
                 {% else %}
-                    {{ job.siae.city|title }} ({{ job.siae.department }})
+                    {{ job.company.city|title }} ({{ job.company.department }})
                 {% endif %}
             </span>
         </div>

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -237,7 +237,6 @@ class SearchCompanyTest(TestCase):
             html=True,
         )
 
-    @pytest.mark.ignore_template_errors
     def test_has_no_active_members(self):
         hiring_str = "recrutements en cours"
         no_hiring_str = (


### PR DESCRIPTION
### Pourquoi ?

C'est une information utile (et cela permet de supprimer une `pytest.mark.ignore_template_errors`)

