### PR TITLE
tests: simplification des JobSeeker/JobSeekerProfileFactory

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -312,6 +312,10 @@ class User(AbstractUser, AddressMixin):
             ),
         ]
 
+    def __init__(self, *args, _auto_create_job_seeker_profile=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._auto_create_job_seeker_profile = _auto_create_job_seeker_profile
+
     def __str__(self):
         return f"{self.get_full_name()} — {self.email}"
 
@@ -342,7 +346,7 @@ class User(AbstractUser, AddressMixin):
             raise ValidationError("Inclusion connect n'est utilisable que par un prescripteur ou employeur.")
 
     def save(self, *args, **kwargs):
-        must_create_profile = self._state.adding
+        must_create_profile = self._state.adding and self._auto_create_job_seeker_profile
 
         if not self.is_job_seeker:
             self.asp_uid = None  # Needs to be done before the call to .validate_unique()

--- a/tests/api/test_geiq.py
+++ b/tests/api/test_geiq.py
@@ -174,7 +174,10 @@ def test_candidatures_geiq_nominal(snapshot):
 
 
 def test_serializer_method_defaults():
-    ja = JobApplicationFactory(with_geiq_eligibility_diagnosis=False)
+    ja = JobApplicationFactory(
+        with_geiq_eligibility_diagnosis=False,
+        job_seeker__jobseeker_profile__education_level="",
+    )
     serializer = serializers.GeiqJobApplicationSerializer()
     assert serializer.get_criteres_eligibilite(ja) == []
     assert serializer.get_niveau_formation(ja) is None

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -187,5 +187,7 @@ class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprov
     Suitable for employee records tests
     """
 
-    job_seeker = factory.SubFactory(JobSeekerWithMockedAddressFactory, with_hexa_address=True)
+    job_seeker = factory.SubFactory(
+        JobSeekerWithMockedAddressFactory, with_hexa_address=True, jobseeker_profile__with_education_level=True
+    )
     sender_prescriber_organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory)

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -12,7 +12,6 @@ from itou.job_applications.enums import Prequalification, ProfessionalSituationE
 from itou.jobs.models import Appellation
 from itou.utils.types import InclusiveDateRange
 from tests.approvals.factories import ApprovalFactory
-from tests.asp.factories import CommuneFactory, CountryFranceFactory
 from tests.companies.factories import CompanyFactory
 from tests.eligibility.factories import EligibilityDiagnosisFactory, GEIQEligibilityDiagnosisFactory
 from tests.prescribers.factories import (
@@ -21,7 +20,6 @@ from tests.prescribers.factories import (
 )
 from tests.users.factories import (
     JobSeekerFactory,
-    JobSeekerProfileWithHexaAddressFactory,
     JobSeekerWithMockedAddressFactory,
     PrescriberFactory,
 )
@@ -189,23 +187,5 @@ class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprov
     Suitable for employee records tests
     """
 
-    job_seeker = factory.SubFactory(JobSeekerWithMockedAddressFactory)
+    job_seeker = factory.SubFactory(JobSeekerWithMockedAddressFactory, with_hexa_address=True)
     sender_prescriber_organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory)
-
-    @factory.post_generation
-    def set_job_seeker_profile(self, create, extracted, **kwargs):
-        if not create:
-            # Simple build, do nothing.
-            return
-        # Create a profile for current user
-        # NOTE(vperron): We have to remove the profile after its creation because our new behaviour in User.save()
-        # forces us to have a JobSeekerProfile ready, immediately. We don't want to adapt the save() to handle a
-        # case that can only happen in tests though.
-        self.job_seeker.jobseeker_profile.delete()
-        self.job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory(
-            user=self.job_seeker,
-            birth_place=CommuneFactory(),
-            birth_country=CountryFranceFactory(),
-        )
-
-        self.job_seeker.save()

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -258,11 +258,15 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.JobSeekerProfile
 
+    class Params:
+        with_education_level = factory.Trait(education_level=factory.fuzzy.FuzzyChoice(EducationLevel.values))
+
     user = factory.SubFactory(JobSeekerFactory)
+
+    education_level = factory.fuzzy.FuzzyChoice(EducationLevel.values + [""])
 
 
 class JobSeekerProfileWithHexaAddressFactory(JobSeekerProfileFactory):
-    education_level = random.choice(EducationLevel.values)
     # Adding a minimum profile with all mandatory fields
     # will avoid many mocks and convolutions during testing.
     hexa_lane_type = random.choice(LaneType.values)

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -172,7 +172,6 @@ class JobSeekerFactory(UserFactory):
                 obj.jobseeker_profile.delete()
                 obj.jobseeker_profile = None
             else:
-                obj._saved_obfuscated_nir = obj.jobseeker_profile.pe_obfuscated_nir
                 obj.jobseeker_profile.save(update_fields=kwargs.keys())
 
 

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -138,11 +138,7 @@ class JobSeekerFactory(UserFactory):
             pole_emploi_id=factory.fuzzy.FuzzyText(length=8, chars=string.digits),
             jobseeker_profile__pole_emploi_since=AllocationDuration.MORE_THAN_24_MONTHS,
         )
-        with_hexa_address = factory.Trait(
-            jobseeker_profile=factory.RelatedFactory(
-                "tests.users.factories.JobSeekerProfileWithHexaAddressFactory", "user"
-            )
-        )
+        with_hexa_address = factory.Trait(jobseeker_profile__with_hexa_address=True)
 
     @factory.lazy_attribute
     def nir(self):
@@ -260,16 +256,13 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
 
     class Params:
         with_education_level = factory.Trait(education_level=factory.fuzzy.FuzzyChoice(EducationLevel.values))
+        with_hexa_address = factory.Trait(
+            hexa_lane_type=factory.fuzzy.FuzzyChoice(LaneType.values),
+            hexa_lane_name=factory.Faker("street_address", locale="fr_FR"),
+            hexa_post_code=factory.Faker("postalcode"),
+            hexa_commune=factory.SubFactory(CommuneFactory),
+        )
 
     user = factory.SubFactory(JobSeekerFactory)
 
     education_level = factory.fuzzy.FuzzyChoice(EducationLevel.values + [""])
-
-
-class JobSeekerProfileWithHexaAddressFactory(JobSeekerProfileFactory):
-    # Adding a minimum profile with all mandatory fields
-    # will avoid many mocks and convolutions during testing.
-    hexa_lane_type = random.choice(LaneType.values)
-    hexa_lane_name = factory.Faker("street_address", locale="fr_FR")
-    hexa_post_code = factory.Faker("postalcode")
-    hexa_commune = factory.SubFactory(CommuneFactory)

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -228,6 +228,8 @@ class JobSeekerWithAddressFactory(JobSeekerFactory):
 class JobSeekerWithMockedAddressFactory(JobSeekerFactory):
     # Needs ASP test fixtures installed
 
+    born_in_france = True
+
     @factory.post_generation
     def set_approval_user(self, create, extracted, **kwargs):
         if not create:
@@ -242,10 +244,6 @@ class JobSeekerWithMockedAddressFactory(JobSeekerFactory):
         self.insee_code = address.get("insee_code")
         self.city = address.get("city")
         self.save()
-
-        self.jobseeker_profile.birth_place = CommuneFactory()
-        self.jobseeker_profile.birth_country = CountryFranceFactory()
-        self.jobseeker_profile.save()
 
 
 class JobSeekerProfileFactory(factory.django.DjangoModelFactory):

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -134,7 +134,10 @@ class JobSeekerFactory(UserFactory):
             with_birth_place=True,
             jobseeker_profile__birth_country=factory.SubFactory(CountryFranceFactory),
         )
-        with_pole_emploi_id = factory.Trait(pole_emploi_id=factory.fuzzy.FuzzyText(length=8, chars=string.digits))
+        with_pole_emploi_id = factory.Trait(
+            pole_emploi_id=factory.fuzzy.FuzzyText(length=8, chars=string.digits),
+            jobseeker_profile__pole_emploi_since=AllocationDuration.MORE_THAN_24_MONTHS,
+        )
 
     @factory.lazy_attribute
     def nir(self):
@@ -255,8 +258,6 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
 
 class JobSeekerProfileWithHexaAddressFactory(JobSeekerProfileFactory):
     education_level = random.choice(EducationLevel.values)
-    # JobSeeker are created with a Pôle emploi ID
-    pole_emploi_since = AllocationDuration.MORE_THAN_24_MONTHS
     # Adding a minimum profile with all mandatory fields
     # will avoid many mocks and convolutions during testing.
     hexa_lane_type = random.choice(LaneType.values)

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -138,6 +138,11 @@ class JobSeekerFactory(UserFactory):
             pole_emploi_id=factory.fuzzy.FuzzyText(length=8, chars=string.digits),
             jobseeker_profile__pole_emploi_since=AllocationDuration.MORE_THAN_24_MONTHS,
         )
+        with_hexa_address = factory.Trait(
+            jobseeker_profile=factory.RelatedFactory(
+                "tests.users.factories.JobSeekerProfileWithHexaAddressFactory", "user"
+            )
+        )
 
     @factory.lazy_attribute
     def nir(self):

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -250,6 +250,8 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.JobSeekerProfile
 
+    user = factory.SubFactory(JobSeekerFactory)
+
 
 class JobSeekerProfileWithHexaAddressFactory(JobSeekerProfileFactory):
     education_level = random.choice(EducationLevel.values)

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -21,7 +21,7 @@ from itou.companies.enums import CompanyKind
 from itou.job_applications.enums import Origin
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.users.enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploiId, Title, UserKind
-from itou.users.models import JobSeekerProfile, User
+from itou.users.models import User
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, RESULTS_BY_ADDRESS
 from tests.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from tests.companies.factories import CompanyFactory
@@ -1313,15 +1313,6 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     assert user.jobseeker_profile.pe_last_certification_attempt_at == datetime.datetime(
         2022, 8, 10, 0, 0, 0, 0, tzinfo=datetime.timezone.utc
     )
-
-
-def test_jobseeker_factory_works_alongside_user_has_data_changed():
-    js = JobSeekerFactory(jobseeker_profile__pe_obfuscated_nir="JAIME_LES_CHATS")
-    assert js._saved_obfuscated_nir == "JAIME_LES_CHATS"
-    assert js.jobseeker_profile.pe_obfuscated_nir == "JAIME_LES_CHATS"
-    profile = JobSeekerProfile.objects.get(user=js)
-    assert profile.pe_obfuscated_nir == "JAIME_LES_CHATS"
-    assert profile.pk == js.jobseeker_profile.pk
 
 
 @pytest.mark.parametrize("user_active", [False, True])

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -45,7 +45,6 @@ from tests.users.factories import (
     EmployerFactory,
     ItouStaffFactory,
     JobSeekerFactory,
-    JobSeekerProfileWithHexaAddressFactory,
     JobSeekerWithAddressFactory,
     PrescriberFactory,
 )
@@ -702,8 +701,10 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         user = prescriber_organization.members.first()
         self.client.force_login(user)
 
-        dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
+        dummy_job_seeker = JobSeekerWithAddressFactory.build(
+            jobseeker_profile__with_hexa_address=True,
+            jobseeker_profile__with_education_level=True,
+        )
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -964,8 +965,10 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         user = prescriber_organization.members.first()
         self.client.force_login(user)
 
-        dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
+        dummy_job_seeker = JobSeekerWithAddressFactory.build(
+            jobseeker_profile__with_hexa_address=True,
+            jobseeker_profile__with_education_level=True,
+        )
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -1278,8 +1281,10 @@ class ApplyAsPrescriberTest(TestCase):
         user = PrescriberFactory()
         self.client.force_login(user)
 
-        dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
+        dummy_job_seeker = JobSeekerWithAddressFactory.build(
+            jobseeker_profile__with_hexa_address=True,
+            jobseeker_profile__with_education_level=True,
+        )
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -1739,8 +1744,10 @@ class ApplyAsCompanyTest(TestCase):
         user = company.members.first()
         self.client.force_login(user)
 
-        dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
+        dummy_job_seeker = JobSeekerWithAddressFactory.build(
+            jobseeker_profile__with_hexa_address=True,
+            jobseeker_profile__with_education_level=True,
+        )
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -2060,8 +2067,10 @@ class DirectHireFullProcessTest(TestCase):
         user = company.members.first()
         self.client.force_login(user)
 
-        dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
+        dummy_job_seeker = JobSeekerWithAddressFactory.build(
+            jobseeker_profile__with_hexa_address=True,
+            jobseeker_profile__with_education_level=True,
+        )
 
         # Step determine the job seeker with a NIR.
         # ----------------------------------------------------------------------
@@ -3770,8 +3779,9 @@ class FindJobSeekerForHireViewTestCase(TestCase):
         user = self.company.members.first()
         self.client.force_login(user)
 
-        dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build()
+        dummy_job_seeker = JobSeekerWithAddressFactory.build(
+            jobseeker_profile__with_hexa_address=True,
+        )
 
         response = self.client.get(self.check_nir_url)
         self.assertContains(response, "Déclarer une embauche")

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -703,7 +703,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.client.force_login(user)
 
         dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build()
+        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -965,7 +965,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         self.client.force_login(user)
 
         dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build()
+        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -1279,7 +1279,7 @@ class ApplyAsPrescriberTest(TestCase):
         self.client.force_login(user)
 
         dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build()
+        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -1740,7 +1740,7 @@ class ApplyAsCompanyTest(TestCase):
         self.client.force_login(user)
 
         dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build()
+        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
 
         # Entry point.
         # ----------------------------------------------------------------------
@@ -2061,7 +2061,7 @@ class DirectHireFullProcessTest(TestCase):
         self.client.force_login(user)
 
         dummy_job_seeker = JobSeekerWithAddressFactory.build()
-        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build()
+        dummy_job_seeker.jobseeker_profile = JobSeekerProfileWithHexaAddressFactory.build(with_education_level=True)
 
         # Step determine the job seeker with a NIR.
         # ----------------------------------------------------------------------


### PR DESCRIPTION
### Pourquoi ?

Pour se rapprocher au plus du comportement natif de factory-boy et ne plus devoir jongler entre les différentes factories.