### PR TITLE
[PASS IAE AI] filtrer les demandes refusées par date pour les AI (part2)

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -462,8 +462,20 @@ class ProlongationCommonAdmin(ItouModelAdmin):
 
 @admin.register(models.ProlongationRequest)
 class ProlongationRequestAdmin(ProlongationCommonAdmin):
-    list_display = ProlongationCommonAdmin.list_display + ("status", "processed_at")
-    list_filter = ("status", "declared_by_siae__kind", "processed_at") + ProlongationCommonAdmin.list_filter
+    list_display = (
+        "pk",
+        "approval",
+        "created_at",
+        "start_at",
+        "end_at",
+        "declared_by",
+        "validated_by",
+        "reason",
+        "status",
+        "processed_at",
+    )
+
+    list_filter = ("status", "declared_by_siae__kind", "created_at") + ProlongationCommonAdmin.list_filter
 
     @admin.display(description="prolongation créée")
     def prolongation(self, obj):


### PR DESCRIPTION
suite #3381 

### Pourquoi ?

* réagencement des colonnes pour faciliter le traitement par le support
* filtre sur `created_at` au lieu de `processed_at` 

### Captures d'écran 

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/abbd1449-9f1d-4119-8730-7e185ef946da)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
