### PR TITLE
scripts : Proposer la suppression du remote git dans `create-fast-machine.sh`

### DIFF
--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -51,11 +51,11 @@ cat << EOF
 
 Vous pouvez maintenant:
  - ✈️ Aller sur la machine:
-    clever ssh --alias $APP_NAME
+    clever ssh --alias "$APP_NAME"
  - 🔨 Jouer un script d’import, par ex:
     cd ~/app_* && ./scripts/imports-asp.sh
  - 🍺 Supprimer la machine:
-    clever delete --alias $APP_NAME --yes && git remote remove $APP_NAME
+    clever delete --alias $APP_NAME --yes && git remote remove "$APP_NAME"
 EOF
 
 exit 0

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -55,7 +55,7 @@ Vous pouvez maintenant:
  - 🔨 Jouer un script d’import, par ex:
     cd ~/app_* && ./scripts/imports-asp.sh
  - 🍺 Supprimer la machine:
-    clever delete --alias $APP_NAME --yes
+    clever delete --alias $APP_NAME --yes && git remote remove $APP_NAME
 EOF
 
 exit 0


### PR DESCRIPTION
### Pourquoi ?

Toujours mieux de nettoyer après avoir fini :smirk_cat:.
![200w](https://github.com/gip-inclusion/les-emplois/assets/20045330/49611753-29db-473e-92b2-480bb2d5ea0e)

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
