### PR TITLE
Tests : Faire en sorte qu'ils passent depuis environnement docker

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -484,6 +484,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     create_employee_record = models.BooleanField(default=True, verbose_name="création d'une fiche salarié")
 
     # The job seeker's resume used for this job application.
+    # TODO: Remove the patchy code block of the `test_bucket` fixture when this field become a ForeignKey()
     resume_link = models.URLField(max_length=500, verbose_name="lien vers un CV", blank=True)
 
     # Who send the job application. It can be the same user as `job_seeker`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,21 @@ def preload_spatial_reference(django_db_setup, django_db_blocker):
 
 @pytest.fixture(autouse=True, scope="session")
 def test_bucket():
+    # TODO: Remove this code block once we stop using a models.URLField() to store a S3 link (ie. `resume_link`)
+    from django.core.validators import URLValidator
+
+    patchy.patch(
+        URLValidator.__call__,
+        '''\
+        @@ -16,3 +16,5 @@ def __call__(self, value):
+             try:
+        +        if value.startswith("''' + settings.AWS_S3_ENDPOINT_URL + '''"):
+        +           return
+                 super().__call__(value)
+             except ValidationError as e:
+        ''',  # fmt: skip
+    )
+
     call_command("configure_bucket", autoexpire=True)
     yield
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -433,7 +433,7 @@ class ApplyAsJobSeekerTest(TestCase):
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [company.job_description_through.first()]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -1110,7 +1110,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
             company.job_description_through.last(),
         ]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -1401,7 +1401,7 @@ class ApplyAsPrescriberTest(TestCase):
             company.job_description_through.last(),
         ]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -1844,7 +1844,7 @@ class ApplyAsCompanyTest(TestCase):
             company.job_description_through.last(),
         ]
         assert job_application.resume_link == (
-            f"http://localhost:9000/tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 


### PR DESCRIPTION
### Pourquoi ?

Le commit d8ef8d0c4 n'était au final pas suffisant, certains tests cassaient quand lancé dans le docker `itou_django`.

### Comment ?

J'ai testé de modifier l’expression régulière de `URLValidator` par différente manière mais sans effet.