### PR TITLE
API candidats : ajout des paramètres `mode_multi_structures` et `uid_structures`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,5 @@
     "explorer.confirmDragAndDrop": false,
     "vim.handleKeys": {
         "<C-p>": false
-     }
+    }
 }

--- a/itou/api/applicants_api/perms.py
+++ b/itou/api/applicants_api/perms.py
@@ -1,21 +1,19 @@
 from rest_framework.permissions import IsAuthenticated
 
-from itou.companies.models import CompanyMembership
-
 
 class ApplicantsAPIPermission(IsAuthenticated):
     def has_permission(self, request, view) -> bool:
         """
-        Check that user:
-            - belongs to one SIAE only (dedicated API account)
-            - is admin
+        Check that user is admin of every companies he belongs to.
         """
         if not super().has_permission(request, view):
             return False
 
-        memberships = request.user.active_or_in_grace_period_company_memberships()
-
-        try:
-            return memberships.get().is_admin
-        except (CompanyMembership.DoesNotExist, CompanyMembership.MultipleObjectsReturned):
+        if not request.user.is_employer:
             return False
+        # If filter with company id: check permission so that it's not to be done later
+        # (and it should save a query too).
+
+        memberships_qs = request.user.active_or_in_grace_period_company_memberships()
+
+        return all(memberships_qs.values_list("is_admin", flat=True))

--- a/itou/api/applicants_api/perms.py
+++ b/itou/api/applicants_api/perms.py
@@ -11,9 +11,8 @@ class ApplicantsAPIPermission(IsAuthenticated):
 
         if not request.user.is_employer:
             return False
-        # If filter with company id: check permission so that it's not to be done later
-        # (and it should save a query too).
 
-        memberships_qs = request.user.active_or_in_grace_period_company_memberships()
-
-        return all(memberships_qs.values_list("is_admin", flat=True))
+        memberships_status_is_admin = request.user.active_or_in_grace_period_company_memberships().values_list(
+            "is_admin", flat=True
+        )
+        return memberships_status_is_admin and all(memberships_status_is_admin)

--- a/itou/api/applicants_api/serializers.py
+++ b/itou/api/applicants_api/serializers.py
@@ -19,7 +19,7 @@ class ApplicantSerializer(serializers.ModelSerializer):
     lieu_naissance = serializers.CharField(source="jobseeker_profile.birth_place")
     pays_naissance = serializers.CharField(source="jobseeker_profile.birth_country")
     lien_cv = serializers.CharField(default=None)  # Deprecated field
-    # TODO: add uid structure
+    uid_structures = serializers.ListField(child=serializers.CharField(), source="companies_uids")
 
     class Meta:
         model = User
@@ -37,6 +37,7 @@ class ApplicantSerializer(serializers.ModelSerializer):
             "lieu_naissance",
             "pays_naissance",
             "lien_cv",
+            "uid_structures",
         )
         read_only_fields = fields
 

--- a/itou/api/applicants_api/serializers.py
+++ b/itou/api/applicants_api/serializers.py
@@ -19,6 +19,7 @@ class ApplicantSerializer(serializers.ModelSerializer):
     lieu_naissance = serializers.CharField(source="jobseeker_profile.birth_place")
     pays_naissance = serializers.CharField(source="jobseeker_profile.birth_country")
     lien_cv = serializers.CharField(default=None)  # Deprecated field
+    # TODO: add uid structure
 
     class Meta:
         model = User

--- a/itou/api/applicants_api/serializers.py
+++ b/itou/api/applicants_api/serializers.py
@@ -43,3 +43,15 @@ class ApplicantSerializer(serializers.ModelSerializer):
 
     def get_civilite(self, obj) -> str:
         return obj.title or "Non fournie"
+
+
+class StringArrayField(serializers.ListField):
+    def to_internal_value(self, data):
+        data = data[0].split(",")  # convert string to list
+        data = [d for d in data if d != ""]
+        return super().to_internal_value(data)
+
+
+class APIParametersSerializer(serializers.Serializer):
+    mode_multi_structures = serializers.BooleanField(required=False)
+    uid_structures = StringArrayField(child=serializers.CharField(), required=False)

--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -73,7 +73,7 @@ L'utilisation de cette API nécessite un jeton d'autorisation (`token`) :
 
 {AUTH_TOKEN_EXPLANATION_TEXT}
 
-Le compte administrateur utilisé peut être membre d'une ou de plusieurs structures.
+Le compte administrateur utilisé peut être membre administrateur d'une ou de plusieurs structures.
 Par défaut, l'API renvoie les candidatures reçues par la première structure dont le compte est membre
 car la première version avait été pensée ainsi.
 
@@ -82,7 +82,7 @@ car la première version avait été pensée ainsi.
 - mode_multi_structures : renvoie les candidats de toutes les structures.
 - uid_structures : renvoie les candidats des structures demandées.
 
-Attention, le compte doit être administrateur des structures.
+Attention, le compte doit être administrateur de toutes les structures dont il est membre.
 
 # Exemples de requêtes
 
@@ -103,8 +103,8 @@ et cliquez sur « Mon espace » > « Accès aux APIs ».
 
 ```bash
 curl
--L '{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?structures_uid=[uid-1]' \
--H 'Authorization: Token [token]'
+'{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?structures_uid=<uid_1>' \
+--header 'Authorization: Token [token]'
 ```
 
 ### Plusieurs structures
@@ -113,8 +113,8 @@ Séparez les identifiants par des virgules.
 
 ```bash
 curl
--L '{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?structures_uid=[uid-1,uid-2,uid-3]' \
--H 'Authorization: Token [token]'
+'{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?structures_uid=<uid_1>,<uid_2>' \
+--header 'Authorization: Token [token]'
 ```
 
 """

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -24,7 +24,7 @@
                                         <thead>
                                             <tr>
                                                 <th scope="col">Nom</th>
-                                                <th scope="col">identifiant unique</th>
+                                                <th scope="col">Identifiant unique</th>
                                             </tr>
                                         </thead>
                                         <tbody>

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -20,9 +20,22 @@
                                     <p>
                                         En tant qu’administrateur des structures suivantes, vous avez accès à l’API Fiches salarié (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/employee-records" target="_blank">voir la documentation ici</a>):
                                     </p>
-                                    <ul>
-                                        {% for siae_name in siaes_names %}<li>{{ siae_name }}</li>{% endfor %}
-                                    </ul>
+                                    <table class="table table-sm">
+                                        <thead>
+                                            <tr>
+                                                <th scope="col">Nom</th>
+                                                <th scope="col">identifiant unique</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for company in companies %}
+                                                <tr>
+                                                    <th scope="row">{{ company.name }}</th>
+                                                    <td>{{ company.uid }}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
                                     <p>
                                         Pour vous connecter à l'API vous devez utiliser l'identifiant "{{ login_string }}" et comme mot de passe le token suivant.
                                     </p>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -5,6 +5,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
+from django.db.models import F
 from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse, reverse_lazy
@@ -366,7 +367,9 @@ def api_token(request, template_name="dashboard/api_token.html"):
     context = {
         "login_string": TOKEN_ID_STR,
         "token": token,
-        "siaes_names": request.user.companymembership_set.active_admin().values_list("company__name", flat=True),
+        "companies": request.user.companymembership_set.active_admin().values(
+            name=F("company__name"), uid=F("company__uid")
+        ),
     }
 
     return render(request, template_name, context)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1529,6 +1529,10 @@ unidecode==1.3.8 \
     --hash=sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4 \
     --hash=sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39
     # via -r requirements/test.txt
+unittest-parametrize==1.4.0 \
+    --hash=sha256:8b9554fbcfd36bfef6c5c522b9146f13647eb4ec589c17af7f67f22793cecb82 \
+    --hash=sha256:f9dcaed821ad19724964a49e7f595311b9a2c5253c61cdb1fb2c01b899af67a2
+    # via -r requirements/test.txt
 uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -21,5 +21,6 @@ pytest-mock  # https://github.com/pytest-dev/pytest-mock/
 pytest-randomly  # https://github.com/pytest-dev/pytest-randomly
 pytest-subtests  # https://github.com/pytest-dev/pytest-subtests
 pytest-xdist  # https://pypi.org/project/pytest-xdist/
+unittest-parametrize  # https://github.com/adamchainz/unittest-parametrize
 respx  # https://lundberg.github.io/respx/
 syrupy  # https://github.com/tophat/syrupy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1384,6 +1384,10 @@ unidecode==1.3.8 \
     --hash=sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4 \
     --hash=sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39
     # via -r requirements/base.txt
+unittest-parametrize==1.4.0 \
+    --hash=sha256:8b9554fbcfd36bfef6c5c522b9146f13647eb4ec589c17af7f67f22793cecb82 \
+    --hash=sha256:f9dcaed821ad19724964a49e7f595311b9a2c5253c61cdb1fb2c01b899af67a2
+    # via -r requirements/test.in
 uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e

--- a/tests/api/applicants_api/tests.py
+++ b/tests/api/applicants_api/tests.py
@@ -115,12 +115,13 @@ class ApplicantsAPITest(APITestCase, ParametrizedTestCase):
 
         num_queries = (
             BASE_NUM_QUERIES
-            + 1  # companymembership check (ApplicantsAPIPermission)
-            + 1  # get_queryset: job_application subquery (job_applications__to_company_id__in)
+            + 1  # companymembership.is_admin check (ApplicantsAPIPermission)
+            + 1  # get_queryset: companies_uids aggregation
+            + 1  # get_queryset: Count job_applications (Exists JobApplication)
         )
         if len(expected_first_names) > 0:
             # Subquery returned results, so the main query is executed.
-            num_queries = num_queries + 1 + 1  # User & UserProfile
+            num_queries = num_queries + 1  # get_queryset: Fetch User + Profile
 
         self.client.force_authenticate(employer)
 
@@ -169,10 +170,10 @@ class ApplicantsAPITest(APITestCase, ParametrizedTestCase):
 
         num_queries = (
             BASE_NUM_QUERIES
-            + 1  # companymembership check (ApplicantsAPIPermission)
-            + 1  # get_queryset: job_application subquery (job_applications__to_company_id__in)
-            + 1  # User
-            + 1  # UserProfile
+            + 1  # companymembership.is_admin check (ApplicantsAPIPermission)
+            + 1  # get_queryset: companies_uids aggregation
+            + 1  # get_queryset: Count job_applications (Exists JobApplication)
+            + 1  # get_queryset: Fetch User + Profile
         )
 
         self.client.force_authenticate(employer)
@@ -247,10 +248,10 @@ class ApplicantsAPITest(APITestCase, ParametrizedTestCase):
         self.client.force_authenticate(user)
         with self.assertNumQueries(
             BASE_NUM_QUERIES
-            + 1  # companymembership check (ApplicantsAPIPermission)
-            + 1  # siaes_companymembership fetch for request.user (get_queryset)
-            + 1  # fetch users
-            + 1  # prefetch linked job applications
+            + 1  # companymembership.is_admin check (ApplicantsAPIPermission)
+            + 1  # get_queryset: companies_uids aggregation
+            + 1  # get_queryset: Count job_applications (Exists JobApplication)
+            + 1  # get_queryset: Fetch User + Profile
         ):
             response = self.client.get(self.URL, format="json")
 

--- a/tests/api/applicants_api/tests.py
+++ b/tests/api/applicants_api/tests.py
@@ -61,7 +61,7 @@ class ApplicantsAPITest(APITestCase):
         assert response.status_code == 403
 
     def test_login_as_siae(self):
-        # Connect with an admin user with member of a sigle SIAE
+        # Connect with an admin user with member of a single SIAE
         user = CompanyFactory(with_membership=True).members.first()
         self.client.force_authenticate(user)
 


### PR DESCRIPTION
### Pourquoi ?

Des consommateurs de notre API se plaignent de ne pas pouvoir récupérer les candidatures de toutes les structures auxquelles ils appartiennent.

### Comment ?

Ajout de deux paramètres optionnels :
- mode_multi_structures
- uid_structures

Ajout de l'identifiant unique des structures dans la page d'information à l'utilisateur (voir capture d'écran ci-dessous).

Mise à jour de la documentation (api/v1/redoc/#tag/candidats/operation/candidats_list).

Technique : utilisation de la bibliothèque [`unittest-parametrize`](https://github.com/adamchainz/unittest-parametrize) pour utiliser la syntaxe de Pytest avec Unittest sans avoir à transformer toutes les classes de test en fonctions. En tous cas pas maintenant. Oui, la flemme, ça compte. 

## Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/ed7f3ef4-f3e2-4a80-befb-8a61d272aa16)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
