### PR TITLE
Permettre aux développeurs de gérer un .envrc local

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,4 @@
 dotenv
+if test -f .envrc.local; then
+    . .envrc.local
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ coverage.xml
 
 # dotenv
 .env
+# direnv
+/.envrc.local
 
 # virtualenv
 .venv*


### PR DESCRIPTION
### Pourquoi ?

Avant 4e24681ba6ea6e7f1f4b0bdd76b81f5b52236283, les développeurs pouvaient configurer leur environnement en entrant dans le répertoire du projet avec direnv. En particulier, activer leur environnement virtuel pour Python.

Après ce commit, les développeurs doivent soit charger l’environnement manuellement, soit modifier leur `$PATH` dans leur `.env` à partir de ce que fait `.venv/bin/activate`.

Avec ce changement, les développeurs peuvent à nouveau personnaliser leur environnement via `.envrc.local`.
