### PR TITLE
docker : Ne plus utiliser le nom de venv par défaut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,7 +71,7 @@ coverage.xml
 .env
 
 # virtualenv
-.venv
+.venv*
 venv/
 ENV/
 Pipfile*

--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -2,3 +2,6 @@
 
 ## 2023-11-16
 - Renommage SIAE en Company dans tout le code non spécifique à l'IAE. De nombreux modèles et champs ont été renommés (avec migrations et renommage en base de données) et des urls ont changé. Voir les PR commençant par « Renommage Siae ».
+
+## 2023-12-18
+- Déplacement du _virtual env_ utilisé par le container de `.venv` à `.venv-docker`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - PYTHONPATH=.
       - ITOU_LOG_LEVEL=DEBUG
       - CELLAR_ADDON_HOST=minio:9000
+      - VIRTUAL_ENV=/app/.venv-docker
     depends_on:
       - postgres
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - PGPASSWORD=password
       - PYTHONPATH=.
       - ITOU_LOG_LEVEL=DEBUG
+      - ITOU_CACHE=/app/.cache
       - CELLAR_ADDON_HOST=minio:9000
       - VIRTUAL_ENV=/app/.venv-docker
     depends_on:

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -45,7 +45,9 @@ RUN apt-get update && apt-get install -y \
 # Add new user to run the whole thing as non-root.
 RUN set -ex \
     && addgroup $APP_USER \
-    && adduser --ingroup $APP_USER --home $APP_DIR --disabled-password $APP_USER;
+    && adduser --ingroup $APP_USER --home /home --disabled-password $APP_USER;
+
+RUN echo '. "$VIRTUAL_ENV"/bin/activate' >> /home/.bashrc
 
 # Setup the entrypoint
 COPY --chown=$APP_USER:$APP_USER --chmod=755 ./docker/dev/django/entrypoint.sh /entrypoint.sh

--- a/docker/dev/django/entrypoint.sh
+++ b/docker/dev/django/entrypoint.sh
@@ -13,7 +13,8 @@ done
 # tail -f /dev/null & wait
 
 make venv
-. .venv/bin/activate
+# shellcheck source=/dev/null
+. "$VIRTUAL_ENV"/bin/activate
 ./manage.py migrate
 ./manage.py runserver 0.0.0.0:8000
 


### PR DESCRIPTION
### Pourquoi ?

Pour ne plus avoir tout qui explose pour la personne utilisant l'env docker ainsi que le venv en local :).
Activer le venv automatiquement lors du login dans le container.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
