### PR TITLE
www.apply: gestion d'une session obsolète empêchant la création d'un candidat

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -584,7 +584,11 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
         self.profile = None
 
     def _get_user_data_from_session(self):
-        return {k: v for k, v in self.job_seeker_session.get("user").items() if k not in ["city_slug", "lack_of_nir"]}
+        return {
+            k: v
+            for k, v in self.job_seeker_session.get("user").items()
+            if k not in ["city_slug", "lack_of_nir", "pole_emploi_id", "lack_of_pole_emploi_id_reason"]
+        }
 
     def _get_profile_data_from_session(self):
         # Dummy fields used by CreateOrUpdateJobSeekerStep3Form()


### PR DESCRIPTION
**Carte Notion : **

### Pourquoi ?
https://itou.sentry.io/issues/4792190341/


### À vérifier

- [ ] Ajouter l'étiquette « no-changelog » ?
- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
