### PR TITLE
Ajout de l'ID 287 de dashboard metabase

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -408,7 +408,7 @@ ASP_ITOU_PREFIX = "99999"
 PILOTAGE_DASHBOARDS_WHITELIST = json.loads(
     os.getenv(
         "PILOTAGE_DASHBOARDS_WHITELIST",
-        "[32, 43, 52, 54, 63, 90, 116, 129, 136, 140, 150, 216, 217, 218, 236, 300, 306, 336]",
+        "[32, 43, 52, 54, 63, 90, 116, 129, 136, 140, 150, 216, 217, 218, 236, 287, 300, 306, 336]",
     )
 )
 


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Mettre-en-prod-le-TB287-public-ETP-88404324d3044e918fe12fb30d1a086a?pvs=4

### Pourquoi ?

Pour pouvoir partager un nouveau tableau de bord Metabase en <iframe> sur le site du Pilotage

### Comment

Ajout de l'ID de dashboard metabase 287 à la constante `PILOTAGE_DASHBOARDS_WHITELIST`
