### PR TITLE
[SUITE ET FIN] Stats : Ouverture du TB310 (Suivi des prescriptions des AHI) à la DRHIL et aux DDETS IAE (en plus des DDETS LOG, DREETS IAE et DIHAL)

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -73,10 +73,6 @@ def get_params_for_region(region):
     return params
 
 
-def get_params_for_idf_region():
-    return get_params_for_region("Île-de-France")
-
-
 def get_params_for_whole_country():
     return {
         mb.DEPARTMENT_FILTER_KEY: list(DEPARTMENTS.values()),
@@ -619,7 +615,7 @@ def stats_drihl_state(request):
     context = {
         "page_title": "Suivi des prescriptions des AHI",
     }
-    return render_stats(request=request, context=context, params=get_params_for_idf_region())
+    return render_stats(request=request, context=context, params=get_params_for_region("Île-de-France"))
 
 
 @login_required


### PR DESCRIPTION
### Pourquoi ?

Quelques correctifs pour finaliser https://github.com/gip-inclusion/les-emplois/pull/3368 qui a été fusionnée sous pression.