### PR TITLE
Message d’information pour inciter les membres d’une organisation à avoir plusieurs administrateurs

### DIFF
--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -1,3 +1,9 @@
+{% if members_stats.admin_count == 1 and members_stats.total_count > 1 %}
+    <p class="mt-4 mb-5">
+        Nous vous recommandons de nommer plusieurs administrateurs
+        afin de garantir l’accès et la sécurité de cet espace professionnel à tous vos membres.
+    </p>
+{% endif %}
 
 <div class="table-responsive-lg mt-3 mt-md-4">
     <table class="table">

--- a/itou/www/institutions_views/views.py
+++ b/itou/www/institutions_views/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.decorators import login_required
+from django.db.models import Count, Q
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse_lazy
@@ -18,6 +19,10 @@ def member_list(request, template_name="institutions/members.html"):
     members = (
         institution.institutionmembership_set.active().select_related("user").all().order_by("-is_admin", "joined_at")
     )
+    members_stats = members.aggregate(
+        total_count=Count("pk"),
+        admin_count=Count("pk", filter=Q(is_admin=True)),
+    )
 
     pending_invitations = None
     # Institution members can only be labor inspectors for the moment,
@@ -28,6 +33,7 @@ def member_list(request, template_name="institutions/members.html"):
     context = {
         "institution": institution,
         "members": members,
+        "members_stats": members_stats,
         "pending_invitations": pending_invitations,
     }
     return render(request, template_name, context)

--- a/itou/www/institutions_views/views.py
+++ b/itou/www/institutions_views/views.py
@@ -16,10 +16,7 @@ def member_list(request, template_name="institutions/members.html"):
     institution = get_current_institution_or_404(request)
 
     members = (
-        institution.institutionmembership_set.filter(is_active=True)
-        .select_related("user")
-        .all()
-        .order_by("-is_admin", "joined_at")
+        institution.institutionmembership_set.active().select_related("user").all().order_by("-is_admin", "joined_at")
     )
 
     pending_invitations = None

--- a/itou/www/prescribers_views/views.py
+++ b/itou/www/prescribers_views/views.py
@@ -54,10 +54,7 @@ def member_list(request, template_name="prescribers/members.html"):
     organization = get_current_org_or_404(request)
 
     members = (
-        organization.prescribermembership_set.filter(is_active=True)
-        .select_related("user")
-        .all()
-        .order_by("-is_admin", "joined_at")
+        organization.prescribermembership_set.active().select_related("user").all().order_by("-is_admin", "joined_at")
     )
     pending_invitations = organization.invitations.pending()
 

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -16,6 +16,7 @@ from itou.job_applications.models import JobApplicationWorkflow
 from tests.companies.factories import (
     CompanyAfterGracePeriodFactory,
     CompanyFactory,
+    CompanyMembershipFactory,
     CompanyPendingGracePeriodFactory,
     CompanyWith2MembershipsFactory,
     CompanyWith4MembershipsFactory,
@@ -120,17 +121,19 @@ class SiaeModelTest(TestCase):
 
     def test_active_members(self):
         company = CompanyWith2MembershipsFactory(membership2__is_active=False)
-        user_with_active_membership = company.members.first()
-        user_with_inactive_membership = company.members.last()
+        active_user_with_active_membership = company.members.first()
+        active_user_with_inactive_membership = company.members.last()
+        inactive_user_with_active_membership = CompanyMembershipFactory(company=company, user__is_active=False)
 
-        assert user_with_inactive_membership not in company.active_members
-        assert user_with_active_membership in company.active_members
+        assert active_user_with_active_membership in company.active_members
+        assert active_user_with_inactive_membership not in company.active_members
+        assert inactive_user_with_active_membership not in company.active_members
 
-        # Deactivate a user
-        user_with_active_membership.is_active = False
-        user_with_active_membership.save()
+        # Deactivate a membership
+        active_user_with_active_membership.is_active = False
+        active_user_with_active_membership.save()
 
-        assert user_with_active_membership not in company.active_members
+        assert active_user_with_active_membership not in company.active_members
 
     def test_active_admin_members(self):
         """

--- a/tests/institutions/tests.py
+++ b/tests/institutions/tests.py
@@ -1,7 +1,11 @@
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertRedirects
 
-from tests.institutions.factories import InstitutionWith2MembershipFactory, InstitutionWithMembershipFactory
+from tests.institutions.factories import (
+    InstitutionMembershipFactory,
+    InstitutionWith2MembershipFactory,
+    InstitutionWithMembershipFactory,
+)
 from tests.users.factories import ItouStaffFactory
 from tests.utils.test import TestCase
 
@@ -22,17 +26,21 @@ class InstitutionModelTest(TestCase):
 
     def test_active_members(self):
         institution = InstitutionWith2MembershipFactory(membership2__is_active=False)
-        user_with_active_membership = institution.members.first()
-        user_with_inactive_membership = institution.members.last()
+        active_user_with_active_membership = institution.members.first()
+        active_user_with_inactive_membership = institution.members.last()
+        inactive_user_with_active_membership = InstitutionMembershipFactory(
+            institution=institution, user__is_active=False
+        )
 
-        assert user_with_inactive_membership not in institution.active_members
-        assert user_with_active_membership in institution.active_members
+        assert active_user_with_active_membership in institution.active_members
+        assert active_user_with_inactive_membership not in institution.active_members
+        assert inactive_user_with_active_membership not in institution.active_members
 
-        # Deactivate a user
-        user_with_active_membership.is_active = False
-        user_with_active_membership.save()
+        # Deactivate a membership
+        active_user_with_active_membership.is_active = False
+        active_user_with_active_membership.save()
 
-        assert user_with_active_membership not in institution.active_members
+        assert active_user_with_active_membership not in institution.active_members
 
 
 def test_deactivate_last_admin(client):

--- a/tests/prescribers/tests.py
+++ b/tests/prescribers/tests.py
@@ -21,6 +21,7 @@ from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory
 from tests.job_applications import factories as job_applications_factories
 from tests.prescribers.factories import (
+    PrescriberMembershipFactory,
     PrescriberOrganizationFactory,
     PrescriberOrganizationWith2MembershipFactory,
     PrescriberOrganizationWithMembershipFactory,
@@ -159,17 +160,19 @@ class PrescriberOrganizationModelTest(TestCase):
 
     def test_active_members(self):
         org = PrescriberOrganizationWith2MembershipFactory(membership2__is_active=False)
-        user_with_active_membership = org.members.first()
-        user_with_inactive_membership = org.members.last()
+        active_user_with_active_membership = org.members.first()
+        active_user_with_inactive_membership = org.members.last()
+        inactive_user_with_active_membership = PrescriberMembershipFactory(organization=org, user__is_active=False)
 
-        assert user_with_inactive_membership not in org.active_members
-        assert user_with_active_membership in org.active_members
+        assert active_user_with_active_membership in org.active_members
+        assert active_user_with_inactive_membership not in org.active_members
+        assert inactive_user_with_active_membership not in org.active_members
 
-        # Deactivate a user
-        user_with_active_membership.is_active = False
-        user_with_active_membership.save()
+        # Deactivate a membership
+        active_user_with_active_membership.is_active = False
+        active_user_with_active_membership.save()
 
-        assert user_with_active_membership not in org.active_members
+        assert active_user_with_active_membership not in org.active_members
 
     def test_add_member(self):
         org = PrescriberOrganizationFactory()

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -1090,6 +1090,8 @@ class EditCompanyViewWithWrongAddressTest(TestCase):
 
 
 class MembersTest(TestCase):
+    MORE_ADMIN_MSG = "Nous vous recommandons de nommer plusieurs administrateurs"
+
     def test_members(self):
         company = CompanyFactory(with_membership=True)
         user = company.members.first()
@@ -1116,6 +1118,37 @@ class MembersTest(TestCase):
         assert active_member_inactive_user not in response.context["members"]
         assert inactive_member_active_user not in response.context["members"]
         assert inactive_member_inactive_user not in response.context["members"]
+
+    def test_members_admin_warning_one_user(self):
+        company = CompanyFactory(with_membership=True)
+        user = company.members.first()
+        self.client.force_login(user)
+        url = reverse("companies_views:members")
+        response = self.client.get(url)
+        self.assertNotContains(response, self.MORE_ADMIN_MSG)
+
+    def test_members_admin_warning_two_users(self):
+        company = CompanyWith2MembershipsFactory()
+        user = company.members.first()
+        self.client.force_login(user)
+        url = reverse("companies_views:members")
+        response = self.client.get(url)
+        self.assertContains(response, self.MORE_ADMIN_MSG)
+
+        # Set all users admins
+        company.memberships.update(is_admin=True)
+        response = self.client.get(url)
+        self.assertNotContains(response, self.MORE_ADMIN_MSG)
+
+    def test_members_admin_warning_many_users(self):
+        company = CompanyWith2MembershipsFactory()
+        CompanyMembershipFactory(company=company, user__is_active=False)
+        CompanyMembershipFactory(company=company, is_admin=False, user__is_active=False)
+        user = company.members.first()
+        self.client.force_login(user)
+        url = reverse("companies_views:members")
+        response = self.client.get(url)
+        self.assertContains(response, self.MORE_ADMIN_MSG)
 
 
 class UserMembershipDeactivationTest(TestCase):

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -1,0 +1,39 @@
+from django.urls import reverse
+
+from tests.institutions.factories import (
+    InstitutionFactory,
+    InstitutionMembershipFactory,
+    InstitutionWithMembershipFactory,
+)
+from tests.utils.test import TestCase
+
+
+class MembersTest(TestCase):
+    MORE_ADMIN_MSG = "Nous vous recommandons de nommer plusieurs administrateurs"
+
+    def test_members(self):
+        institution = InstitutionWithMembershipFactory()
+        user = institution.members.first()
+        self.client.force_login(user)
+        url = reverse("institutions_views:members")
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+    def test_active_members(self):
+        institution = InstitutionFactory()
+        active_member_active_user = InstitutionMembershipFactory(institution=institution)
+        active_member_inactive_user = InstitutionMembershipFactory(institution=institution, user__is_active=False)
+        inactive_member_active_user = InstitutionMembershipFactory(institution=institution, is_active=False)
+        inactive_member_inactive_user = InstitutionMembershipFactory(
+            institution=institution, is_active=False, user__is_active=False
+        )
+
+        self.client.force_login(active_member_active_user.user)
+        url = reverse("institutions_views:members")
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert len(response.context["members"]) == 1
+        assert active_member_active_user in response.context["members"]
+        assert active_member_inactive_user not in response.context["members"]
+        assert inactive_member_active_user not in response.context["members"]
+        assert inactive_member_inactive_user not in response.context["members"]

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from tests.institutions.factories import (
     InstitutionFactory,
     InstitutionMembershipFactory,
+    InstitutionWith2MembershipFactory,
     InstitutionWithMembershipFactory,
 )
 from tests.utils.test import TestCase
@@ -37,3 +38,34 @@ class MembersTest(TestCase):
         assert active_member_inactive_user not in response.context["members"]
         assert inactive_member_active_user not in response.context["members"]
         assert inactive_member_inactive_user not in response.context["members"]
+
+    def test_members_admin_warning_one_user(self):
+        institution = InstitutionWithMembershipFactory()
+        user = institution.members.first()
+        self.client.force_login(user)
+        url = reverse("institutions_views:members")
+        response = self.client.get(url)
+        self.assertNotContains(response, self.MORE_ADMIN_MSG)
+
+    def test_members_admin_warning_two_users(self):
+        institution = InstitutionWith2MembershipFactory()
+        user = institution.members.first()
+        self.client.force_login(user)
+        url = reverse("institutions_views:members")
+        response = self.client.get(url)
+        self.assertContains(response, self.MORE_ADMIN_MSG)
+
+        # Set all users admins
+        institution.memberships.update(is_admin=True)
+        response = self.client.get(url)
+        self.assertNotContains(response, self.MORE_ADMIN_MSG)
+
+    def test_members_admin_warning_many_users(self):
+        institution = InstitutionWith2MembershipFactory()
+        InstitutionMembershipFactory(institution=institution, user__is_active=False)
+        InstitutionMembershipFactory(institution=institution, is_admin=False, user__is_active=False)
+        user = institution.members.first()
+        self.client.force_login(user)
+        url = reverse("institutions_views:members")
+        response = self.client.get(url)
+        self.assertContains(response, self.MORE_ADMIN_MSG)


### PR DESCRIPTION
### Carte Notion :

https://www.notion.so/plateforme-inclusion/En-tant-que-membre-du-tableau-de-bord-de-mon-entreprise-je-souhaite-tre-inform-de-l-utilit-d-avoi-337e6d4b8cee4feca0a25789b37bbf8f?pvs=4

### Pourquoi ?

- Beaucoup de sollicitations au support pour nommer un autre admin quand l’unique admin de la structure l’a quittée
- Solution trouvée lors d’un atelier en équipe  https://www.notion.so/plateforme-inclusion/Nouvelle-r-gle-pour-d-signer-les-admin-par-d-faut-755915e399294537b8a4d27988bede45

### Comment ? <!-- optionnel -->

Informer les utilisateurs par le biais d'un message d'informations présent uniquement s'il y a plusieurs membres actifs mais seulement un administrateur.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?


### Notes

- L'implémentation des tests a mis en évidence que la méthode `MembershipQuerySet.active` n'est employée que sur les entreprises. Les membres des prescripteurs et institutions partenaires filtraient directement sur le statut `is_active` du membership et non pas également sur le `is_active` de l'utilisateur.
- Je n'ai pas observé de raison qui pourrait expliquer pourquoi seul le membership devrait être vérifié pour ces derniers
- Le premier commit inclut donc un "fix" qui fait usage de la méthode `MembershipQuerySet.active` pour tout type d'organisation. SI tout bon je pourrai le fusionner.