### PR TITLE
Anomalie UI : le “i” est décalé quand la suspension du PASS n’est pas possible [GEN-7815]

### DIFF
--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -26,8 +26,10 @@
                                     </div>
                                 {% elif hire_by_other_siae %}
                                     <div class="col-12 col-lg-auto">
-                                        <span class="btn btn-block btn-link disabled text-muted">Suspendre</span>
-                                        <i class="btn btn-link ri-information-line ri-xl text-info ps-2 pe-3 font-weight-medium" data-bs-toggle="tooltip" title="La suspension n’est pas possible car un autre employeur a embauché le candidat."></i>
+                                        <div class="btn btn-ico">
+                                            <span class="disabled">Suspendre</span>
+                                            <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="La suspension n’est pas possible car un autre employeur a embauché le candidat."></i>
+                                        </div>
                                     </div>
                                 {% endif %}
                                 {% if approval_can_be_prolonged %}


### PR DESCRIPTION
### Captures d'écran <!-- optionnel -->

![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/ff873a97-0776-4b09-b5b2-9cc44da97ccd)

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
