### PR TITLE
Vérification d'unicité du NIR: simplification

### DIFF
--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -38,10 +38,6 @@ class UserAdminForm(UserChangeForm):
             if self.instance.email_already_exists(email, exclude_pk=self.instance.pk):
                 raise ValidationError(User.ERROR_EMAIL_ALREADY_EXISTS)
 
-        nir = self.cleaned_data["nir"]
-        if nir and self.instance.nir_already_exists(nir=nir, exclude_pk=self.instance.pk):
-            raise ValidationError("Le NIR de ce candidat est déjà associé à un autre utilisateur.")
-
         if self.instance.is_job_seeker:
             # Update job seeker geolocation
             try:

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -728,13 +728,6 @@ class User(AbstractUser, AddressMixin):
         return uuid.uuid4().hex
 
     @classmethod
-    def nir_already_exists(cls, nir, exclude_pk=None):
-        queryset = cls.objects.filter(nir=nir)
-        if exclude_pk:
-            queryset = queryset.exclude(pk=exclude_pk)
-        return queryset.exists()
-
-    @classmethod
     def email_already_exists(cls, email, exclude_pk=None):
         """
         RFC 5321 Part 2.4 states that only the domain portion of an email

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -95,8 +95,7 @@ class JobSeekerNirForm(forms.Form):
 
     def clean_nir(self):
         nir = self.cleaned_data["nir"].replace(" ", "")
-        user_exists = User.nir_already_exists(nir=nir)
-        if user_exists:
+        if User.objects.filter(nir=nir).exists():
             raise ValidationError("Un compte avec ce numéro existe déjà.")
         return nir
 

--- a/tests/users/test_admin_forms.py
+++ b/tests/users/test_admin_forms.py
@@ -98,7 +98,7 @@ class UserAdminFormTest(TestCase):
 
         form = UserAdminForm(data_new_user)
         assert not form.is_valid()
-        assert "Le NIR de ce candidat est déjà associé à un autre utilisateur." in form.errors["__all__"]
+        assert "Ce numéro de sécurité sociale est déjà associé à un autre utilisateur." in form.errors["__all__"]
 
         # updating user - nir not modified
         form = UserAdminForm(data=data_user, instance=user)
@@ -118,4 +118,4 @@ class UserAdminFormTest(TestCase):
         data_user["nir"] = existing_nir
         form = UserAdminForm(data=data_user, instance=user)
         assert not form.is_valid()
-        assert "Le NIR de ce candidat est déjà associé à un autre utilisateur." in form.errors["__all__"]
+        assert "Ce numéro de sécurité sociale est déjà associé à un autre utilisateur." in form.errors["__all__"]

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -175,11 +175,6 @@ class ModelTest(TestCase):
         assert User.email_already_exists("foo@bar.com")
         assert User.email_already_exists("FOO@bar.com")
 
-    def test_nir_already_exists(self):
-        user = JobSeekerFactory()
-        assert User.nir_already_exists(user.nir)
-        assert not User.nir_already_exists(JobSeekerFactory.build().nir)
-
     def test_save_for_unique_email_on_create_and_update(self):
         """
         Ensure `email` is unique when using the save() method for creating or updating a User instance.


### PR DESCRIPTION
### Pourquoi ?

Moins de code -> moins de problème