### PR TITLE
[NE PAS SUPPRIMER] Recette jetable pour PE

### DIFF
--- a/itou/utils/apis/__init__.py
+++ b/itou/utils/apis/__init__.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from .pole_emploi import PoleEmploiApiClient
 
 
+# Values updated in review app's environment to communicate with
+# PE's pre-production servers.
 def pole_emploi_api_client():
     return PoleEmploiApiClient(
         settings.API_ESD["BASE_URL"],


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?

Pôle emploi réécrit les endpoints que nous appelons pour mettre à jour le PASS chez eux. Ils ont demandé un environnement de démo.