### PR TITLE
Fiches Salarié : Archiver plutôt que désactiver les “FS Orphelines” [GEN-7836]

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -48,27 +48,24 @@ class Command(BaseCommand):
             self.stdout.write(" - done!")
 
     def _check_orphans(self, dry_run):
-        # Report all orphans employee records (bad asp_id)
-
-        # Exclude the one that are already DISABLED, and also the ARCHIVED ones as they are now unusable
-        orphans = EmployeeRecord.objects.orphans().exclude(status__in=[Status.DISABLED, Status.ARCHIVED])
+        # Exclude the ones that are already ARCHIVED as they are already unusable
+        orphans = EmployeeRecord.objects.orphans().exclude(status__in=[Status.ARCHIVED])
 
         self.stdout.write("* Checking orphans employee records:")
 
-        if len(orphans) == 0:
+        orphans_count = orphans.count()
+        if not orphans_count:
             self.stdout.write(" - none found (great!)")
         else:
-            self.stdout.write(f" - found {len(orphans)} orphan(s)")
+            self.stdout.write(f" - found {orphans_count} orphan(s)")
 
             if dry_run:
                 return
 
-            self.stdout.write(" - fixing orphans: switching status to DISABLED")
+            self.stdout.write(" - fixing orphans: switching status to ARCHIVED")
 
             with transaction.atomic():
-                for orphan in orphans:
-                    if orphan.can_be_disabled:
-                        orphan.update_as_disabled()
+                orphans.update(status=Status.ARCHIVED)
 
             self.stdout.write(" - done!")
 

--- a/tests/employee_record/test_sanitize_employee_records.py
+++ b/tests/employee_record/test_sanitize_employee_records.py
@@ -55,7 +55,7 @@ def test_3436_errors_check(command):
 
 def test_orphans_check(command):
     # Check if any orphan (mismatch in `asp_id`)
-    factories.EmployeeRecordFactory(status=models.Status.DISABLED)
+    factories.EmployeeRecordFactory(status=models.Status.ARCHIVED)
     employee_record = factories.BareEmployeeRecordFactory(status=models.Status.PROCESSED)
     employee_record.asp_id += 1
     employee_record.save()
@@ -63,11 +63,11 @@ def test_orphans_check(command):
     command._check_orphans(dry_run=False)
 
     employee_record.refresh_from_db()
-    assert employee_record.status == models.Status.DISABLED
+    assert employee_record.status == models.Status.ARCHIVED
     assert command.stdout.getvalue().split("\n") == [
         "* Checking orphans employee records:",
         " - found 1 orphan(s)",
-        " - fixing orphans: switching status to DISABLED",
+        " - fixing orphans: switching status to ARCHIVED",
         " - done!",
         "",
     ]


### PR DESCRIPTION
### Pourquoi ?

Voir commit.

### Comment ? <!-- optionnel -->

Voir commit.

Pas de script à part pour gérer l'existant, les nombres étant raisonnables tout sera fait au premier passage :
```
In [2]: EmployeeRecord.objects.orphans().exclude(status__in=[Status.ARCHIVED]).count()
Out[2]: 7819
```
En local :
```
$ time ./manage.py sanitize_employee_records
...
real    0m21.106s
user    0m2.909s
sys     0m0.568s
```

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
