### PR TITLE
[CANDIDATURE GEIQ] afficher les actions préalables pour les candidats et les prescripteurs

### DIFF
--- a/itou/templates/apply/includes/job_application_prior_action.html
+++ b/itou/templates/apply/includes/job_application_prior_action.html
@@ -11,7 +11,7 @@
     <div>
         Date de fin : <b>{{ prior_action.dates.upper }}</b>
     </div>
-    {% if job_application.can_change_prior_actions %}
+    {% if job_application.can_change_prior_actions and request.user.is_employer %}
         <div class="my-3">
             {# Delete button with its confirmation modal #}
             <button class="btn btn-link" data-bs-toggle="modal" data-bs-target="#delete_prior_action_{{ prior_action.pk }}_modal">
@@ -55,7 +55,7 @@
                     hx-swap="outerHTML">Modifier les informations</button>
         </div>
     {% endif %}
-    {% if job_application.can_change_prior_actions or not hide_final_hr %}<hr>{% endif %}
+    {% if job_application.can_change_prior_actions and request.user.is_employer or not hide_final_hr %}<hr>{% endif %}
 </div>
 {% if add_prior_action_form %}
     {# A new prior action has been added and is being swapped to replace the add form: we now need a new one #}

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -30,6 +30,15 @@
         <h3>Candidature envoyée par</h3>
         {% include "apply/includes/job_application_sender_info.html" with job_application=job_application %}
 
+        {# Prior actions info #}
+        {% if job_application.can_have_prior_action %}
+            <hr>
+            <h3>Action préalable à l'embauche</h3>
+            {% for prior_action in job_application.prior_actions.all %}
+                {% include "apply/includes/job_application_prior_action.html" with job_application=job_application prior_action=prior_action add_prior_action_form=None hide_final_hr=forloop.last %}
+            {% endfor %}
+        {% endif %}
+
         {# Negative answers ------------------------------------------------------------------------- #}
         {% include "apply/includes/job_application_answers.html" with job_application=job_application %}
 


### PR DESCRIPTION
[GEIQ : afficher les informations associées a(ux) action(s) préalable(s) à l’embauche dans la page candidature pour les candidats et prescripteurs](https://www.notion.so/plateforme-inclusion/GEIQ-afficher-les-informations-associ-es-a-ux-action-s-pr-alable-s-l-embauche-dans-la-page-ca-1a8aba474fb84deeb1d644c71c52a481?pvs=4)

## Résumé du besoin :
Savoir qu’une action préalable à l’embauche a été ajoutée par un employeur sur une candidature 

## Pourquoi ?
Partage de l’information au prescripteur et candidat sur l’avancée du recrutement et sur les détails relatifs à l’action préalable ajoutée par le recruteur. 

## Comment répondre à ce besoin ?
Afficher les actions préalables à l’embauche sur la pages candidature pour eux (comme c’est le cas pour le GEIQ)

### Captures d'écran 

vue employeur

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/c59894cf-084e-4ab5-85bf-daa575cd1d9b)

vue candidat

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/ab94550a-dc41-49f8-8582-551eb1ed9ece)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
