### PR TITLE
Notification des PASS IAE à pole emploi: ajout du statut READY

### DIFF
--- a/itou/analytics/approvals.py
+++ b/itou/analytics/approvals.py
@@ -20,6 +20,7 @@ def collect_analytics_data(before):
             ),
         ),
         pe_notify_error=Count("pk", filter=Q(pe_notification_status=api_enums.PEApiNotificationStatus.ERROR)),
+        pe_notify_ready=Count("pk", filter=Q(pe_notification_status=api_enums.PEApiNotificationStatus.READY)),
     )
     cancelled_counts = approvals_models.CancelledApproval.objects.filter(created_at__lt=before).aggregate(
         total=Count("pk"),
@@ -34,6 +35,7 @@ def collect_analytics_data(before):
             ),
         ),
         pe_notify_error=Count("pk", filter=Q(pe_notification_status=api_enums.PEApiNotificationStatus.ERROR)),
+        pe_notify_ready=Count("pk", filter=Q(pe_notification_status=api_enums.PEApiNotificationStatus.READY)),
     )
     return {
         models.DatumCode.APPROVAL_COUNT: counts["total"],
@@ -45,4 +47,5 @@ def collect_analytics_data(before):
             counts["pe_notify_pending"] + cancelled_counts["pe_notify_pending"]
         ),
         models.DatumCode.APPROVAL_PE_NOTIFY_ERROR: counts["pe_notify_error"] + cancelled_counts["pe_notify_error"],
+        models.DatumCode.APPROVAL_PE_NOTIFY_READY: counts["pe_notify_ready"] + cancelled_counts["pe_notify_ready"],
     }

--- a/itou/analytics/migrations/0001_initial.py
+++ b/itou/analytics/migrations/0001_initial.py
@@ -29,6 +29,7 @@ class Migration(migrations.Migration):
                             ("AP-101", "PASS IAE synchronisés avec succès avec pole emploi"),
                             ("AP-102", "PASS IAE en attente de synchronisation avec pole emploi"),
                             ("AP-103", "PASS IAE en erreur de synchronisation avec pole emploi"),
+                            ("AP-104", "PASS IAE prêts à être synchronisés avec pole emploi"),
                         ],
                     ),
                 ),

--- a/itou/analytics/models.py
+++ b/itou/analytics/models.py
@@ -23,6 +23,7 @@ class DatumCode(models.TextChoices):
     APPROVAL_PE_NOTIFY_SUCCESS = "AP-101", "PASS IAE synchronisés avec succès avec pole emploi"
     APPROVAL_PE_NOTIFY_PENDING = "AP-102", "PASS IAE en attente de synchronisation avec pole emploi"
     APPROVAL_PE_NOTIFY_ERROR = "AP-103", "PASS IAE en erreur de synchronisation avec pole emploi"
+    APPROVAL_PE_NOTIFY_READY = "AP-104", "PASS IAE prêts à être synchronisés avec pole emploi"
 
 
 class Datum(models.Model):

--- a/itou/approvals/migrations/0001_initial.py
+++ b/itou/approvals/migrations/0001_initial.py
@@ -94,6 +94,7 @@ class Migration(migrations.Migration):
                     models.CharField(
                         choices=[
                             ("notification_pending", "Pending"),
+                            ("notification_ready", "Ready"),
                             ("notification_success", "Success"),
                             ("notification_error", "Error"),
                             ("notification_should_retry", "Should Retry"),
@@ -225,6 +226,7 @@ class Migration(migrations.Migration):
                     models.CharField(
                         choices=[
                             ("notification_pending", "Pending"),
+                            ("notification_ready", "Ready"),
                             ("notification_success", "Success"),
                             ("notification_error", "Error"),
                             ("notification_should_retry", "Should Retry"),

--- a/itou/approvals/migrations/0017_cancelledapproval.py
+++ b/itou/approvals/migrations/0017_cancelledapproval.py
@@ -36,6 +36,7 @@ class Migration(migrations.Migration):
                     models.CharField(
                         choices=[
                             ("notification_pending", "Pending"),
+                            ("notification_ready", "Ready"),
                             ("notification_success", "Success"),
                             ("notification_error", "Error"),
                             ("notification_should_retry", "Should Retry"),

--- a/itou/utils/apis/enums.py
+++ b/itou/utils/apis/enums.py
@@ -85,6 +85,7 @@ class PEApiNotificationStatus(models.TextChoices):
     The default value is PENDING, meaning we never tried to notify PE yet.
 
     Then it could be:
+    - READY if the approval can be sent (all the required fields are present and the approval has already started)
     - SUCCESS if the whole notification was indeed an acknowledged success
     - SHOULD_RETRY if we encountered recoverable errors along the way
     - ERROR in the case of unrecoverable errors, in which case:
@@ -104,6 +105,7 @@ class PEApiNotificationStatus(models.TextChoices):
     """
 
     PENDING = "notification_pending"
+    READY = "notification_ready"
     SUCCESS = "notification_success"
     ERROR = "notification_error"
     # HTTP errors: timeouts, DNS issues, bad auth, too many requests.

--- a/tests/analytics/test_approvals.py
+++ b/tests/analytics/test_approvals.py
@@ -12,6 +12,7 @@ def test_datum_name_value():
     assert models.DatumCode.APPROVAL_PE_NOTIFY_SUCCESS.value == "AP-101"
     assert models.DatumCode.APPROVAL_PE_NOTIFY_PENDING.value == "AP-102"
     assert models.DatumCode.APPROVAL_PE_NOTIFY_ERROR.value == "AP-103"
+    assert models.DatumCode.APPROVAL_PE_NOTIFY_READY.value == "AP-104"
 
 
 def test_collect_analytics_data_return_all_codes():
@@ -21,6 +22,7 @@ def test_collect_analytics_data_return_all_codes():
         models.DatumCode.APPROVAL_PE_NOTIFY_SUCCESS,
         models.DatumCode.APPROVAL_PE_NOTIFY_PENDING,
         models.DatumCode.APPROVAL_PE_NOTIFY_ERROR,
+        models.DatumCode.APPROVAL_PE_NOTIFY_READY,
     }
 
 
@@ -31,6 +33,7 @@ def test_collect_analytics_when_approvals_do_not_exist():
         models.DatumCode.APPROVAL_PE_NOTIFY_SUCCESS: 0,
         models.DatumCode.APPROVAL_PE_NOTIFY_PENDING: 0,
         models.DatumCode.APPROVAL_PE_NOTIFY_ERROR: 0,
+        models.DatumCode.APPROVAL_PE_NOTIFY_READY: 0,
     }
 
 
@@ -45,6 +48,7 @@ def test_collect_analytics_with_data():
         2, pe_notification_status=api_enums.PEApiNotificationStatus.SHOULD_RETRY
     )
     approvals_factories.ApprovalFactory.create_batch(2, pe_notification_status=api_enums.PEApiNotificationStatus.ERROR)
+    approvals_factories.ApprovalFactory.create_batch(1, pe_notification_status=api_enums.PEApiNotificationStatus.READY)
 
     approvals_factories.CancelledApprovalFactory.create_batch(
         1, pe_notification_status=api_enums.PEApiNotificationStatus.SUCCESS
@@ -58,11 +62,15 @@ def test_collect_analytics_with_data():
     approvals_factories.CancelledApprovalFactory.create_batch(
         4, pe_notification_status=api_enums.PEApiNotificationStatus.ERROR
     )
+    approvals_factories.CancelledApprovalFactory.create_batch(
+        2, pe_notification_status=api_enums.PEApiNotificationStatus.READY
+    )
 
     assert approvals.collect_analytics_data(timezone.now()) == {
-        models.DatumCode.APPROVAL_COUNT: 9,
-        models.DatumCode.APPROVAL_CANCELLED: 10,
+        models.DatumCode.APPROVAL_COUNT: 10,
+        models.DatumCode.APPROVAL_CANCELLED: 12,
         models.DatumCode.APPROVAL_PE_NOTIFY_SUCCESS: 4,
         models.DatumCode.APPROVAL_PE_NOTIFY_PENDING: 9,
         models.DatumCode.APPROVAL_PE_NOTIFY_ERROR: 6,
+        models.DatumCode.APPROVAL_PE_NOTIFY_READY: 3,
     }


### PR DESCRIPTION
### Pourquoi ?

Pour différencier les PASS prêts à être envoyés des PASS pending par manque d'infos ou car commençant dans le futur.
Plutôt que de rajouter un statut POSTPONED et devoir gérer les transitions de PENDING (état par défaut) à POSTPONED puis de POSTPONED vers PENDING il était plus simple de rajouter un état READY indiquant que toutes les infos sont bien disponibles et que le PASS peut être envoyé.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
