### PR TITLE
Candidatures : message en l'absence de telephone renseigné lors de la confirmation [GEN-5256]

### DIFF
--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -58,7 +58,17 @@
                                     <p>
                                         <span class="text-muted">N&deg; de téléphone</span>
                                         <br />
-                                        <b>{{ job_application.job_seeker.phone|format_phone|default:"Non renseigné" }}</b>
+                                        {% if job_application.job_seeker.phone %}
+                                            <b>{{ job_application.job_seeker.phone|format_phone }}</b>
+                                        {% elif request.user.is_job_seeker %}
+                                            <b>Non renseigné</b>
+                                            <p class="text-warning fst-italic">
+                                                L’ajout du numéro de téléphone permet à l’employeur de vous contacter plus facilement.
+                                            </p>
+                                        {% else %}
+                                            <b>Non renseigné</b>
+                                            <p class="text-warning fst-italic">L’ajout du numéro de téléphone facilitera la prise de contact avec le candidat.</p>
+                                        {% endif %}
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
[Carte Notion](https://www.notion.so/plateforme-inclusion/En-tant-qu-employeur-je-souhaite-que-les-num-ros-de-t-l-phones-des-candidats-soient-renseign-s-afin--857b793d366f475ab359aa8913aa99bc?pvs=4)

### Pourquoi ?

Augmenter la complétude du numéro de téléphone des candidats 


### Captures d'écran <!-- optionnel -->

![vue professionnel](https://github.com/gip-inclusion/les-emplois/assets/11419273/843bd2e7-627c-4097-a2ad-30e7b8126919)

![vue employeur](https://github.com/gip-inclusion/les-emplois/assets/11419273/bbc8582f-4d1f-4a54-bc0a-8e1d5202dd30)

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
