### PR TITLE
Makefile: correction de la vérification des migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ quality: $(VENV_REQUIREMENT)
 	ruff check $(LINTER_CHECKED_DIRS)
 	djlint --lint --check itou
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
-	python manage.py makemigrations --check --dry-run --noinput || echo "⚠ Missing migration ⚠"
+	python manage.py makemigrations --check --dry-run --noinput || (echo "⚠ Missing migration ⚠"; exit 1)
 
 fix: $(VENV_REQUIREMENT)
 	black $(LINTER_CHECKED_DIRS)


### PR DESCRIPTION
### Pourquoi ?

cassé dans 2c77b028cf36ec6ad467ad1641b40f8bc90ddd7a
En cas de migration manquante, le `echo` se lance bien mais le script se termine alors sur un exit code 0 et `make quality` passe...
