### PR TITLE
Correction de la valeur PE_PRESCRIBER_FILTER_VALUE

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -12,7 +12,7 @@ DEPARTMENT_FILTER_KEY = "d%C3%A9partement"
 REGION_FILTER_KEY = "r%C3%A9gion"
 PRESCRIBER_FILTER_KEY = "prescripteur"
 JOB_APPLICATION_ORIGIN_FILTER_KEY = "origine_candidature"
-PE_PRESCRIBER_FILTER_VALUE = "Prescripteur habilité PE"
+PE_PRESCRIBER_FILTER_VALUE = "Pôle emploi"
 PE_FILTER_VALUE = "Pôle emploi"
 
 METABASE_DASHBOARDS = {


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Suite a des[ modifications côté C2](https://github.com/gip-inclusion/pilotage-airflow/pull/202), Correction de la valeur PE_PRESCRIBER_FILTER_VALUE

