### PR TITLE
Modification UI des boutons "Supprimer" dans les modales

### DIFF
--- a/itou/templates/apply/includes/job_application_prior_action.html
+++ b/itou/templates/apply/includes/job_application_prior_action.html
@@ -40,10 +40,13 @@
                                   class="d-block js-prevent-multiple-submit">
                                 {% csrf_token %}
                                 <div class="text-end">
-                                    <button class="btn btn-outline-primary btn-sm" data-bs-dismiss="modal" aria-label="Annuler" type="button">
+                                    <button class="btn btn-outline-primary btn-sm" data-bs-dismiss="modal" aria-label="Annuler la suppression de l'action préalable à l'embauche" type="button">
                                         Annuler
                                     </button>
-                                    <button class="btn btn-danger btn-sm" data-bs-dismiss="modal" aria-label="Supprimer">Supprimer</button>
+                                    <button class="btn btn-danger btn-sm" data-bs-dismiss="modal" aria-label="Supprimer l'action préalable à l'embauche">
+                                        <i class="ri-delete-bin-line font-weight-normal" aria-hidden="true"></i>
+                                        <span>Supprimer</span>
+                                    </button>
                                 </div>
                             </form>
                         </div>

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -114,10 +114,13 @@
                                                                         {% csrf_token %}
                                                                         <input type="hidden" name="action" value="delete" />
                                                                         <input type="hidden" name="job_description_id" value="{{ job_description.id }}" />
-                                                                        <button class="btn btn-outline-primary btn-sm" data-bs-dismiss="modal" aria-label="Annuler" type="button">
+                                                                        <button class="btn btn-outline-primary btn-sm" data-bs-dismiss="modal" aria-label="Annuler la suppression de la fiche de poste" type="button">
                                                                             Annuler
                                                                         </button>
-                                                                        <button class="btn btn-primary btn-sm" aria-label="Supprimer">Supprimer</button>
+                                                                        <button class="btn btn-sm btn-ico btn-danger" aria-label="Supprimer la fiche de poste">
+                                                                            <i class="ri-delete-bin-line font-weight-normal" aria-hidden="true"></i>
+                                                                            <span>Supprimer</span>
+                                                                        </button>
                                                                     </form>
                                                                 </div>
                                                             </div>


### PR DESCRIPTION
**Carte Notion :** https://www.notion.so/plateforme-inclusion/Modale-Supprimer-la-fiche-de-poste-Passer-le-btn-en-danger-icon-6b53adc2ea5142e69aeb221fd4f18868?pvs=4

### Pourquoi ?

Parcque les UX y préfèrent

### Comment ? <!-- optionnel -->

Changements du DOM et des classes css

### Captures d'écran <!-- optionnel -->
Avant
![Untitled](https://github.com/gip-inclusion/les-emplois/assets/3874024/5ba9d830-190b-4a3c-a0d1-1e04a3e58d83)

Apres
![capture 2023-12-11 à 10 43 25](https://github.com/gip-inclusion/les-emplois/assets/3874024/925afdaf-76da-4eb2-bd22-e80c5aae04a9)


