### PR TITLE
Fiches salarié : Nettoyage des FS orphelines faisant doublon

### DIFF
--- a/itou/employee_record/management/commands/clean_orphans.py
+++ b/itou/employee_record/management/commands/clean_orphans.py
@@ -1,0 +1,44 @@
+import django.db.transaction as transaction
+from django.db.models import Count, F
+
+from itou.employee_record.models import EmployeeRecord
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
+
+    @transaction.atomic()
+    def handle(self, *, wet_run=False, **options):
+        ja_with_multiple_er = (
+            EmployeeRecord.objects.values("job_application")
+            .annotate(cnt=Count("job_application"))
+            .filter(cnt__gt=1)
+            .values_list("job_application", flat=True)
+        )
+        print(f"Found {ja_with_multiple_er.count()} job applications with more than 1 employee record")
+        for ja_pk in ja_with_multiple_er:
+            all_related_er = EmployeeRecord.objects.filter(job_application=ja_pk)
+            orphaned_er = all_related_er.orphans()
+
+            # Fewer orphans than non-orphans, we can safely delete the orphans
+            if orphaned_er.count() < all_related_er.count():
+                print(f"Deleting all orphans for job_application={ja_pk}: {orphaned_er.values_list('pk', flat=True)}")
+                if wet_run:
+                    orphaned_er.delete()
+                continue
+
+            # Same numbers of orphans than non-orphans, keep the last one (probably :P)
+            # Using `asp_batch_file` because it holds the timestamp of when it was sent while `updated_at` and
+            # `created_at` can have been touched, putting nulls last to prefer employee records that were really sent.
+            to_delete = orphaned_er.order_by(
+                F("asp_batch_file").desc(nulls_last=True),
+                "-updated_at",
+                "-created_at",
+            )[1:].values_list("pk", flat=True)  # fmt: skip
+            print(f"Deleting oldest orphans for job_application={ja_pk}: {to_delete}")
+            if wet_run:
+                EmployeeRecord.objects.filter(pk__in=to_delete).delete()


### PR DESCRIPTION
> [!IMPORTANT]  
> A relire et déployer après #3499 et avant #3500.

### Pourquoi ?

En faisant une vérification de dernière minute pour #3500, je me suis rendu compte que la PR allais créer des problèmes sur le long terme, toute les FS orpheline allaient redevenir "visible" là où auparavant on les filtraient, ce qui aurais pour conséquence de ne plus avoir 1 FS active pour 1 candidature.

Supprimer toutes les FS orphelines n'est pas possible car cela allais faire réapparaître de _nombreuses_ demandes de création dans le tableau de bord des employeurs pour des salariés n'étant plus dans la structure.

Je suis donc parti sur la logique que si l'on supprime la notion de FS orpheline alors il faut aussi adapter nos données pour faire comme si cette notion n'avais jamais existé et ne garder qu'une FS (possiblement orpheline, pour le moment) pour chaque candidature.

Le script trouve ~7950 candidatures ayant plus de 1 FS, et 124 SIAE sont concernés
90% tombent dans le cas simple où l'on supprime les FS orphelines car une non-orpheline existe.
Les 735 FS restantes tombent dans l'autre cas et l'heuristique d'utiliser `asp_batch_file` semble fait le boulot d'après les cas que j'ai pris au hasard, au pire si il y a des ratés cela ne devrais pas avoir trop d'impact et de ce que j'ai vu la grosse majorité de ces cas vient des ensembliers (Actual et Eureka) ayant connus des changements de SIRET massif récemment.

J'ai refait passer mon script qui regarde pour chaque SIAE la sortie de `JobApplication.eligible_as_employee_record()` et aucune différence entre avant/après dans les tableaux de bord employeur :).

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
