### PR TITLE
[STATS] harmonisation de l'appel aux évènements matomo

### DIFF
--- a/itou/files/forms.py
+++ b/itou/files/forms.py
@@ -7,6 +7,7 @@ from django.utils.html import format_html
 from openpyxl import load_workbook
 
 from itou.utils.constants import ITOU_HELP_CENTER_URL, MB
+from itou.utils.templatetags.matomo import matomo_event
 
 
 class ItouFileInput(forms.FileInput):
@@ -91,15 +92,14 @@ class ItouFileField(forms.FileField):
                        target="_blank"
                        rel="noopener"
                        class="matomo-event has-external-link"
-                       matomo-category="ajout-fichier-candidature"
-                       matomo-action="clic"
-                       matomo-option="clic-sur-lien-aide-pdf"
+                       %s
                        aria-label="Découvrez comment le convertir (ouverture dans un nouvel onglet)">
                         Découvrez comment le convertir.
                     </a>
                 </p>
                """,
                 f"{ITOU_HELP_CENTER_URL}/articles/16875396981777--Convertir-votre-document-en-format-PDF",
+                matomo_event("ajout-fichier-candidature", "clic", "clic-sur-lien-aide-pdf"),
             )
 
     def clean(self, data, initial=None):

--- a/itou/static/js/matomo.js
+++ b/itou/static/js/matomo.js
@@ -2,17 +2,14 @@ htmx.onLoad((target) => {
 
     /********************************************************************
        Send an event to Matomo on click.
-       Legacy usage:
-       <a href="#" class="matomo-event" data-matomo-category="MyCategory"
-       data-matomo-action="MyAction" data-matomo-option="MyOption" >
-       New usage:
-         <a href="#" data-matomo-event="true" data-matomo-category="MyCategory"
-            data-matomo-action="MyAction" data-matomo-option="MyOption" >
-        With matomo-attributes tag:
-         {% load matomo %}
+       Usage with matomo-attributes tag:
+            {% load matomo %}
             <a href="#" {% matomo_event "MyCategory" "MyAction" "MyOption" %} >
+        Converted by simpletag to:
+            <a href="#" data-matomo-event="true" data-matomo-category="MyCategory"
+            data-matomo-action="MyAction" data-matomo-option="MyOption" >
     ********************************************************************/
-    $('[data-matomo-event="true"], .matomo-event', target).on("click", function() {
+    $('data-matomo-event="true"', target).on("click", function() {
         var category = $(this).data("matomo-category");
         var action = $(this).data("matomo-action");
         var option = $(this).data("matomo-option");

--- a/itou/templates/account/activate_inclusion_connect_account.html
+++ b/itou/templates/account/activate_inclusion_connect_account.html
@@ -4,6 +4,7 @@
 {% load redirection_fields %}
 {% load static %}
 {% load theme_inclusion %}
+{% load matomo %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
@@ -26,11 +27,7 @@
                             Il vous permettra d'accéder aux différents services partenaires avec <b>le même identifiant et le même mot de passe.</b>
                         </p>
                         <p>Il vous suffit de cliquer sur le bouton ci-desous pour activer votre compte</p>
-                        <a href="{{ inclusion_connect_url }}"
-                           class="btn btn-block btn-primary matomo-event"
-                           data-matomo-category="activation {{ matomo_account_type }}"
-                           data-matomo-action="clic"
-                           data-matomo-option="activer-son-compte-inclusion-connect">
+                        <a href="{{ inclusion_connect_url }}" class="btn btn-block btn-primary" {% matomo_event "activation "|add:matomo_account_type "clic" "activer-son-compte-inclusion-connect" %}>
                             Activer mon compte Inclusion Connect
                         </a>
                         <a class="btn btn-link btn-block"

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -3,6 +3,7 @@
 {% load redirection_fields %}
 {% load static %}
 {% load theme_inclusion %}
+{% load matomo %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
@@ -17,11 +18,7 @@
                         {% if uses_inclusion_connect %}
                             {% if inclusion_connect_url %}
                                 <div class="text-center">
-                                    <a href="{{ inclusion_connect_url }}"
-                                       class="btn-inclusion-connect matomo-event"
-                                       data-matomo-category="connexion {{ matomo_account_type }}"
-                                       data-matomo-action="clic"
-                                       data-matomo-option="se-connecter-avec-inclusion-connect">
+                                    <a href="{{ inclusion_connect_url }}" class="btn-inclusion-connect" {% matomo_event "connexion "|add:matomo_account_type "clic" "se-connecter-avec-inclusion-connect" %}>
                                         <picture>
                                             <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
                                             <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" alt="Se connecter avec Inclusion Connect">

--- a/itou/templates/apply/includes/buttons/archive.html
+++ b/itou/templates/apply/includes/buttons/archive.html
@@ -1,3 +1,4 @@
+{% load matomo %}
 <button data-bs-toggle="modal" data-bs-target="#delete-job-application" class="btn btn-outline-primary btn-block btn-ico">
     <i class="ri-delete-bin-line ri-lg"></i>
     <span>Supprimer cette candidature</span>
@@ -28,10 +29,8 @@
                 <div class="modal-footer">
                     <a href="#" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" aria-label="Non">Non</a>
                     <input type="submit"
-                           class="btn btn-sm btn-danger matomo-event"
-                           data-matomo-category="employeurs"
-                           data-matomo-action="clic"
-                           data-matomo-option="suppression-candidature"
+                           class="btn btn-sm btn-danger"
+                           {% matomo_event "employeurs" "clic" "suppression-candidature" %}
                            rel="noopener"
                            aria-label="Oui, je souhaite supprimer cette candidature"
                            value="Oui, je souhaite supprimer cette candidature">

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load str_filters %}
+{% load matomo %}
 
 {% block title %}Candidatures {{ block.super }}{% endblock %}
 
@@ -90,9 +91,7 @@
                                         <a class="btn btn-sm btn-outline-primary bg-white"
                                            href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                            aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
-                                           data-matomo-category="candidature"
-                                           data-matomo-action="clic"
-                                           data-matomo-option="voir_candidature_prescripteur">Voir sa candidature</a>
+                                           {% matomo_event "candidature" "clic" "voir_candidature_prescripteur" %}>Voir sa candidature</a>
                                     </div>
                                 </div>
                             {% endfor %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -105,8 +105,7 @@
                                         <a class="btn btn-sm btn-outline-primary bg-white"
                                            href="{% url 'apply:details_for_company' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                            aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
-                                           {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>
-                                        Voir sa candidature</a>
+                                           {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>Voir sa candidature</a>
                                     </div>
                                 </div>
 

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -1,6 +1,7 @@
 {% extends "apply/process_base.html" %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
+{% load matomo %}
 
 {% block content_extend %}
     {# Job seeker info ------------------------------------------------------------------------- #}
@@ -65,11 +66,7 @@
             <p>
                 La consultation et la gestion du PASS IAE (exemple : « suspendre » ou « prolonger » un PASS IAE) se fait depuis le profil salarié.
             </p>
-            <a class="btn btn-block btn-primary matomo-event"
-               href="{% url 'approvals:detail' pk=job_application.approval.id %}"
-               data-matomo-category="salaries"
-               data-matomo-action="clic"
-               data-matomo-option="detail-salarie-depuis-candidature">Accéder au profil salarié</a>
+            <a class="btn btn-block btn-primary" href="{% url 'approvals:detail' pk=job_application.approval.id %}" {% matomo_event "salaries" "clic" "detail-salarie-depuis-candidature" %}>Accéder au profil salarié</a>
         </div>
     {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -55,7 +55,7 @@
                         <div class="col">
                             <p class="mb-0">
                                 Vous possédez un numéro de sécurité sociale temporaire ?
-                                <button name="skip" value="1" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="candidature">
+                                <button name="skip" value="1" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "candidature" %}>
                                     Cliquez ici pour accéder à l'étape suivante.
                                 </button>
                             </p>

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load matomo %}
 
 {% block title %}Profil salarié - {{ approval.user.get_full_name }} {{ block.super }}{% endblock %}
 
@@ -54,10 +55,8 @@
                                     </div>
                                 {% endif %}
                                 <div class="col-12 col-lg-auto">
-                                    <a class="btn btn-primary btn-block btn-ico matomo-event"
-                                       data-matomo-action="telechargement-pdf"
-                                       data-matomo-category="agrement"
-                                       data-matomo-option="detail-agrement"
+                                    <a class="btn btn-primary btn-block btn-ico"
+                                       {% matomo_event "telechargement-pdf" "agrement" "detail-agrement" %}
                                        href="{% url 'approvals:display_printable_approval' approval_id=approval.id %}"
                                        target="_blank"
                                        rel="noopener"

--- a/itou/templates/approvals/includes/job_applications.html
+++ b/itou/templates/approvals/includes/job_applications.html
@@ -1,3 +1,4 @@
+{% load matomo %}
 <div class="card c-card has-links-inside my-4">
     <div class="card-body">
         {% include "approvals/includes/job_description_creation.html" with job_application=job_application %}
@@ -6,10 +7,8 @@
 
     <div class="card-footer text-end bg-light">
         <a href="{% url 'apply:details_for_company' job_application_id=job_application.id %}"
-           class="btn btn-sm btn-outline-primary bg-white matomo-event"
-           data-matomo-category="salaries"
-           data-matomo-action="clic"
-           data-matomo-option="detail-candidature"
+           class="btn btn-sm btn-outline-primary bg-white"
+           {% matomo_event "salaries" "clic" "detail-candidature" %}
            aria-label="Voir la candidature de {{ job_application.sender.get_full_name }}">Voir sa candidature</a>
     </div>
 </div>

--- a/itou/templates/approvals/includes/list_card.html
+++ b/itou/templates/approvals/includes/list_card.html
@@ -1,5 +1,6 @@
 {% load format_filters %}
 {% load str_filters %}
+{% load matomo %}
 
 <div class="c-card card my-4 has-links-inside">
     <div class="card-header pb-3">
@@ -31,10 +32,8 @@
 
     <div class="card-footer text-end bg-light">
         <a href="{% url 'approvals:detail' pk=approval.id %}"
-           class="btn btn-sm btn-outline-primary bg-white matomo-event"
-           data-matomo-category="salaries"
-           data-matomo-action="clic"
-           data-matomo-option="details-salarie"
+           class="btn btn-sm btn-outline-primary bg-white"
+           {% matomo_event "salaries" "clic" "details-salarie" %}
            aria-label="Voir le profil de {{ approval.user.get_full_name }}">Voir son profil</a>
     </div>
 </div>

--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load matomo %}
 
 {% comment %} takes argument siae <Siae>{% endcomment %}
 <div class="card c-card has-links-inside mb-3 mb-md-4">
@@ -11,11 +12,9 @@
                         <span class="badge badge-sm rounded-pill bg-accent-02-lighter text-primary">Réservé au public éligible au contrat PEC</span>
                     {% endif %}
                 {% else %}
-                    <a class="matomo-event btn btn-sm btn-ico btn-link text-start p-0 mh-auto"
+                    <a class="btn btn-sm btn-ico btn-link text-start p-0 mh-auto"
                        href="{{ job_description.company.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
-                       data-matomo-category="candidature"
-                       data-matomo-action="clic"
-                       data-matomo-option="clic-structure-fichedeposte"
+                       {% matomo_event "candidature" "clic" "clic-structure-fichedeposte" %}
                        target="_blank"
                        aria-label="Ouvrir la page de la structure dans un nouvel onglet">
                         <span>{{ job_description.company.kind }} - {{ job_description.company.display_name }}</span>
@@ -39,11 +38,9 @@
         <div class="mb-3">
             {# Do not use is_external as it might evolve, and do not use a specific property. Covered by a test. #}
             {% if job_description.is_from_pole_emploi %}Offre proposée et gérée par pole-emploi.fr{% endif %}
-            <a class="matomo-event d-block h3 mb-2"
+            <a class="d-block h3 mb-2"
                href="{{ job_description.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}"
-               data-matomo-category="candidature"
-               data-matomo-action="clic"
-               {% if job_description.is_external %} rel="noopener" target="_blank" data-matomo-option="clic-card-fichedeposte-externe" aria-label="Visiter l'offre sur le site d'origine" {% else %} data-matomo-option="clic-card-fichedeposte" aria-label="Aller vers la description de ce poste"  {% endif %}>
+               {% if job_description.is_external %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte-externe" %} rel="noopener" target="_blank" aria-label="Visiter l'offre sur le site d'origine" {% else %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte" %} aria-label="Aller vers la description de ce poste" {% endif %}>
                 {{ job_description.display_name | capfirst }}
                 {% if job_description.is_external %}<i class="ri-external-link-line ri-lg ms-1"></i>{% endif %}
             </a>

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -16,7 +16,7 @@
             {% endif %}
         </p>
         <h3 class="mb-2">
-            <a class="matomo-event" href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" data-matomo-category="candidature" data-matomo-action="clic" data-matomo-option="clic-structure">{{ siae.display_name }}</a>
+            <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" {% matomo_event "candidature" "clic" "clic-structure" %}>{{ siae.display_name }}</a>
             {# Display non-user-edited name too, but only if it's not the same text #}
             {% if siae.brand and siae.brand|lower != siae.name|lower %}
                 <small class="text-muted">({{ siae.name|title }})</small>
@@ -36,11 +36,7 @@
                 <span class="text-muted fs-sm ms-1">de votre lieu de recherche.</span>
             </span>
             {% if siae.active_job_descriptions %}
-                <a class="d-none d-md-inline font-weight-bold matomo-event mt-3 mt-md-0"
-                   href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}#metiers"
-                   data-matomo-category="candidature"
-                   data-matomo-action="clic"
-                   data-matomo-option="clic-metiers">
+                <a class="d-none d-md-inline font-weight-bold mt-3 mt-md-0" href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}#metiers" {% matomo_event "candidature" "clic" "clic-metiers" %}>
                     Voir tous les métiers ({{ siae.active_job_descriptions|length }})
                 </a>
             {% endif %}

--- a/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
@@ -1,11 +1,10 @@
+{% load matomo %}
 {% comment %} takes 2 arguments: job=<JobDescription> is_appended=<Bool> {% endcomment %}
 
 <li class="list-group-item list-group-item-action py-2 {% if is_appended %}border-top{% endif %}">
-    <a class="d-flex flex-wrap align-items-center text-decoration-none matomo-event"
+    <a class="d-flex flex-wrap align-items-center text-decoration-none"
        href="{% if job.pk %}{{ job.get_absolute_url }}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
-       data-matomo-category="candidature"
-       data-matomo-action="clic"
-       data-matomo-option="clic-metiers">
+       {% matomo_event "candidature" "clic" "clic-metiers" %}>
         <div class="d-inline">
             <span class="font-weight-bold me-1 me-md-2">{{ job.display_name }}</span>
             {% if job.is_popular %}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load format_filters %}
 {% load static tally %}
+{% load matomo %}
 {% block title %}Tableau de bord {{ block.super }}{% endblock %}
 
 {% block messages %}
@@ -132,11 +133,7 @@
                                     </p>
                                     <div class="row g-0">
                                         <div class="col-12 col-md-auto mt-2">
-                                            <a href="{{ ic_activate_url }}"
-                                               class="btn btn-primary btn-block matomo-event"
-                                               data-matomo-category="activation {{ request.user.kind }}"
-                                               data-matomo-action="clic"
-                                               data-matomo-option="activer-son-compte-inclusion-connect-bandeau">Activer Inclusion Connect</a>
+                                            <a href="{{ ic_activate_url }}" class="btn btn-primary btn-block" {% matomo_event "activation "|add:request.user.kind "clic" "activer-son-compte-inclusion-connect-bandeau" %}>Activer Inclusion Connect</a>
                                         </div>
                                         <div class="col-12 col-md-auto mt-2">
                                             <a class="btn btn-link btn-block"

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -1,6 +1,7 @@
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
+{% load matomo %}
 
 <div class="row">
     <div class="col-12 col-lg-8 order-2 order-lg-1">
@@ -63,10 +64,8 @@
                         <span>Suspendre</span>
                     </a>
                 {% endif %}
-                <a class="btn btn-outline-primary btn-block matomo-event"
-                   data-matomo-action="telechargement-pdf"
-                   data-matomo-category="agrement"
-                   data-matomo-option="detail-agrement"
+                <a class="btn btn-outline-primary btn-block"
+                   {% matomo_event "telechargement-pdf" "agrement" "detail-agrement" %}
                    href="{% url 'approvals:display_printable_approval' approval_id=job_application.approval.id %}"
                    target="_blank">Afficher le PASS IAE</a>
             {% endwith %}

--- a/itou/templates/inclusion_connect/includes/description.html
+++ b/itou/templates/inclusion_connect/includes/description.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load theme_inclusion %}
+{% load matomo %}
 
 <h2>Créez un compte les emplois de l’inclusion avec Inclusion Connect</h2>
 <p class="mt-5">
@@ -9,11 +10,7 @@
 
 {% if inclusion_connect_url %}
     <div class="text-center">
-        <a href="{{ inclusion_connect_url }}"
-           class="btn-inclusion-connect matomo-event"
-           data-matomo-category="inscription {{ matomo_account_type }}"
-           data-matomo-action="clic"
-           data-matomo-option="se-connecter-avec-inclusion-connect">
+        <a href="{{ inclusion_connect_url }}" class="btn-inclusion-connect" {% matomo_event "inscription "|add:matomo_account_type "clic" "se-connecter-avec-inclusion-connect" %}>
             <picture>
                 <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
                 <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" alt="Se connecter avec Inclusion Connect">

--- a/itou/templates/layout/_footer.html
+++ b/itou/templates/layout/_footer.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load theme_inclusion %}
+{% load matomo %}
 
 <footer role="contentinfo" id="footer">
 
@@ -30,24 +31,14 @@
                     <strong>Besoin d'aide ?</strong>
                     <ul>
                         <li>
-                            <a href="{{ ITOU_HELP_CENTER_URL }}"
-                               rel="noopener"
-                               target="_blank"
-                               aria-label="Accéder à l'espace de documentation (nouvel onglet)"
-                               class="matomo-event"
-                               data-matomo-category="help"
-                               data-matomo-action="clic"
-                               data-matomo-option="footer_documentation">Documentation</a>
+                            <a href="{{ ITOU_HELP_CENTER_URL }}" rel="noopener" target="_blank" aria-label="Accéder à l'espace de documentation (nouvel onglet)" {% matomo_event "help" "clic" "footer_documentation" %}>Documentation</a>
                         </li>
                         <li>
                             <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
                                rel="noopener"
                                target="_blank"
                                aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)"
-                               class="matomo-event"
-                               data-matomo-category="help"
-                               data-matomo-action="clic"
-                               data-matomo-option="footer_comprendre-liae">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
+                               {% matomo_event "help" "clic" "footer_comprendre-liae" %}>Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
                         </li>
                         <li>
                             <a href="https://updown.io/p/vjjst" target="_blank" aria-label="Disponibilité (ouverture dans un nouvel onglet)">Disponibilité</a>

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -14,22 +14,18 @@
                 <li>
                     <a href="{{ ITOU_HELP_CENTER_URL }}"
                        rel="noopener"
-                       class="dropdown-item has-external-link matomo-event"
+                       class="dropdown-item has-external-link"
                        target="_blank"
                        aria-label="Accéder à l'espace de documentation (nouvel onglet)"
-                       data-matomo-category="help"
-                       data-matomo-action="clic"
-                       data-matomo-option="header_documentation">Documentation</a>
+                       {% matomo_event "help" "clic" "header_documentation" %}>Documentation</a>
                 </li>
                 <li>
                     <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733403281937--Comprendre-l-IAE"
                        rel="noopener"
-                       class="dropdown-item has-external-link matomo-event"
+                       class="dropdown-item has-external-link"
                        target="_blank"
                        aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)"
-                       data-matomo-category="help"
-                       data-matomo-action="clic"
-                       data-matomo-option="header_comprendre-liae">Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
+                       {% matomo_event "help" "clic" "header_comprendre-liae" %}>Qui peut bénéficier des contrats d'IAE&nbsp;?</a>
                 </li>
                 {% if user.is_authenticated %}
                     {% if user.is_employer or user.is_prescriber_with_authorized_org %}

--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -36,7 +36,7 @@
                         <li>
                             <a href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite"
                                rel="noopener"
-                               class="dropdown-item has-external-link matomo-event"
+                               class="dropdown-item has-external-link"
                                target="_blank"
                                aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)"
                                {% matomo_event "help" "clic" "header_prescrire-parcours-iae-guide" %}>Prescrire un parcours IAE (guide pratique)</a>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load str_filters %}
+{% load matomo %}
 
 {% block title %}
     {% if form.is_valid %}
@@ -27,10 +28,8 @@
                         {% endif %}
                         <ul class="s-tabs-01__nav nav nav-tabs mt-3 mt-md-5">
                             <li class="nav-item" role="presentation">
-                                <a class="matomo-event nav-link {% if request.resolver_match.view_name == "search:employers_results" %}active{% endif %}"
-                                   data-matomo-category="candidature"
-                                   data-matomo-action="clic"
-                                   data-matomo-option="clic-onglet-employeur"
+                                <a class="nav-link {% if request.resolver_match.view_name == "search:employers_results" %}active{% endif %}"
+                                   {% matomo_event "candidature" "clic" "clic-onglet-employeur" %}
                                    href="{% url "search:employers_results" %}?{{ filters_query_string }}">
                                     <i class="ri-hotel-line ri-xl font-weight-normal me-1"></i>
                                     <span>
@@ -39,10 +38,8 @@
                                 </a>
                             </li>
                             <li class="nav-item" role="presentation">
-                                <a class="matomo-event nav-link {% if request.resolver_match.view_name == "search:job_descriptions_results" %}active{% endif %}"
-                                   data-matomo-category="candidature"
-                                   data-matomo-action="clic"
-                                   data-matomo-option="clic-onglet-fichesdeposte"
+                                <a class="nav-link {% if request.resolver_match.view_name == "search:job_descriptions_results" %}active{% endif %}"
+                                   {% matomo_event "candidature" "clic" "clic-onglet-fichesdeposte" %}
                                    href="{% url "search:job_descriptions_results" %}?{{ filters_query_string }}">
                                     <i class="ri-briefcase-4-line ri-xl font-weight-normal me-1"></i>
                                     <span class="d-inline d-lg-none">

--- a/itou/templates/signup/includes/france_connect_button.html
+++ b/itou/templates/signup/includes/france_connect_button.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load matomo %}
 
 <p class="mb-0">
     <strong>Utilisez FranceConnect pour vous connecter ou créer un compte</strong>.
@@ -7,12 +8,7 @@
     FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne.
 </p>
 <div class="text-center">
-    <a href="{% url 'france_connect:authorize' %}"
-       aria-label="S'identifier avec FranceConnect"
-       class="matomo-event"
-       data-matomo-category="inscription-candidat"
-       data-matomo-action="clic"
-       data-matomo-option="se-connecter-avec-france-connect">
+    <a href="{% url 'france_connect:authorize' %}" aria-label="S'identifier avec FranceConnect" {% matomo_event "inscription-candidat" "clic" "se-connecter-avec-france-connect" %}>
         <img class="img-fluid mb-1 itou-france-connect" alt="">
     </a>
     <br>

--- a/itou/templates/signup/includes/no_email_link.html
+++ b/itou/templates/signup/includes/no_email_link.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load matomo %}
 
 <a href="#" data-bs-toggle="modal" data-bs-target="#no-email-modal">
     {% if link_text %}
@@ -31,10 +32,8 @@
             <div class="modal-footer">
                 <a aria-label="Ouverture dans un nouvel onglet"
                    href="https://compte.laposte.net/inscription/index.do?srv_gestion=POLEEMPLOI"
-                   class="btn btn-sm btn-primary btn-ico matomo-event"
-                   data-matomo-category="inscription-candidat"
-                   data-matomo-action="clic"
-                   data-matomo-option="je-n-ai-pas-d-adresse-email"
+                   class="btn btn-sm btn-primary btn-ico"
+                   {% matomo_event "inscription-candidat" "clic" "je-n-ai-pas-d-adresse-email" %}
                    rel="noopener"
                    target="_blank">
                     <span>Créer une adresse e-mail</span>

--- a/itou/templates/signup/includes/peamu_button.html
+++ b/itou/templates/signup/includes/peamu_button.html
@@ -1,12 +1,7 @@
 {% load static %}
+{% load matomo %}
 
 <form method="post" action="{% url 'pe_connect:authorize' %}">
     {% csrf_token %}
-    <input type="image"
-           src="{% static 'img/peamu_btn.svg' %}"
-           alt="Se connecter avec votre compte Pôle emploi"
-           class="matomo-event"
-           data-matomo-category="inscription-candidat"
-           data-matomo-action="clic"
-           data-matomo-option="se-connecter-avec-pe">
+    <input type="image" src="{% static 'img/peamu_btn.svg' %}" alt="Se connecter avec votre compte Pôle emploi" {% matomo_event "inscription-candidat" "clic" "se-connecter-avec-pe" %}>
 </form>

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load redirection_fields %}
 {% load static %}
+{% load matomo %}
 
 {% block title %}Inscription candidat {{ block.super }}{% endblock %}
 
@@ -29,7 +30,7 @@
                             {% if form.errors %}
                                 <div class="alert alert-info">
                                     Vous possédez un numéro de sécurité sociale temporaire ?
-                                    <button name="skip" value="1" class="btn btn-link p-0 matomo-event" data-matomo-category="nir-temporaire" data-matomo-action="etape-suivante" data-matomo-option="inscription">
+                                    <button name="skip" value="1" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "inscription" %}>
                                         Cliquez ici pour accéder à l'étape suivante.
                                     </button>
                                 </div>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -11,15 +11,15 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
                       
                           <li>
-                              <a aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_prescrire-parcours-iae-guide" href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite" rel="noopener" target="_blank">Prescrire un parcours IAE (guide pratique)</a>
+                              <a aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_prescrire-parcours-iae-guide" href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite" rel="noopener" target="_blank">Prescrire un parcours IAE (guide pratique)</a>
                           </li>
                       
                   
@@ -94,15 +94,15 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
                       
                           <li>
-                              <a aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_prescrire-parcours-iae-guide" href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite" rel="noopener" target="_blank">Prescrire un parcours IAE (guide pratique)</a>
+                              <a aria-label="Prescrire un parcours IAE (guide pratique) (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_prescrire-parcours-iae-guide" href="https://travail-emploi.gouv.fr/actualites/l-actualite-du-ministere/article/guide-pratique-la-prescription-de-parcours-d-insertion-par-l-activite" rel="noopener" target="_blank">Prescrire un parcours IAE (guide pratique)</a>
                           </li>
                       
                   
@@ -188,10 +188,10 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
                       
@@ -274,10 +274,10 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
                       
@@ -360,10 +360,10 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
                       
@@ -439,10 +439,10 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
                       
@@ -518,10 +518,10 @@
           <div class="dropdown-menu" id="helpDropdown">
               <ul class="list-unstyled">
                   <li>
-                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
+                      <a aria-label="Accéder à l'espace de documentation (nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_documentation" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr" rel="noopener" target="_blank">Documentation</a>
                   </li>
                   <li>
-                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link matomo-event" data-matomo-action="clic" data-matomo-category="help" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
+                      <a aria-label="Qui peut bénéficier des contrats d'IAE ? (ouverture dans un nouvel onglet)" class="dropdown-item has-external-link" data-matomo-action="clic" data-matomo-category="help" data-matomo-event="true" data-matomo-option="header_comprendre-liae" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733403281937--Comprendre-l-IAE" rel="noopener" target="_blank">Qui peut bénéficier des contrats d'IAE ?</a>
                   </li>
                   
               </ul>

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -880,7 +880,7 @@
   
                                       <div class="card-footer text-end bg-light">
                                           
-                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_prescripteur" href="/apply/11111111-1111-1111-1111-111111111111/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/11111111-1111-1111-1111-111111111111/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
                                       </div>
                                   </div>
                               
@@ -948,7 +948,7 @@
                                                   En attente de réponse depuis 3 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_prescripteur" href="/apply/22222222-2222-2222-2222-222222222222/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/22222222-2222-2222-2222-222222222222/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
                                       </div>
                                   </div>
                               
@@ -1016,7 +1016,7 @@
                                                   En attente de réponse depuis 8 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-option="voir_candidature_prescripteur" href="/apply/33333333-3333-3333-3333-333333333333/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de J… H…" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/33333333-3333-3333-3333-333333333333/prescriber/details?back_url=/apply/prescriber/list">Voir sa candidature</a>
                                       </div>
                                   </div>
                               
@@ -1116,8 +1116,7 @@
   
                                       <div class="card-footer text-end bg-light">
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">
-                                          Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
                                       </div>
                                   </div>
   
@@ -1221,8 +1220,7 @@
                                                   En attente de réponse depuis 3 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">
-                                          Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
                                       </div>
                                   </div>
   
@@ -1296,8 +1294,7 @@
                                                   En attente de réponse depuis 8 semaines.
                                               </span>
                                           
-                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">
-                                          Voir sa candidature</a>
+                                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-sm btn-outline-primary bg-white" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
                                       </div>
                                   </div>
   


### PR DESCRIPTION
### Pourquoi ?

En préparation de la revue des évènements matomo diffusés par le site, cette PR harmanise l'implémentation de ces évènements.

La nouvelle implémentation bénéfiice du `simple_tag` `matomo_event`

#### Ancienne syntaxe : 
```
class="matomo-event" 
data-matomo-category="category_name"
data-matomo-action="action_name"
data-matomo-option="option_name"
```

#### Syntaxe avec le `simple_tag`
En début de gabarit : `{% load matomo %}`
Dans le corps gabarit :
* `{% matomo_event "category_name" "action_name" "option_name" %}`
* `{% matomo_event "category_name"|add:var-to-be-concactenated "action_name" "option_name" %}` en cas d'aggrégation de vars

### Notes 

Simplification du script `matomo.js` : suppression de l'interpretation de `class=matomo-event`

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
