### PR TITLE
[CANDIDATURE] tooltip sur le motif de refus

### DIFF
--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -25,7 +25,7 @@
    data-bs-placement="top"
    title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
                                 {% elif radio.data.value == RefusalReason.NO_POSITION %}
-                                    {{ radio.choice_label }}&nbsp;<i class="ri-question-fill ri-xl text-button ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
+                                    {{ radio.choice_label }}&nbsp;<i class="ri-information-line ri-xl text-button ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
 
                                 {% else %}
                                     {{ radio.choice_label }}
@@ -34,6 +34,9 @@
                         </li>
                     {% endfor %}
                 </ul>
+                <div class="c-info refusal-reason-no-position-info d-none">
+                    <span class="c-info__summary">En choisissant ce motif, les fiches de postes associées seront dépubliées.</span>
+                </div>
             </div>
 
             {% if form.answer_to_prescriber %}
@@ -57,4 +60,19 @@
 
         </form>
     </div>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script nonce="{{ CSP_NONCE }}">
+        $(document).ready(function() {
+            $('input[name="refusal_reason"]').change(function() {
+                if (this.value === 'no_position') {
+                    $('.refusal-reason-no-position-info').removeClass('d-none');
+                } else {
+                    $('.refusal-reason-no-position-info').addClass('d-none');
+                }
+            });
+        });
+    </script>
 {% endblock %}

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -20,7 +20,7 @@
                             <label for="{{ radio.id_for_label }}">
                                 {{ radio.tag }}
                                 {% if radio.data.value == RefusalReason.PREVENT_OBJECTIVES %}
-                                    {{ radio.choice_label }}&nbsp;<i class="ri-question-fill ri-xl text-button ms-1"
+                                    {{ radio.choice_label }}&nbsp;<i class="ri-information-line ri-xl text-button ms-1"
    data-bs-toggle="tooltip"
    data-bs-placement="top"
    title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -24,6 +24,9 @@
    data-bs-toggle="tooltip"
    data-bs-placement="top"
    title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
+                                {% elif radio.data.value == RefusalReason.NO_POSITION %}
+                                    {{ radio.choice_label }}&nbsp;<i class="ri-question-fill ri-xl text-button ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
+
                                 {% else %}
                                     {{ radio.choice_label }}
                                 {% endif %}


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/POC-Modifier-le-motif-Pas-de-poste-disponible-a016e0eb1e884e498cd7c051f511901f?pvs=4

### Pourquoi ?

Afficher un tooltip sur le refus "pas de recrutement en cours"
Afficher un `alert-info` quand ce motif de refus est sélectionné.

### Comment ?

Ajout script.

### Captures d'écran

formulaire au chargement

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/ef44a8e5-fc2d-4a5f-983a-e08d4a7fab96)

tooltip au survol

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/7553295a-cfbf-4906-8c3c-eea68a130d6d)

motif selectionné

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/5da3ac91-2e87-4a22-a5e1-9cb3fc8c01b8)



### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
