### PR TITLE
Fiches salarié : Utiliser la même clause d’unicité que l’ASP [GEN-7786]

### DIFF
--- a/itou/api/c4_api/serializers.py
+++ b/itou/api/c4_api/serializers.py
@@ -74,7 +74,7 @@ class C4CompanySerializer(serializers.ModelSerializer):
             # for this asp_id on another siae : use the oldest.
             a_parent_siae = (
                 Company.objects.exclude(source=Company.SOURCE_USER_CREATED)
-                .filter(convention__asp_id=obj.asp_id)
+                .filter(convention=obj.convention, siret__startswith=obj.siren)
                 .order_by("created_at", "pk")
                 .first()
             )

--- a/itou/api/data_inclusion_api/serializers.py
+++ b/itou/api/data_inclusion_api/serializers.py
@@ -84,7 +84,7 @@ class CompanySerializer(serializers.ModelSerializer):
             # for this asp_id on another siae : use the oldest.
             a_parent_siae = (
                 Company.objects.exclude(source=Company.SOURCE_USER_CREATED)
-                .filter(convention__asp_id=obj.asp_id)
+                .filter(convention=obj.convention, siret__startswith=obj.siren)
                 .order_by("created_at", "pk")
                 .first()
             )

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -139,7 +139,7 @@ class Command(BaseCommand):
         ):
             assert siae.should_have_convention
 
-            asp_id = siae.asp_id
+            asp_id = siae.convention.asp_id
             row = ASP_ID_TO_SIAE_ROW.get(asp_id)
 
             if row is None:

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -309,12 +309,6 @@ class Company(AddressMixin, OrganizationAbstract):
         return self.convention and self.convention.is_active
 
     @property
-    def asp_id(self):
-        if self.convention:
-            return self.convention.asp_id
-        return None
-
-    @property
     def is_opcs(self):
         return self.kind == CompanyKind.OPCS
 

--- a/itou/employee_record/migrations/0011_clean_orphans_duplicate.py
+++ b/itou/employee_record/migrations/0011_clean_orphans_duplicate.py
@@ -40,5 +40,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(_clean_orphans_duplicate, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(_clean_orphans_duplicate, reverse_code=migrations.RunPython.noop, elidable=True),
     ]

--- a/itou/employee_record/migrations/0012_clean_data_to_change_unique_constraint.py
+++ b/itou/employee_record/migrations/0012_clean_data_to_change_unique_constraint.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+from django.db.models import Count
+
+
+def clean_data(apps, schema_editor):
+    EmployeeRecord = apps.get_model("employee_record", "EmployeeRecord")
+    EmployeeRecordUpdateNotification = apps.get_model("employee_record", "EmployeeRecordUpdateNotification")
+    # Build needed querysets
+    not_unique_approval_numbers = (
+        EmployeeRecord.objects.values("asp_measure", "siret", "approval_number")
+        .annotate(count=Count("pk"))
+        .filter(count__gt=1)
+        .values_list("approval_number", flat=True)
+    )
+    curated_not_unique_objects_qs = EmployeeRecord.objects.filter(
+        # The associated convention is not active anymore,
+        # not doing something smarter to let the constraint failed if needed.
+        siret="37882551700030",
+        asp_id="921",
+        asp_measure="AI_DC",
+        approval_number__in=not_unique_approval_numbers,
+    )
+    linked_notifications_qs = EmployeeRecordUpdateNotification.objects.filter(
+        employee_record__in=curated_not_unique_objects_qs.values("pk")
+    )
+    # Delete the curated employee records and theirs notifications
+    linked_notifications_qs.delete()
+    curated_not_unique_objects_qs.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("employee_record", "0011_clean_orphans_duplicate"),
+    ]
+
+    operations = [
+        migrations.RunPython(clean_data, reverse_code=migrations.RunPython.noop, elidable=True),
+    ]

--- a/itou/employee_record/migrations/0013_change_unique_constraint.py
+++ b/itou/employee_record/migrations/0013_change_unique_constraint.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("employee_record", "0012_clean_data_to_change_unique_constraint"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="employeerecord",
+            name="unique_asp_id_approval_number_asp_measure",
+        ),
+        migrations.AddConstraint(
+            model_name="employeerecord",
+            constraint=models.UniqueConstraint(
+                fields=("asp_measure", "siret", "approval_number"), name="unique_asp_measure_siret_approval_number"
+            ),
+        ),
+    ]

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -189,7 +189,7 @@ class EmployeeRecord(ASPExchangeInformation):
 
     # These fields are duplicated to act as constraint fields on DB level
     approval_number = models.CharField(max_length=12, verbose_name="numéro d'agrément")
-    asp_id = models.PositiveIntegerField(verbose_name="identifiant ASP de la SIAE")
+    asp_id = models.PositiveIntegerField(verbose_name="identifiant ASP de la SIAE")  # TODO(rsebille): Remove it.
     asp_measure = models.CharField(verbose_name="mesure ASP de la SIAE", choices=SiaeMeasure.choices)
 
     # If the SIAE is an "antenna",
@@ -218,15 +218,15 @@ class EmployeeRecord(ASPExchangeInformation):
         verbose_name_plural = "fiches salarié"
         constraints = ASPExchangeInformation.Meta.constraints + [
             models.UniqueConstraint(
-                fields=["asp_id", "approval_number", "asp_measure"],
-                name="unique_asp_id_approval_number_asp_measure",
+                fields=["asp_measure", "siret", "approval_number"],
+                name="unique_asp_measure_siret_approval_number",
             ),
         ]
 
     def __str__(self):
         return (
             f"PK:{self.pk} PASS:{self.approval_number} SIRET:{self.siret} JA:{self.job_application} "
-            f"JOBSEEKER:{self.job_seeker} STATUS:{self.status} ASP_ID:{self.asp_id}"
+            f"JOBSEEKER:{self.job_seeker} STATUS:{self.status}"
         )
 
     def _clean_job_application(self):

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -43,7 +43,7 @@
   Preflight activated, checking for possible serialization errors...
   Found 1 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 1 objects)
-  ERROR: serialization of PK:42 PASS: SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan MARTINEZ — email@example.com STATUS:READY ASP_ID:21 failed!
+  ERROR: serialization of PK:42 PASS: SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan MARTINEZ — email@example.com STATUS:READY failed!
   > Got AttributeError when attempting to get a value for field `passDateDeb` on serializer `_PersonSerializer`.
   > The serializer field might be named incorrectly and not match any attribute or key on the `EmployeeRecord` instance.
   > Original exception text was: 'NoneType' object has no attribute 'start_at'.

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -515,7 +515,7 @@ class EmployeeRecordLifeCycleTest(TestCase):
         old_company = self.employee_record.job_application.to_company
 
         assert self.employee_record.siret == old_company.siret
-        assert self.employee_record.asp_id == old_company.asp_id
+        assert self.employee_record.asp_id == old_company.convention.asp_id
 
         self.employee_record.update_as_sent(self.faker.unique.asp_batch_filename(), 1, None)
         self.employee_record.update_as_processed("", "", None)
@@ -529,7 +529,7 @@ class EmployeeRecordLifeCycleTest(TestCase):
         self.employee_record.update_as_new()
 
         assert self.employee_record.siret == new_company.siret
-        assert self.employee_record.asp_id == new_company.asp_id
+        assert self.employee_record.asp_id == new_company.convention.asp_id
 
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -618,7 +618,7 @@ class TestEmployeeRecordQueryset:
 
         assert EmployeeRecord.objects.asp_duplicates().count() == 1
 
-    def test_for_siae(self):
+    def test_for_company(self):
         employee_record_1, employee_record_2 = EmployeeRecordFactory.create_batch(2)
 
         assert (
@@ -627,13 +627,6 @@ class TestEmployeeRecordQueryset:
         assert (
             EmployeeRecord.objects.for_company(employee_record_2.job_application.to_company).get() == employee_record_2
         )
-
-    def test_for_siae_with_different_asp_id(self):
-        employee_record = EmployeeRecordFactory(asp_id=0)
-
-        assert list(EmployeeRecord.objects.for_company(employee_record.job_application.to_company)) == [
-            employee_record
-        ]
 
 
 @pytest.mark.parametrize("factory", [BareEmployeeRecordFactory, BareEmployeeRecordUpdateNotificationFactory])

--- a/tests/job_applications/test_eligibility.py
+++ b/tests/job_applications/test_eligibility.py
@@ -102,14 +102,6 @@ def test_existing_new_employee_records():
     ]
 
 
-def test_existing_new_employee_records_are_eligible_with_a_different_asp_id():
-    employee_record = EmployeeRecordWithProfileFactory(status=er_enums.Status.NEW, asp_id=0)
-
-    assert list(JobApplication.objects.eligible_as_employee_record(employee_record.job_application.to_company)) == [
-        employee_record.job_application
-    ]
-
-
 @pytest.mark.parametrize("field", ["asp_measure", "siret", "approval_number"])
 def test_existing_new_employee_records_are_eligible_with_a_different_value_for_field(field):
     employee_record = EmployeeRecordWithProfileFactory(status=er_enums.Status.NEW, **{field: ""})

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -601,7 +601,7 @@ class CreateEmployeeRecordStep4Test(AbstractCreateEmployeeRecordTest):
 
     def test_retrieved_employee_record_is_the_most_recent_one(self):
         older_employee_record = EmployeeRecordFactory(
-            asp_id=0,
+            siret="00000000000000",
             job_application=self.job_application,
             created_at=self.faker.date_time(end_datetime="-1d", tzinfo=datetime.UTC),
         )
@@ -650,7 +650,7 @@ class CreateEmployeeRecordStep5Test(AbstractCreateEmployeeRecordTest):
 
     def test_retrieved_employee_record_is_the_most_recent_one(self):
         older_employee_record = EmployeeRecordFactory(
-            asp_id=0,
+            siret="00000000000000",
             job_application=self.job_application,
             created_at=self.faker.date_time(end_datetime="-1d", tzinfo=datetime.UTC),
         )


### PR DESCRIPTION
> [!IMPORTANT]  
> A relire et déployer après #3500 (et donc #3509 ainsi que #3499).

### Pourquoi ?

La clause d’unicité utilisée par l’ASP est : Siret + Mesure + PASS IAE
Notre clause d’unicité est : ASP ID + Mesure + PASS IAE

Empêche la création d’une FS pour : 1 ASP ID, plusieurs Siret

### Comment ? <!-- optionnel -->

Changement de la clause d'unicité.
2 SIAE ont des données non-compatible avec la nouvelle clause :
- J'en ai corrigé 1 à la main car seulement 1 FS et celle-ci étaient `ARCHIVED` car orpheline.
- La seconde est corrigée dans une migration en supprimant les (24) FS en doublons et qui sont associées à une SIAE avec une convention expirées suite à son changement d'ASP ID.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
