### PR TITLE
[PASS IAE AI] CORRECTION MESSAGE pour les pass arrivant à expiration dans moins de 30 jours

### DIFF
--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -61,12 +61,13 @@
                                                 </div>
                                                 <div class="col">
                                                     <p class="mb-2">
-                                                        <strong>Information sur la régularisation des PASS IAE pour les AI :</strong>
+                                                        <strong>Mise à jour de la date de fin du PASS IAE :</strong>
                                                     </p>
                                                     <p class="mb-0">
-                                                        À titre exceptionnel, au regard du nombre important de PASS IAE arrivant à expiration d'ici la fin de l’année, il a été convenu de reporter la date de fin des PASS IAE concernés par des prolongations refusées par les prescripteurs habilités (dans une limite de 30 jours maximum), afin d’éviter la perte éventuelle des aides au poste. Dans ce cas, la date de fin du PASS sera actualisée à la date du refus par le prescripteur habilité.
+                                                        Elle sera visible après l'acceptation ou le refus par le prescripeur habilité.
                                                         <br>
-                                                        En cas d’acceptation, la durée de prolongation demandée s’applique.
+                                                        Pour permettre au prescripteur habilité de valider votre demande, un delai de 30 jours lui est accordé.
+                                                        L'aide au poste est maintenue pendant ce délai.
                                                     </p>
                                                 </div>
                                             </div>

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -456,11 +456,8 @@ class ApprovalProlongationTest(TestCase):
         self.client.force_login(employer)
         url = reverse("approvals:declare_prolongation", kwargs={"approval_id": approval.pk})
 
-        html_message = (
-            '<p class="mb-2">'
-            "    <strong>Information sur la régularisation des PASS IAE pour les AI :</strong>"
-            "</p>"
-        )
+        message_1 = "<strong>Mise à jour de la date de fin du PASS IAE :</strong>"
+        message_2 = "L'aide au poste est maintenue pendant ce délai."
 
         post_data = {
             "end_at": approval.end_at + relativedelta(days=90),
@@ -478,7 +475,8 @@ class ApprovalProlongationTest(TestCase):
         response = self.client.post(url, data=post_data)
         assert response.status_code == 200
         assert response.context["ai_renew_approval_display_message"] is True
-        self.assertContains(response, html_message, html=True)
+        self.assertContains(response, message_1, html=True)
+        self.assertContains(response, message_2)
 
         # test approval prolongation for AI, with approval end_at - current date > 30 days
         approval.end_at += relativedelta(days=1)
@@ -487,7 +485,8 @@ class ApprovalProlongationTest(TestCase):
         response = self.client.post(url, data=post_data)
         assert response.status_code == 200
         assert response.context["ai_renew_approval_display_message"] is False
-        self.assertNotContains(response, html_message, html=True)
+        self.assertNotContains(response, message_2, html=True)
+        self.assertNotContains(response, message_2)
 
         # test approval prolongation not for AI, with approval end_at - current date <= 30 days
         approval.end_at = timezone.localdate() + relativedelta(days=10)


### PR DESCRIPTION
[carte notion](https://www.notion.so/plateforme-inclusion/R-gul-PASS-AI-Prolonger-de-1-mois-les-PASS-IAE-concern-s-par-une-demande-de-prolongation-tardive--36b86457aab94b399b8c5d003d300bf2?pvs=4)

### Pourquoi ?

simplification du message pour une meilleure compréhension

### Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/e4d93a8a-f665-4be8-8a63-282897e82b25)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
