### PR TITLE
Retirer des boutons inutile qui risque de faire sortir l’utilisateur du parcours

### DIFF
--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -64,9 +64,6 @@
                             </div>
                             <div class="form-row align-items-center justify-content-end gx-3 mt-3">
                                 <div class="form-group col-6 col-lg-auto">
-                                    <a href="{% url "search:employers_home" %}" class="btn btn-outline-primary btn-block">Revenir à la recherche</a>
-                                </div>
-                                <div class="form-group col-6 col-lg-auto">
                                     <a class="btn btn-primary btn-block" href="{% url "dashboard:index" %}">Tableau de bord</a>
                                 </div>
                             </div>
@@ -99,9 +96,6 @@
                         {% endif %}
                     {% else %}
                         <div class="form-row align-items-center justify-content-end gx-3 mt-3">
-                            <div class="form-group col-6 col-lg-auto">
-                                <a href="{% url "search:employers_home" %}" class="btn btn-outline-primary btn-block">Revenir à la recherche</a>
-                            </div>
                             <div class="form-group col-6 col-lg-auto">
                                 <a class="btn btn-primary btn-block" href="{% url "dashboard:index" %}">Tableau de bord</a>
                             </div>

--- a/itou/templates/apply/submit/check_job_seeker_info_for_hire.html
+++ b/itou/templates/apply/submit/check_job_seeker_info_for_hire.html
@@ -21,7 +21,6 @@
         <hr class="my-4">
 
         <div class="text-end">
-            <a class="btn btn-link" href="{% url "dashboard:index" %}">Retour au Tableau de bord</a>
             <a class="btn btn-primary" href="{% url 'apply:check_prev_applications_for_hire' company_pk=siae.pk job_seeker_pk=job_seeker.pk %}">Poursuivre l’embauche</a>
         </div>
     </div>


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/retirer-des-boutons-inutile-qui-risque-de-faire-sortir-l-utilisateur-du-parcours-boost-9c7eaa761fbb46a582d8f76a0029983e?pvs=4


### Comment ? 

- supprimer les boutons "Revenir à la recherche" lors de l'enregistrement d'une candidature
- supprimer le boutont "Retour au tableau de bord" lors la déclaration d'une embauche

### Captures d'écran 

Enregistrer une candidature

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/c8bf38bc-faa3-4083-b9d2-01e9c1e22cd8)

Déclarer une embauche

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/68db6b0c-9066-4a15-a2d2-fe8c7e7d9284)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
