### PR TITLE
tests: Forcer le paramètre de configuration `METABASE_HASH_SALT`

### DIFF
--- a/tests/metabase/conftest.py
+++ b/tests/metabase/conftest.py
@@ -12,7 +12,7 @@ from itou.metabase.tables.utils import (
 
 
 @pytest.fixture(name="metabase")
-def metabase_fixture(monkeypatch):
+def metabase_fixture(monkeypatch, settings):
     class FakeMetabase:
         """
         This fake metabase database allows us to benefit from all
@@ -39,6 +39,9 @@ def metabase_fixture(monkeypatch):
 
     monkeypatch.setattr(dataframes, "MetabaseDatabaseCursor", FakeMetabase)
     monkeypatch.setattr(db, "MetabaseDatabaseCursor", FakeMetabase)
+    # This setting need to be editable in `dev` to manually test transferring data from "les emplois" to "pilotage",
+    # but the one used in `test` should be fixed, `dev` inheriting from `test` we can't put it in settings.
+    monkeypatch.setattr(settings, "METABASE_HASH_SALT", None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Pourquoi ?

Pouvoir lancer `populate_metabase_emplois` et la suite de tests sans avoir à modifier son `.env` à chaque fois :).

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
