### PR TITLE
[GEN-2736] Retirer le lien vers les campagnes expérimentales de l’historique du contrôle a posteriori

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -1,3 +1,4 @@
+import datetime
 from pathlib import Path
 
 from django.conf import settings
@@ -133,7 +134,11 @@ class EvaluationCampaignQuerySet(models.QuerySet):
 
     def viewable(self):
         recent_q = Q(ended_at__gte=timezone.now() - CAMPAIGN_VIEWABLE_DURATION)
-        return self.filter(self.in_progress_q | recent_q)
+        return (
+            self.filter(self.in_progress_q | recent_q)
+            # Ignore first evaluation campaigns, they were a test.
+            .exclude(evaluated_period_end_at__lt=datetime.date(2022, 1, 1))
+        )
 
 
 class EvaluationCampaign(models.Model):

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -5,11 +5,9 @@ from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
-from django.db.models import Q
 from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse, reverse_lazy
-from django.utils import timezone
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_POST
@@ -26,7 +24,6 @@ from itou.institutions.models import Institution
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.openid_connect.inclusion_connect import constants as ic_constants
 from itou.prescribers.models import PrescriberOrganization
-from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
 from itou.users.enums import MATOMO_ACCOUNT_TYPE, IdentityProvider, UserKind
 from itou.users.models import User
@@ -87,10 +84,7 @@ def _employer_dashboard_context(request):
         "evaluated_siae_notifications": (
             EvaluatedSiae.objects.for_company(current_org)
             .exclude(notified_at=None)
-            .filter(
-                Q(evaluation_campaign__ended_at=None)
-                | Q(evaluation_campaign__ended_at__gte=timezone.now() - CAMPAIGN_VIEWABLE_DURATION)
-            )
+            .viewable()
             .select_related("evaluation_campaign")
         ),
         "job_applications_categories": job_applications_categories,

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
@@ -219,8 +217,6 @@ def evaluation_campaign_data_context(evaluated_siae):
         EvaluatedSiae.objects.viewable()
         .filter(siae=evaluated_siae.siae_id)
         .exclude(pk=evaluated_siae.pk)
-        # Ignore first evaluation campaigns, they were a test.
-        .exclude(evaluation_campaign__evaluated_period_end_at__lt=datetime.date(2022, 1, 1))
         .order_by("-evaluation_campaign__evaluated_period_start_at")
         .select_related("evaluation_campaign", "sanctions")
         .prefetch_related("evaluated_job_applications__evaluated_administrative_criteria")


### PR DESCRIPTION
### Pourquoi ?

Elles ne sont pas censées compter.
