### PR TITLE
[Boost] Ajout du guide a la prescription dans la navigation pour les employeurs et les PH [GEN-3635]

### DIFF
--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -1,4 +1,5 @@
 {% load redirection_fields %}
+{% load matomo %}
 
 <ul>
     <li class="dropdown">
@@ -30,6 +31,18 @@
                        data-matomo-action="clic"
                        data-matomo-option="header_comprendre-liae">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
                 </li>
+                {% if user.is_authenticated %}
+                    {% if user.is_employer or user.is_prescriber_with_authorized_org %}
+                        <li>
+                            <a href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite"
+                               rel="noopener"
+                               class="dropdown-item has-external-link matomo-event"
+                               target="_blank"
+                               aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)"
+                               {% matomo_event "help" "clic" "header_prescrire-parcours-iae-guide" %}>Prescrire un parcours IAE (guide pratique)</a>
+                        </li>
+                    {% endif %}
+                {% endif %}
             </ul>
         </div>
     </li>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -1,0 +1,538 @@
+# serializer version: 1
+# name: test_navigation_authenticated[AuthorizedPrescriber]
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          
+  
+          <li class="dropdown">
+              <button aria-controls="dashboardUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">
+                  Mon espace
+              </button>
+              <div class="dropdown-menu" id="dashboardUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <div class="dropdown-item">
+                              <div class="d-flex align-items-center">
+                                  <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+                                  <div class="flex-grow-1 ms-2 lh-sm">
+                                      
+                                          <span>John DOE</span>
+                                          <br/>
+                                      
+                                      <span class="fs-sm lh-sm text-muted">john.doe@example.com</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </li>
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      
+                      <li>
+                          <form action="/accounts/logout/" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <button class="dropdown-item text-danger">Déconnexion</button>
+                          </form>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---
+# name: test_navigation_authenticated[Employer]
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          
+  
+          <li class="dropdown">
+              <button aria-controls="dashboardUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">
+                  Mon espace
+              </button>
+              <div class="dropdown-menu" id="dashboardUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <div class="dropdown-item">
+                              <div class="d-flex align-items-center">
+                                  <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+                                  <div class="flex-grow-1 ms-2 lh-sm">
+                                      
+                                          <span>John DOE</span>
+                                          <br/>
+                                      
+                                      <span class="fs-sm lh-sm text-muted">john.doe@example.com</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </li>
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
+                      </li>
+                      
+                          <li>
+                              <a class="dropdown-item" href="/dashboard/edit_user_notifications">Mes notifications</a>
+                          </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      
+                          <li>
+                              <a class="dropdown-item text-primary" href="/dashboard/token_api">Accès aux APIs</a>
+                          </li>
+                          <li>
+                              <div class="dropdown-divider"></div>
+                          </li>
+                      
+                      <li>
+                          <form action="/accounts/logout/" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <button class="dropdown-item text-danger">Déconnexion</button>
+                          </form>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---
+# name: test_navigation_authenticated[JobSeeker]
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          
+  
+          <li class="dropdown">
+              <button aria-controls="dashboardUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">
+                  Mon espace
+              </button>
+              <div class="dropdown-menu" id="dashboardUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <div class="dropdown-item">
+                              <div class="d-flex align-items-center">
+                                  <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+                                  <div class="flex-grow-1 ms-2 lh-sm">
+                                      
+                                          <span>John DOE</span>
+                                          <br/>
+                                      
+                                      <span class="fs-sm lh-sm text-muted">john.doe@example.com</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </li>
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
+                      </li>
+                      
+                          <li>
+                              <a class="dropdown-item" href="/accounts/password/change/">Modifier mon mot de passe</a>
+                          </li>
+                          <li>
+                              <a class="dropdown-item" href="/dashboard/edit_user_email">Modifier mon adresse e-mail</a>
+                          </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      
+                      <li>
+                          <form action="/accounts/logout/" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <button class="dropdown-item text-danger">Déconnexion</button>
+                          </form>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---
+# name: test_navigation_authenticated[LaborInspector]
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          
+  
+          <li class="dropdown">
+              <button aria-controls="dashboardUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">
+                  Mon espace
+              </button>
+              <div class="dropdown-menu" id="dashboardUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <div class="dropdown-item">
+                              <div class="d-flex align-items-center">
+                                  <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+                                  <div class="flex-grow-1 ms-2 lh-sm">
+                                      
+                                          <span>John DOE</span>
+                                          <br/>
+                                      
+                                      <span class="fs-sm lh-sm text-muted">john.doe@example.com</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </li>
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
+                      </li>
+                      
+                          <li>
+                              <a class="dropdown-item" href="/accounts/password/change/">Modifier mon mot de passe</a>
+                          </li>
+                          <li>
+                              <a class="dropdown-item" href="/dashboard/edit_user_email">Modifier mon adresse e-mail</a>
+                          </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      
+                      <li>
+                          <form action="/accounts/logout/" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <button class="dropdown-item text-danger">Déconnexion</button>
+                          </form>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---
+# name: test_navigation_authenticated[PrescriberWithOrganization]
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          
+  
+          <li class="dropdown">
+              <button aria-controls="dashboardUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">
+                  Mon espace
+              </button>
+              <div class="dropdown-menu" id="dashboardUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <div class="dropdown-item">
+                              <div class="d-flex align-items-center">
+                                  <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+                                  <div class="flex-grow-1 ms-2 lh-sm">
+                                      
+                                          <span>John DOE</span>
+                                          <br/>
+                                      
+                                      <span class="fs-sm lh-sm text-muted">john.doe@example.com</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </li>
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      
+                      <li>
+                          <form action="/accounts/logout/" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <button class="dropdown-item text-danger">Déconnexion</button>
+                          </form>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---
+# name: test_navigation_authenticated[PrescriberWithoutOrganization]
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          
+  
+          <li class="dropdown">
+              <button aria-controls="dashboardUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" type="button">
+                  Mon espace
+              </button>
+              <div class="dropdown-menu" id="dashboardUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <div class="dropdown-item">
+                              <div class="d-flex align-items-center">
+                                  <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+                                  <div class="flex-grow-1 ms-2 lh-sm">
+                                      
+                                          <span>John DOE</span>
+                                          <br/>
+                                      
+                                      <span class="fs-sm lh-sm text-muted">john.doe@example.com</span>
+                                  </div>
+                              </div>
+                          </div>
+                      </li>
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
+                      </li>
+                      
+                      <li>
+                          <div class="dropdown-divider"></div>
+                      </li>
+                      
+                      <li>
+                          <form action="/accounts/logout/" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <button class="dropdown-item text-danger">Déconnexion</button>
+                          </form>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---
+# name: test_navigation_not_authenticated
+  '''
+  <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
+                          
+  
+  <ul>
+      <li class="dropdown">
+          <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
+          <div class="dropdown-menu" id="helpDropdown">
+              <ul class="list-unstyled">
+                  <li>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                  </li>
+                  <li>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                  </li>
+              </ul>
+          </div>
+      </li>
+      
+          <li>
+              <a class="btn btn-ico btn-outline-primary" href="/signup/" type="button">
+                  <i aria-hidden="true" class="ri-user-add-line"></i>
+                  <span>S'inscrire</span>
+              </a>
+          </li>
+          <li class="dropdown">
+              <button aria-controls="loginUserDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-icon btn-primary" data-bs-toggle="dropdown">
+                  <i aria-hidden="true" class="ri-login-box-line"></i>
+                  <span>Se connecter</span>
+              </button>
+              <div class="dropdown-menu" id="loginUserDropdown">
+                  <ul class="list-unstyled">
+                      <li>
+                          <a class="dropdown-item" href="/login/job_seeker">
+                              Candidat
+                          </a>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/login/prescriber">
+                              Prescripteur
+                          </a>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/login/employer">
+                              Employeur solidaire
+                          </a>
+                      </li>
+                      <li>
+                          <a class="dropdown-item" href="/login/labor_inspector">
+                              Institution partenaire
+                          </a>
+                      </li>
+                  </ul>
+              </div>
+          </li>
+      
+  </ul>
+  
+                      </nav>
+  '''
+# ---

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -4,6 +4,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -15,6 +16,13 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
+                      
+                          <li>
+                              <a aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_prescrire-parcours-iae-guide" href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite" rel="noopener" target="_blank">Prescrire un parcours IAE (guide pratique)</a>
+                          </li>
+                      
+                  
               </ul>
           </div>
       </li>
@@ -79,6 +87,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -90,6 +99,13 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
+                      
+                          <li>
+                              <a aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_prescrire-parcours-iae-guide" href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite" rel="noopener" target="_blank">Prescrire un parcours IAE (guide pratique)</a>
+                          </li>
+                      
+                  
               </ul>
           </div>
       </li>
@@ -165,6 +181,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -176,6 +193,9 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
+                      
+                  
               </ul>
           </div>
       </li>
@@ -247,6 +267,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -258,6 +279,9 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
+                      
+                  
               </ul>
           </div>
       </li>
@@ -329,6 +353,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -340,6 +365,9 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
+                      
+                  
               </ul>
           </div>
       </li>
@@ -404,6 +432,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -415,6 +444,9 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
+                      
+                  
               </ul>
           </div>
       </li>
@@ -479,6 +511,7 @@
   <nav aria-label="Navigation principale" id="nav-primary" role="navigation">
                           
   
+  
   <ul>
       <li class="dropdown">
           <button aria-controls="helpDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-link dropdown-toggle" data-bs-toggle="dropdown" type="button">Besoin d'aide ?</button>
@@ -490,6 +523,7 @@
                   <li>
                       <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
+                  
               </ul>
           </div>
       </li>

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -46,6 +46,7 @@ def test_list_view(snapshot, client):
         + 1  # check user memberships
         + 1  # fetch prolongation requests rows
         + 1  # count prolongation requests rows (from pager)
+        + 1  # `is_prescriber_with_authorized_org()` in nav
         + 3  # savepoint, update session, release savepoint
     )
     with assertNumQueries(num_queries):

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -583,6 +583,7 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             + 1  # fetch user
             + 1  # fetch user memberships
             + 1  # fetch companies_jobdescription (get_object_or_404)
+            + 1  # `is_prescriber_with_authorized_org()` in nav
             + 1  # fetch companies_jobdescription (others_active_jobs)
             + 3  # update session
         ):

--- a/tests/www/test_layout.py
+++ b/tests/www/test_layout.py
@@ -1,0 +1,35 @@
+from functools import partial
+
+import pytest
+from django.urls import reverse
+
+from tests.users.factories import EmployerFactory, JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
+from tests.utils.test import parse_response_to_soup
+
+
+def test_navigation_not_authenticated(snapshot, client):
+    response = client.get(reverse("home:hp"), follow=True)
+    assert str(parse_response_to_soup(response, "#nav-primary")) == snapshot
+
+
+@pytest.mark.parametrize(
+    "user_factory",
+    [
+        pytest.param(JobSeekerFactory, id="JobSeeker"),
+        pytest.param(partial(EmployerFactory, with_company=True), id="Employer"),
+        pytest.param(partial(LaborInspectorFactory, membership=True), id="LaborInspector"),
+        pytest.param(PrescriberFactory, id="PrescriberWithoutOrganization"),
+        pytest.param(
+            partial(PrescriberFactory, membership__organization__authorized=False),
+            id="PrescriberWithOrganization",
+        ),
+        pytest.param(
+            partial(PrescriberFactory, membership__organization__authorized=True),
+            id="AuthorizedPrescriber",
+        ),
+    ],
+)
+def test_navigation_authenticated(snapshot, client, user_factory):
+    client.force_login(user_factory(for_snapshot=True, email="john.doe@example.com"))
+    response = client.get(reverse("home:hp"), follow=True)
+    assert str(parse_response_to_soup(response, "#nav-primary")) == snapshot


### PR DESCRIPTION
### Pourquoi ?

Ce guide existe et est un outil pour les nouveaux PH qu’il faut leur mettre à dispo au bon endroit

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
