### PR TITLE
Utilitaires de test : gerer le remplacement des urls complexes

### DIFF
--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -53,7 +53,7 @@ def pprint_html(response, **selectors):
     print("\n\n".join([elt.prettify() for elt in parser.find_all(**selectors)]))
 
 
-def parse_response_to_soup(response, selector=None, no_html_body=False, replace_objects_pk_in_href=None):
+def parse_response_to_soup(response, selector=None, no_html_body=False, replace_in_href=None):
     soup = BeautifulSoup(response.content, "html5lib", from_encoding=response.charset or "utf-8")
     if no_html_body:
         # If the provided HTML does not contain <html><body> tags
@@ -68,9 +68,9 @@ def parse_response_to_soup(response, selector=None, no_html_body=False, replace_
         soup["nonce"] = "NORMALIZED_CSP_NONCE"
     for csp_nonce_script in soup.find_all("script", {"nonce": True}):
         csp_nonce_script["nonce"] = "NORMALIZED_CSP_NONCE"
-    if replace_objects_pk_in_href:
+    if replace_in_href:
         for links in soup.find_all(attrs={"href": True}):
-            for obj in replace_objects_pk_in_href:
+            for obj in replace_in_href:
                 links.attrs["href"] = links.attrs["href"].replace(str(obj.pk), f"[PK of {type(obj).__name__}]")
     return soup
 

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -69,9 +69,14 @@ def parse_response_to_soup(response, selector=None, no_html_body=False, replace_
     for csp_nonce_script in soup.find_all("script", {"nonce": True}):
         csp_nonce_script["nonce"] = "NORMALIZED_CSP_NONCE"
     if replace_in_href:
+        replacements = [
+            replacement
+            if isinstance(replacement, tuple)
+            else (str(replacement.pk), f"[PK of {type(replacement).__name__}]")
+            for replacement in replace_in_href
+        ]
         for links in soup.find_all(attrs={"href": True}):
-            for obj in replace_in_href:
-                links.attrs["href"] = links.attrs["href"].replace(str(obj.pk), f"[PK of {type(obj).__name__}]")
+            [links.attrs.update({"href": links.attrs["href"].replace(*replacement)}) for replacement in replacements]
     return soup
 
 

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -71,7 +71,14 @@ class CardViewTest(TestCase):
         tab_content_soup = parse_response_to_soup(
             response,
             selector=".tab-content",
-            replace_objects_pk_in_href=[job_description, company],
+            replace_in_href=[
+                (
+                    f"/company/job_description/{job_description.pk}/card",
+                    "/company/job_description/[PK of JobDescription]/card",
+                ),
+                (f"?back_url=/company/{company.pk}/card", "?back_url=/company/[PK of Company]/card"),
+                (f"/apply/{company.pk}/start", "/apply/[PK of Company]/start"),
+            ],
         )
         assert str(tab_content_soup) == self.snapshot(name="tab-content")
 
@@ -94,7 +101,14 @@ class CardViewTest(TestCase):
         tab_content_soup = parse_response_to_soup(
             response,
             selector=".tab-content",
-            replace_objects_pk_in_href=[job_description, company],
+            replace_in_href=[
+                (
+                    f"/company/job_description/{job_description.pk}/card",
+                    "/company/job_description/[PK of JobDescription]/card",
+                ),
+                (f"?back_url=/company/{company.pk}/card", "?back_url=/company/[PK of Company]/card"),
+                (f"/apply/{company.pk}/start", "/apply/[PK of Company]/start"),
+            ],
         )
         assert str(tab_content_soup) == self.snapshot(name="tab-content")
 
@@ -128,7 +142,18 @@ class CardViewTest(TestCase):
         tab_content_soup = parse_response_to_soup(
             response,
             selector=".tab-content",
-            replace_objects_pk_in_href=[active_job_description, other_job_description, company],
+            replace_in_href=[
+                (
+                    f"/company/job_description/{active_job_description.pk}/card",
+                    "/company/job_description/[PK of JobDescription]/card",
+                ),
+                (
+                    f"/company/job_description/{other_job_description.pk}/card",
+                    "/company/job_description/[PK of JobDescription]/card",
+                ),
+                (f"?back_url=/company/{company.pk}/card", "?back_url=/company/[PK of Company]/card"),
+                (f"/apply/{company.pk}/start", "/apply/[PK of Company]/start"),
+            ],
         )
         assert str(tab_content_soup) == self.snapshot(name="tab-content")
 
@@ -151,7 +176,14 @@ class CardViewTest(TestCase):
         tab_content_soup = parse_response_to_soup(
             response,
             selector=".tab-content",
-            replace_objects_pk_in_href=[job_description, company],
+            replace_in_href=[
+                (
+                    f"/company/job_description/{job_description.pk}/card",
+                    "/company/job_description/[PK of JobDescription]/card",
+                ),
+                (f"?back_url=/company/{company.pk}/card", "?back_url=/company/[PK of Company]/card"),
+                (f"/apply/{company.pk}/start", "/apply/[PK of Company]/start"),
+            ],
         )
         assert str(tab_content_soup) == self.snapshot(name="tab-content")
 

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -119,7 +119,7 @@ class ListEmployeeRecordsTest(TestCase):
             parse_response_to_soup(
                 response,
                 selector=".employee-records-list .card-body > div:last-child",
-                replace_objects_pk_in_href=[self.job_application],
+                replace_in_href=[self.job_application],
             )
         ) == self.snapshot(name="action")
 
@@ -141,7 +141,7 @@ class ListEmployeeRecordsTest(TestCase):
                 parse_response_to_soup(
                     response,
                     selector=".employee-records-list .card-body > div:last-child",
-                    replace_objects_pk_in_href=[self.job_application, employee_record],
+                    replace_in_href=[self.job_application, employee_record],
                 )
             )
             == self.snapshot()
@@ -163,7 +163,7 @@ class ListEmployeeRecordsTest(TestCase):
             parse_response_to_soup(
                 response,
                 selector=".employee-records-list .card-body > div:last-child",
-                replace_objects_pk_in_href=[self.job_application],
+                replace_in_href=[self.job_application],
             )
         ) == self.snapshot(name="action")
 
@@ -185,7 +185,7 @@ class ListEmployeeRecordsTest(TestCase):
                 parse_response_to_soup(
                     response,
                     selector=".employee-records-list .card-body > div:last-child",
-                    replace_objects_pk_in_href=[self.job_application, employee_record],
+                    replace_in_href=[self.job_application, employee_record],
                 )
             )
             == self.snapshot()
@@ -202,7 +202,7 @@ class ListEmployeeRecordsTest(TestCase):
                 parse_response_to_soup(
                     response,
                     selector=".employee-records-list .card-body > div:last-child",
-                    replace_objects_pk_in_href=[self.job_application, employee_record],
+                    replace_in_href=[self.job_application, employee_record],
                 )
             )
             == self.snapshot()
@@ -225,7 +225,7 @@ class ListEmployeeRecordsTest(TestCase):
             parse_response_to_soup(
                 response,
                 selector=".employee-records-list .card-body > div:last-child",
-                replace_objects_pk_in_href=[self.job_application],
+                replace_in_href=[self.job_application],
             )
         ) == self.snapshot(name="action")
 
@@ -247,7 +247,7 @@ class ListEmployeeRecordsTest(TestCase):
             parse_response_to_soup(
                 response,
                 selector=".employee-records-list .card-body > div:last-child",
-                replace_objects_pk_in_href=[new_er],
+                replace_in_href=[new_er],
             )
         ) == self.snapshot(name="action")
 


### PR DESCRIPTION
### Pourquoi ?

Rendre `parse_response_to_soup` capable de gérer les urls complexes dans les snapshots.

ie : `href="http://localhost:8000/company/job_description/[PK of JobDescription]/card?back_url=/company/[PK of Company]/card"`

### Comment ? 

Modifier le traitement du paramètre  `replace_objects_pk_in_href` : 
1. Si reçoit une liste de tuple, remplacement du premier membre du tuple par le second
2. Sinon, maintien du fonctionnement existant, remplacement des PK de la liste d'objet de la liste

###
- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
