### PR TITLE
[FIX #3327] approvals : annuler une suspension

### DIFF
--- a/itou/templates/approvals/suspension_action_choice.html
+++ b/itou/templates/approvals/suspension_action_choice.html
@@ -28,7 +28,7 @@
                         <form method="post">
                             {% csrf_token %}
                             <div class="form-check">
-                                <input class="form-check-input" type="radio" name="action" id="endDateRadios" value="update-enddate" checked>
+                                <input class="form-check-input" type="radio" name="action" id="endDateRadios" value="update_enddate" checked>
                                 <label class="form-check-label" for="endDateRadios">
                                     Lever la suspension pour <strong class="text-success">réintégrer ce candidat</strong>
                                 </label>

--- a/tests/www/approvals_views/test_suspend.py
+++ b/tests/www/approvals_views/test_suspend.py
@@ -290,6 +290,24 @@ class ApprovalSuspendActionChoiceViewTest(TestCase):
         assert response.context["suspension"] == self.suspension
         assert response.context["back_url"] == reverse("approvals:detail", kwargs={"pk": self.suspension.approval_id})
 
+    def test_input_action_names(self):
+        self.client.force_login(self.employer)
+
+        response = self.client.get(self.url)
+        assertContains(
+            response,
+            (
+                '<input class="form-check-input" type="radio" name="action" '
+                'id="endDateRadios" value="update_enddate" checked>'
+            ),
+            status_code=200,
+        )
+        assertContains(
+            response,
+            '<input class="form-check-input" type="radio" name="action" id="deleteRadios" value="delete">',
+            status_code=200,
+        )
+
     def test_post_delete(self):
         self.client.force_login(self.employer)
 


### PR DESCRIPTION
### Pourquoi ?

typo in action_name, fix #3327

### Comment ?

ajout d'un test sur les action_name  dans le gabarit

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
