### PR TITLE
[GEN-7763] Liste de diffusion Mailjet: considérer les utilisateurs IC comme ayant une adresse email vérifiée

### DIFF
--- a/itou/users/management/commands/new_users_to_mailjet.py
+++ b/itou/users/management/commands/new_users_to_mailjet.py
@@ -6,7 +6,7 @@ import httpx
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.core.management import BaseCommand
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 from sentry_sdk.crons import monitor
 
@@ -14,7 +14,7 @@ from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
 from itou.companies.models import CompanyMembership
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberMembership
-from itou.users.enums import UserKind
+from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
 from itou.utils.iterators import chunks
 
@@ -113,7 +113,8 @@ class Command(BaseCommand):
                         primary=True,
                         verified=True,
                     )
-                ),
+                )
+                | Q(identity_provider=IdentityProvider.INCLUSION_CONNECT),  # IC verifies emails on its own
                 date_joined__gte=self.campaign_start(),
                 is_active=True,
             )

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -662,7 +662,7 @@ class TestCommandNewUsersToMailJet:
             email="timmy.timber@mailinator.com",
             identity_provider=IdentityProvider.INCLUSION_CONNECT,
         )
-        timmy = PrescriberMembershipFactory(user=timmy, organization__kind=PrescriberOrganizationKind.OTHER)
+        PrescriberMembershipFactory(user=timmy, organization__kind=PrescriberOrganizationKind.OTHER)
         # Past users are ignored.
         PrescriberFactory(with_verified_email=True, date_joined=datetime.datetime(2023, 1, 12, tzinfo=datetime.UTC))
         # Inactive users are ignored.


### PR DESCRIPTION
### Pourquoi ?

Les utilisateurs IC n'utilisent plus le modèle Email d'allauth et n'ont donc plus d'email vérifié coté Emplois: on considère leur email vérifié coté Inclusion Connect.
