### PR TITLE
[PASS IAE AI] filtrer les demandes refusées par date pour les AI

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -463,7 +463,7 @@ class ProlongationCommonAdmin(ItouModelAdmin):
 @admin.register(models.ProlongationRequest)
 class ProlongationRequestAdmin(ProlongationCommonAdmin):
     list_display = ProlongationCommonAdmin.list_display + ("status", "processed_at")
-    list_filter = ("status",) + ProlongationCommonAdmin.list_filter
+    list_filter = ("status", "declared_by_siae__kind", "processed_at") + ProlongationCommonAdmin.list_filter
 
     @admin.display(description="prolongation créée")
     def prolongation(self, obj):


### PR DESCRIPTION
[**Carte Notion : **](https://www.notion.so/plateforme-inclusion/R-gul-PASS-AI-Prolonger-de-1-mois-les-PASS-IAE-concern-s-par-une-demande-de-prolongation-tardive--6e6696e99bcf45869f6802dcdafc0c50?pvs=4)

### Pourquoi ?

rechercher manuellement les demandes de prolongations refusées pour les AI pour ajuster manuellement la durée du PASS. 
suite de #3377 

### Comment ? 

* ajout de 2 filtres dans l'admin

### Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/bd6fda06-cdab-474e-a458-a376e3035f31)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
