### PR TITLE
PASS IAE: augmentation de la taille des batchs des envois à pole emploi

### DIFF
--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -10,8 +10,9 @@ from itou.utils.apis import enums as api_enums
 
 
 # arbitrary value, set so that we don't run the cron for too long.
-# if the delay is set to 1 second, then this would take approximately 20 seconds
-MAX_APPROVALS_PER_RUN = 10
+# if the delay is set to 1 second, then this would take approximately 200 seconds
+# Since the cron runs every 5 minutes, it should be fine
+MAX_APPROVALS_PER_RUN = 100
 
 
 class Command(BaseCommand):

--- a/tests/approvals/test_notify_pole_emploi.py
+++ b/tests/approvals/test_notify_pole_emploi.py
@@ -566,6 +566,8 @@ class ApprovalsSendToPeManagementTestCase(TestCase):
     @patch.object(CancelledApproval, "notify_pole_emploi")
     @patch.object(Approval, "notify_pole_emploi")
     @patch("itou.approvals.management.commands.send_approvals_to_pe.sleep")
+    # smaller batch to ease testing
+    @patch("itou.approvals.management.commands.send_approvals_to_pe.MAX_APPROVALS_PER_RUN", 10)
     def test_invalid_job_seeker_for_pole_emploi(self, sleep_mock, notify_mock, cancelled_notify_mock):
         stdout = io.StringIO()
         # create ignored Approvals, will not even be counted in the batch. the cron will wait for


### PR DESCRIPTION
### Pourquoi ?

Comme on a 140 000 PASS à renvoyer, cela risque de prendre beaucoup de temps avec des batchs de 10.
