### PR TITLE
[GEN-7888] Map conseiller

### DIFF
--- a/itou/openid_connect/inclusion_connect/enums.py
+++ b/itou/openid_connect/inclusion_connect/enums.py
@@ -9,3 +9,4 @@ class InclusionConnectChannel(str, enum.Enum):
     INVITATION = "invitation"
     POLE_EMPLOI = "pole_emploi"
     ACTIVATION = "activation"
+    MAP_CONSEILLER = "map_conseiller"

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -1,10 +1,16 @@
 import dataclasses
+import logging
 
 from django.db import models
 
+from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import IdentityProvider, UserKind
+from itou.users.models import User
 
 from ..models import OIDConnectState, OIDConnectUserData
+
+
+logger = logging.getLogger(__name__)
 
 
 class InclusionConnectState(OIDConnectState):
@@ -19,6 +25,15 @@ class InclusionConnectPrescriberData(OIDConnectUserData):
     kind: str = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
     login_allowed_user_kinds = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
+
+    def join_org(self, user: User, safir: str):
+        try:
+            organization = PrescriberOrganization.objects.get(code_safir_pole_emploi=safir)
+        except PrescriberOrganization.DoesNotExist:
+            logger.error(f"Organization with SAFIR {safir} does not exist. Unable to add user {user.email}.")
+            raise
+        if not organization.has_member(user):
+            organization.add_member(user)
 
 
 @dataclasses.dataclass

--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -82,11 +82,13 @@ def _generate_inclusion_params_from_session(ic_data):
         "state": state,
         "nonce": crypto.get_random_string(length=12),
     }
-    if (user_email := ic_data.get("user_email")) is not None:
+    if channel := ic_data.get("channel"):
+        data["channel"] = channel
+    if user_email := ic_data.get("user_email"):
         data["login_hint"] = user_email
-    if (lastname := ic_data.get("user_lastname")) is not None:
+    if lastname := ic_data.get("user_lastname"):
         data["lastname"] = lastname
-    if (firstname := ic_data.get("user_firstname")) is not None:
+    if firstname := ic_data.get("user_firstname"):
         data["firstname"] = firstname
     return data
 
@@ -121,11 +123,11 @@ def inclusion_connect_authorize(request):
         user_kind=user_kind, previous_url=previous_url, next_url=next_url, is_login=not register
     )
 
-    user_email = request.GET.get("user_email")
-    channel = request.GET.get("channel")
-    if user_email:
-        ic_data.user_email = user_email
+    if channel := request.GET.get("channel"):
         ic_data.channel = channel
+
+    if user_email := request.GET.get("user_email"):
+        ic_data.user_email = user_email
         ic_data.user_firstname = request.GET.get("user_firstname")
         ic_data.user_lastname = request.GET.get("user_lastname")
 

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -74,6 +74,27 @@ def add_url_params(url: str, params: dict[str, str]) -> str:
     return new_url
 
 
+def get_url_param_value(url: str, key: str) -> str:
+    """Get a parameter value from a provided URL..
+
+    :param url: string of target URL
+    :param key: key of the requested param
+    :return: value of the requested param
+
+    >> url = 'http://localhost:8000/?channel=map_conseiller
+    >> key = "channel"
+    >> get_url_param_value(url, key)
+    'map_conseiller'
+    """
+    from urllib.parse import parse_qs, urlparse
+
+    parsed_url = urlparse(url)
+    key_list = parse_qs(parsed_url.query).get(key)
+    if key_list:
+        return key_list[0]
+    return None
+
+
 class SiretConverter:
     """
     Custom path converter for Siret.

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -51,6 +51,7 @@ from itou.utils.urls import (
     get_external_link_markup,
     get_safe_url,
     get_tally_form_url,
+    get_url_param_value,
 )
 from itou.utils.validators import (
     alphanumeric,
@@ -890,6 +891,21 @@ class UtilsUrlsTestCase(TestCase):
             f'<a href="{url}" rel="noopener" target="_blank" aria-label="Ouverture dans un nouvel onglet">{text}</a>'
         )
         assert get_external_link_markup(url=url, text=text) == expected
+
+
+@pytest.mark.parametrize(
+    "url,expected_value",
+    [
+        ("https://domain.com/hey_there?channel=map_conseiller", "map_conseiller"),
+        ("https://domain.com/hey_there?channel=", ""),
+        ("https://domain.com/hey_there", None),
+        ("https://[::1/", None),
+        ("that-is-not-a-url", None),
+        ("12345", None),
+    ],
+)
+def test_get_url_param_value(url, expected_value):
+    assert get_url_param_value(url, "channel") == expected_value
 
 
 class MockedCompanySignupTokenGenerator(CompanySignupTokenGenerator):


### PR DESCRIPTION
### Pourquoi ?

En tant que prescripteur, je pourrai voir la liste des candidatures d'un candidat que j'accompagne drectement sur MAP Conseiller. En cliquant sur le lien, je peux voir le détail de la candidature sans avoir à saisir mes identifiants (MAP ou les emplois).

La suite du parcours est [dans cette PR](https://github.com/gip-inclusion/inclusion-connect/pull/426).

### Comment ?

Redirection vers Inclusion Connect si « channel=`map_conseiller` » est présent dans l'URL.
:warning: Une seconde PR suivra, sur Inclusion Connect, pour effectuer une redirection vers PEAM-A lorsque ce même paramètre est détecté dans l'URL. Selon PE, le conseiller n'aura pas besoin de saisir de nouveau ses identifiants car c'est géré « automagiquement ».

J'ai utilisé le paramètre « channel » qui avait l'avantage de déjà exister mais je suis preneuse de votre avis.

Au passage, j'ajoute un petit utilitaire qui récupère la valeur d'un paramètre dans une URL non gérée par Django. En effet, l'URL « next_url » est justement celle qui contient le paramètre « channel ». Je n'ai pas trouvé de meilleure alternative (mais peut-être suis-je passée à côté d'une subtilité djangoesque).

Lorsqu'un code SAFIR est renvoyé par IC et que le compte prescripteur n'existe pas, nous en créons un et le rattachons à la bonne agence. Si l'agence n'est pas trouvée, un message d'erreur s'affiche.

### Captures d'écran

:smirk: C'est tout l'intérêt de cette PR...

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
