### PR TITLE
admin: ajout d'une action pour détecter des incohérences sur les données

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -14,6 +14,7 @@ from itou.employee_record.constants import EMPLOYEE_RECORD_FEATURE_AVAILABILITY_
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
 from itou.utils.admin import (
+    InconsistencyCheckMixin,
     ItouModelAdmin,
     ItouStackedInline,
     ItouTabularInline,
@@ -177,7 +178,7 @@ class StartDateFilter(admin.SimpleListFilter):
 
 
 @admin.register(models.Approval)
-class ApprovalAdmin(ItouModelAdmin):
+class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
     form = ApprovalAdminForm
     list_display = (
         "pk",
@@ -227,6 +228,13 @@ class ApprovalAdmin(ItouModelAdmin):
     )
     change_list_template = "admin/approvals/change_list_with_stats.html"
     stats_url = reverse_lazy("admin:approvals_approval_sent_to_pe_stats")
+
+    INCONSISTENCY_CHECKS = [
+        (
+            "PASS IAE lié au diagnostic d'un autre candidat",
+            lambda q: q.inconsistent_eligibility_diagnosis_job_seeker(),
+        ),
+    ]
 
     def get_queryset(self, request):
         queryset = super().get_queryset(request)

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -11,7 +11,7 @@ from django.contrib.postgres.fields import ArrayField, RangeBoundary, RangeOpera
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
 from django.db import models, transaction
-from django.db.models import Case, Count, OuterRef, Q, Subquery, When
+from django.db.models import Case, Count, F, OuterRef, Q, Subquery, When
 from django.db.models.functions import Now, TruncDate
 from django.utils import timezone
 from django.utils.functional import cached_property
@@ -228,6 +228,9 @@ class ApprovalQuerySet(CommonApprovalQuerySet):
             .with_assigned_company()
             .filter(assigned_company=company_id)
         )
+
+    def inconsistent_eligibility_diagnosis_job_seeker(self):
+        return self.filter(eligibility_diagnosis__isnull=False).exclude(eligibility_diagnosis__job_seeker=F("user"))
 
 
 class PENotificationMixin(models.Model):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -415,6 +415,19 @@ class JobApplicationQuerySet(models.QuerySet):
             .order_by("-hiring_start_at")
         )
 
+    def inconsistent_approval_user(self):
+        return self.filter(approval__isnull=False).exclude(approval__user=F("job_seeker"))
+
+    def inconsistent_eligibility_diagnosis_job_seeker(self):
+        return self.filter(eligibility_diagnosis__isnull=False).exclude(
+            eligibility_diagnosis__job_seeker=F("job_seeker")
+        )
+
+    def inconsistent_geiq_eligibility_diagnosis_job_seeker(self):
+        return self.filter(geiq_eligibility_diagnosis__isnull=False).exclude(
+            geiq_eligibility_diagnosis__job_seeker=F("job_seeker")
+        )
+
 
 class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     """

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -613,6 +613,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
                     )
                     messages.info(request, message)
 
+                self.check_inconsistencies(request, models.User.objects.filter(pk__in=(from_user.pk, to_user.pk)))
                 return redirect(
                     reverse(
                         "admin:users_user_change",

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -180,7 +180,25 @@ class TestTransferUserData:
         assert job_application.job_seeker == to_user
         assert approval.user == to_user
         assertMessages(
-            response, [("INFO", f"Transfert effectué avec succès de l'utilisateur {from_user} vers {to_user}.")]
+            response,
+            [
+                ("INFO", f"Transfert effectué avec succès de l'utilisateur {from_user} vers {to_user}."),
+                (
+                    "WARNING",
+                    (
+                        "2 objets incohérents: <ul>"
+                        '<li class="warning">'
+                        f'<a href="/admin/job_applications/jobapplication/{job_application.pk}/change/">'
+                        f"candidature - {job_application.pk}"
+                        "</a>: Candidature liée au diagnostic d&#x27;un autre candidat</li>"
+                        '<li class="warning">'
+                        f'<a href="/admin/approvals/approval/{job_application.approval.pk}/change/">'
+                        f"PASS IAE - {job_application.approval.pk}"
+                        "</a>: PASS IAE lié au diagnostic d&#x27;un autre candidat</li>"
+                        "</ul>"
+                    ),
+                ),
+            ],
         )
         user_content_type = ContentType.objects.get_for_model(User)
         to_user_remark = PkSupportRemark.objects.filter(content_type=user_content_type, object_id=to_user.pk).first()


### PR DESCRIPTION
**Carte Notion : ** https://www.notion.so/plateforme-inclusion/Admin-Transfert-des-donn-es-candidats-Ajouter-texte-pour-l-agent-support-vigilance-de-la-coh-re-f27d4c6d4e9a4b748d8b219d858fd30b?pvs=4

### Pourquoi ?

Lors de modification pour gérer les doublons d'utilisateur, il peut arriver de créer des incohérences entre les candidatures/PASS & diag.
