### PR TITLE
Stats : Montrer la section Pilotage à tous les utilisateurs professionnels

### DIFF
--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -18,10 +18,15 @@ def can_view_stats_dashboard_widget(request):
     """
     Whether a stats section should be displayed on the user's dashboard.
 
-    It should be displayed if one or more stats sections are available for the user.
+    It should be displayed for all professional users (employers, prescribers and labor inspectors).
     """
     return (
-        can_view_stats_siae(request)
+        request.user.is_employer
+        or request.user.is_prescriber
+        or request.user.is_labor_inspector
+        # All conditions below are useless/redundant with the main conditions above as they are
+        # all sub cases of them. We still include them to keep things as explicit as possible.
+        or can_view_stats_siae(request)
         or can_view_stats_siae_aci(request)
         or can_view_stats_siae_etp(request)
         or can_view_stats_cd(request)

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -18,27 +18,10 @@ def can_view_stats_dashboard_widget(request):
     """
     Whether a stats section should be displayed on the user's dashboard.
 
-    It should be displayed for all professional users (employers, prescribers and labor inspectors).
+    It should be displayed to all professional users, even when no specific can_view_stats_* condition
+    is available to them.
     """
-    return (
-        request.user.is_employer
-        or request.user.is_prescriber
-        or request.user.is_labor_inspector
-        # All conditions below are useless/redundant with the main conditions above as they are
-        # all sub cases of them. We still include them to keep things as explicit as possible.
-        or can_view_stats_siae(request)
-        or can_view_stats_siae_aci(request)
-        or can_view_stats_siae_etp(request)
-        or can_view_stats_cd(request)
-        or can_view_stats_pe(request)
-        or can_view_stats_ddets_iae(request)
-        or can_view_stats_ddets_log(request)
-        or can_view_stats_dreets_iae(request)
-        or can_view_stats_dgefp(request)
-        or can_view_stats_dihal(request)
-        or can_view_stats_drihl(request)
-        or can_view_stats_iae_network(request)
-    )
+    return request.user.is_employer or request.user.is_prescriber or request.user.is_labor_inspector
 
 
 def can_view_stats_siae(request):

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -22,6 +22,8 @@ def can_view_stats_dashboard_widget(request):
     """
     return (
         can_view_stats_siae(request)
+        or can_view_stats_siae_aci(request)
+        or can_view_stats_siae_etp(request)
         or can_view_stats_cd(request)
         or can_view_stats_pe(request)
         or can_view_stats_ddets_iae(request)

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -51,7 +51,7 @@ def test_can_view_stats_cd():
     )
     request = get_request(org.members.get())
     assert not utils.can_view_stats_cd(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)
 
     # Admin prescriber of authorized CD can access.
     org = PrescriberOrganizationWithMembershipFactory(
@@ -79,7 +79,7 @@ def test_can_view_stats_cd():
     )
     request = get_request(org.members.get())
     assert not utils.can_view_stats_cd(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)
 
     # Non CD organization does not give access.
     org = PrescriberOrganizationWithMembershipFactory(
@@ -89,12 +89,12 @@ def test_can_view_stats_cd():
     )
     request = get_request(org.members.get())
     assert not utils.can_view_stats_cd(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)
 
     # Prescriber without organization cannot access.
     request = get_request(PrescriberFactory())
     assert not utils.can_view_stats_cd(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)
 
 
 def test_can_view_stats_pe_as_regular_pe_agency():
@@ -202,7 +202,7 @@ def test_can_view_stats_ddets_iae():
     institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
     request = get_request(institution.members.get())
     assert not utils.can_view_stats_ddets_iae(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)
 
 
 def test_can_view_stats_dreets_iae():
@@ -224,7 +224,7 @@ def test_can_view_stats_dreets_iae():
     institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
     request = get_request(institution.members.get())
     assert not utils.can_view_stats_dreets_iae(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)
 
 
 def test_can_view_stats_dgefp():
@@ -246,4 +246,4 @@ def test_can_view_stats_dgefp():
     institution = InstitutionWithMembershipFactory(kind=InstitutionKind.OTHER, department="93")
     request = get_request(institution.members.get())
     assert not utils.can_view_stats_dgefp(request)
-    assert not utils.can_view_stats_dashboard_widget(request)
+    assert utils.can_view_stats_dashboard_widget(request)


### PR DESCRIPTION
**Fil slack : https://itou-inclusion.slack.com/archives/C04SAGUGJFJ/p1700818972747209**

### Pourquoi ?

Pour donner plus de visibilité aux stats publiques de Pilotage à tous les utilisateurs pros du C1, pas juste ceux qui ont accès à des stats privées.

### Comment ?

On montre à tous les utilisateurs du C1 sauf les candidats, l'encart simple suivant :

![image](https://github.com/gip-inclusion/les-emplois/assets/10533583/23a69816-47ff-44df-be46-60ec9bbedd61)
