### PR TITLE
[Reprise de stock civilité] Rendre obligatoire la civilité du candidat

### DIFF
--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -25,6 +25,33 @@
                 <div class="col-12 col-lg-8">
                     <div class="c-form">
                         <h2>Informations personnelles</h2>
+                        {% if request.user.is_job_seeker and not request.user.title %}
+                            <div id="missing-infos-warning" class="alert alert-warning" role="status">
+                                <div class="row">
+                                    <div class="col-auto pe-0">
+                                        <i class="ri-information-line ri-xl text-warning"></i>
+                                    </div>
+                                    <div class="col">
+                                        <p class="mb-2">
+                                            <strong>Informations manquantes</strong>
+                                        </p>
+                                        <p>Une ou plusieurs informations de votre profil sont nécessaires pour utiliser votre espace candidat.</p>
+                                        <p class="mb-0">
+                                            Les champs suivants ne sont pas renseignés :
+                                            <ul>
+                                                {% for field in form %}
+                                                    {% if field.field.required and not field.value or field.name == 'phone' and not field.value %}
+                                                        <li>
+                                                            <strong>{{ field.label }}</strong>
+                                                        </li>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </ul>
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}
                         {% if request.user.is_job_seeker %}
                             {% include "dashboard/includes/edit_job_seeker_info_form.html" with prev_url=prev_url submit_label="Enregistrer et quitter" %}
                         {% else %}

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -12,6 +12,7 @@
     {% if form.nir_error %}{{ form.nir_error|safe }}{% endif %}
     {% bootstrap_form_errors form type='non_fields' %}
     {% bootstrap_field form.email %}
+    {% bootstrap_field form.title %}
     {% bootstrap_field form.first_name %}
     {% bootstrap_field form.last_name %}
     {% bootstrap_field form.nir %}

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -60,6 +60,7 @@ class EditJobSeekerInfoForm(JobSeekerNIRUpdateMixin, MandatoryAddressFormMixin, 
         ]
         help_texts = {
             "birthdate": "Au format JJ/MM/AAAA, par exemple 20/12/1978",
+            "phone": "L'ajout du numéro de téléphone permet à l'employeur de vous contacter plus facilement.",
         }
 
     def __init__(self, *args, **kwargs):

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -43,6 +43,7 @@ class EditJobSeekerInfoForm(JobSeekerNIRUpdateMixin, MandatoryAddressFormMixin, 
         model = User
         fields = [
             "email",
+            "title",
             "first_name",
             "last_name",
             "nir",
@@ -66,6 +67,7 @@ class EditJobSeekerInfoForm(JobSeekerNIRUpdateMixin, MandatoryAddressFormMixin, 
         super().__init__(*args, **kwargs)
         assert self.instance.is_job_seeker, self.instance
 
+        self.fields["title"].required = True
         self.fields["birthdate"].required = True
         self.fields["birthdate"].widget = DuetDatePickerWidget(
             attrs={

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -178,6 +178,10 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                 context["active_campaigns"].append(campaign)
             else:
                 context["closed_campaigns"].append(campaign)
+    elif request.user.is_job_seeker:
+        # Force the job seeker to fill its title to use the site
+        if not request.user.title:
+            return HttpResponseRedirect(reverse("dashboard:edit_user_info"))
 
     return render(request, template_name, context)
 

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -55,7 +55,7 @@ def mock_oauth_dance(client, expected_route="dashboard:index"):
 
     state = FranceConnectState.save_state()
     url = reverse("france_connect:callback")
-    response = client.get(url, data={"code": "123", "state": state})
+    response = client.get(url, data={"code": "123", "state": state}, follow=True)
     assertRedirects(response, reverse(expected_route))
     return response
 
@@ -314,8 +314,6 @@ class FranceConnectTest(TestCase):
         """
         response = mock_oauth_dance(self.client)
         assert auth.get_user(self.client).is_authenticated
-        # Follow the redirection.
-        response = self.client.get(response.url)
         logout_url = reverse("account_logout")
         self.assertContains(response, logout_url)
         assert self.client.session.get(constants.FRANCE_CONNECT_SESSION_TOKEN)

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -273,7 +273,8 @@ class FranceConnectTest(TestCase):
 
     @respx.mock
     def test_callback(self):
-        mock_oauth_dance(self.client)
+        # New created job seeker has no title and is redirected to complete its infos
+        mock_oauth_dance(self.client, expected_route="dashboard:edit_user_info")
         assert User.objects.count() == 1
         user = User.objects.get(email=FC_USERINFO["email"])
         assert user.first_name == FC_USERINFO["given_name"]
@@ -312,7 +313,8 @@ class FranceConnectTest(TestCase):
         When ac IC user wants to log out from his local account,
         he should be logged out too from IC.
         """
-        response = mock_oauth_dance(self.client)
+        # New created job seeker has no title and is redirected to complete its infos
+        response = mock_oauth_dance(self.client, expected_route="dashboard:edit_user_info")
         assert auth.get_user(self.client).is_authenticated
         logout_url = reverse("account_logout")
         self.assertContains(response, logout_url)

--- a/tests/openid_connect/pe_connect/tests.py
+++ b/tests/openid_connect/pe_connect/tests.py
@@ -66,7 +66,7 @@ def mock_oauth_dance(
 
     state = PoleEmploiConnectState.save_state()
     url = reverse("pe_connect:callback")
-    response = client.get(url, data={"code": "123", "state": state})
+    response = client.get(url, data={"code": "123", "state": state}, follow=True)
     assertRedirects(response, reverse(expected_route))
     return response
 
@@ -321,8 +321,6 @@ class TestPoleEmploiConnect:
         """
         response = mock_oauth_dance(client)
         assert auth.get_user(client).is_authenticated
-        # Follow the redirection.
-        response = client.get(response.url)
         logout_url = reverse("account_logout")
         assertContains(response, logout_url)
         assert client.session.get(constants.PE_CONNECT_SESSION_TOKEN)

--- a/tests/www/dashboard/__snapshots__/tests.ambr
+++ b/tests/www/dashboard/__snapshots__/tests.ambr
@@ -1,4 +1,134 @@
 # serializer version: 1
+# name: EditUserInfoViewTest.test_edit_without_title[missing title warning with phone and address]
+  '''
+  <div class="alert alert-warning" id="missing-infos-warning" role="status">
+                                  <div class="row">
+                                      <div class="col-auto pe-0">
+                                          <i class="ri-information-line ri-xl text-warning"></i>
+                                      </div>
+                                      <div class="col">
+                                          <p class="mb-2">
+                                              <strong>Informations manquantes</strong>
+                                          </p>
+                                          <p>Une ou plusieurs informations de votre profil sont nécessaires pour utiliser votre espace candidat.</p>
+                                          <p class="mb-0">
+                                              Les champs suivants ne sont pas renseignés :
+                                              </p><ul>
+                                                  
+                                                      
+                                                  
+                                                      
+                                                          <li>
+                                                              <strong>Civilité</strong>
+                                                          </li>
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                          <li>
+                                                              <strong>Téléphone</strong>
+                                                          </li>
+                                                      
+                                                  
+                                                      
+                                                          <li>
+                                                              <strong>Adresse</strong>
+                                                          </li>
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                              </ul>
+                                          <p></p>
+                                      </div>
+                                  </div>
+                              </div>
+  '''
+# ---
+# name: EditUserInfoViewTest.test_edit_without_title[missing title warning without phone and with birthdate]
+  '''
+  <div class="alert alert-warning" id="missing-infos-warning" role="status">
+                                  <div class="row">
+                                      <div class="col-auto pe-0">
+                                          <i class="ri-information-line ri-xl text-warning"></i>
+                                      </div>
+                                      <div class="col">
+                                          <p class="mb-2">
+                                              <strong>Informations manquantes</strong>
+                                          </p>
+                                          <p>Une ou plusieurs informations de votre profil sont nécessaires pour utiliser votre espace candidat.</p>
+                                          <p class="mb-0">
+                                              Les champs suivants ne sont pas renseignés :
+                                              </p><ul>
+                                                  
+                                                      
+                                                  
+                                                      
+                                                          <li>
+                                                              <strong>Civilité</strong>
+                                                          </li>
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                          <li>
+                                                              <strong>Date de naissance</strong>
+                                                          </li>
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                                      
+                                                  
+                                              </ul>
+                                          <p></p>
+                                      </div>
+                                  </div>
+                              </div>
+  '''
+# ---
 # name: test_alert_message_for_ai_stock_prolongation[AI]
   '''
   <div class="alert alert-info" id="AIStockProlongationAlert">

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -732,6 +732,19 @@ class DashboardViewTest(TestCase):
             f"&source={settings.ITOU_ENVIRONMENT}",
         )
 
+    def test_job_seeker_without_title_redirected(self):
+        user = JobSeekerFactory(title="")
+        self.client.force_login(user)
+
+        response = self.client.get(reverse("dashboard:index"))
+        self.assertRedirects(response, reverse("dashboard:edit_user_info"))
+
+        user.title = Title.M
+        user.save(update_fields=("title",))
+
+        response = self.client.get(reverse("dashboard:index"))
+        assert response.status_code == 200
+
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class EditUserInfoViewTest(InclusionConnectBaseTestCase):

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -753,6 +753,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
 
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -779,6 +780,30 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         # Ensure that the job seeker cannot edit email here.
         assert user.email != post_data["email"]
 
+    def test_edit_title_required(self):
+        user = JobSeekerFactory()
+        self.client.force_login(user)
+        url = reverse("dashboard:edit_user_info")
+        response = self.client.get(url)
+        post_data = {
+            "email": user.email,
+            "title": "",
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "birthdate": "20/12/1978",
+            "phone": user.phone,
+            "lack_of_pole_emploi_id_reason": user.lack_of_pole_emploi_id_reason,
+            "address_line_1": "10, rue du Gué",
+            "address_line_2": "Sous l'escalier",
+            "post_code": "35400",
+            "city": "Saint-Malo",
+            "lack_of_nir": False,
+            "nir": user.nir,
+        }
+        response = self.client.post(url, data=post_data)
+        assert response.status_code == 200
+        assert response.context["form"].errors.get("title") == ["Ce champ est obligatoire."]
+
     def test_edit_with_lack_of_nir_reason(self):
         user = JobSeekerFactory(nir="", lack_of_nir_reason=LackOfNIRReason.TEMPORARY_NUMBER)
         self.client.force_login(user)
@@ -792,6 +817,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         NEW_NIR = "1 970 13625838386"
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -823,6 +849,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         NEW_NIR = "1 970 13625838386"
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -856,6 +883,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
 
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -981,6 +1009,7 @@ class EditJobSeekerInfo(TestCase):
 
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -1041,6 +1070,7 @@ class EditJobSeekerInfo(TestCase):
         NEW_NIR = "1 970 13625838386"
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -1085,6 +1115,7 @@ class EditJobSeekerInfo(TestCase):
 
         post_data = {
             "email": "bob@saintclar.net",
+            "title": "M",
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "birthdate": "20/12/1978",
@@ -1226,6 +1257,7 @@ class EditJobSeekerInfo(TestCase):
         self.assertContains(response, "Adresse électronique")
 
         post_data = {
+            "title": "M",
             "email": new_email,
             "birthdate": "20/12/1978",
             "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
@@ -1276,6 +1308,7 @@ class EditJobSeekerInfo(TestCase):
         self.assertNotContains(response, "Adresse électronique")
 
         post_data = {
+            "title": "M",
             "email": new_email,
             "birthdate": "20/12/1978",
             "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,
@@ -1318,6 +1351,7 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
         url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
         post_data = {
+            "title": "M",
             "email": user.email,
             "birthdate": "20/12/1978",
             "lack_of_pole_emploi_id_reason": LackOfPoleEmploiId.REASON_NOT_REGISTERED,

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -299,7 +299,8 @@ class JobSeekerSignupTest(TestCase):
         fc_url = reverse("france_connect:authorize")
         self.assertContains(response, fc_url)
 
-        mock_oauth_dance(self.client)
+        # New created job seeker has no title and is redirected to complete its infos
+        mock_oauth_dance(self.client, expected_route="dashboard:edit_user_info")
         job_seeker = User.objects.get(email=FC_USERINFO["email"])
         assert nir == job_seeker.nir
         assert job_seeker.has_jobseeker_profile
@@ -324,7 +325,8 @@ class JobSeekerSignupTest(TestCase):
         fc_url = reverse("france_connect:authorize")
         self.assertContains(response, fc_url)
 
-        mock_oauth_dance(self.client)
+        # New created job seeker has no title and is redirected to complete its infos
+        mock_oauth_dance(self.client, expected_route="dashboard:edit_user_info")
         job_seeker = User.objects.get(email=FC_USERINFO["email"])
         assert not job_seeker.nir
         assert job_seeker.has_jobseeker_profile


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Reprise-de-stock-civilit-Rendre-obligatoire-la-civilit-du-candidat-afa04f9bd69b4311b6ef786f048947bb?pvs=4

:warning: Seuls les 4 derniers commits sont à relire, les autres faisant parti de la PR #3407

### Pourquoi ?

Les nouveaux candidats doivent remplir ce champs à l'inscription mais on a 390k candidats sans civilité.
