### PR TITLE
Makefile: ajout d'un message pour clarifier l'absence d'une migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ quality: $(VENV_REQUIREMENT)
 	ruff check $(LINTER_CHECKED_DIRS)
 	djlint --lint --check itou
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
-	python manage.py makemigrations --check --dry-run --noinput
+	python manage.py makemigrations --check --dry-run --noinput || echo "⚠ Missing migration ⚠"
 
 fix: $(VENV_REQUIREMENT)
 	black $(LINTER_CHECKED_DIRS)


### PR DESCRIPTION
### Pourquoi ?

Sinon, il faut remarquer que rien d'autres n'a échoué et qu'il n'y a pas le message "No changes detected".

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
