### PR TITLE
[STATS] amélioration de tags

### DIFF
--- a/itou/templates/apply/includes/accept_section.html
+++ b/itou/templates/apply/includes/accept_section.html
@@ -20,7 +20,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                <button class="btn btn-sm btn-primary" hx-post={{ request.path }} hx-vals='{"confirmed": "True"}' hx-include="#acceptForm" {% matomo_event "candidature" "submit" "accept_application" %}>Confirmer
+                <button class="btn btn-sm btn-primary" hx-post={{ request.path }} hx-vals='{"confirmed": "True"}' hx-include="#acceptForm" {% matomo_event "candidature" "submit" "accept_application_confirmation" %}>Confirmer
                 </button>
             </div>
         </div>

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -1,5 +1,6 @@
 {% load django_bootstrap5 %}
 {% load str_filters %}
+{% load matomo %}
 <div class="c-form">
     <form id="acceptForm" method="post" hx-post="{{ request.path }}" hx-swap="outerHTML show:#acceptForm:top" hx-select="#acceptForm" class="js-format-nir">
         {% if has_form_error %}
@@ -57,7 +58,9 @@
                     <a class="btn btn-block btn-outline-primary" href="{{ back_url }}">Retour</a>
                 </div>
                 <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button class="btn btn-ico btn-block btn-primary" aria-label="Valider l’embauche de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
+                    <button class="btn btn-ico btn-block btn-primary"
+                            aria-label="Valider l’embauche de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}"
+                            {% matomo_event "candidature" "submit" "accept_application_submit" %}>
                         <i class="ri-check-line ri-xl"></i>
                         <span>Valider l’embauche</span>
                     </button>

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -120,7 +120,7 @@
 
 <a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_pk=job_seeker.pk %}?back_url={{ request.get_full_path|urlencode }}{% if job_application %}&from_application={{ job_application.pk }}{% endif %}{% endif %}"
    class="btn btn-ico btn-secondary{% if not can_edit_personal_information %} disabled{% endif %}"
-   {% if with_matomo_event %}{% matomo_event "salaries" "clic" "modifier-les-informations-personnelles" %}{% endif %}
+   {% if with_matomo_event %}{% matomo_event "salaries" "clic" "edit_jobseeker_infos" %}{% endif %}
    aria-label="Modifier les informations personnelles de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
     <i class="ri-pencil-line font-weight-medium" aria-hidden="true"></i>
     <span>Modifier les informations personnelles</span>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load str_filters %}
+{% load matomo %}
 
 {% block title %}Candidatures reçues {{ block.super }}{% endblock %}
 
@@ -104,9 +105,8 @@
                                         <a class="btn btn-sm btn-outline-primary bg-white"
                                            href="{% url 'apply:details_for_company' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                            aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
-                                           data-matomo-category="candidature"
-                                           data-matomo-action="clic"
-                                           data-matomo-option="voir_candidature_employeur">Voir sa candidature</a>
+                                           {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>
+                                        Voir sa candidature</a>
                                     </div>
                                 </div>
 

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -55,7 +55,7 @@
                     <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_company' job_application_id=job_application.id %}">Annuler</a>
                 </div>
                 <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button type="submit" class="btn btn-block btn-danger" {% matomo_event "candidature" "submit" "refuse_application" %}>
+                    <button type="submit" class="btn btn-block btn-danger" {% matomo_event "candidature" "submit" "refuse_application_submit" %}>
                         Confirmer le refus
                     </button>
                 </div>

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -32,7 +32,7 @@
     <hr class="my-4">
     <div class="form-group text-end">
         <a class="btn btn-link" href="{{ prev_url }}">Annuler</a>
-        <button type="submit" class="btn btn-primary" {% matomo_event "salaries" "submit" "modifier-les-informations-personnelles" %}>
+        <button type="submit" class="btn btn-primary" {% matomo_event "salaries" "submit" "edit_jobseeker_infos_submit" %}>
             {{ submit_label }}
         </button>
     </div>

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -1116,7 +1116,8 @@
   
                                       <div class="card-footer text-end bg-light">
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">
+                                          Voir sa candidature</a>
                                       </div>
                                   </div>
   
@@ -1220,7 +1221,8 @@
                                                   En attente de réponse depuis 3 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">
+                                          Voir sa candidature</a>
                                       </div>
                                   </div>
   
@@ -1294,7 +1296,8 @@
                                                   En attente de réponse depuis 8 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">
+                                          Voir sa candidature</a>
                                       </div>
                                   </div>
   


### PR DESCRIPTION
### Pourquoi ?

#### désambiguation de tags
Matomo ne prend que soit le nom, soit la catégorie, soit l'action d'un évènement pour parémetrer un objectif, sans combinaison possible. Le nom des évènements doit alors être unique :
- `accept_application` / `accept_application_submit` / `accept_application_modal_confirmation` 
- `refuse_application` ∕ `refuse_application_submit`
- `edit_jobseeker_infos` / `edit_jobseeker_infos_submit`

#### harmonisation des tags FR
- utiliser `-` et à place de `_` dans les tags FR : `voir-candidature-employeur`


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
