### PR TITLE
Prévenir les SIAE du délai d’intégration dans l’Extranet IAE de l’ASP

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -18,6 +18,7 @@
         <li>
             Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.
         </li>
+        <li>La visualisation dans l’Extranet IAE 2.0 interviendra dans les 2 heures suivant l’envoi.</li>
     </ul>
     {% if form.status.value == "NEW" %}
         <p>


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/BOOST-Pr-venir-les-SIAE-du-d-lai-d-int-gration-dans-l-Extranet-IAE-de-l-ASP-bb08521f3e9c4bfbaa61546c0ac1499b?pvs=4

### Pourquoi ?

Certaines SIAE s’inquiètent de ne pas voir dans l’Extranet IAE 2.0 de l’ASP leurs fiches salariés et/ou les mises à jours de la date de fin 

### À vérifier

- [ ] Ajouter l'étiquette « no-changelog » ?
- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
