### PR TITLE
[GEN-7796] Admin : Fonction “transfert” des objets puis arriver sur la bonne page

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -591,7 +591,7 @@ class ItouUserAdmin(UserAdmin):
                 return redirect(
                     reverse(
                         "admin:users_user_change",
-                        kwargs={"object_id": to_user.pk},
+                        kwargs={"object_id": from_user.pk},
                     )
                 )
         title = f"Transfert des données de { from_user }"

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -172,7 +172,7 @@ class TestTransferUserData:
         assertContains(response, str(approval))
 
         response = admin_client.post(transfer_url_2, data={"fields_to_transfer": ["job_applications", "approvals"]})
-        assertRedirects(response, reverse("admin:users_user_change", kwargs={"object_id": to_user.pk}))
+        assertRedirects(response, reverse("admin:users_user_change", kwargs={"object_id": from_user.pk}))
 
         job_application.refresh_from_db()
         approval.refresh_from_db()


### PR DESCRIPTION
### Pourquoi ?

Cela correspond plus à l'utilisation effectuée par le support
