### PR TITLE
[GEN-5180] En tant que prescripteur qui reçoit un refus pour motif autre je suis invité à contacter l’employeur si je souhaite en savoir +

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -798,6 +798,13 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         return self.logs.select_related("user").filter(to_state=JobApplicationWorkflow.STATE_ACCEPTED).last().user
 
     @property
+    def refused_by(self):
+        if self.state.is_refused and (
+            last_log := self.logs.select_related("user").filter(to_state=JobApplicationWorkflow.STATE_REFUSED).last()
+        ):
+            return last_log.user
+
+    @property
     def can_be_cancelled(self):
         if self.origin == Origin.AI_STOCK:
             return False
@@ -829,6 +836,10 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.state == JobApplicationWorkflow.STATE_REFUSED
             and self.refusal_reason == RefusalReason.DEACTIVATION.value
         )
+
+    @property
+    def is_refused_for_other_reason(self):
+        return self.state.is_refused and self.refusal_reason == RefusalReason.OTHER
 
     @property
     def hiring_starts_in_future(self):

--- a/itou/templates/apply/includes/job_application_answers.html
+++ b/itou/templates/apply/includes/job_application_answers.html
@@ -1,3 +1,4 @@
+{% load matomo %}
 
 {% if job_application.answer or job_application.state.is_refused %}
     <hr>
@@ -21,4 +22,59 @@
             {{ job_application.answer|linebreaks }}
         </blockquote>
     {% endif %}
+
+    {% if display_refusal_info %}
+        <div class="c-info">
+            <button class="c-info__summary collapsed"
+                    {% matomo_event "candidature" "clic" "prescriber_displayed_company_details" %}
+                    data-bs-toggle="collapse"
+                    data-bs-target="#collapseInfoExample"
+                    aria-expanded="false"
+                    aria-controls="collapseInfoExample">
+                <span>Contactez l’employeur pour en savoir plus</span>
+            </button>
+            <div class="c-info__detail collapse" id="collapseInfoExample">
+                <p>
+                    L’employeur a refusé la candidature avec le motif “Autre”.
+                    <br>
+                    Si les détails apportés dans le message de réponse ne vous ont pas permis d’en savoir plus, vous pouvez contacter l’employeur.
+                </p>
+
+                <p class="text-primary fs-sm font-weight-bold my-3">Coordonnées de l’employeur :</p>
+                <ul class="list-unstyled">
+                    {% if refused_by %}
+                        <li class="d-flex justify-content-start align-items-center">
+                            <a href="{% url 'companies_views:card' siae_id=job_application.to_company.pk %}" class="btn-link btn-ico">
+                                <i class="ri-user-line ri-lg font-weight-normal"></i>
+                                <span>{{ refused_by.get_full_name }}</span>
+                            </a>
+                        </li>
+                    {% endif %}
+                    <li class="d-flex justify-content-start align-items-center">
+                        <a href="{% url 'companies_views:card' siae_id=job_application.to_company.pk %}" class="btn-link btn-ico">
+                            <i class="ri-community-line ri-lg font-weight-normal"></i>
+                            <span>{{ job_application.to_company.display_name }}</span>
+                        </a>
+                    </li>
+                    <li class="d-flex justify-content-start align-items-center">
+                        <a href="mailto:{{ refusal_contact_email }}" class="btn-link btn-ico">
+                            <i class="ri-mail-line ri-lg font-weight-normal"></i>
+                            <span>{{ refusal_contact_email }}</span>
+                        </a>
+                        {% matomo_event "candidature" "clic" "prescriber_copied_company_email" as matomo_event_attrs %}
+                        {% include "includes/copy_to_clipboard.html" with content=refusal_contact_email css_classes="btn-ico btn-link btn-sm ms-2 py-0" matomo_event_attrs=matomo_event_attrs placement="right" %}
+                    </li>
+                    <li class="d-flex justify-content-start align-items-center">
+                        <a href="tel:{{ job_application.to_company.phone|cut:" " }}" class="btn-link btn-ico">
+                            <i class="ri-phone-line ri-lg font-weight-normal"></i>
+                            <span>{{ job_application.to_company.phone }}</span>
+                        </a>
+                        {% matomo_event "candidature" "clic" "prescriber_copied_company_phone" as matomo_event_attrs %}
+                        {% include "includes/copy_to_clipboard.html" with content=job_application.to_company.phone css_classes="btn-ico btn-link btn-sm ms-2 py-0" matomo_event_attrs=matomo_event_attrs placement="right" %}
+                    </li>
+                </ul>
+            </div>
+        </div>
+    {% endif %}
+
 {% endif %}

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -57,7 +57,7 @@
                             <p>
                                 <i class="ri-mail-line"></i>
                                 <a class="btn-link me-3" href="mailto:{{ prolongation_request.contact_email }}">{{ prolongation_request.contact_email }}</a>
-                                {% include 'includes/copy_to_clipboard.html' with content=prolongation_request.contact_email css_classes="btn-secondary" %}
+                                {% include 'includes/copy_to_clipboard.html' with content=prolongation_request.contact_email css_classes="btn btn-ico btn-secondary" %}
                             </p>
                             <p>
                                 <i class="ri-phone-line"></i>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -51,7 +51,7 @@
                                     <span>Postuler</span>
                                 </a>
                             {% endif %}
-                            {% include 'includes/copy_to_clipboard.html' with content=job.get_absolute_url text="Copier le lien de cette fiche" placement="bottom" css_classes="btn btn-outline-primary btn-block" %}
+                            {% include 'includes/copy_to_clipboard.html' with content=job.get_absolute_url text="Copier le lien de cette fiche" placement="bottom" css_classes="btn btn-ico btn-outline-primary btn-block" %}
                         </div>
                         <div class="c-box">
                             <span class="fs-xs lh-sm">{{ siae.kind }} - {{ siae.get_kind_display }}</span>

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -50,7 +50,7 @@
                                                 <span>{{ token.key }}</span>
                                             </div>
                                             <div class="form-group mb-0 col-4 text-end">
-                                                {% include 'includes/copy_to_clipboard.html' with content=token.key text="Copier le token" css_classes="btn-primary" %}
+                                                {% include 'includes/copy_to_clipboard.html' with content=token.key text="Copier le token" css_classes="btn btn-ico btn-primary" %}
                                             </div>
                                         </div>
                                     </div>

--- a/itou/templates/includes/copy_to_clipboard.html
+++ b/itou/templates/includes/copy_to_clipboard.html
@@ -1,9 +1,4 @@
-<button class="js-copy-to-clipboard btn btn-ico {{ css_classes }}"
-        data-copy-to-clipboard="{{ content }}"
-        data-bs-toggle="tooltip"
-        data-bs-placement="{{ placement|default:"top" }}"
-        data-bs-trigger="manual"
-        data-bs-original-title="Copié !">
+<button class="js-copy-to-clipboard {{ css_classes|default:"btn btn-ico" }}" {% if matomo_event_attrs %}{{ matomo_event_attrs }}{% endif %} data-copy-to-clipboard="{{ content }}" data-bs-toggle="tooltip" data-bs-placement="{{ placement|default:"top" }}" data-bs-trigger="manual" data-bs-original-title="Copié !">
     <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
     <span>{{ text|default:"Copier" }}</span>
 </button>

--- a/itou/templates/invitations_views/includes/pending_invitations.html
+++ b/itou/templates/invitations_views/includes/pending_invitations.html
@@ -31,7 +31,7 @@
                         <td>{{ invitation.sent_at|date:"d F Y à H:i" }}</td>
                         <td>{{ invitation.expiration_date|date:"d F Y à H:i" }}</td>
                         <td>
-                            {% include 'includes/copy_to_clipboard.html' with content=invitation.acceptance_link css_classes="btn-outline-primary btn-sm" %}
+                            {% include 'includes/copy_to_clipboard.html' with content=invitation.acceptance_link css_classes="btn btn-ico btn-outline-primary btn-sm" %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -183,6 +183,14 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
         .first()
     )
 
+    # Refused applications information is providen to prescribers
+    if display_refusal_info := job_application.is_refused_for_other_reason:
+        refused_by = job_application.refused_by
+        refusal_contact_email = refused_by.email if refused_by else job_application.to_company.email
+    else:
+        refused_by = None
+        refusal_contact_email = ""
+
     context = {
         "can_view_personal_information": request.user.can_view_personal_information(job_application.job_seeker),
         "can_edit_personal_information": request.user.can_edit_personal_information(job_application.job_seeker),
@@ -192,6 +200,9 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
         "transition_logs": transition_logs,
         "back_url": back_url,
         "matomo_custom_title": "Candidature",
+        "display_refusal_info": display_refusal_info,
+        "refused_by": refused_by,
+        "refusal_contact_email": refusal_contact_email,
     }
 
     return render(request, template_name, context)


### PR DESCRIPTION
### Carte Notion

https://www.notion.so/plateforme-inclusion/En-tant-que-prescripteur-qui-re-oit-un-refus-pour-motif-autre-je-suis-invit-contacter-l-employeur-81f39548494042538ee5d8d935c8d9ce?pvs=4

### Pourquoi ?

Les prescripteurs se plaignent de ne pas être suffisamment informés lorsque l’employeur sélectionne le motif autre 

### Comment ? <!-- optionnel -->

Lorsqu’un employeur a choisi le motif  de refus “Autre" on affiche au prescripteur les coordonnées de l’employeur et on l’incite à le contacter

### Captures d'écran <!-- optionnel -->

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
