### PR TITLE
[GEN-7755] Lancement de ShellCheck dans pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
         entry: djlint --reformat
         types: [html]
         language: system
+      - id: shellcheck
+        name: ShellCheck
+        entry: shellcheck
+        types: [shell]
+        language: system

--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -5,3 +5,4 @@
 
 ## 2023-12-18
 - Déplacement du _virtual env_ utilisé par le container de `.venv` à `.venv-docker`.
+- Ajout de ShellCheck à la configuration de pre-commit.


### PR DESCRIPTION
### Pourquoi ?

Il est lancé dans la CI mais pas en local. C'est dommage car cela permettrait de repérer les erreurs en amont.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
