### PR TITLE
Embauche : masquer l'alerte sur le Pass expiré lors du dépot de candidature [GEN-7451]

### DIFF
--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -35,7 +35,7 @@ Arguments:
         {% else %}
             Numéro d'agrément :
         {% endif %}
-        {% if user.is_employer and hiring_pending %}
+        {% if user.is_employer and common_approval.is_in_waiting_period and common_approval.user.has_valid_diagnosis %}
             {% comment %}
             If the PASS IAE number is displayed at this time, some employers think that there is
             no need to validate the application because a number is already assigned.
@@ -74,25 +74,26 @@ Arguments:
             {% endif %}
         </ul>
     {% elif common_approval.is_in_waiting_period %}
-        <p class="text-danger">
-            <b>Expiré</b> le {{ common_approval.end_at|date:"d/m/Y" }} (depuis {{ common_approval.end_at|timesince }})
-        </p>
-
-        {% if user.is_employer %}
-            {% if hiring_pending and job_application.get_eligibility_diagnosis.is_valid %}
-                {% comment %}
+        {% if user.is_employer and common_approval.user.has_valid_diagnosis %}
+            {% comment %}
             When an authorized prescriber bypasses the waiting period and sends a candidate
             with an "expired" approval, the employer receives the application with the mention
             "expired". He thinks that the hiring is impossible when he just has to validate
             the job application to get a new PASS IAE.
 
             Show a message explaining that.
-                {% endcomment %}
 
-                <p>
-                    <b>Un diagnostic d'éligibilité valide existe pour ce candidat. Vous pouvez obtenir un PASS IAE.</b>
-                </p>
-            {% endif %}
+            vincentporte 12.12.2023 : also considering the case when an employer hiring a candidate
+            with an expired approval, but with a valid diagnosis made by authorized prescriber.
+            {% endcomment %}
+
+            <p>
+                <b>Un diagnostic d'éligibilité valide existe pour ce candidat. Vous pouvez obtenir un PASS IAE.</b>
+            </p>
+        {% else %}
+            <p class="text-danger">
+                <b>Expiré</b> le {{ common_approval.end_at|date:"d/m/Y" }} (depuis {{ common_approval.end_at|timesince }})
+            </p>
         {% endif %}
     {% endif %}
 </div>

--- a/tests/www/approvals_views/__snapshots__/test_includes.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_includes.ambr
@@ -1,0 +1,374 @@
+# serializer version: 1
+# name: TestStatusInclude.test_expired_approval_with_eligibility_diagnosis_for_employer[expired_approval_with_eligibility_diagnosis_for_employer]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              
+              <b>pour obtenir son numéro, vous devez valider l'embauche et demander l'obtention d'un PASS IAE.</b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          
+              
+  
+              <p>
+                  <b>Un diagnostic d'éligibilité valide existe pour ce candidat. Vous pouvez obtenir un PASS IAE.</b>
+              </p>
+          
+      
+  </div>
+  
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_expired_approval_with_eligibility_diagnosis_for_jobseeker[expired_approval_with_eligibility_diagnosis_for_jobseeker]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          
+              <p class="text-danger">
+                  <b>Expiré</b> le 01/01/2022 (depuis 1 semaine, 2 jours)
+              </p>
+          
+      
+  </div>
+  
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_expired_approval_with_eligibility_diagnosis_for_prescriber[expired_approval_with_eligibility_diagnosis_for_prescriber]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          
+              <p class="text-danger">
+                  <b>Expiré</b> le 01/01/2022 (depuis 1 semaine, 2 jours)
+              </p>
+          
+      
+  </div>
+  
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_expired_approval_without_eligibility_diagnosis_for_employer[expired_approval_without_eligibility_diagnosis_for_employer]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          
+              <p class="text-danger">
+                  <b>Expiré</b> le 01/01/2022 (depuis 1 semaine, 2 jours)
+              </p>
+          
+      
+  </div>
+  
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_valid_approval_for_employer[valid_approval_for_employer]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          <p class="mb-1">Date de début : 01/01/2000</p>
+          <ul class="list-unstyled">
+              <li class="h4 mt-4 mb-2">
+                  Nombre de jours restants sur le PASS IAE : 357198 jours
+                  <i class="ri-information-line ri-xl text-info"
+                     data-bs-toggle="tooltip"
+                     title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+              </li>
+  
+              
+  
+              
+                  <li class="pb-2">
+                      Date de fin prévisionnelle : 01/01/3000
+                      <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
+                  </li>
+              
+          </ul>
+      
+  </div>
+  
+  
+      
+      
+          
+      
+  
+      
+      
+          
+      
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_valid_approval_for_prescriber[expired_approval_for_employer]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          <p class="mb-1">Date de début : 01/01/2000</p>
+          <ul class="list-unstyled">
+              <li class="h4 mt-4 mb-2">
+                  Nombre de jours restants sur le PASS IAE : 357198 jours
+                  <i class="ri-information-line ri-xl text-info"
+                     data-bs-toggle="tooltip"
+                     title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+              </li>
+  
+              
+  
+              
+                  <li class="pb-2">
+                      Date de fin prévisionnelle : 01/01/3000
+                      <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
+                  </li>
+              
+          </ul>
+      
+  </div>
+  
+  
+      
+      
+          
+      
+  
+      
+      
+          
+      
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_valid_approval_for_prescriber[valid_approval_for_prescriber]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <p class="text-center">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" alt="Logo du PASS IAE">
+          
+      </p>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          <p class="mb-1">Date de début : 01/01/2000</p>
+          <ul class="list-unstyled">
+              <li class="h4 mt-4 mb-2">
+                  Nombre de jours restants sur le PASS IAE : 357198 jours
+                  <i class="ri-information-line ri-xl text-info"
+                     data-bs-toggle="tooltip"
+                     title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+              </li>
+  
+              
+  
+              
+                  <li class="pb-2">
+                      Date de fin prévisionnelle : 01/01/3000
+                      <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
+                  </li>
+              
+          </ul>
+      
+  </div>
+  
+  
+      
+      
+          
+      
+  
+      
+      
+          
+      
+  
+  
+  '''
+# ---

--- a/tests/www/approvals_views/test_includes.py
+++ b/tests/www/approvals_views/test_includes.py
@@ -1,0 +1,90 @@
+import datetime
+
+import pytest  # noqa
+from django.template import Context, Template
+from freezegun import freeze_time
+
+from tests.approvals.factories import ApprovalFactory
+from tests.eligibility.factories import EligibilityDiagnosisFactory
+from tests.users.factories import EmployerFactory, PrescriberFactory
+
+
+@freeze_time("2022-01-10")
+class TestStatusInclude:
+    def test_valid_approval_for_employer(self, snapshot, db):
+        context = Context(
+            {
+                "common_approval": ApprovalFactory(for_snapshot=True),
+                "user": EmployerFactory(),
+                "hiring_pending": False,
+                "job_application": None,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert rendered_template == snapshot(name="valid_approval_for_employer")
+
+    def test_valid_approval_for_prescriber(self, snapshot, db):
+        context = Context(
+            {
+                "common_approval": ApprovalFactory(for_snapshot=True),
+                "user": PrescriberFactory(),
+                "hiring_pending": False,
+                "job_application": None,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert rendered_template == snapshot(name="valid_approval_for_prescriber")
+
+    def test_expired_approval_without_eligibility_diagnosis_for_employer(self, snapshot, db):
+        context = Context(
+            {
+                "common_approval": ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1)),
+                "user": EmployerFactory(),
+                "hiring_pending": False,
+                "job_application": None,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert rendered_template == snapshot(name="expired_approval_without_eligibility_diagnosis_for_employer")
+
+    def test_expired_approval_with_eligibility_diagnosis_for_employer(self, snapshot, db):
+        approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
+        approval.eligibility_diagnosis = EligibilityDiagnosisFactory(job_seeker=approval.user)
+        context = Context(
+            {
+                "common_approval": approval,
+                "user": EmployerFactory(),
+                "hiring_pending": False,
+                "job_application": None,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert rendered_template == snapshot(name="expired_approval_with_eligibility_diagnosis_for_employer")
+
+    def test_expired_approval_with_eligibility_diagnosis_for_prescriber(self, snapshot, db):
+        approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
+        approval.eligibility_diagnosis = EligibilityDiagnosisFactory(job_seeker=approval.user)
+        context = Context(
+            {
+                "common_approval": approval,
+                "user": PrescriberFactory(),
+                "hiring_pending": False,
+                "job_application": None,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert rendered_template == snapshot(name="expired_approval_with_eligibility_diagnosis_for_prescriber")
+
+    def test_expired_approval_with_eligibility_diagnosis_for_jobseeker(self, snapshot, db):
+        approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
+        approval.eligibility_diagnosis = EligibilityDiagnosisFactory(job_seeker=approval.user)
+        context = Context(
+            {
+                "common_approval": approval,
+                "user": approval.user,
+                "hiring_pending": False,
+                "job_application": None,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert rendered_template == snapshot(name="expired_approval_with_eligibility_diagnosis_for_jobseeker")


### PR DESCRIPTION
### Pourquoi ?

Ne pas afficher l'alerte sur le Pass expiré si le candidat a un diagnostique d'éligibilité valide et fait par un prescripteur, lors de la déclaration d'embauche

### Comment ? 

Mise à jour du gabarit `approvals/includes/status.html`


### Captures d'écran 

`check-infos`
![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/27aaa389-b3e5-4029-b10a-0d6d8ad87895)

`check-previous-application`
![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/21ee73d4-96be-4596-97c7-fa65e328ac4a)

`confirm`
![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/bbe4f22e-8180-4484-80e8-6c6a3fa3f0b6)

> [!NOTE]
> le cas des diagnostiques réalisés par un employeur est déjà géré par ailleurs. Contrôle inutile dans l'include
>  ![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/a517c3e6-b80c-44c0-a76a-406b8547dacd)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
