### PR TITLE
Metabase : Ajout du référentiel du type prescripteur (`c1_ref_type_prescripteur`)

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -66,6 +66,7 @@ from itou.metabase.tables import (
     users,
 )
 from itou.metabase.tables.utils import get_active_companies_pks
+from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.siae_evaluations.models import (
     EvaluatedAdministrativeCriteria,
@@ -475,6 +476,7 @@ class Command(BaseCommand):
         enum_to_table = {
             Origin: "c1_ref_origine_candidature",
             ContractType: "c1_ref_type_contrat",
+            PrescriberOrganizationKind: "c1_ref_type_prescripteur",
         }
         for enum, table_name in enum_to_table.items():
             self.stdout.write(f"Preparing content for {table_name} table...")

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -970,7 +970,7 @@ def test_populate_enums():
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
     num_queries += 1  # COMMIT (rename_table_atomically RENAME TABLE)
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
-    num_queries *= 2  # We inject thus many enums so far.
+    num_queries *= 3  # We inject thus many enums so far.
     with assertNumQueries(num_queries):
         management.call_command("populate_metabase_emplois", mode="enums")
 
@@ -988,6 +988,11 @@ def test_populate_enums():
         cursor.execute("SELECT * FROM c1_ref_type_contrat ORDER BY code")
         rows = cursor.fetchall()
         assert rows[0] == ("APPRENTICESHIP", "Contrat d'apprentissage")
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM c1_ref_type_prescripteur ORDER BY code")
+        rows = cursor.fetchall()
+        assert rows[0] == ("AFPA", "AFPA - Agence nationale pour la formation professionnelle des adultes")
 
 
 def test_data_inconsistencies(capsys):


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Technique-DNRY-Injecter-la-donn-e-type-prescripteur-directement-depuis-le-C1-1cd4e97f65be49c6afa7afd6149d0167 et https://www.notion.so/plateforme-inclusion/Uniformiser-les-labels-prescripteurs-dans-les-TB-efedd3d00a984a1c83c81cb79a6ae01d**

### Pourquoi ?

Les analystes ont hardcodé les différents type de prescripteur ici ([lien](https://github.com/gip-inclusion/pilotage-airflow/blob/main/dbt/seeds/prescripteurs_habilites/nom_prescripteur.csv)) et ici ([lien](https://github.com/gip-inclusion/pilotage-airflow/blob/main/dbt/seeds/prescripteurs_habilites/organisations_libelles.csv)). Bref, ce jeu de données initialement du C1 est au final présent en 3 exemplaires au lieu d'un seul o_O.

Il est temps de revenir à un seul exemplaire propre (`c1_ref_type_prescripteur` introduit par cette PR) qui contiendra toujours les derniers changements du C1. Et à terme les analystes pourront supprimer les deux seeds mentionnées plus haut.

Objectif : DNRY.