### PR TITLE
templates.stats: Remove some "Nouveau" badges

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -36,14 +36,12 @@
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Focus auto-prescription</span>
                         </a>
-                        {% include "dashboard/includes/stats_new_badge.html" %}
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_siae_follow_siae_evaluation' %}" class="btn-link btn-ico">
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Suivre le contrôle a posteriori</span>
                         </a>
-                        {% include "dashboard/includes/stats_new_badge.html" %}
                     </li>
                 {% endif %}
                 {% if can_view_stats_cd %}


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Supprimer-les-tags-nouveaux-de-quelques-tableaux-de-bord-priv-s-sur-c1-10531ae97c6d4e00ae9ddf2780ccdadb

### Pourquoi ?

TAG Nouveau qui apparaît sur plusieurs TDB mais qui ne sont plus nouveaux

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
