### PR TITLE
[gitignore] repertoire backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ imports
 exports
 !exports/*.md
 
+# Backup files
+backups
+
 # Debian
 .bash_history
 .python_history


### PR DESCRIPTION
### Pourquoi ?

Le téléchargement de la dernière image de la base de prod peut-être stockée dans le répertoire `backups`.
Ignorer ce répertoire 

A discuter en équipe


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
