### PR TITLE
Ajout d'une vue d'erreur personnalisée

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from django.views.generic import TemplateView
 from itou.utils import redirect_legacy_views
 from itou.utils.urls import SiretConverter
 from itou.www.dashboard import views as dashboard_views
+from itou.www.error import server_error
 from itou.www.login import views as login_views
 from itou.www.signup import views as signup_views
 
@@ -87,3 +88,6 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     import debug_toolbar
 
     urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+
+
+handler500 = server_error

--- a/itou/templates/500.html
+++ b/itou/templates/500.html
@@ -7,10 +7,9 @@
     <h2>Une erreur technique s'est produite.</h2>
     <p>Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.</p>
 
-    {# Using ITOU_HELP_CENTER_URL would have required a custom error handler. #}
     <p>
         Toutefois, nous vous invitons à contacter
-        <a href="https://aide.emplois.inclusion.beta.gouv.fr/">l'assistance de la Plateforme de l'inclusion</a>
+        <a href="{{ ITOU_HELP_CENTER_URL }}">l'assistance de la Plateforme de l'inclusion</a>
         afin que nous disposions de toutes les informations nécessaires à la résolution du problème.
     </p>
 {% endblock %}

--- a/itou/www/error.py
+++ b/itou/www/error.py
@@ -1,0 +1,27 @@
+from csp.context_processors import nonce
+from django.http import HttpResponseServerError
+from django.template import TemplateDoesNotExist, loader
+from django.views.decorators.csrf import requires_csrf_token
+from django.views.defaults import ERROR_500_TEMPLATE_NAME, ERROR_PAGE_TEMPLATE
+
+from itou.utils.settings_context_processors import expose_settings
+
+
+@requires_csrf_token
+def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
+    try:
+        template = loader.get_template(template_name)
+    except TemplateDoesNotExist:
+        if template_name != ERROR_500_TEMPLATE_NAME:
+            # Reraise if it's a missing custom template.
+            raise
+        return HttpResponseServerError(
+            ERROR_PAGE_TEMPLATE % {"title": "Server Error (500)", "details": ""},
+        )
+    try:
+        # Those two context processors are needed for layout/base.html
+        context = expose_settings(request) | nonce(request)
+    except Exception:
+        # This shouldn't happen, but we really don't want the error page to also crash
+        context = {}
+    return HttpResponseServerError(template.render(context))

--- a/tests/www/test_error.py
+++ b/tests/www/test_error.py
@@ -1,0 +1,39 @@
+import pytest
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.middleware.csrf import CsrfViewMiddleware
+from django.test import RequestFactory
+from django.urls import reverse
+from pytest_django.asserts import assertContains
+
+from itou.www.error import server_error
+from tests.utils.tests import get_response_for_middlewaremixin
+
+
+class FailingForm:
+    def __init__(self):
+        raise Exception("Something bad")
+
+
+def test_error_handling(client, mocker):
+    mocker.patch("itou.www.search.views.SiaeSearchForm", FailingForm)
+
+    # Make sure we get the original exception
+    # and not some "Undefined template variable" in layout/base.html template
+    with pytest.raises(Exception, match="Something bad"):
+        # We use this view and form because:
+        # - it is simple
+        # - we need to be able to patch something inside it to fail
+        client.get(reverse("search:employers_home"))
+
+
+def test_handler500_view():
+    factory = RequestFactory()
+    request = factory.get("/")
+    SessionMiddleware(get_response_for_middlewaremixin).process_request(request)
+    CsrfViewMiddleware(get_response_for_middlewaremixin).process_request(request)
+    response = server_error(request)
+    assertContains(
+        response,
+        "Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.",
+        status_code=500,
+    )

--- a/tests/www/test_error.py
+++ b/tests/www/test_error.py
@@ -5,6 +5,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 
+from itou.utils import constants as global_constants
 from itou.www.error import server_error
 from tests.utils.tests import get_response_for_middlewaremixin
 
@@ -37,3 +38,4 @@ def test_handler500_view():
         "Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.",
         status_code=500,
     )
+    assertContains(response, global_constants.ITOU_HELP_CENTER_URL, status_code=500)


### PR DESCRIPTION
### Pourquoi ?

- cela nous permet d'avoir une page d'erreur complète avec:
  - des meta remplies
  - le JS qui fonctionne (matomo & tarteaucitron)
  - le lien "Besoin d'aide" qui fonctionne
- et surtout pour les devs cela permet d'avoir le test qui dit pourquoi il échoue et non plus `Undefined template variable 'ITOU_PROTOCOL' in '.../itou/templates/layout/base.html'`
