### PR TITLE
settings.dev: Allow customizing Metabase configuration variables

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -66,11 +66,11 @@ if SQL_DEBUG:  # noqa: F405
     }
 
 # use almost the same settings for metabase as base PG.
-METABASE_HOST = os.getenv("PGHOST", "127.0.0.1")  # noqa: F405
-METABASE_PORT = os.getenv("PGPORT", "5432")  # noqa: F405
-METABASE_USER = os.getenv("PGUSER", "postgres")  # noqa: F405o
-METABASE_PASSWORD = os.getenv("PGPASSWORD", "password")  # noqa: F405
-METABASE_DATABASE = os.getenv("PGDATABASE", "metabase")  # noqa: F405
+METABASE_HOST = os.getenv("METABASE_HOST", os.getenv("PGHOST", "127.0.0.1"))  # noqa: F405
+METABASE_PORT = os.getenv("METABASE_PORT", os.getenv("PGPORT", "5432"))  # noqa: F405
+METABASE_USER = os.getenv("METABASE_USER", os.getenv("PGUSER", "postgres"))  # noqa: F405o
+METABASE_PASSWORD = os.getenv("METABASE_PASSWORD", os.getenv("PGPASSWORD", "password"))  # noqa: F405
+METABASE_DATABASE = os.getenv("METABASE_DATABASE", os.getenv("PGDATABASE", "metabase"))  # noqa: F405
 
 FORCE_IC_LOGIN = os.getenv("FORCE_IC_LOGIN", "True") == "True"
 


### PR DESCRIPTION
### Pourquoi ?

Permettre l'utilisation de DB (ou autres) différentes entre `gip-inclusion/les-emplois` et `gip-inclusion/pilotage-airflow`.

@dejafait @YannickPassa Je vous met en relecteurs car _normalement_ vous êtes les seuls à avoir éventuellement besoin de ça, ça devrait rien casser sauf si vous avez définis une variable `METABASE_` mais pas trop de raison _a priori_.
### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
