### PR TITLE
PASS IAE: nouvelle augmentation de la taille des batchs des envois à pole emploi

### DIFF
--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -10,9 +10,9 @@ from itou.utils.apis import enums as api_enums
 
 
 # arbitrary value, set so that we don't run the cron for too long.
-# if the delay is set to 1 second, then this would take approximately 200 seconds
+# if the delay is set to 1 second, then this would take approximately 280 seconds
 # Since the cron runs every 5 minutes, it should be fine
-MAX_APPROVALS_PER_RUN = 100
+MAX_APPROVALS_PER_RUN = 140
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
### Pourquoi ?

Beaucoup de PASS à envoyer et aucune raison de vouloir garder des petits batchs (tant que les crons ne se marchent pas dessus).
