### PR TITLE
[GEN-7294] Modifier la règle d’affichage de la liste des organisations conventionnées pour les admin d’un CD

### DIFF
--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -42,7 +42,7 @@ class PrescriberOrganizationManager(models.Manager):
         Returns organizations accredited by the given organization.
         """
         if org.kind == PrescriberOrganizationKind.DEPT and org.is_authorized:
-            return self.filter(department=org.department, is_brsa=True)
+            return self.filter(department=org.department, is_brsa=True, is_authorized=True)
         return self.none()
 
     def create_organization(self, attributes):

--- a/tests/www/prescribers_views/test_list.py
+++ b/tests/www/prescribers_views/test_list.py
@@ -34,6 +34,11 @@ def test_list_accredited_organizations(client):
         kind=PrescriberOrganizationKind.OTHER,
         is_brsa=True,
     )
+    non_authorized_org = PrescriberOrganizationFactory(
+        department=organization.department,
+        kind=PrescriberOrganizationKind.OTHER,
+        is_brsa=True,
+    )
     authorized_but_not_brsa_org = PrescriberOrganizationFactory(
         authorized=True,
         department=organization.department,
@@ -44,6 +49,7 @@ def test_list_accredited_organizations(client):
     response = client.get(reverse("prescribers_views:list_accredited_organizations"))
     assertContains(response, accredited_org.display_name)
     assertNotContains(response, accredited_org_from_other_department.display_name)
+    assertNotContains(response, non_authorized_org.display_name)
     assertNotContains(response, authorized_but_not_brsa_org.display_name)
 
 


### PR DESCRIPTION
### Pourquoi ?

La règle actuelle ne convient pas.
