### PR TITLE
Stats : Ajout de stats IAE pour les CD (déploiement national)

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -44,20 +44,27 @@
                         </a>
                     </li>
                 {% endif %}
+                {% if can_view_stats_cd %}
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_cd_iae' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Voir les données IAE de mon département</span>
+                        </a>
+                        {% include "dashboard/includes/stats_new_badge.html" %}
+                    </li>
+                {% endif %}
                 {% if can_view_stats_cd_whitelist %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_cd_hiring' %}" class="btn-link btn-ico">
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Voir les données facilitation de l'embauche</span>
                         </a>
-                        {% include "dashboard/includes/stats_new_badge.html" %}
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_cd_brsa' %}" class="btn-link btn-ico">
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Suivre les prescriptions des accompagnateurs des publics bRSA</span>
                         </a>
-                        {% include "dashboard/includes/stats_new_badge.html" %}
                     </li>
                 {% endif %}
                 {% if can_view_stats_cd_aci %}
@@ -66,7 +73,6 @@
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                             <span>Suivi du cofinancement des ACI</span>
                         </a>
-                        {% include "dashboard/includes/stats_new_badge.html" %}
                     </li>
                 {% endif %}
                 {% if can_view_stats_pe %}

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -45,6 +45,11 @@ METABASE_DASHBOARDS = {
     #
     # Prescriber stats - CD.
     #
+    "stats_cd_iae": {
+        "dashboard_id": 118,
+        "tally_popup_form_id": "npD4g8",
+        "tally_embed_form_id": "m6ZrqY",
+    },
     "stats_cd_hiring": {
         "dashboard_id": 346,
     },

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -122,6 +122,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_siae": stats_utils.can_view_stats_siae(request),
         "can_view_stats_siae_aci": stats_utils.can_view_stats_siae_aci(request),
         "can_view_stats_siae_etp": stats_utils.can_view_stats_siae_etp(request),
+        "can_view_stats_cd": stats_utils.can_view_stats_cd(request),
         "can_view_stats_cd_whitelist": stats_utils.can_view_stats_cd_whitelist(request),
         "can_view_stats_cd_aci": stats_utils.can_view_stats_cd_aci(request),
         "can_view_stats_pe": stats_utils.can_view_stats_pe(request),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
         name="stats_siae_follow_siae_evaluation",
     ),
     # Prescriber stats - CD.
+    path("cd/iae", views.stats_cd_iae, name="stats_cd_iae"),
     path("cd/hiring", views.stats_cd_hiring, name="stats_cd_hiring"),
     path("cd/brsa", views.stats_cd_brsa, name="stats_cd_brsa"),
     path("cd/aci", views.stats_cd_aci, name="stats_cd_aci"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -281,6 +281,11 @@ def render_stats_cd(request, page_title, params=None):
 
 
 @login_required
+def stats_cd_iae(request):
+    return render_stats_cd(request=request, page_title="Données IAE")
+
+
+@login_required
 def stats_cd_hiring(request):
     if not utils.can_view_stats_cd_whitelist(request):
         raise PermissionDenied


### PR DESCRIPTION
**Carte Notion : https://www.notion.so/plateforme-inclusion/Publier-le-TB118-aux-CD-2e66a24c98384a0e9ac3696a41d31396**

### Pourquoi ?

Proposer des données de références sur le nombre et le parcours des bénéficiaires (entrées / sorties / durée).

### Captures d'écran

<img width="468" alt="image" src="https://github.com/gip-inclusion/les-emplois/assets/10533583/0d20708d-1132-4e54-bdea-69bfa92baa9c">

<img width="773" alt="image" src="https://github.com/gip-inclusion/les-emplois/assets/10533583/a6e8e81a-aec7-46a3-b86b-94008abe3515">
