### PR TITLE
tests: clairement spécifier quand un test nécessite que le demandeur d'emploi ait un identifiant pole emploi

### DIFF
--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -318,7 +318,7 @@ class ApprovalModelTest(TestCase):
 
         # With an existing valid `PoleEmploiApproval`.
 
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(with_pole_emploi_id=True)
         job_application = JobApplicationFactory(job_seeker=user)
         valid_pe_approval = PoleEmploiApprovalFactory(
             pole_emploi_id=user.pole_emploi_id,
@@ -747,7 +747,7 @@ class PoleEmploiApprovalManagerTest(TestCase):
 
     def test_find_for_user(self):
         # given a User, ensure we can find a PE approval using its pole_emploi_id and not the others.
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(with_pole_emploi_id=True)
         pe_approval = PoleEmploiApprovalFactory(pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate)
         # just another approval, to be sure we don't find the other one "by chance"
         PoleEmploiApprovalFactory()

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -43,7 +43,7 @@ class EligibilityDiagnosisQuerySetTest(TestCase):
 class EligibilityDiagnosisManagerTest(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.job_seeker = JobSeekerFactory()
+        cls.job_seeker = JobSeekerFactory(with_pole_emploi_id=True)
 
     def test_no_diagnosis(self):
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self.job_seeker)

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1167,7 +1167,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         When a job seeker's application is accepted, the others are marked obsolete.
         """
-        job_seeker = JobSeekerFactory()
+        job_seeker = JobSeekerFactory(with_pole_emploi_id=True)
         # A valid Pôle emploi ID should trigger an automatic approval delivery.
         assert job_seeker.pole_emploi_id != ""
 
@@ -1237,7 +1237,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         When a Pôle emploi approval already exists, it is reused.
         """
-        job_seeker = JobSeekerFactory()
+        job_seeker = JobSeekerFactory(with_pole_emploi_id=True)
         pe_approval = PoleEmploiApprovalFactory(
             pole_emploi_id=job_seeker.pole_emploi_id, birthdate=job_seeker.birthdate
         )
@@ -1327,6 +1327,7 @@ class JobApplicationWorkflowTest(TestCase):
     def test_accept_job_application_sent_by_job_seeker_with_a_pole_emploi_id_no_pe_approval(self):
         job_seeker = JobSeekerFactory(
             nir="",
+            with_pole_emploi_id=True,
         )
         job_application = JobApplicationSentByJobSeekerFactory(
             job_seeker=job_seeker,
@@ -1366,6 +1367,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         job_application = JobApplicationSentByPrescriberOrganizationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING,
+            job_seeker__with_pole_emploi_id=True,
         )
         # A valid Pôle emploi ID should trigger an automatic approval delivery.
         assert job_application.job_seeker.pole_emploi_id != ""
@@ -1396,6 +1398,7 @@ class JobApplicationWorkflowTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             state=JobApplicationWorkflow.STATE_PROCESSING,
+            job_seeker__with_pole_emploi_id=True,
         )
         # A valid Pôle emploi ID should trigger an automatic approval delivery.
         assert job_application.job_seeker.pole_emploi_id != ""
@@ -1424,7 +1427,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         An authorized prescriber can bypass the waiting period.
         """
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(with_pole_emploi_id=True)
         # Ended 1 year ago.
         end_at = datetime.date.today() - relativedelta(years=1)
         start_at = end_at - relativedelta(years=2)
@@ -1520,7 +1523,10 @@ class JobApplicationWorkflowTest(TestCase):
         Basically the same as the 'accept' part, except we don't create an approval
         and we don't notify
         """
-        job_application = JobApplicationWithoutApprovalFactory(state=JobApplicationWorkflow.STATE_PROCESSING)
+        job_application = JobApplicationWithoutApprovalFactory(
+            state=JobApplicationWorkflow.STATE_PROCESSING,
+            job_seeker__with_pole_emploi_id=True,
+        )
         # A valid Pôle emploi ID should trigger an automatic approval delivery.
         assert job_application.job_seeker.pole_emploi_id != ""
         job_application.accept(user=job_application.to_company.members.first())
@@ -1565,6 +1571,7 @@ class JobApplicationWorkflowTest(TestCase):
             state=JobApplicationWorkflow.STATE_PROCESSING,
             to_company__kind=CompanyKind.EI,
             eligibility_diagnosis=None,
+            job_seeker__with_pole_emploi_id=True,
         )
 
         to_company = job_application.to_company

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -155,6 +155,7 @@ def test_populate_job_seekers():
         nir="271049232724647",
         geocoding_score=1,
         coords=Point(0, 0),  # QPV utils is mocked
+        with_pole_emploi_id=True,
     )
     job_application_2 = JobApplicationFactory(
         with_approval=True,
@@ -172,6 +173,7 @@ def test_populate_job_seekers():
     user_3 = JobSeekerFactory(
         pk=26587,
         nir="297016314515713",
+        with_pole_emploi_id=True,
     )
     job_application_3 = JobApplicationFactory(
         job_seeker=user_3,

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -119,7 +119,6 @@ class LaborInspectorFactory(UserFactory):
 class JobSeekerFactory(UserFactory):
     title = random.choice(Title.values)
     kind = UserKind.JOB_SEEKER
-    pole_emploi_id = factory.fuzzy.FuzzyText(length=8, chars=string.digits)
 
     class Params:
         # Reminder : ASP models are "read-only", they must not be saved.
@@ -134,6 +133,7 @@ class JobSeekerFactory(UserFactory):
             with_birth_place=True,
             jobseeker_profile__birth_country=factory.SubFactory(CountryFranceFactory),
         )
+        with_pole_emploi_id = factory.Trait(pole_emploi_id=factory.fuzzy.FuzzyText(length=8, chars=string.digits))
 
     @factory.lazy_attribute
     def nir(self):

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -945,7 +945,7 @@ def user_with_approval_in_waiting_period():
 class LatestApprovalTestCase(TestCase):
     @freezegun.freeze_time("2022-08-10")
     def test_merge_approvals_timeline_case1(self):
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(with_pole_emploi_id=True)
 
         ApprovalFactory(
             user=user,
@@ -978,7 +978,7 @@ class LatestApprovalTestCase(TestCase):
 
     @freezegun.freeze_time("2022-08-10")
     def test_merge_approvals_timeline_case2(self):
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(with_pole_emploi_id=True)
 
         # PoleEmploiApproval 1.
         PoleEmploiApprovalFactory(
@@ -1065,7 +1065,7 @@ class LatestApprovalTestCase(TestCase):
         assert user.latest_approval is None
 
     def test_status_with_valid_pole_emploi_approval(self):
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(with_pole_emploi_id=True)
         pe_approval = PoleEmploiApprovalFactory(pole_emploi_id=user.pole_emploi_id, birthdate=user.birthdate)
         assert not user.has_no_common_approval
         assert user.has_valid_common_approval

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -473,7 +473,7 @@ class ProcessViewsTest(TestCase):
         city = self.get_random_city()
         today = timezone.localdate()
 
-        job_seeker = JobSeekerWithAddressFactory(city=city.name)
+        job_seeker = JobSeekerWithAddressFactory(city=city.name, with_pole_emploi_id=True)
         address = {
             "address_line_1": job_seeker.address_line_1,
             "post_code": job_seeker.post_code,
@@ -640,7 +640,7 @@ class ProcessViewsTest(TestCase):
         city = self.get_random_city()
         today = timezone.localdate()
         # the old job of job seeker
-        job_seeker_user = JobSeekerWithAddressFactory()
+        job_seeker_user = JobSeekerWithAddressFactory(with_pole_emploi_id=True)
         old_job_application = JobApplicationFactory(
             with_approval=True,
             job_seeker=job_seeker_user,
@@ -741,7 +741,7 @@ class ProcessViewsTest(TestCase):
 
     def test_accept_and_update_hiring_start_date_of_two_job_applications(self, *args, **kwargs):
         city = self.get_random_city()
-        job_seeker = JobSeekerWithAddressFactory()
+        job_seeker = JobSeekerWithAddressFactory(with_pole_emploi_id=True)
         base_for_post_data = {
             "address_line_1": job_seeker.address_line_1,
             "post_code": job_seeker.post_code,
@@ -841,7 +841,7 @@ class ProcessViewsTest(TestCase):
         city = self.get_random_city()
 
         company = CompanyFactory(with_membership=True)
-        job_seeker = JobSeekerWithAddressFactory(city=city.name)
+        job_seeker = JobSeekerWithAddressFactory(city=city.name, with_pole_emploi_id=True)
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING,
             job_seeker=job_seeker,
@@ -923,6 +923,7 @@ class ProcessViewsTest(TestCase):
         job_application = JobApplicationSentByJobSeekerFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING,
             job_seeker__nir="",
+            job_seeker__with_pole_emploi_id=True,
         )
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
@@ -975,6 +976,7 @@ class ProcessViewsTest(TestCase):
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING,
             job_seeker__nir="",
+            job_seeker__with_pole_emploi_id=True,
         )
         other_job_seeker = JobSeekerWithAddressFactory()
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
@@ -1015,6 +1017,7 @@ class ProcessViewsTest(TestCase):
         job_application = JobApplicationSentByJobSeekerFactory(
             state=JobApplicationWorkflow.STATE_PROCESSING,
             job_seeker__nir="",
+            job_seeker__with_pole_emploi_id=True,
         )
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
@@ -1058,6 +1061,7 @@ class ProcessViewsTest(TestCase):
             state=JobApplicationWorkflow.STATE_PROCESSING,
             job_seeker__nir="",
             job_seeker__lack_of_nir_reason=LackOfNIRReason.TEMPORARY_NUMBER,
+            job_seeker__with_pole_emploi_id=True,
         )
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
@@ -1317,7 +1321,7 @@ class ProcessViewsTest(TestCase):
         # A canceled job application is not linked to an approval
         # unless the job seeker has an accepted job application.
         city = self.get_random_city()
-        job_seeker = JobSeekerWithAddressFactory(city=city.name)
+        job_seeker = JobSeekerWithAddressFactory(city=city.name, with_pole_emploi_id=True)
         job_application = JobApplicationFactory(
             state=JobApplicationWorkflow.STATE_CANCELLED,
             job_seeker=job_seeker,

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -478,7 +478,7 @@ class ApplyAsJobSeekerTest(TestCase):
         """
         company = CompanyWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
 
-        user = JobSeekerFactory(nir="")
+        user = JobSeekerFactory(nir="", with_pole_emploi_id=True)
         self.client.force_login(user)
 
         # Entry point.
@@ -1572,7 +1572,7 @@ class ApplyAsPrescriberNirExceptionsTest(TestCase):
         This NIR account is empty.
         An update is expected.
         """
-        job_seeker = JobSeekerFactory(nir="")
+        job_seeker = JobSeekerFactory(nir="", with_pole_emploi_id=True)
         # Create an approval to bypass the eligibility diagnosis step.
         PoleEmploiApprovalFactory(birthdate=job_seeker.birthdate, pole_emploi_id=job_seeker.pole_emploi_id)
         company, user = self.create_test_data()
@@ -1637,7 +1637,11 @@ class ApplyAsPrescriberNirExceptionsTest(TestCase):
         assert job_seeker.nir == nir
 
     def test_one_account_lack_of_nir_reason(self):
-        job_seeker = JobSeekerFactory(nir="", lack_of_nir_reason=LackOfNIRReason.TEMPORARY_NUMBER)
+        job_seeker = JobSeekerFactory(
+            nir="",
+            lack_of_nir_reason=LackOfNIRReason.TEMPORARY_NUMBER,
+            with_pole_emploi_id=True,
+        )
         # Create an approval to bypass the eligibility diagnosis step.
         PoleEmploiApprovalFactory(birthdate=job_seeker.birthdate, pole_emploi_id=job_seeker.pole_emploi_id)
         siae, user = self.create_test_data()
@@ -3994,7 +3998,7 @@ class GEIQEligibilityForHireTestCase(TestCase):
 class HireConfirmationTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.job_seeker = JobSeekerWithAddressFactory(first_name="Clara", last_name="Sion")
+        cls.job_seeker = JobSeekerWithAddressFactory(first_name="Clara", last_name="Sion", with_pole_emploi_id=True)
         [cls.city] = create_test_cities(["67"], num_per_department=1)
 
     def _reverse(self, view_name):

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -420,7 +420,7 @@ class CreateEmployeeRecordStep3Test(AbstractCreateEmployeeRecordTest):
         super().setUp()
         self.job_application = JobApplicationWithApprovalNotCancellableFactory(
             to_company=self.company,
-            job_seeker=JobSeekerWithMockedAddressFactory(born_in_france=True),
+            job_seeker=JobSeekerWithMockedAddressFactory(born_in_france=True, with_pole_emploi_id=True),
         )
         self.job_seeker = self.job_application.job_seeker
         self.url = reverse("employee_record_views:create_step_3", args=(self.job_application.id,))


### PR DESCRIPTION
### Pourquoi ?

Plutôt que reposer sur le comportement par défaut de la factory.

Et cela me permettra de faire une transition plus douce (et une PR plus courte) lors de la bascule des champs `pole_emploi_id` / `lack_of_pole_emploi_id_reason`  du modèle `User` au modèle `JobSeekerProfile`.
