### PR TITLE
Correction d'une mauvaise utilisation du block content_title_wrapper

### DIFF
--- a/itou/templates/account/account_type_selection.html
+++ b/itou/templates/account/account_type_selection.html
@@ -4,17 +4,7 @@
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}
-    <section class="s-title-01">
-        <div class="s-title-01__container container">
-            <div class="s-title-01__row row">
-                <div class="s-title-01__col col-12">
-                    <h1>Connexion</h1>
-                </div>
-            </div>
-        </div>
-    </section>
-{% endblock %}
+{% block content_title %}<h1>Connexion</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">


### PR DESCRIPTION
### Pourquoi ?

Pour corriger une erreur que j'avais faite dans [cette PR](https://github.com/gip-inclusion/les-emplois/pull/3417/files#diff-ee78cb95f43868c0b768f9ead6c6b1104aa02e55dc286a5b9e1dd18c0e29243c)


