### PR TITLE
Modèle `User()` : Vérifier que le lien est actif dans `.is_prescriber_with_authorized_org()` et 2 nettoyages

### DIFF
--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -40,8 +40,11 @@ class JobApplicationAdminForm(forms.ModelForm):
                 # Sender is optional, but if it exists, check its role.
                 if not sender.is_prescriber:
                     raise ValidationError("Emetteur du mauvais type.")
-                # Request organization only if prescriber is linked to organization
-                if sender.is_prescriber_with_org and sender_prescriber_organization is None:
+                # Request organization only if prescriber is actively linked to an organization
+                if (
+                    sender_prescriber_organization is None
+                    and sender.prescribermembership_set.filter(is_active=True).exists()
+                ):
                     raise ValidationError("Organisation du prescripteur émettrice manquante.")
             else:
                 raise ValidationError("Emetteur prescripteur manquant.")

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -592,7 +592,9 @@ class User(AbstractUser, AddressMixin):
     def is_prescriber_with_authorized_org(self):
         return (
             self.is_prescriber
-            and self.prescriberorganization_set.filter(is_authorized=True, members__is_active=True).exists()
+            and self.prescribermembership_set.filter(
+                is_active=True, organization__is_authorized=True, user__is_active=True
+            ).exists()
         )
 
     def is_prescriber_of_authorized_organization(self, organization_id):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -585,10 +585,6 @@ class User(AbstractUser, AddressMixin):
         return False
 
     @cached_property
-    def is_prescriber_with_org(self):
-        return self.is_prescriber and self.prescribermembership_set.filter(is_active=True).exists()
-
-    @cached_property
     def is_prescriber_with_authorized_org(self):
         return (
             self.is_prescriber

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -597,13 +597,6 @@ class User(AbstractUser, AddressMixin):
             ).exists()
         )
 
-    def is_prescriber_of_authorized_organization(self, organization_id):
-        return self.prescriberorganization_set.filter(
-            pk=organization_id,
-            is_authorized=True,
-            prescribermembership__is_active=True,
-        ).exists()
-
     @property
     def has_external_data(self):
         return self.is_job_seeker and hasattr(self, "jobseekerexternaldata")

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1333,3 +1333,16 @@ def test_jobseeker_factory_works_alongside_user_has_data_changed():
     profile = JobSeekerProfile.objects.get(user=js)
     assert profile.pe_obfuscated_nir == "JAIME_LES_CHATS"
     assert profile.pk == js.jobseeker_profile.pk
+
+
+@pytest.mark.parametrize("user_active", [False, True])
+@pytest.mark.parametrize("membership_active", [False, True])
+@pytest.mark.parametrize("organization_authorized", [False, True])
+def test_is_prescriber_with_authorized_org(user_active, membership_active, organization_authorized):
+    prescriber = PrescriberFactory(is_active=user_active)
+    PrescriberMembershipFactory(
+        is_active=membership_active, user=prescriber, organization__is_authorized=organization_authorized
+    )
+    assert prescriber.is_prescriber_with_authorized_org is all(
+        [user_active, membership_active, organization_authorized]
+    )

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -89,17 +89,6 @@ class ManagerTest(TestCase):
 
 
 class ModelTest(TestCase):
-    def test_prescriber_of_authorized_organization(self):
-        prescriber = PrescriberFactory()
-
-        assert not prescriber.is_prescriber_of_authorized_organization(1)
-
-        prescribermembership = PrescriberMembershipFactory(user=prescriber, organization__is_authorized=False)
-        assert not prescriber.is_prescriber_of_authorized_organization(prescribermembership.organization_id)
-
-        prescribermembership = PrescriberMembershipFactory(user=prescriber, organization__is_authorized=True)
-        assert prescriber.is_prescriber_of_authorized_organization(prescribermembership.organization_id)
-
     def test_generate_unique_username(self):
         unique_username = User.generate_unique_username()
         assert unique_username == uuid.UUID(unique_username, version=4).hex


### PR DESCRIPTION
### Pourquoi ?

Exactitude.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
