### PR TITLE
Déclaration d'embauche: gestion des demandeurs d'emploi ayant eu un PASS dans les 2 dernières années

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -1461,6 +1461,7 @@ class UpdateJobSeekerStepEndView(UpdateJobSeekerBaseView):
 def eligibility_for_hire(request, company_pk, job_seeker_pk, template_name="apply/submit/eligibility_for_hire.html"):
     company = get_object_or_404(Company.objects.member_required(request.user), pk=company_pk)
     job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), pk=job_seeker_pk)
+    _check_job_seeker_approval(request, job_seeker, company)
     next_url = reverse("apply:hire_confirmation", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk})
     bypass_eligibility_conditions = [
         # Don't perform an eligibility diagnosis is the SIAE doesn't need it,
@@ -1532,6 +1533,7 @@ def hire_confirmation(request, company_pk, job_seeker_pk, template_name="apply/s
         geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(job_seeker, company).first()
         eligibility_diagnosis = None
     else:
+        _check_job_seeker_approval(request, job_seeker, company)
         # General IAE eligibility case
         eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(job_seeker, for_siae=company)
         geiq_eligibility_diagnosis = None


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/D-claration-d-embauche-rapide-pour-un-demandeur-d-emploi-ayant-eu-un-PASS-il-y-a-moins-de-2-ans-1e1521f59e894b5fa5ffdea6da310b60?pvs=4

### Pourquoi ?

Dans ce cas seul un prescripteur habilité peut recréer un PASS et un employeur ne pourra pas aller au bout du parcours:
il faut donc lui mettre un message clair plutôt que la dernière étape ne plante.