### PR TITLE
Mise à jour des titres de l'écran de recherche des emplois

### DIFF
--- a/itou/templates/includes/pagination_for_title.html
+++ b/itou/templates/includes/pagination_for_title.html
@@ -1,0 +1,1 @@
+{% if page.display_pager %}&nbsp;(page {{ page.number }} sur {{ page.paginator.num_pages }}){% endif %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -3,14 +3,15 @@
 
 {% block title %}
     {% if form.is_valid %}
-        Employeurs solidaires à {{ distance }} km du centre de {{ city }}
+        Emplois inclusifs à {{ distance }} km du centre de {{ city }}
+        {% include "includes/pagination_for_title.html" with page=results_page only %}
     {% else %}
-        Recherche d'employeurs solidaires
+        Rechercher un emploi inclusif
     {% endif %}
     {{ block.super }}
 {% endblock %}
 
-{% block content_title %}<h1>Rechercher des employeurs solidaires</h1>{% endblock %}
+{% block content_title %}<h1>Rechercher un emploi inclusif</h1>{% endblock %}
 
 {% block content %}
     <section class="s-tabs-01">

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -56,9 +56,9 @@ class SearchCompanyTest(TestCase):
         ):
             response = self.client.get(self.url, {"city": city_slug})
 
-        self.assertContains(response, "Employeurs solidaires à 25 km du centre de Paris (75)")
+        self.assertContains(response, "Emplois inclusifs à 25 km du centre de Paris (75)")
         # look for the matomo_custom_title
-        self.assertContains(response, "Recherche d&#x27;employeurs solidaires")
+        self.assertContains(response, "Rechercher un emploi inclusif")
         self.assertContains(
             response,
             """Employeurs <span class="badge badge-sm rounded-pill bg-info-lighter text-info">2</span>""",
@@ -307,7 +307,7 @@ class JobDescriptionSearchViewTest(TestCase):
         ):
             response = self.client.get(self.url, {"city": city_slug})
 
-        self.assertContains(response, "Employeurs solidaires à 25 km du centre de Paris (75)")
+        self.assertContains(response, "Emplois inclusifs à 25 km du centre de Paris (75)")
         self.assertContains(
             response,
             """


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Mettre-en-coh-rence-le-titre-de-la-page-de-r-sultats-du-moteur-de-recherche-avec-le-contenu-recherch-526682b5fa47459b81e5d39ad5962720?pvs=4

### Pourquoi ?

Mettre en cohérence le titre de la page de résultats du moteur de recherche avec le contenu recherché 


### Captures d'écran 

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/bbb62f43-11f8-4653-ad12-4a460b522b12)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
