### PR TITLE
Recherche Candidatures Company : variabilité du message d'absence de résultat [GEN-3296]

### DIFF
--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -77,7 +77,13 @@
                             <div class="text-center my-3 my-md-4">
                                 <img class="img-fluid" src="{% static 'img/illustration-siae-card-no-result.svg' %}" alt="" loading="lazy">
                                 <p class="mb-1 mt-3">
-                                    <strong>Aucune candidature pour le moment</strong>
+                                    <strong>
+                                        {% if pending_states_job_applications_count == 0 %}
+                                            Aucune candidature pour le moment
+                                        {% else %}
+                                            Aucune candidature ne correspond aux filtres sélectionnés
+                                        {% endif %}
+                                    </strong>
                                 </p>
                                 <p>
                                     <i>

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -171,6 +171,9 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
     """
     company = get_current_company_or_404(request)
     job_applications = company.job_applications_received
+    pending_states_job_applications_count = job_applications.filter(
+        state__in=JobApplicationWorkflow.PENDING_STATES
+    ).count()
 
     filters_form = CompanyFilterJobApplicationsForm(job_applications, company, request.GET or None)
 
@@ -199,6 +202,7 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
         "job_applications_page": job_applications_page,
         "filters_form": filters_form,
         "filters_counter": filters_counter,
+        "pending_states_job_applications_count": pending_states_job_applications_count,
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
### Pourquoi ?

Faire varier le message d'absence de résultat de recherche selon que la compagnie a des candidatures nouvelles, à l'étude, en attente, ou non.

### Comment ? 

AJout d'une variable de contexte pour dénombrer les candidatures dans l'un des états `pending_states` avant application des filtres

### Captures d'écran

Compagnie avec des `pending_states applications`
![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/6d1a7df8-eff7-449f-bf00-b02890555237)

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/6142aba4-6956-4bff-bffd-76326d9d479a)

Compagnie sans `pending_states application`

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/c469137f-f16c-44d0-8858-cd33eb847d35)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
