### PR TITLE
Vue "Description du poste": correction de l'affichage des autres postes + réduction requêtes

### DIFF
--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -32,7 +32,9 @@ ITOU_SESSION_JOB_DESCRIPTION_KEY = "edit_job_description_key"
 
 
 def job_description_card(request, job_description_id, template_name="companies/job_description_card.html"):
-    job_description = get_object_or_404(JobDescription.objects.select_related("location"), pk=job_description_id)
+    job_description = get_object_or_404(
+        JobDescription.objects.select_related("appellation", "company", "location"), pk=job_description_id
+    )
     back_url = get_safe_url(request, "back_url")
     company = job_description.company
     can_update_job_description = (

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -41,7 +41,7 @@ def job_description_card(request, job_description_id, template_name="companies/j
 
     # select_related on company, location useful for _list_siae_actives_jobs_row.html template
     others_active_jobs = (
-        JobDescription.objects.select_related("appellation", "location", "siae")
+        JobDescription.objects.select_related("appellation", "company", "location")
         .filter(is_active=True, company=company)
         .exclude(id=job_description_id)
         .order_by("-updated_at", "-created_at")

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -586,9 +586,8 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch django session
             + 1  # fetch user
             + 1  # fetch user memberships
-            + 1  # fetch companies_jobdescription
-            + 1  # fetch companies infos
-            + 1  # fetch jobappelation
+            + 1  # fetch companies_jobdescription (get_object_or_404)
+            + 1  # fetch companies_jobdescription (others_active_jobs)
             + 3  # update session
         ):
             response = self.client.get(self.url)
@@ -610,9 +609,8 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             BASE_NUM_QUERIES
             + 1  # fetch django session
             + 1  # fetch user
-            + 1  # fetch companies_jobdescription
-            + 1  # fetch companies infos
-            + 1  # fetch jobappelation
+            + 1  # fetch companies_jobdescription (get_object_or_404)
+            + 1  # fetch companies_jobdescription (others_active_jobs)
             + 3  # update session
         ):
             response = self.client.get(self.url)

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -22,7 +22,7 @@ from tests.companies.factories import (
 )
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import EmployerFactory
-from tests.utils.test import TestCase, parse_response_to_soup
+from tests.utils.test import BASE_NUM_QUERIES, TestCase, parse_response_to_soup
 
 
 @pytest.mark.usefixtures("unittest_compatibility")
@@ -550,7 +550,12 @@ class JobDescriptionCardViewTest(TestCase):
         job_description.open_positions = 1234
         job_description.save()
         url = reverse("companies_views:job_description_card", kwargs={"job_description_id": job_description.pk})
-        response = self.client.get(url)
+        with self.assertNumQueries(
+            BASE_NUM_QUERIES
+            + 1  # select jobdescription (get_object_or_404)
+            + 1  # select other jobdescription (others_active_jobs)
+        ):
+            response = self.client.get(url)
         assert response.context["job"] == job_description
         assert response.context["siae"] == company
         self.assertContains(response, job_description.description)

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -567,6 +567,11 @@ class JobDescriptionCardViewTest(TestCase):
         self.assertContains(response, escape(company.display_name))
         self.assertNotContains(response, OPEN_POSITION_TEXT)
 
+        # Check other jobs
+        assert response.context["others_active_jobs"].count() == 3
+        for other_active_job in response.context["others_active_jobs"]:
+            self.assertContains(response, other_active_job.display_name, html=True)
+
 
 class ShowAndSelectFinancialAnnexTest(TestCase):
     def test_asp_source_siae_admin_can_see_but_cannot_select_af(self):


### PR DESCRIPTION
### Pourquoi ?

Les autres postes [ne s'affichaient pas](https://itou-inclusion.slack.com/archives/C0412CTV63D/p1701786817678629) et on préfère faire peu de requêtes à la DB.