### PR TITLE
[PASS IAE AI] message pour les pass arrivant à expiration dans moins de 30 jours

### DIFF
--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -53,6 +53,25 @@
                                             ({{ form.instance.validated_by.email }})
                                         </p>
                                     {% endif %}
+                                    {% if ai_renew_approval_display_message %}
+                                        <div class="mt-3 alert alert-info" role="status">
+                                            <div class="row">
+                                                <div class="col-auto pe-0">
+                                                    <i class="ri-information-line ri-xl text-info"></i>
+                                                </div>
+                                                <div class="col">
+                                                    <p class="mb-2">
+                                                        <strong>Information sur la régularisation des PASS IAE pour les AI :</strong>
+                                                    </p>
+                                                    <p class="mb-0">
+                                                        À titre exceptionnel, au regard du nombre important de PASS IAE arrivant à expiration d'ici la fin de l’année, il a été convenu de reporter la date de fin des PASS IAE concernés par des prolongations refusées par les prescripteurs habilités (dans une limite de 30 jours maximum), afin d’éviter la perte éventuelle des aides au poste. Dans ce cas, la date de fin du PASS sera actualisée à la date du refus par le prescripteur habilité.
+                                                        <br>
+                                                        En cas d’acceptation, la durée de prolongation demandée s’applique.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
                                 </div>
                             </div>
 


### PR DESCRIPTION

**Carte Notion : ** https://www.notion.so/plateforme-inclusion/R-gul-PASS-AI-Prolonger-de-1-mois-les-PASS-IAE-concern-s-par-une-demande-de-prolongation-tardive--133fbe5d5d1f42caa46542dc4f9beb6a?pvs=4

### Pourquoi ?

1. éviter les relances support sur le traitement des renouvellements de PASS AI de fin novembre 
2. éviter la perte des aides aux postes pour les prolongations refusées 

### Comment ?

Ajout d'une bannière d'information lors de la prévisualisation de la demande de prolongation

⚠️ ne concerne que les AI 
⚠️ pas de limite de temps, mais potentiellement à démonter fin 2023

### Captures d'écran 

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/aae36c20-497b-4193-967f-f11bf1f4a08b)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
