### PR TITLE
Refonte UX/UI - Boutons de formulaire + champs obligatoires [GEN-7943]

### DIFF
--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -3,6 +3,7 @@
 
 {% load account %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Confirmer l'adresse e-mail {{ block.super }}{% endblock %}
 
@@ -32,7 +33,7 @@
                             {# See Allauth.account.adapter.DefaultAccountAdapter.is_safe_url #}
                             {% if request.GET.next %}<input type="hidden" name="next" value="{{ request.GET.next }}">{% endif %}
 
-                            <div class="form-group">{% bootstrap_button "Confirmer" button_type="submit" button_class="btn btn-primary" %}</div>
+                            {% itou_buttons_form primary_label="Confirmer" show_mandatory_fields_mention=False %}
 
                         </form>
 

--- a/itou/templates/account/includes/login_form.html
+++ b/itou/templates/account/includes/login_form.html
@@ -1,5 +1,6 @@
 {% load django_bootstrap5 %}
 {% load redirection_fields %}
+{% load buttons_form %}
 
 <form method="post" class="js-prevent-multiple-submit">
     {% csrf_token %}
@@ -15,8 +16,7 @@
         </div>
     </fieldset>
     <div class="form-row justify-content-end">
-        <div class="form-group col-12 col-lg-auto">
-            {% bootstrap_button "Se connecter" button_class="btn btn-primary btn-block" %}
-        </div>
+        {% url 'home:hp' as reset_url %}
+        {% itou_buttons_form primary_label="Se connecter" reset_url=reset_url %}
     </div>
 </form>

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -2,6 +2,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load redirection_fields %}
+{% load buttons_form %}
 
 {% block title %}Déconnexion {{ block.super }}{% endblock %}
 
@@ -21,9 +22,8 @@
 
                             {% redirection_input_field value=redirect_field_value %}
 
-                            <div class="form-group">
-                                {% bootstrap_button "Se déconnecter" button_type="submit" button_class="btn btn-primary" %}
-                            </div>
+                            {% url 'home:hp' as reset_url %}
+                            {% itou_buttons_form primary_label="Se déconnecter" reset_url=reset_url %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/account/password_change.html
+++ b/itou/templates/account/password_change.html
@@ -2,6 +2,7 @@
 {% extends "layout/base.html" %}
 
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Modifier votre mot de passe {{ block.super }}{% endblock %}
 
@@ -25,10 +26,8 @@
 
                             {% bootstrap_form form alert_error_type="all" %}
 
-                            <div class="form-group">
-                                <a class="btn btn-outline-primary" href="{% url 'dashboard:index' %}">Annuler</a>
-                                {% bootstrap_button "Modifier le mot de passe" button_type="submit" button_class="btn btn-primary" %}
-                            </div>
+                            {% url 'home:hp' as reset_url %}
+                            {% itou_buttons_form primary_label="Modifier le mot de passe" reset_url=reset_url %}
                         </form>
                     {% endif %}
                 </div>

--- a/itou/templates/account/password_reset.html
+++ b/itou/templates/account/password_reset.html
@@ -2,6 +2,7 @@
 {% extends "layout/base.html" %}
 {% load account %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Réinitialisation du mot de passe {{ block.super }}{% endblock %}
 
@@ -26,9 +27,8 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">
-                            {% bootstrap_button "Réinitialiser votre mot de passe" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
+                        {% url 'home:hp' as reset_url %}
+                        {% itou_buttons_form primary_label="Réinitialiser votre mot de passe" reset_url=reset_url %}
 
                     </form>
                 </div>

--- a/itou/templates/account/password_reset_from_key.html
+++ b/itou/templates/account/password_reset_from_key.html
@@ -1,6 +1,7 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Modification de votre mot de passe {{ block.super }}{% endblock %}
 
@@ -39,9 +40,8 @@
                                 {% bootstrap_field form.password1 %}
                                 {% bootstrap_field form.password2 %}
 
-                                <div class="form-group">
-                                    {% bootstrap_button "Modifier le mot de passe" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
+                                {% url 'home:hp' as reset_url %}
+                                {% itou_buttons_form primary_label="Modifier le mot de passe" reset_url=reset_url %}
 
                             </form>
 

--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Modification de la date de contrat {{ block.super }}{% endblock %}
 
@@ -22,18 +23,7 @@
 
                             {% bootstrap_form form alert_error_type="all" %}
 
-                            <hr>
-                            <div class="form-row align-items-center justify-content-end">
-                                <div class="form-group mb-0 col-6 col-lg-auto">
-                                    <a class="btn btn-outline-primary" href="{{ prev_url }}" aria-label="Annuler la modification de la date de contrat">Annuler</a>
-                                </div>
-                                <div class="form-group mb-0 col-6 col-lg-auto">
-                                    <button type="submit" class="btn btn-block btn-primary" aria-label="Enregistrer la modification de la date de contrat">
-                                        Enregistrer
-                                    </button>
-                                </div>
-                            </div>
-
+                            {% itou_buttons_form primary_label="Enregistrer" reset_url=prev_url matomo_category="salarie" matomo_action="submit" matomo_name="modifier-la-date-de-contrat" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/apply/includes/geiq/check_geiq_eligibility_form.html
+++ b/itou/templates/apply/includes/geiq/check_geiq_eligibility_form.html
@@ -3,13 +3,25 @@
 {% include "apply/includes/geiq/geiq_administrative_criteria_form.html" %}
 <hr>
 <div class="text-primary">{% bootstrap_field form.proof_of_eligibility %}</div>
-<hr>
 
-<div class="my-4 text-end">
-    <a href="{{ back_url }}" class="btn btn-link">Annuler</a>
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirm_geiq_eligibility_modal" {% if not form.proof_of_eligibility.value or form.errors %}disabled{% endif %}>
-        Valider les critères d'éligibilité GEIQ
-    </button>
+<hr class="mb-3">
+<div class="form-row align-items-center justify-content-end gx-3">
+    <div class="form-group col-12 col-lg order-3 order-lg-1">
+        <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+            <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+            <span>Annuler</span>
+        </a>
+    </div>
+    <div class="form-group col col-lg-auto order-2 order-lg-3">
+        <button type="button"
+                class="btn btn-block btn-primary"
+                data-bs-toggle="modal"
+                data-bs-target="#confirm_geiq_eligibility_modal"
+                aria-label="Continuer sans valider les critères GEIQ"
+                {% if not form.proof_of_eligibility.value or form.errors %}disabled{% endif %}>
+            <span>Valider les critères d'éligibilité GEIQ</span>
+        </button>
+    </div>
 </div>
 
 <div id="confirm_geiq_eligibility_modal" class="modal fade" tabindex="-1" aria-hidden="true">

--- a/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
+++ b/itou/templates/apply/includes/geiq/continue_without_geiq_diagnosis_form.html
@@ -2,13 +2,19 @@
 
 {% include "apply/includes/geiq/progress_bar.html" with progress=progress only %}
 
-<hr>
-
-<div class="my-4 text-end">
-    <a href="" class="btn btn-link">Annuler</a>
-    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#confirm_no_allowance_modal">
-        Continuer sans valider les critères GEIQ
-    </button>
+<hr class="mb-3">
+<div class="form-row align-items-center justify-content-end gx-3">
+    <div class="form-group col-12 col-lg order-3 order-lg-1">
+        <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+            <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+            <span>Annuler</span>
+        </a>
+    </div>
+    <div class="form-group col col-lg-auto order-2 order-lg-3">
+        <button type="button" class="btn btn-block btn-primary" data-bs-toggle="modal" data-bs-target="#confirm_no_allowance_modal" aria-label="Continuer sans valider les critères GEIQ">
+            <span>Continuer sans valider les critères GEIQ</span>
+        </button>
+    </div>
 </div>
 
 {% include "apply/includes/geiq/no_allowance_modal.html" with next_url=next_url only %}

--- a/itou/templates/apply/includes/geiq_eligibility_section.html
+++ b/itou/templates/apply/includes/geiq_eligibility_section.html
@@ -44,9 +44,14 @@
                             <form action="{{ geiq_criteria_form_url }}" method="post" hx-target="#geiq_form">
                                 {% csrf_token %}
                                 <div id="geiq_form">
-                                    <hr>
-                                    <div class="text-end">
-                                        <a href="{{ back_url }}" class="btn btn-link mb-2">Annuler</a>
+                                    <hr class="mb-3">
+                                    <div class="form-row align-items-center justify-content-end gx-3">
+                                        <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                            <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                                                <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                                                <span>Annuler</span>
+                                            </a>
+                                        </div>
                                     </div>
                                 </div>
                             </form>

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -1,6 +1,8 @@
 {% load django_bootstrap5 %}
 {% load str_filters %}
 {% load matomo %}
+{% load buttons_form %}
+
 <div class="c-form">
     <form id="acceptForm" method="post" hx-post="{{ request.path }}" hx-swap="outerHTML show:#acceptForm:top" hx-select="#acceptForm" class="js-format-nir">
         {% if has_form_error %}
@@ -51,21 +53,6 @@
         {% bootstrap_field form_accept.hiring_end_at %}
         {% bootstrap_field form_accept.answer %}
 
-        <div class="form-group">
-            <hr>
-            <div class="form-row align-items-center justify-content-end">
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <a class="btn btn-block btn-outline-primary" href="{{ back_url }}">Retour</a>
-                </div>
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button class="btn btn-ico btn-block btn-primary"
-                            aria-label="Valider l’embauche de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}"
-                            {% matomo_event "candidature" "submit" "accept_application_submit" %}>
-                        <i class="ri-check-line ri-xl"></i>
-                        <span>Valider l’embauche</span>
-                    </button>
-                </div>
-            </div>
-        </div>
+        {% itou_buttons_form primary_label="Valider l'embauche" primary_aria_label="Valider l’embauche de "|add:job_seeker.get_full_name|mask_unless:can_view_personal_information reset_url=back_url %}
     </form>
 </div>

--- a/itou/templates/apply/process_cancel.html
+++ b/itou/templates/apply/process_cancel.html
@@ -1,5 +1,6 @@
 {% extends "apply/process_base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block content_extend %}
     <div class="alert alert-warning alert-dismissible fade show" role="status">
@@ -25,15 +26,8 @@
 
         <input type="hidden" name="confirm" value="true">
 
-        <hr>
-        <div class="form-row align-items-center justify-content-end">
-            <div class="form-group mb-0 col-6 col-lg-auto">
-                <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_company' job_application_id=job_application.id %}">Retour</a>
-            </div>
-            <div class="form-group mb-0 col-6 col-lg-auto">
-                {% bootstrap_button "Confirmer l'annulation de l'embauche" button_type="submit" button_class="btn btn-danger btn-block" %}
-            </div>
-        </div>
+        {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
+        {% itou_buttons_form primary_label="Confirmer l'annulation de l'embauche" reset_url=reset_url show_mandatory_fields_mention=False %}
 
     </form>
 {% endblock %}

--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -1,7 +1,7 @@
 {% extends "apply/process_base.html" %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block content_extend %}
     <div class="c-form mb-4">
@@ -11,20 +11,8 @@
 
             {% bootstrap_form form alert_error_type="all" %}
 
-            <hr>
-            <div class="form-row align-items-center justify-content-end">
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_company' job_application_id=job_application.id %}">Annuler</a>
-                </div>
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button type="submit"
-                            class="btn btn-block btn-success"
-                            aria-label="Mettre la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }} en liste d'attente"
-                            {% matomo_event "candidature" "submit" "postpone_application" %}>
-                        Mettre en liste d'attente
-                    </button>
-                </div>
-            </div>
+            {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
+            {% itou_buttons_form primary_label="Mettre en liste d'attente" reset_url=reset_url show_mandatory_fields_mention=False matomo_category="candidature" matomo_action="submit" matomo_event="postpone_application" %}
 
         </form>
     </div>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -1,6 +1,6 @@
 {% extends "apply/process_base.html" %}
 {% load django_bootstrap5 %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block content_extend %}
     <div class="c-form">
@@ -49,17 +49,8 @@
 
             {% bootstrap_field form.answer %}
 
-            <hr>
-            <div class="form-row align-items-center justify-content-end">
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <a class="btn btn-outline-primary btn-block" href="{% url 'apply:details_for_company' job_application_id=job_application.id %}">Annuler</a>
-                </div>
-                <div class="form-group mb-0 col-6 col-lg-auto">
-                    <button type="submit" class="btn btn-block btn-danger" {% matomo_event "candidature" "submit" "refuse_application_submit" %}>
-                        Confirmer le refus
-                    </button>
-                </div>
-            </div>
+            {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
+            {% itou_buttons_form primary_label="Confirmer le refus" reset_url=reset_url matomo_category="candidature" matomo_action="submit" matomo_event="refuse_application_submit" %}
 
         </form>
     </div>

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Postuler {{ block.super }}{% endblock %}
 
@@ -112,22 +113,9 @@
 
                             {% block form_content %}{% endblock %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                {% if back_url %}
-                                    <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                        <a class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="{{ back_url }}" aria-label="Retourner à l'étape précédente">
-                                            <i class="ri-arrow-go-back-line ri-lg"></i>
-                                            <span>Retour</span>
-                                        </a>
-                                    </div>
-                                {% endif %}
-                                {% block form_submit_button %}
-                                    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                        <button type="submit" class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante">Suivant</button>
-                                    </div>
-                                {% endblock %}
-                            </div>
+                            {% block form_submit_button %}
+                                {% itou_buttons_form primary_label="Suivant" secondary_url=back_url %}
+                            {% endblock %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load str_filters %}
+{% load buttons_form %}
 
 {% block title %}Création du compte candidat {{ block.super }}{% endblock %}
 
@@ -96,11 +97,7 @@
                                         {% bootstrap_field form.phone %}
                                     </fieldset>
 
-                                    <hr class="my-5">
-                                    <div class="form-group text-end">
-                                        <button type="reset" class="btn btn-link" data-swap-element=".c-form">Annuler</button>
-                                        {% bootstrap_button "Enregistrer" button_type="submit" button_class="btn btn-primary" %}
-                                    </div>
+                                    {% itou_buttons_form primary_label="Enregistrer" reset_url=reset_url %}
                                 </form>
                             </div>
                         {% endif %}

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load matomo %}
+{% load buttons_form %}
 
 {% block progress_title %}{{ block.super }} - Message & CV{% endblock %}
 {% block step_title %}Finaliser la candidature{% endblock %}
@@ -232,13 +233,9 @@
 {% endblock %}
 
 {% block form_submit_button %}
-    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-        <button class="btn btn-primary btn-block" {% matomo_event "candidature" "submit" "candidature_"|add:request.user.get_kind_display %}>
-            {% if request.user.is_employer %}
-                Enregistrer
-            {% else %}
-                Envoyer la candidature
-            {% endif %}
-        </button>
-    </div>
+    {% if request.user.is_employer %}
+        {% itou_buttons_form primary_label="Enregistrer" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_event="candidature_employer" %}
+    {% else %}
+        {% itou_buttons_form primary_label="Envoyer la candidature" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_event="candidature_"|add:request.user.get_kind_display %}
+    {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit/check_job_seeker_info_for_hire.html
+++ b/itou/templates/apply/submit/check_job_seeker_info_for_hire.html
@@ -1,5 +1,6 @@
 {% extends "apply/submit_base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block content_title %}
     <h1>
@@ -18,11 +19,8 @@
 
         {% include "apply/includes/profile_infos.html" %}
 
-        <hr class="my-4">
-
-        <div class="text-end">
-            <a class="btn btn-primary" href="{% url 'apply:check_prev_applications_for_hire' company_pk=siae.pk job_seeker_pk=job_seeker.pk %}">Poursuivre l’embauche</a>
-        </div>
+        {% url 'apply:check_prev_applications_for_hire' company_pk=siae.pk job_seeker_pk=job_seeker.pk as primary_url %}
+        {% itou_buttons_form primary_url=primary_url primary_label="Poursuivre l'embauche" secondary_url=back_url show_mandatory_fields_mention=False %}
     </div>
 
 {% endblock %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}
     {% if update_job_seeker %}
@@ -64,21 +65,11 @@
                             {% csrf_token %}
 
                             {% block form_content %}{% endblock %}
-
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                {% if back_url %}
-                                    <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                        <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
-                                            <i class="ri-arrow-go-back-line ri-lg"></i>
-                                            <span>Retour</span>
-                                        </a>
-                                    </div>
-                                {% endif %}
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary btn-block" %}
-                                </div>
-                            </div>
+                            {% if back_url == reset_url %}
+                                {% itou_buttons_form primary_label="Suivant" reset_url=reset_url %}
+                            {% else %}
+                                {% itou_buttons_form primary_label="Suivant" secondary_url=back_url reset_url=reset_url %}
+                            {% endif %}
                         </form>
                     </div>
                 </div>
@@ -104,3 +95,10 @@
         })
     </script>
 {% endblock %}
+
+
+{% comment %}FAILED tests/www/apply/test_submit.py::ApplyAsPrescriberTest::test_apply_as_prescriber - Failed: Undefined template variable 'reset_url' in '/home/vincentporte/Entreprises/Neuralia.co.Products/betagouv/itou/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html'
+FAILED tests/www/apply/test_submit.py::ApplyAsAuthorizedPrescriberTest::test_apply_as_prescriber_with_pending_authorization - Failed: Undefined template variable 'reset_url' in '/home/vincentporte/Entreprises/Neuralia.co.Products/betagouv/itou/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html'
+FAILED tests/www/apply/test_submit.py::ApplyAsAuthorizedPrescriberTest::test_apply_as_authorized_prescriber - Failed: Undefined template variable 'reset_url' in '/home/vincentporte/Entreprises/Neuralia.co.Products/betagouv/itou/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html'
+FAILED tests/www/apply/test_submit.py::DirectHireFullProcessTest::test_hire_as_company - Failed: Undefined template variable 'reset_url' in '/home/vincentporte/Entreprises/Neuralia.co.Products/betagouv/itou/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html'
+FAILED tests/www/apply/test_submit.py::ApplyAsCompanyTest::test_apply_as_company - Failed: Undefined template variable 'reset_url' in '/home/vincentporte/Entreprises/Neuralia.co.Products/betagouv/itou/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html'{% endcomment %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_end.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
+{% load buttons_form %}
 
 {% block title %}
     {% if update_job_seeker %}
@@ -41,22 +42,11 @@
 
                             {% include "apply/includes/profile_infos.html" %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    {% if update_job_seeker %}
-                                        {% bootstrap_button "Valider les informations" button_type="submit" button_class="btn btn-primary btn-block" %}
-                                    {% else %}
-                                        {% bootstrap_button "Créer le compte candidat" button_type="submit" button_class="btn btn-primary btn-block" %}
-                                    {% endif %}
-                                </div>
-                            </div>
+                            {% if update_job_seeker %}
+                                {% itou_buttons_form primary_label="Valider les informations" secondary_url=back_url reset_url=reset_url show_mandatory_fields_mention=False %}
+                            {% else %}
+                                {% itou_buttons_form primary_label="Créer le compte candidat" secondary_url=back_url reset_url=reset_url show_mandatory_fields_mention=False %}
+                            {% endif %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -3,6 +3,7 @@
 {% load format_filters %}
 {% load str_filters %}
 {% load matomo %}
+{% load buttons_form %}
 {% load static %}
 
 {% block title_messages %}
@@ -87,18 +88,7 @@
                 </div>
             {% endif %}
             {# Reload this page and show a modal containing more information about the job seeker. #}
-            <hr>
-            <div class="form-row align-items-center gx-3">
-                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
-                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                        <span>Retour</span>
-                    </a>
-                </div>
-                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary btn-block" name="preview" value="1" %}
-                </div>
-            </div>
+            {% itou_buttons_form primary_label="Suivant" primary_name="preview" primary_value="1" %}
         </div>
         {% if preview_mode %}
             <!-- Modal -->

--- a/itou/templates/apply/submit_step_check_prev_applications.html
+++ b/itou/templates/apply/submit_step_check_prev_applications.html
@@ -1,5 +1,6 @@
 {% extends "apply/submit_base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block content_extend %}
     <div class="alert alert-warning">
@@ -19,14 +20,6 @@
         {% csrf_token %}
         <input type="hidden" name="force_new_application" value="force">
 
-        <hr>
-        <div class="form-row align-items-center justify-content-end">
-            <div class="form-group mb-0 col-6 col-lg-auto">
-                <a class="btn btn-outline-primary btn-block" href="{% url 'dashboard:index' %}">Annuler</a>
-            </div>
-            <div class="form-group mb-0 col-6 col-lg-auto">
-                {% bootstrap_button "Postuler à nouveau" button_type="submit" button_class="btn btn-primary btn-block" %}
-            </div>
-        </div>
+        {% itou_buttons_form primary_label="Postuler à nouveau" %}
     </form>
 {% endblock %}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -3,6 +3,7 @@
 {% load format_filters %}
 {% load static %}
 {% load str_filters %}
+{% load buttons_form %}
 
 {% block left_column %}
     <form method="post" class="js-prevent-multiple-submit js-format-nir">
@@ -38,18 +39,7 @@
                 {% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}
             </div>
 
-            <hr>
-            <div class="form-row align-items-center gx-3">
-                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
-                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                        <span>Retour</span>
-                    </a>
-                </div>
-                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary btn-block" name="preview" value="1" %}
-                </div>
-            </div>
+            {% itou_buttons_form primary_label="Suivant" secondary_url=back_url primary_name="preview" primary_value="1" %}
         </div>
         {% if preview_mode %}
             <!-- Modal -->

--- a/itou/templates/apply/submit_step_job_seeker_check_info.html
+++ b/itou/templates/apply/submit_step_job_seeker_check_info.html
@@ -1,5 +1,6 @@
 {% extends "apply/submit_base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block content_extend %}
     <div class="alert alert-warning">
@@ -11,12 +12,7 @@
 
         {% bootstrap_form form alert_error_type="all" %}
 
-        <hr>
-        <div class="form-row align-items-center justify-content-end">
-            <div class="form-group mb-0 col-12 col-lg-auto">
-                {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary btn-block" %}
-            </div>
-        </div>
+        {% itou_buttons_form primary_label="Continuer" %}
     </form>
 
 {% endblock %}

--- a/itou/templates/apply/submit_step_pending_authorization.html
+++ b/itou/templates/apply/submit_step_pending_authorization.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load buttons_form %}
 
 {% block content_title_wrapper %}{% endblock %}
 
@@ -29,14 +30,9 @@
                             </div>
                             <strong>Êtes-vous certain de vouloir continuer ?</strong>
                         </div>
-                        <div class="form-row align-items-center justify-content-end">
-                            <div class="form-group mb-0 col-6 col-lg-auto">
-                                <a class="btn btn-link btn-block" aria-label="Revenir à la recherche" href="{% url 'search:employers_home' %}">Revenir à la recherche</a>
-                            </div>
-                            <div class="form-group mb-0 col-6 col-lg-auto">
-                                <a href="{% url 'apply:check_nir_for_sender' company_pk=siae.pk %}" class="btn btn-primary btn-block">Suivant</a>
-                            </div>
-                        </div>
+                        {% url 'search:employers_home' as reset_url %}
+                        {% url 'apply:check_nir_for_sender' company_pk=siae.pk as primary_url %}
+                        {% itou_buttons_form primary_label="Suivant" primary_url=primary_url reset_url=reset_url %}
                     </div>
                 </div>
             </div>

--- a/itou/templates/approvals/includes/prolongation_declaration_form.html
+++ b/itou/templates/approvals/includes/prolongation_declaration_form.html
@@ -1,4 +1,6 @@
 {% load django_bootstrap5 %}
+{% load buttons_form %}
+
 <form id="mainForm" method="post" class="js-prevent-multiple-submit"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
     {% csrf_token %}
 
@@ -9,11 +11,5 @@
 
     {% include "approvals/includes/declaration_upload_panel.html" %}
 
-    <hr />
-
-    <div class="form-group text-end">
-        <a class="btn btn-outline-primary" href="{{ back_url }}">Retour</a>
-        {# Enable preview mode: preview=1. #}
-        {% bootstrap_button "Valider la déclaration" button_type="submit" button_class="btn btn-primary" name="preview" value="1" %}
-    </div>
+    {% itou_buttons_form primary_label="Valider la déclaration" secondary_url=back_url primary_name="preview" primary_value="1" %}
 </form>

--- a/itou/templates/approvals/pe_approval_search.html
+++ b/itou/templates/approvals/pe_approval_search.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Prolonger ou suspendre un agrément émis par Pôle emploi {{ block.super }}{% endblock %}
 
@@ -33,12 +34,7 @@
 
                             {% bootstrap_form form alert_error_type="all" %}
 
-                            <hr>
-                            <div class="form-row align-items-center justify-content-end gx-3">
-                                <div class="form-group col-12 col-lg-auto">
-                                    {% bootstrap_button "Rechercher" button_type="submit" button_class="btn btn-primary w-100 w-lg-auto" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Rechercher" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/approvals/pe_approval_search_found.html
+++ b/itou/templates/approvals/pe_approval_search_found.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Prolonger ou suspendre un agrément émis par Pôle emploi {{ block.super }}{% endblock %}
 
@@ -44,18 +45,9 @@
                                 </p>
                                 <p>Nous allons l'importer dans votre compte pour vous permettre de le suspendre ou de le prolonger.</p>
                                 <p>Mais avant, nous avons besoin de connaître l'adresse e-mail de votre salarié(e).</p>
-                                <hr>
-                                <div class="form-row align-items-center justify-content-end gx-3">
-                                    <div class="form-group col-6 col-lg-auto">
-                                        <a href="{{ back_url }}" class="btn btn-block btn-ico btn-outline-primary">
-                                            <i class="ri-close-fill ri-lg"></i>
-                                            <span>Annuler</span>
-                                        </a>
-                                    </div>
-                                    <div class="form-group col-6 col-lg-auto">
-                                        <a class="btn btn-primary btn-block" href="{% url 'approvals:pe_approval_search_user' approval.pk %}">Continuer</a>
-                                    </div>
-                                </div>
+
+                                {% url 'approvals:pe_approval_search_user' approval.pk as primary_url %}
+                                {% itou_buttons_form primary_label="Continuer" primary_url=primary_url secondary_url=back_url %}
                             </div>
                         {% endif %}
 

--- a/itou/templates/approvals/pe_approval_search_user.html
+++ b/itou/templates/approvals/pe_approval_search_user.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Prolonger ou suspendre un agrément émis par Pôle emploi {{ block.super }}{% endblock %}
 
@@ -25,12 +26,7 @@
                                 {% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" %}
                             </div>
 
-                            <hr>
-                            <div class="form-row align-items-center justify-content-end gx-3">
-                                <div class="form-group col-12 col-lg-auto">
-                                    {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary w-100 w-lg-auto" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Continuer" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/approvals/prolongation_requests/deny.html
+++ b/itou/templates/approvals/prolongation_requests/deny.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load theme_inclusion %}
+{% load buttons_form %}
 
 {% block title %}
     Refuser la demande de prolongation - {{ prolongation_request.approval.user.get_full_name }} {{ block.super }}

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Suspendre le PASS IAE {{ block.super }}{% endblock %}
 
@@ -50,20 +51,7 @@
 
                                 {% bootstrap_field form.reason_explanation %}
 
-                                <hr>
-                                <div class="form-row align-items-center gx-3">
-                                    <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                        <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto">
-                                            <i class="ri-arrow-go-back-line ri-lg"></i>
-                                            <span>Retour</span>
-                                        </a>
-                                    </div>
-                                    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                        <button type="submit" class="btn btn-primary" name="preview" value="1" aria-label="Valider la suspension du PASS IAE de {{ approval.user.get_full_name }}">
-                                            Valider la suspension
-                                        </button>
-                                    </div>
-                                </div>
+                                {% itou_buttons_form primary_label="Valider la suspension" primary_aria_label="Valider la suspension du PASS IAE de "|add:approval.user.get_full_name primary_name="preview" primary_value=1 reset_url=back_url %}
 
                             </form>
                         </div>
@@ -97,23 +85,12 @@
                                     </div>
                                 </div>
 
-                                <div class="alert alert-warning" role="status">
-                                    <p>
-                                        En confirmant cette demande je certifie sur l'honneur que le motif de suspension choisi correspond à la situation du salarié.
-                                    </p>
-                                    {# Allow the user to modify the suspension: edit=1. #}
-                                    <div class="d-flex justify-content-end gap-3">
-                                        <div>
-                                            <button type="submit" class="btn btn-outline-primary" aria-label="Annuler la suspension du PASS IAE de {{ approval.user.get_full_name }}" name="edit" value="1">
-                                                Annuler
-                                            </button>
-                                        </div>
-                                        {# Create a suspension: save=1. #}
-                                        <div>
-                                            <button type="submit" class="btn btn-primary" aria-label="Confirmer la suspension du PASS IAE de {{ approval.user.get_full_name }}"name="save" value="1">
-                                                Confirmer la suspension
-                                            </button>
-                                        </div>
+                                <div class="card my-3">
+                                    <div class="card-body">
+                                        <p>
+                                            En confirmant cette demande je certifie sur l'honneur que le motif de suspension choisi correspond à la situation du salarié.
+                                        </p>
+                                        {% itou_buttons_form primary_label="Confirmer la suspension" primary_aria_label="Confirmer la suspension du PASS IAE de "|add:approval.user.get_full_name primary_name="save" primary_value=1 secondary_url=request.path|add:"?back_url="|add:back_url secondary_name="edit" secondary_value="1" reset_url=back_url show_mandatory_fields_mention=False %}
                                     </div>
                                 </div>
 

--- a/itou/templates/approvals/suspension_action_choice.html
+++ b/itou/templates/approvals/suspension_action_choice.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
@@ -39,18 +40,7 @@
                                     Confirmer la <strong class="text-danger">suppression définitive</strong> de cette suspension
                                 </label>
                             </div>
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Suivant" reset_url=back_url %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/approvals/suspension_delete.html
+++ b/itou/templates/approvals/suspension_delete.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
+{% load buttons_form %}
 
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
@@ -49,17 +50,7 @@
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}
                             <input type="hidden" name="confirm" value="true">
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    {% bootstrap_button "Confirmer la suppression" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Confirmer la suppression" secondary_url=back_url reset_url=reset_url %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Modifier la suspension de PASS IAE {{ block.super }}{% endblock %}
 
@@ -25,18 +26,7 @@
 
                             {% bootstrap_form form %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    {% bootstrap_button "Valider" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Valider" secondary_url=back_url %}
 
                         </form>
                     </div>

--- a/itou/templates/approvals/suspension_update_enddate.html
+++ b/itou/templates/approvals/suspension_update_enddate.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
@@ -34,18 +35,7 @@
 
                             {% bootstrap_form form %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Suivant" secondary_url=back_url reset_url=reset_url %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/create_siae.html
+++ b/itou/templates/companies/create_siae.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Créer une nouvelle structure {{ block.super }}{% endblock %}
 
@@ -54,18 +55,7 @@
                                     </div>
                                 </div>
                             </div>
-
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Enregister la fiche structure">Enregistrer</button>
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Enregistrer" primary_aria_label="Enregister la fiche structure" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_job_description.html
+++ b/itou/templates/companies/edit_job_description.html
@@ -1,7 +1,7 @@
 {% extends "layout/base.html" %}
 {% load static %}
 {% load django_bootstrap5 %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Enregistrer une fiche de poste {{ block.super }}{% endblock %}
 
@@ -54,20 +54,9 @@
                             <div id="_other_contract_type_group">{% bootstrap_field form.other_contract_type %}</div>
                             {% bootstrap_field form.hours_per_week %}
                             {% bootstrap_field form.open_positions %}
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{% url "companies_views:job_description_list" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à la liste des métiers">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante" {% matomo_event "employeurs" "submit" "edit-infos-fiche-poste" %}>
-                                        Suivant
-                                    </button>
-                                </div>
-                            </div>
+
+                            {% url "companies_views:job_description_list" as reset_url %}
+                            {% itou_buttons_form primary_label="Suivant" reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_event="edit-infos-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_job_description_details.html
+++ b/itou/templates/companies/edit_job_description_details.html
@@ -1,7 +1,7 @@
 {% extends "layout/base.html" %}
 {% load static %}
 {% load django_bootstrap5 %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Modifier les détails de la fiche de poste {{ block.super }}{% endblock %}
 
@@ -86,20 +86,9 @@
                                 {% bootstrap_field form.is_qpv_mandatory %}
                             {% endif %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{% url "companies_views:edit_job_description" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Passer à l'étape suivante" {% matomo_event "employeurs" "submit" "edit-description-fiche-poste" %}>
-                                        Suivant
-                                    </button>
-                                </div>
-                            </div>
+                            {% url "companies_views:edit_job_description" as secondary_url %}
+                            {% url "companies_views:job_description_list" as reset_url %}
+                            {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_event="edit-description-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_job_description_preview.html
+++ b/itou/templates/companies/edit_job_description_preview.html
@@ -1,6 +1,6 @@
 {% extends "layout/base.html" %}
 {% load static %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Validation de la fiche de poste {{ block.super }}{% endblock %}
 
@@ -53,19 +53,9 @@
 
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{% url "companies_views:edit_job_description_details" %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'étape précédente">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Publier la fiche de poste" {% matomo_event "employeurs" "submit" "publier-fiche-poste" %}>
-                                        Publier la fiche de poste
-                                    </button>
-                                </div>
-                            </div>
+                            {% url "companies_views:edit_job_description_details" as secondary_url %}
+                            {% url "companies_views:job_description_list" as reset_url %}
+                            {% itou_buttons_form primary_label="Publier la fiche de poste" primary_aria_label="Publier la fiche de poste" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_event="publier-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_siae.html
+++ b/itou/templates/companies/edit_siae.html
@@ -2,7 +2,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load theme_inclusion %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Modifier les coordonnées de votre structure {{ block.super }}{% endblock %}
 
@@ -74,20 +74,7 @@
                             {% bootstrap_field form.email %}
                             {% bootstrap_field form.website %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Vers l'étape suivante du formulaire" {% matomo_event "employeurs" "submit" "maj-contact-structure" %}>
-                                        Suivant
-                                    </button>
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Suivant" matomo_category="employeurs" matomo_action="submit" matomo_event="maj-contact-structure" %}
                         </form>
 
                     </div>

--- a/itou/templates/companies/edit_siae_description.html
+++ b/itou/templates/companies/edit_siae_description.html
@@ -2,7 +2,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load theme_inclusion %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Modifier les coordonnées de votre structure {{ block.super }}{% endblock %}
 
@@ -74,20 +74,7 @@
                                 </div>
                             </div>
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ prev_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'édition des coordonnées">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Vers l'étape suivante du formulaire" {% matomo_event "employeurs" "submit" "maj-description-structure" %}>
-                                        Suivant
-                                    </button>
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Suivant" secondary_url=prev_url secondary_aria_label="Retourner à l'édition des coordonnées" matomo_category="employeurs" matomo_action="submit" matomo_event="maj-description-structure" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -3,7 +3,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load theme_inclusion %}
-{% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Modifier les coordonnées de votre structure {{ block.super }}{% endblock %}
 
@@ -130,19 +130,7 @@
                                 </div>
                             </div>
 
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{{ prev_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner à l'édition de la description">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Publier le formulaire" {% matomo_event "employeurs" "submit" "publier-infos-structure" %}>
-                                        Publier
-                                    </button>
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Publier" secondary_url=prev_url secondary_aria_label="Retourner à l'édition de la description" matomo_category="employeurs" matomo_action="submit" matomo_event="publier-infos-structure" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/select_financial_annex.html
+++ b/itou/templates/companies/select_financial_annex.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Sélectionner une annexe financière {{ block.super }}{% endblock %}
 
@@ -22,12 +23,7 @@
 
                             {% bootstrap_field select_form.financial_annexes %}
 
-                            <hr>
-                            <div class="form-row align-items-center justify-content-end">
-                                <div class="form-group col-12 col-lg-auto">
-                                    {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary w-100 w-lg-auto" %}
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Continuer" %}
 
                         </form>
                     </div>

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Modifier mon profil {{ block.super }}{% endblock %}
 
@@ -83,11 +84,8 @@
                                     <div class="col-9">{% bootstrap_field form.city %}</div>
                                 </div>
 
-                                <hr class="my-4">
-                                <div class="form-group text-end">
-                                    <a class="btn btn-link" href="{{ prev_url }}">Annuler</a>
-                                    {% bootstrap_button "Enregistrer et quitter" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
+                                {% comment "prev_url may be not useful anymore, remove it from the view" %}{% endcomment %}
+                                {% itou_buttons_form primary_label="Enregistrer et quitter" secondary_url=prev_url %}
                             </form>
                         {% endif %}
                     </div>

--- a/itou/templates/dashboard/edit_user_notifications.html
+++ b/itou/templates/dashboard/edit_user_notifications.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Mes notifications {{ block.super }}{% endblock %}
 
@@ -25,11 +26,8 @@
                                 {% bootstrap_field new_job_app_notification_form.qualified field_class="form-check form-switch" show_label=False %}
                             {% endif %}
 
-                            <div class="form-group">
-                                <a class="btn btn-outline-primary" href="{{ back_url }}">Annuler</a>
-                                {% bootstrap_button "Enregistrer" button_type="submit" button_class="btn btn-primary" %}
-                            </div>
-
+                            {% comment "back_url may be not useful anymore, remove it from the view" %}{% endcomment %}
+                            {% itou_buttons_form primary_label="Enregistrer" secondary_url=back_url %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -6,7 +6,8 @@
 {% endcomment %}
 
 {% load django_bootstrap5 %}
-{% load matomo %}
+{% load buttons_form %}
+
 <form method="post" class="js-prevent-multiple-submit js-format-nir">
     {% csrf_token %}
 
@@ -29,12 +30,6 @@
     {% bootstrap_field form.pole_emploi_id %}
     {% bootstrap_field form.lack_of_pole_emploi_id_reason %}
 
-    <hr class="my-4">
-    <div class="form-group text-end">
-        <a class="btn btn-link" href="{{ prev_url }}">Annuler</a>
-        <button type="submit" class="btn btn-primary" {% matomo_event "salaries" "submit" "edit_jobseeker_infos_submit" %}>
-            {{ submit_label }}
-        </button>
-    </div>
+    {% itou_buttons_form primary_label=submit_label reset_url=prev_url matomo_category="salaries" matomo_action="submit" matomo_event="edit_jobseeker_infos_submit" %}
 
 </form>

--- a/itou/templates/eligibility/includes/form.html
+++ b/itou/templates/eligibility/includes/form.html
@@ -9,6 +9,7 @@
 
 {% endcomment %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 <form method="post" role="form" class="js-prevent-multiple-submit">
 
@@ -36,16 +37,10 @@
         En cliquant sur "Valider l’éligibilité du candidat" vous confirmez que le candidat est éligible à l'insertion par l'activité économique et
         vous vous engagez à conserver les justificatifs correspondants aux critères d'éligibilité sélectionnés pendant 24 mois, en cas de contrôle.
     </p>
-    <hr>
-    <div class="form-row align-items-center justify-content-end">
-        {% if cancel_url %}
-            <div class="form-group mb-0 col-6 col-lg-auto">
-                <a class="btn btn-outline-primary btn-block" href="{{ cancel_url }}">Annuler</a>
-            </div>
-        {% endif %}
-        <div class="form-group mb-0 col-6 col-lg-auto">
-            {% bootstrap_button "Valider l’éligibilité du candidat" button_type="submit" button_class="btn btn-primary btn-block" %}
-        </div>
-    </div>
+    {% if cancel_url %}
+        {% itou_buttons_form primary_label="Valider l’éligibilité du candidat" reset_url=cancel_url show_mandatory_fields_mention=False %}
+    {% else %}
+        {% itou_buttons_form primary_label="Valider l’éligibilité du candidat" show_mandatory_fields_mention=False %}
+    {% endif %}
 
 </form>

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -4,6 +4,7 @@
 {% load str_filters %}
 {% load theme_inclusion %}
 {% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Créer une fiche salarié {{ block.super }}{% endblock %}
 {% block content_title %}
@@ -49,18 +50,13 @@
                                 </ul>
                             {% endif %}
 
-                            <hr>
-                            <p class="fs-xs">* champ obligatoire</p>
-                            <div class="form-group text-end">
-                                {% if wizard.steps.prev %}
-                                    {% bootstrap_button "Retour" button_type="submit" button_class="btn btn-outline-primary" name="wizard_goto_step" value=wizard.steps.prev %}
-                                {% else %}
-                                    <a class="btn btn-link btn-outline-primary" href="{% url "employee_record_views:list" %}?status=NEW">Annuler</a>
-                                {% endif %}
-                                <button class="btn btn-primary" {% if not wizard.steps.next %}{% matomo_event "fiches-salarié" "submit" "création" %}{% endif %}>
-                                    {{ wizard.steps.next|yesno:"Suivant,Confirmer" }}
-                                </button>
-                            </div>
+                            {% url "employee_record_views:list" as reset_url %}
+                            {% if wizard.steps.prev %}
+                                {% url 'employee_record_views:add' as secondary_url %}
+                                {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" secondary_url=secondary_url|add:wizard.steps.prev secondary_name="wizard_goto_step" secondary_value=wizard.steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_event="création" %}
+                            {% else %}
+                                {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" %}
+                            {% endif %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load format_filters %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}
     Désactiver la fiche salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}
@@ -48,10 +49,8 @@
                     <form method="post" class="js-prevent-multiple-submit">
                         {% csrf_token %}
                         <input type="hidden" name="confirm" value="true">
-                        <div class="form-group">
-                            <a class="btn btn-outline-primary" href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}">Retour à la liste</a>
-                            {% bootstrap_button "Confirmer la désactivation" button_type="submit" button_class="btn btn-danger" %}
-                        </div>
+                        {% url "employee_record_views:list" as secondary_url %}
+                        {% itou_buttons_form primary_label="Confirmer la désactivation" reset_url=secondary_url|add:"?status="|add:employee_record.status show_mandatory_fields_mention=False %}
                     </form>
                 </div>
             </div>

--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -1,4 +1,5 @@
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 <div class="row">
     <div class="col-12 col-lg-8">
@@ -22,28 +23,11 @@
                     </div>
                     {% bootstrap_field form.birth_place %}
                 </fieldset>
-                <hr class="mb-3">
-                <div class="row">
-                    <div class="col-12 mb-3">
-                        <small id="fieldRequired">* champs obligatoires</small>
-                    </div>
-                    <div class="col-12">
-                        <div class="form-row align-items-center justify-content-lg-between">
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-2 order-md-1">
-                                <a href="{% url "employee_record_views:list" %}?status={{ request.GET.from_status|default:"NEW" }}" class="btn btn-block btn-ico btn-link ps-lg-0 justify-content-center">
-                                    <i class="ri-arrow-go-back-line ri-lg"></i>
-                                    <span>Retour à la liste</span>
-                                </a>
-                            </div>
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
-                                    <span>Étape suivante</span>
-                                    <i class="ri-arrow-right-line ri-lg"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {% url "employee_record_views:list" as secondary_url %}
+                {% if request.GET.status %}
+                    {% url_add_query secondary_url status=request.GET.status as secondary_url %}
+                {% endif %}
+                {% itou_buttons_form primary_label="Suivant" reset_url=secondary_url secondary_url=back_url %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -1,5 +1,6 @@
 {% load django_bootstrap5 %}
 {% load buttons_form %}
+{% load url_add_query %}
 
 <div class="row">
     <div class="col-12 col-lg-8">

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -1,4 +1,5 @@
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 <div class="row">
     <div class="col-12">
@@ -16,7 +17,7 @@
                                 </p>
                                 <ul>
                                     <li>
-                                        Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Étape suivante»</b> en bas de page.
+                                        Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Suivant»</b> en bas de page.
                                     </li>
                                     <li>
                                         Si elle ne correspond pas, veuillez la modifier à l'aide du formulaire ci-dessous, puis cliquez
@@ -88,37 +89,14 @@
                 </div>
                 <div class="row">
                     <div class="col-12 col-lg-8">
-                        <hr class="mb-3">
-                        <div class="row">
-                            <div class="col-12 mb-3">
-                                <small id="fieldRequired">* champs obligatoires</small>
-                            </div>
-                            <div class="col-12">
-                                <div class="form-row align-items-center justify-content-lg-between">
-                                    <div class="form-group col-12 col-md-6 col-lg-auto order-3 order-md-1">
-                                        <a href="{% url "employee_record_views:create" job_application.id %}" class="btn btn-block btn-ico btn-link ps-0 justify-content-center" aria-label="Retour à l'étape précédente">
-                                            <i class="ri-arrow-left-line ri-lg"></i>
-                                            <span>Étape précédente</span>
-                                        </a>
-                                    </div>
-                                    {% if profile.hexa_address_filled %}
-                                        <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                            <a href="{% url "employee_record_views:create_step_3" job_application.id %}" class="btn btn-block btn-ico btn-primary justify-content-center" aria-label="Passer à l'étape suivante">
-                                                <span>Étape suivante</span>
-                                                <i class="ri-arrow-right-line ri-lg"></i>
-                                            </a>
-                                        </div>
-                                    {% else %}
-                                        <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2" data-bs-toggle="tooltip" data-bs-placement="top" title="Merci de valider l'adresse pour passer à l'étape suivante">
-                                            <button class="btn btn-block btn-ico btn-primary justify-content-center" disabled>
-                                                <span>Étape suivante</span>
-                                                <i class="ri-arrow-right-line ri-lg"></i>
-                                            </button>
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </div>
+                        {% url "employee_record_views:create" job_application.id as secondary_url %}
+                        {% url "employee_record_views:list" as reset_url %}
+                        {% if profile.hexa_address_filled %}
+                            {% url "employee_record_views:create_step_3" job_application.id as primary_url %}
+                            {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
+                        {% else %}
+                            {% itou_buttons_form primary_label="Suivant" primary_deactivated=True secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
+                        {% endif %}
                     </div>
                 </div>
             </form>

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -1,5 +1,6 @@
 {% load django_bootstrap5 %}
 {% load buttons_form %}
+{% load url_add_query %}
 
 <div class="row">
     <div class="col-12">
@@ -89,13 +90,18 @@
                 </div>
                 <div class="row">
                     <div class="col-12 col-lg-8">
+                        {% url "employee_record_views:create_step_3" job_application.id as primary_url %}
                         {% url "employee_record_views:create" job_application.id as secondary_url %}
                         {% url "employee_record_views:list" as reset_url %}
+                        {% if request.GET.status %}
+                            {% url_add_query primary_url status=request.GET.status as primary_url %}
+                            {% url_add_query secondary_url status=request.GET.status as secondary_url %}
+                            {% url_add_query reset_url status=request.GET.status as reset_url %}
+                        {% endif %}
                         {% if profile.hexa_address_filled %}
-                            {% url "employee_record_views:create_step_3" job_application.id as primary_url %}
-                            {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
+                            {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url %}
                         {% else %}
-                            {% itou_buttons_form primary_label="Suivant" primary_deactivated=True secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
+                            {% itou_buttons_form primary_label="Suivant" primary_deactivated=True secondary_url=secondary_url reset_url=reset_url %}
                         {% endif %}
                     </div>
                 </div>

--- a/itou/templates/employee_record/includes/create_step_3.html
+++ b/itou/templates/employee_record/includes/create_step_3.html
@@ -1,11 +1,12 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load buttons_form %}
+{% load url_add_query %}
 
 <div class="row">
     <div class="col-12 col-lg-8">
         <div class="c-form">
-            <form method="post" action="{% url "employee_record_views:create_step_3" job_application.id %}" class="js-prevent-multiple-submit">
+            <form method="post" class="js-prevent-multiple-submit">
                 {% csrf_token %}
                 <fieldset>
                     <legend>Situation du salarié</legend>
@@ -67,9 +68,17 @@
                         {% bootstrap_field form.aah_allocation_since %}
                     </div>
                 </fieldset>
+
+
+
+
                 {% url "employee_record_views:create_step_2" job_application.id as secondary_url %}
                 {% url "employee_record_views:list" as reset_url %}
-                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
+                {% if request.GET.status %}
+                    {% url_add_query secondary_url status=request.GET.status as secondary_url %}
+                    {% url_add_query reset_url status=request.GET.status as reset_url %}
+                {% endif %}
+                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/create_step_3.html
+++ b/itou/templates/employee_record/includes/create_step_3.html
@@ -1,5 +1,6 @@
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 <div class="row">
     <div class="col-12 col-lg-8">
@@ -66,28 +67,9 @@
                         {% bootstrap_field form.aah_allocation_since %}
                     </div>
                 </fieldset>
-                <hr class="mb-3">
-                <div class="row">
-                    <div class="col-12 mb-3">
-                        <small id="fieldRequired">* champs obligatoires</small>
-                    </div>
-                    <div class="col-12">
-                        <div class="form-row align-items-center justify-content-lg-between">
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-3 order-md-1">
-                                <a href="{% url "employee_record_views:create_step_2" job_application.id %}" class="btn btn-block btn-ico btn-link ps-0 justify-content-center" aria-label="Retour à l'étape précédente">
-                                    <i class="ri-arrow-left-line ri-lg"></i>
-                                    <span>Étape précédente</span>
-                                </a>
-                            </div>
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
-                                    <span>Étape suivante</span>
-                                    <i class="ri-arrow-right-line ri-lg"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {% url "employee_record_views:create_step_2" job_application.id as secondary_url %}
+                {% url "employee_record_views:list" as reset_url %}
+                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -1,5 +1,6 @@
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 <div class="row">
     <div class="col-12 col-lg-8">
@@ -13,25 +14,9 @@
                     </p>
                     {% bootstrap_form form alert_error_type="all" %}
                 </fieldset>
-                <hr class="mb-3">
-                <div class="row">
-                    <div class="col-12">
-                        <div class="form-row align-items-center justify-content-lg-between">
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-3 order-md-1">
-                                <a href="{% url "employee_record_views:create_step_3" job_application.id %}" class="btn btn-block btn-ico btn-link ps-0 justify-content-center" aria-label="Retour à l'étape précédente">
-                                    <i class="ri-arrow-left-line ri-lg"></i>
-                                    <span>Étape précédente</span>
-                                </a>
-                            </div>
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button class="btn btn-block btn-ico btn-primary" aria-label="Passer à l'étape suivante">
-                                    <span>Étape suivante</span>
-                                    <i class="ri-arrow-right-line ri-lg"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {% url "employee_record_views:create_step_3" job_application.id as secondary_url %}
+                {% url "employee_record_views:list" as reset_url %}
+                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -1,11 +1,12 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load buttons_form %}
+{% load url_add_query %}
 
 <div class="row">
     <div class="col-12 col-lg-8">
         <div class="c-form">
-            <form method="post" action="{% url "employee_record_views:create_step_4" job_application.id %}" class="js-prevent-multiple-submit">
+            <form method="post" class="js-prevent-multiple-submit">
                 {% csrf_token %}
                 <fieldset>
                     <legend>Annexe financière</legend>
@@ -16,7 +17,11 @@
                 </fieldset>
                 {% url "employee_record_views:create_step_3" job_application.id as secondary_url %}
                 {% url "employee_record_views:list" as reset_url %}
-                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url|add:"?status=NEW" %}
+                {% if request.GET.status %}
+                    {% url_add_query secondary_url status=request.GET.status as secondary_url %}
+                    {% url_add_query reset_url status=request.GET.status as reset_url %}
+                {% endif %}
+                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load matomo %}
 {% load buttons_form %}
+{% load url_add_query %}
 
 <div class="row">
     <div class="col-12 col-lg-8 order-2 order-lg-1">
@@ -28,7 +29,11 @@
                 {% csrf_token %}
                 {% url "employee_record_views:create_step_4" employee_record.job_application.id as secondary_url %}
                 {% url "employee_record_views:list" as reset_url %}
-                {% itou_buttons_form primary_label="Valider la fiche salarié" secondary_url=secondary_url show_mandatory_fields_mention=False reset_url=reset_url|add:"?status=NEW" %}
+                {% if request.GET.status %}
+                    {% url_add_query secondary_url status=request.GET.status as secondary_url %}
+                    {% url_add_query reset_url status=request.GET.status as reset_url %}
+                {% endif %}
+                {% itou_buttons_form primary_label="Valider la fiche salarié" secondary_url=secondary_url show_mandatory_fields_mention=False reset_url=reset_url %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -2,6 +2,7 @@
 {% load format_filters %}
 {% load static %}
 {% load matomo %}
+{% load buttons_form %}
 
 <div class="row">
     <div class="col-12 col-lg-8 order-2 order-lg-1">
@@ -25,25 +26,9 @@
 
             <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.id %}" class="js-prevent-multiple-submit">
                 {% csrf_token %}
-                <hr class="mb-3">
-                <div class="row">
-                    <div class="col-12">
-                        <div class="form-row align-items-center justify-content-lg-between">
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-3 order-md-1">
-                                <a href="{% url "employee_record_views:create_step_4" employee_record.job_application.id %}" class="btn btn-block btn-ico btn-link ps-0 justify-content-center" aria-label="Retour à l'étape précédente">
-                                    <i class="ri-arrow-left-line ri-lg"></i>
-                                    <span>Étape précédente</span>
-                                </a>
-                            </div>
-                            <div class="form-group col-12 col-md-6 col-lg-auto order-1 order-md-2">
-                                <button class="btn btn-block btn-ico btn-primary">
-                                    <span>Valider la fiche salarié</span>
-                                    <i class="ri-arrow-right-line ri-lg"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                {% url "employee_record_views:create_step_4" employee_record.job_application.id as secondary_url %}
+                {% url "employee_record_views:list" as reset_url %}
+                {% itou_buttons_form primary_label="Valider la fiche salarié" secondary_url=secondary_url show_mandatory_fields_mention=False reset_url=reset_url|add:"?status=NEW" %}
             </form>
         </div>
     </div>

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -129,7 +129,7 @@
                     {% if item.employee_record_new %}
                         <a href="{% url "employee_record_views:disable" item.employee_record_new.id %}" class="btn btn-sm btn-outline-primary mt-2">Désactiver la fiche salarié</a>
                     {% endif %}
-                    <a href="{% url "employee_record_views:create" item.id %}?from_status=NEW" class="btn btn-sm btn-primary mt-2">Compléter la fiche salarié</a>
+                    <a href="{% url "employee_record_views:create" item.id %}?status=NEW" class="btn btn-sm btn-primary mt-2">Compléter la fiche salarié</a>
                 </div>
             {% endif %}
         {% else %}
@@ -141,7 +141,7 @@
                 {% endif %}
                 <a href="{% url "employee_record_views:summary" employee_record.id %}" class="btn btn-sm btn-outline-primary mt-2">Voir le détail de la fiche salarié</a>
                 {% if employee_record.status == "REJECTED" %}
-                    <a href="{% url "employee_record_views:create" item.id %}?from_status={{ employee_record.status }}" class="btn btn-sm btn-primary mt-2">Modifier la fiche salarié</a>
+                    <a href="{% url "employee_record_views:create" item.id %}?status={{ employee_record.status }}" class="btn btn-sm btn-primary mt-2">Modifier la fiche salarié</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load format_filters %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}
     Réactiver la fiche salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}
@@ -48,10 +49,8 @@
                     <form method="post" class="js-prevent-multiple-submit">
                         {% csrf_token %}
                         <input type="hidden" name="confirm" value="true">
-                        <div class="form-group">
-                            <a class="btn btn-outline-primary" href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}">Retour à la liste</a>
-                            {% bootstrap_button "Confirmer la réactivation" button_type="submit" button_class="btn btn-danger" %}
-                        </div>
+                        {% url "employee_record_views:list" as secondary_url %}
+                        {% itou_buttons_form primary_label="Confirmer la réactivation" reset_url=secondary_url|add:"?status="|add:employee_record.status show_mandatory_fields_mention=False %}
                     </form>
                 </div>
             </div>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -17,22 +17,17 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8 order-2 order-lg-1">
-                    <div class="c-box">
-                        {% include "employee_record/includes/employee_record_summary.html" %}
-                        {% if employee_record.status != "ARCHIVED" %}
-                            <hr class="mb-3">
-                            <div class="row mt-3">
-                                <div class="col-12 col-md-auto">
-                                    <a href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}" class="btn btn-block btn-link ps-lg-0">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour à la liste</span>
-                                    </a>
-                                </div>
-                            </div>
-                        {% endif %}
-                    </div>
+                    <div class="c-box">{% include "employee_record/includes/employee_record_summary.html" %}</div>
                 </div>
                 <div class="col-12 col-lg-4 order-1 order-lg-2 mb-3">
+                    {% if employee_record.status != "ARCHIVED" %}
+                        <div class="c-box mb-4">
+                            <a href="{% url "employee_record_views:list" %}?status={{ employee_record.status }}" class="btn btn-block btn-link btn-ico">
+                                <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
+                                <span>Liste des fiches salarié</span>
+                            </a>
+                        </div>
+                    {% endif %}
                     {% if employee_record.status != "READY" and employee_record.status != "SENT" and employee_record.status != "ARCHIVED" %}
                         <div class="c-box mb-4">
                             {% if employee_record.status == "NEW" %}

--- a/itou/templates/includes/deactivate_member.html
+++ b/itou/templates/includes/deactivate_member.html
@@ -1,3 +1,5 @@
+{% load buttons_form %}
+
 <div class="content-small">
     <h1>Retrait d'un collaborateur</h1>
     <div class="mt-4 alert alert-warning">
@@ -18,10 +20,8 @@
     </ul>
 
     <form action="{% url base_url|add:":deactivate_member" target_member.pk %}" method="post">
+        {% url base_url|add:":members" as reset_url %}
         {% csrf_token %}
-        <div class="mt-4 form-group">
-            <a class="btn btn-outline-primary" href="{% url base_url|add:":members" %}">Annuler</a>
-            <button class="btn btn-primary submit">Retirer l'utilisateur</button>
-        </div>
+        {% itou_buttons_form primary_label="Retirer l'utilisateur" reset_url=reset_url %}
     </form>
 </div>

--- a/itou/templates/includes/update_admin.html
+++ b/itou/templates/includes/update_admin.html
@@ -1,3 +1,4 @@
+{% load buttons_form %}
 
 <div class="content-small">
     {% if action == "remove" %}
@@ -21,16 +22,12 @@
     </ul>
 
     <form action="{% url base_url|add:":update_admin_role" action target_member.pk %}" method="post">
+        {% url base_url|add:":members" as reset_url %}
         {% csrf_token %}
-        <div class="mt-4 form-group">
-            <a class="btn btn-outline-primary" href="{% url base_url|add:":members" %}">Annuler</a>
-            <button class="btn btn-primary submit">
-                {% if action == "remove" %}
-                    Retirer les droits administrateur
-                {% else %}
-                    Ajouter les droits administrateur
-                {% endif %}
-            </button>
-        </div>
+        {% if action == "remove" %}
+            {% itou_buttons_form primary_label="Retirer les droits administrateur" reset_url=reset_url %}
+        {% else %}
+            {% itou_buttons_form primary_label="Ajouter les droits administrateur" reset_url=reset_url %}
+        {% endif %}
     </form>
 </div>

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load static %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Invitation {{ block.super }}{% endblock %}
 
@@ -38,25 +39,7 @@
                                 <span>Ajouter un autre collaborateur</span>
                             </button>
 
-                            <hr class="mb-3">
-                            <div class="row">
-                                <div class="col-12">
-                                    <div class="form-row align-items-center justify-content-end">
-                                        <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                            <a href="{{ back_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retour à l'étape précédente">
-                                                <i class="ri-arrow-go-back-line ri-lg"></i>
-                                                <span>Retour</span>
-                                            </a>
-                                        </div>
-                                        <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                            <button class="btn btn-ico btn-block btn-primary">
-                                                <i class="ri-send-plane-line ri-lg"></i>
-                                                <span>Envoyer</span>
-                                            </button>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Envoyer" reset_url=back_url %}
                         </form>
                     </div>
 

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block title %}Modifier cette organisation {{ block.super }}{% endblock %}
 
@@ -30,18 +31,7 @@
 
                             {% bootstrap_form form alert_error_type="all" %}
 
-                            <hr>
-                            <div class="form-row align-items-center gx-3">
-                                <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                    <a href="{% url 'dashboard:index' %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Retourner au tableau de bord">
-                                        <i class="ri-arrow-go-back-line ri-lg"></i>
-                                        <span>Retour</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                    <button class="btn btn-primary btn-block" aria-label="Enregistrer la modification">Enregistrer</button>
-                                </div>
-                            </div>
+                            {% itou_buttons_form primary_label="Enregistrer" primary_aria_label="Enregistrer la modification" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/siae_evaluations/includes/criteria_form.html
+++ b/itou/templates/siae_evaluations/includes/criteria_form.html
@@ -1,4 +1,5 @@
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 <form method="post" role="form" class="js-prevent-multiple-submit">
 
@@ -29,7 +30,5 @@
         {% endfor %}
     {% endif %}
 
-    <div class="form-group text-end">
-        {% bootstrap_button "Enregistrer ce(s) critère(s)" button_type="submit" button_class="btn btn-primary" %}
-    </div>
+    {% itou_buttons_form primary_label="Enregistrer ce(s) critère(s)" %}
 </form>

--- a/itou/templates/siae_evaluations/samples_selection.html
+++ b/itou/templates/siae_evaluations/samples_selection.html
@@ -2,6 +2,7 @@
 {% load format_filters %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Sélectionner l’échantillon pour {{ evaluation_campaign }} {{ block.super }}{% endblock %}
 
@@ -85,19 +86,11 @@
                                         <p>{{ min }}% {{ form.chosen_percent }} {{ max }}%</p>
                                     </div>
 
-                                    <div class="form-group text-end">
-                                        {% bootstrap_button "Valider" button_type="submit" button_class="btn btn-primary" %}
-                                    </div>
+                                    {% itou_buttons_form primary_label="Valider" secondary_url=back_url %}
                                 </form>
                             {% endif %}
                         </div>
                     </div>
-
-                    {% if back_url %}
-                        <p class="mt-4">
-                            <a href="{{ back_url }}">Retour</a>
-                        </p>
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/itou/templates/signup/choose_user_kind.html
+++ b/itou/templates/signup/choose_user_kind.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 {% block content %}
     <section class="s-section">
@@ -9,7 +10,7 @@
                     <h1>Inscription</h1>
 
                     <div class="c-form mb-5">
-                        <h2>Sélectionnez votre profil</h2>
+                        <h2>Sélectionnez votre profil *</h2>
 
                         <form method="post">
                             {% csrf_token %}
@@ -18,9 +19,7 @@
                             {% include "signup/includes/user_kind_radio.html" with kind="prescriber" label="Prescripteur / Orienteur" description="Vous accompagnez des candidats dans leur recherche d’emploi inclusif" only %}
                             {% include "signup/includes/user_kind_radio.html" with kind="employer" label="Employeur solidaire" description="Vous travaillez dans une structure inclusive qui recrute et accompagne des candidats (SIAE, GEIQ, EA, EATT, OPCS)" only %}
 
-                            <div class="form-group text-end">
-                                {% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary" %}
-                            </div>
+                            {% itou_buttons_form primary_label="Suivant" %}
                         </form>
                     </div>
 

--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 tally str_filters %}
+{% load buttons_form %}
 
 {% block title %}Employeur solidaire - Inscription {{ block.super }}{% endblock %}
 
@@ -21,9 +22,7 @@
 
                         {% bootstrap_form siren_form alert_error_type="all" %}
 
-                        <div class="form-group text-end">
-                            {% bootstrap_button "Rechercher" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
+                        {% itou_buttons_form primary_label="Rechercher" %}
 
                     </form>
 
@@ -114,9 +113,7 @@
                                     <br>
                                     - Pour les GEIQ, il s’agit du correspondant enregistré dans la liste des GEIQ transmises par la FFGEIQ.
                                 </p>
-                                <div class="form-group text-end">
-                                    {% bootstrap_button "Envoyer ma demande de validation" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
+                                {% itou_buttons_form primary_label="Envoyer ma demande de validation" %}
                             </form>
 
                         </div>

--- a/itou/templates/signup/includes/submit_rgpd.html
+++ b/itou/templates/signup/includes/submit_rgpd.html
@@ -1,4 +1,5 @@
 {% load django_bootstrap5 %}
+{% load buttons_form %}
 
 <p>
     Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez
@@ -12,6 +13,4 @@
         les conditions générales d'utilisation
     </a><i class="ri-external-link-line ms-1"></i>.
 </p>
-<div class="form-group text-end">
-    {% bootstrap_button "Inscription" button_type="submit" button_class="btn btn-primary" %}
-</div>
+{% itou_buttons_form primary_label="Inscription" %}

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -3,6 +3,7 @@
 {% load redirection_fields %}
 {% load static %}
 {% load matomo %}
+{% load buttons_form %}
 
 {% block title %}Inscription candidat {{ block.super }}{% endblock %}
 
@@ -36,7 +37,7 @@
                                 </div>
                             {% endif %}
 
-                            <div class="form-group">{% bootstrap_button "Suivant" button_type="submit" button_class="btn btn-primary" %}</div>
+                            {% itou_buttons_form primary_label="Suivant" %}
 
                         </form>
                         <p class="mt-5">

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load redirection_fields %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Inscription candidat {{ block.super }}{% endblock %}
 
@@ -24,7 +25,7 @@
 
                             {% bootstrap_form form alert_error_type="all" %}
 
-                            <div class="form-group">{% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}</div>
+                            {% itou_buttons_form primary_label="Continuer" %}
 
                         </form>
                     </div>

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
@@ -26,7 +27,7 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">{% bootstrap_button "Rechercher" button_type="submit" button_class="btn btn-primary" %}</div>
+                        {% itou_buttons_form primary_label="Rechercher" %}
 
                     </form>
 

--- a/itou/templates/signup/prescriber_check_pe_email.html
+++ b/itou/templates/signup/prescriber_check_pe_email.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Prescripteur France Travail - Inscription {{ block.super }}{% endblock %}
 
@@ -27,10 +28,7 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">
-                            <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
+                        {% itou_buttons_form primary_label="Continuer" secondary_url=prev_url %}
 
                     </form>
                 </div>

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
@@ -34,11 +35,7 @@
 
                                 {% bootstrap_form form alert_error_type="all" %}
 
-                                <hr class="my-5">
-                                <div class="form-group text-end">
-                                    <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                                    {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
+                                {% itou_buttons_form primary_label="Continuer" secondary_url=prev_url %}
 
                             </form>
                         </div>

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
@@ -26,10 +27,7 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">
-                            <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
+                        {% itou_buttons_form primary_label="Continuer" secondary_url=prev_url %}
 
                     </form>
                 </div>

--- a/itou/templates/signup/prescriber_confirm_authorization.html
+++ b/itou/templates/signup/prescriber_confirm_authorization.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
@@ -32,10 +33,7 @@
                                 {% bootstrap_form_errors form type="all" %}
                                 {% bootstrap_field form.confirm_authorization show_label=False %}
 
-                                <div class="form-group">
-                                    <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                                    {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}
-                                </div>
+                                {% itou_buttons_form primary_label="Continuer" secondary_url=prev_url %}
 
                             </form>
                         </div>

--- a/itou/templates/signup/prescriber_is_pole_emploi.html
+++ b/itou/templates/signup/prescriber_is_pole_emploi.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
@@ -22,7 +23,7 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">{% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}</div>
+                        {% itou_buttons_form primary_label="Continuer" %}
 
                     </form>
                 </div>

--- a/itou/templates/signup/prescriber_pole_emploi_safir_code.html
+++ b/itou/templates/signup/prescriber_pole_emploi_safir_code.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load buttons_form %}
 
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
@@ -22,10 +23,7 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">
-                            <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
+                        {% itou_buttons_form primary_label="Continuer" secondary_url=prev_url %}
 
                     </form>
                 </div>

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -2,6 +2,7 @@
 {% load django_bootstrap5 %}
 {% load static %}
 {% load format_filters %}
+{% load buttons_form %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
@@ -27,10 +28,8 @@
 
                         {% bootstrap_form form alert_error_type="all" %}
 
-                        <div class="form-group">
-                            <a class="btn btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                            {% bootstrap_button "Valider la demande" button_type="submit" button_class="btn btn-primary" %}
-                        </div>
+                        {% itou_buttons_form primary_label="Valider la demande" secondary_url=prev_url %}
+
                     </form>
                 </div>
             </div>

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -1,0 +1,90 @@
+{% load matomo %}
+
+<div class="row">
+    <div class="col-12">
+        <hr class="mb-3">
+        {% if show_mandatory_fields_mention %}<small class="d-inline-block mb-3">* champs obligatoires</small>{% endif %}
+        <div class="form-row align-items-center justify-content-end gx-3">
+            <div class="form-group col-12 col-lg order-3 order-lg-1">
+                {% if secondary_url %}
+                    <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
+                        <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                        <span>Annuler</span>
+                    </button>
+                {% else %}
+                    <a href="{% if reset_url %}{{ reset_url }}{% else %}{% url 'dashboard:index' %}{% endif %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                        <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                        <span>Annuler</span>
+                    </a>
+                {% endif %}
+            </div>
+            {% if secondary_url %}
+                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                    <a href="{{ secondary_url }}"
+                       class="btn btn-outline-primary"
+                       aria-label="{% if secondary_aria_label %}{{ secondary_aria_label }}{% else %}Retourner à l'étape précédente{% endif %}"
+                       {% if secondary_name and secondary_value %}name="{{ secondary_name }}" value="{{ secondary_value }}"{% endif %}>
+                        <span>Retour</span>
+                    </a>
+                </div>
+            {% endif %}
+            <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                {% if primary_deactivated %}
+                    <button type="button" class="btn btn-block btn-primary disabled">
+                        <span>{{ primary_label }}</span>
+                    </button>
+                {% elif primary_url %}
+                    <a href="{{ primary_url }}"
+                       class="btn btn-block btn-primary"
+                       aria-label="{% if primary_aria_label %}{{ primary_aria_label }}{% else %}Passer à l'étape suivante{% endif %}"
+                       {% if primary_name and primary_value %}name="{{ primary_name }}" value="{{ primary_value }}"{% endif %}
+                       {% if matomo_category and matomo_action and matomo_name %}{% matomo_event matomo_category matomo_action matomo_name %}{% endif %}>
+                        <span>{{ primary_label }}</span>
+                    </a>
+                {% else %}
+                    <button type="submit"
+                            class="btn btn-block btn-primary"
+                            aria-label="{% if primary_aria_label %}{{ primary_aria_label }}{% else %}Passer à l'étape suivante{% endif %}"
+                            {% if primary_name and primary_value %}name="{{ primary_name }}" value="{{ primary_value }}"{% endif %}
+                            {% if matomo_category and matomo_action and matomo_name %}{% matomo_event matomo_category matomo_action matomo_name %}{% endif %}>
+                        <span>{{ primary_label }}</span>
+                    </button>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</div>
+
+<div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            {% if modal_content_save_and_quit %}
+                <div class="modal-header">
+                    <h3 class="modal-title">Enregistrer et quitter ?</h3>
+                </div>
+                <div class="modal-body">
+                    Les informations renseignées seront enregistrées.
+                    <br>
+                    Vous pourrez terminer de les compléter plus tard.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                    <a href="{% if reset_url %}{{ reset_url }}{% else %}{% url 'dashboard:index' %}{% endif %}" class="btn btn-sm btn-danger">Enregistrer et quitter</a>
+                </div>
+            {% else %}
+                <div class="modal-header">
+                    <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                </div>
+                <div class="modal-body">
+                    Les informations renseignées ne seront pas enregistrées.
+                    <br>
+                    Cette action est irréversible.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                    <a href="{% if reset_url %}{{ reset_url }}{% else %}{% url 'dashboard:index' %}{% endif %}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -19,16 +19,16 @@
                 {% endif %}
             </div>
             {% if secondary_url %}
-                <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                <div class="form-group col col-lg-auto order-1 order-lg-2">
                     <a href="{{ secondary_url }}"
-                       class="btn btn-outline-primary"
+                       class="btn btn-block btn-outline-primary"
                        aria-label="{% if secondary_aria_label %}{{ secondary_aria_label }}{% else %}Retourner à l'étape précédente{% endif %}"
                        {% if secondary_name and secondary_value %}name="{{ secondary_name }}" value="{{ secondary_value }}"{% endif %}>
                         <span>Retour</span>
                     </a>
                 </div>
             {% endif %}
-            <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+            <div class="form-group col col-lg-auto order-2 order-lg-3">
                 {% if primary_deactivated %}
                     <button type="button" class="btn btn-block btn-primary disabled">
                         <span>{{ primary_label }}</span>

--- a/itou/utils/templatetags/buttons_form.py
+++ b/itou/utils/templatetags/buttons_form.py
@@ -1,0 +1,85 @@
+from django import template
+
+
+register = template.Library()
+
+
+@register.inclusion_tag("./utils/templatetags/buttons_form.html", takes_context=False)
+def itou_buttons_form(**kwargs):
+    """
+    Render buttons on forms.
+
+    **Tag name**::
+
+        itou_buttons_form
+
+    **Parameters**::
+
+        primary_label
+            The label for the primary button.
+            Default: "Suivant"
+
+        primary_url
+            The url for the primary button. If True, display href as a button, instead of a submit button.
+            Optional
+            Default: None
+
+        secondary_url
+            The url for the secondary button.
+            Optional
+            Default: None
+
+        reset_url
+            The url for the reset button. If True, display href link, whether reset_submit exists or not.
+            Optional
+            Default: 'dashboard:index'
+
+        reset_submit
+            display a reset button, if True and reset_url is not set.
+            Optional
+            Default: False
+
+        matomo_category & matomo_action & matomo_name
+            If set together, the buttons will send a matomo event on click.
+            Optional
+            Default: None
+
+        show_mandatory_fields_mention
+            if True, show the mention "champs obligatoires" on the form.
+            Default: True
+
+        primary_disabled
+            if True, the primary button is disabled.
+            Optional
+            Default: False
+
+        primary_name & primary_value
+            If set together, the name and value for the primary button.
+            Optional
+            Default: None
+
+        secondary_name & secondary_value
+            If set together, the name and value for the secondary button.
+            Optional
+            Default: None
+
+        modal_content_save_and_quit
+            if set, force alternate modal content for the save and quit button.
+            Optional
+            Default: None
+
+
+    **Usage**::
+
+        {% itou_buttons_form  %}
+
+    **Example**::
+
+        {% itou_buttons_form reset_submit=True %}
+    """
+    if kwargs.get("primary_label") is None:
+        kwargs["primary_label"] = "Suivant"
+    if kwargs.get("show_mandatory_fields_mention") is None:
+        kwargs["show_mandatory_fields_mention"] = True
+
+    return {**kwargs}

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -117,6 +117,7 @@ class ApplyStepBaseView(LoginRequiredMixin, TemplateView):
             "siae": self.company,
             "back_url": self.get_back_url(),
             "hire_process": self.hire_process,
+            "reset_url": reverse("dashboard:index"),
         }
 
 
@@ -749,6 +750,7 @@ class CheckJobSeekerInformationsForHire(ApplicationBaseView):
         return super().get_context_data(**kwargs) | {
             "profile": self.job_seeker.jobseeker_profile,
             "hiring_pending": True,
+            "back_url": reverse("apply:check_nir_for_hire", kwargs={"company_pk": self.company.pk}),
         }
 
 
@@ -1197,6 +1199,10 @@ class ApplicationEndView(ApplyStepBaseView):
             "can_view_personal_information": self.request.user.can_view_personal_information(
                 self.job_application.job_seeker
             ),
+            "reset_url": reverse(
+                "apply:application_end",
+                kwargs={"company_pk": self.company.pk, "application_pk": self.job_application.pk},
+            ),
         }
 
 
@@ -1226,6 +1232,9 @@ class UpdateJobSeekerBaseView(SessionNamespaceRequiredMixin, ApplyStepBaseView):
             "step_3_url": reverse(
                 "apply:update_job_seeker_step_3_for_hire" if self.hire_process else "apply:update_job_seeker_step_3",
                 kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+            ),
+            "reset_url": reverse(
+                "apply:application_jobs", kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
             ),
         }
 

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -638,6 +638,7 @@ def suspension_update_enddate(request, suspension_id, template_name="approvals/s
     context = {
         "suspension": suspension,
         "back_url": back_url,
+        "reset_url": reverse("approvals:detail", kwargs={"pk": suspension.approval_id}),
         "form": form,
     }
     return render(request, template_name, context)
@@ -673,6 +674,7 @@ def suspension_delete(request, suspension_id, template_name="approvals/suspensio
     context = {
         "suspension": suspension,
         "back_url": back_url,
+        "reset_url": reverse("approvals:detail", kwargs={"pk": suspension.approval_id}),
         "lost_days": (timezone.localdate() - suspension.start_at).days + 1,
     }
     return render(request, template_name, context)

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -125,6 +125,8 @@ class AddView(LoginRequiredMixin, NamedUrlSessionWizardView):
                         "employee_record_views:create",
                         kwargs={"job_application_id": employee_record.job_application.pk},
                     )
+                    + "?back_url="
+                    + reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
                 )
             else:  # An employee record exists, show the summary
                 return HttpResponseRedirect(
@@ -270,6 +272,7 @@ def create(request, job_application_id, template_name="employee_record/create.ht
         "steps": STEPS,
         "step": 1,
         "matomo_custom_title": "Nouvelle fiche salarié ASP - Étape 1",
+        "back_url": request.GET.get("back_url"),
     }
 
     return render(request, template_name, context)

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -199,6 +199,8 @@ def join_prescriber_organization(request, invitation_id):
 
 @login_required
 def invite_employer(request, template_name="invitations_views/create.html"):
+    form_post_url = reverse("invitations_views:invite_employer")
+    back_url = reverse("companies_views:members")
     company = get_current_company_or_404(request)
     form_kwargs = {"sender": request.user, "company": company}
     formset = EmployerInvitationFormSet(data=request.POST or None, form_kwargs=form_kwargs)
@@ -213,10 +215,8 @@ def invite_employer(request, template_name="invitations_views/create.html"):
             s = pluralizefr(len(formset.forms))
             messages.success(request, f"Invitation{s} envoyée{s}", extra_tags="toasts")
 
-            return redirect(request.path)
+            return redirect(back_url)
 
-    form_post_url = reverse("invitations_views:invite_employer")
-    back_url = reverse("companies_views:members")
     context = {"back_url": back_url, "form_post_url": form_post_url, "formset": formset, "organization": company}
 
     return render(request, template_name, context)

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -17,7 +17,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -73,7 +73,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -129,7 +129,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -185,7 +185,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -241,7 +241,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -297,7 +297,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -353,7 +353,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -409,7 +409,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -465,7 +465,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <a href="/next"
                          class="btn btn-block btn-primary"
@@ -521,7 +521,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <a href="/next"
                          class="btn btn-block btn-primary"
@@ -577,16 +577,16 @@
                   
               </div>
               
-                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                  <div class="form-group col col-lg-auto order-1 order-lg-2">
                       <a href="/prev"
-                         class="btn btn-outline-primary"
+                         class="btn btn-block btn-outline-primary"
                          aria-label="label"
                          >
                           <span>Retour</span>
                       </a>
                   </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -642,16 +642,16 @@
                   
               </div>
               
-                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                  <div class="form-group col col-lg-auto order-1 order-lg-2">
                       <a href="/do"
-                         class="btn btn-outline-primary"
+                         class="btn btn-block btn-outline-primary"
                          aria-label="Retourner à l'étape précédente"
                          name="name" value="1">
                           <span>Retour</span>
                       </a>
                   </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -707,16 +707,16 @@
                   
               </div>
               
-                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                  <div class="form-group col col-lg-auto order-1 order-lg-2">
                       <a href="/do"
-                         class="btn btn-outline-primary"
+                         class="btn btn-block btn-outline-primary"
                          aria-label="Retourner à l'étape précédente"
                          >
                           <span>Retour</span>
                       </a>
                   </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
@@ -772,7 +772,7 @@
                   
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -1,0 +1,812 @@
+# serializer version: 1
+# name: TestButtonsForm.test_itou_buttons_form[no params]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_form_reset_url[default_reset_url]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_form_reset_url[reset_url]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/reset" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/reset" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_mandatory_fields_mention[no_mandatory_fields_mention]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_matomo_event[matomo_event]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              data-matomo-event="true" data-matomo-category="category" data-matomo-action="action" data-matomo-option="name">
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_primary_aria_label[with_primary_aria_label]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="label"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_primary_disabled[with_primary_disabled]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_primary_name_and_value[with_primary_name_and_value]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              name="name" value="1"
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_primary_url[with_primary_url]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <a href="/next"
+                         class="btn btn-block btn-primary"
+                         aria-label="Passer à l'étape suivante"
+                         
+                         >
+                          <span>Suivant</span>
+                      </a>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_primary_url_name_value_aria_label_and_matomo_tags[with_primary_url_name_value_aria_label_and_matomo_tags]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <a href="/next"
+                         class="btn btn-block btn-primary"
+                         aria-label="label"
+                         name="name" value="1"
+                         data-matomo-event="true" data-matomo-category="category" data-matomo-action="action" data-matomo-option="name">
+                          <span>Suivant</span>
+                      </a>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_secondary_aria_label[with_secondary_aria_label]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </button>
+                  
+              </div>
+              
+                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                      <a href="/prev"
+                         class="btn btn-outline-primary"
+                         aria-label="label"
+                         >
+                          <span>Retour</span>
+                      </a>
+                  </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_secondary_name_and_value[with_secondary_name_and_value]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </button>
+                  
+              </div>
+              
+                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                      <a href="/do"
+                         class="btn btn-outline-primary"
+                         aria-label="Retourner à l'étape précédente"
+                         name="name" value="1">
+                          <span>Retour</span>
+                      </a>
+                  </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_itou_buttons_with_secondary_url[no_form_title]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </button>
+                  
+              </div>
+              
+                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                      <a href="/do"
+                         class="btn btn-outline-primary"
+                         aria-label="Retourner à l'étape précédente"
+                         >
+                          <span>Retour</span>
+                      </a>
+                  </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---
+# name: TestButtonsForm.test_save_and_quit_modal_content[save_and_quit_modal_content]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="Passer à l'étape suivante"
+                              
+                              >
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Enregistrer et quitter ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées seront enregistrées.
+                      <br>
+                      Vous pourrez terminer de les compléter plus tard.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Enregistrer et quitter</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -9,3 +9,75 @@ def test_matomo_event():
         'data-matomo-action="action" data-matomo-option="option" >'
     )
     assert template.render(Context({})) == expected_render
+
+
+class TestButtonsForm:
+    def test_itou_buttons_form(self, snapshot):
+        template = Template("{% load buttons_form %}{% itou_buttons_form %}")
+        assert template.render(Context({})) == snapshot(name="no params")
+
+    def test_itou_buttons_form_reset_url(self, snapshot):
+        template = Template("{% load buttons_form %}{% itou_buttons_form %}")
+        assert template.render(Context({})) == snapshot(name="default_reset_url")
+
+        template = Template('{% load buttons_form %}{% itou_buttons_form reset_url="/reset" %}')
+        assert template.render(Context({})) == snapshot(name="reset_url")
+
+    def test_itou_buttons_with_primary_name_and_value(self, snapshot):
+        template = Template('{% load buttons_form %}{% itou_buttons_form primary_name="name" primary_value="1" %}')
+        assert template.render(Context({})) == snapshot(name="with_primary_name_and_value")
+
+    def test_itou_buttons_with_primary_aria_label(self, snapshot):
+        template = Template('{% load buttons_form %}{% itou_buttons_form primary_aria_label="label" %}')
+        assert template.render(Context({})) == snapshot(name="with_primary_aria_label")
+
+    def test_itou_buttons_with_primary_url(self, snapshot):
+        template = Template('{% load buttons_form %}{% itou_buttons_form primary_url="/next" %}')
+        assert template.render(Context({})) == snapshot(name="with_primary_url")
+
+    def test_itou_buttons_with_primary_url_name_value_aria_label_and_matomo_tags(self, snapshot):
+        template = Template(
+            "{% load buttons_form %}"
+            '{% itou_buttons_form primary_url="/next" primary_name="name" primary_value="1" '
+            'primary_aria_label="label" '
+            'matomo_category="category" matomo_action="action" matomo_name="name" %}'
+        )
+        assert template.render(Context({})) == snapshot(name="with_primary_url_name_value_aria_label_and_matomo_tags")
+
+    def test_itou_buttons_with_primary_disabled(self, snapshot):
+        template = Template("{% load buttons_form %}{% itou_buttons_form primary_disabled=True %}")
+        assert template.render(Context({})) == snapshot(name="with_primary_disabled")
+
+    def test_itou_buttons_with_secondary_aria_label(self, snapshot):
+        template = Template(
+            '{% load buttons_form %}{% itou_buttons_form secondary_url="/prev" secondary_aria_label="label" %}'
+        )
+        assert template.render(Context({})) == snapshot(name="with_secondary_aria_label")
+
+    def test_itou_buttons_with_secondary_url(self, snapshot):
+        template = Template('{% load buttons_form %}{% itou_buttons_form secondary_url="/do" %}')
+        assert template.render(Context({})) == snapshot(name="no_form_title")
+
+    def test_itou_buttons_with_secondary_name_and_value(self, snapshot):
+        template = Template(
+            (
+                '{% load buttons_form %}{% itou_buttons_form secondary_url="/do" '
+                'secondary_name="name" secondary_value="1" %}'
+            )
+        )
+        assert template.render(Context({})) == snapshot(name="with_secondary_name_and_value")
+
+    def test_itou_buttons_matomo_event(self, snapshot):
+        template = Template(
+            "{% load buttons_form %}"
+            '{% itou_buttons_form matomo_category="category" matomo_action="action" matomo_name="name" %}'
+        )
+        assert template.render(Context({})) == snapshot(name="matomo_event")
+
+    def test_itou_buttons_mandatory_fields_mention(self, snapshot):
+        template = Template("{% load buttons_form %}{% itou_buttons_form show_mandatory_fields_mention=False %}")
+        assert template.render(Context({})) == snapshot(name="no_mandatory_fields_mention")
+
+    def test_save_and_quit_modal_content(self, snapshot):
+        template = Template("{% load buttons_form %}{% itou_buttons_form modal_content_save_and_quit=True %}")
+        assert template.render(Context({})) == snapshot(name="save_and_quit_modal_content")

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3930,6 +3930,11 @@ class CheckJobSeekerInformationsForHireTestCase(TestCase):
                 kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk},
             ),
         )
+
+        self.assertContains(
+            response,
+            reverse("apply:check_nir_for_hire", kwargs={"company_pk": company.pk}),
+        )
         self.assertContains(response, reverse("dashboard:index"))
 
     def test_geiq(self):

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -1,0 +1,82 @@
+# serializer version: 1
+# name: ApprovalSuspendViewTest.test_delete_suspension[delete_suspension_form]
+  '''
+  <div class="c-form">
+                          <p>
+                              <strong>Action choisie</strong> : Confirmer la <strong class="text-danger">suppression définitive</strong> de cette suspension.
+                          </p>
+                          <div class="alert alert-danger fade show" role="status">
+                              <div class="row">
+                                  <div class="col-auto pe-0">
+                                      <i class="ri-information-line ri-xl text-danger"></i>
+                                  </div>
+                                  <div class="col">
+                                      <p class="mb-0">
+                                          Attention : la suppression définitive de cette suspension aura pour conséquence de :
+                                          </p><ul>
+                                              <li>
+                                                  <strong>Réduire la durée restante de ce PASS IAE de 1 jour.</strong>
+                                              </li>
+                                          </ul>
+                                      <p></p>
+                                  </div>
+                              </div>
+                          </div>
+                          <hr/>
+                          <form class="js-prevent-multiple-submit" method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                              <input name="confirm" type="hidden" value="true"/>
+                              
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                      <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                      <span>Annuler</span>
+                  </button>
+              </div>
+              
+                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                      <a aria-label="Retourner à l'étape précédente" class="btn btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
+                          <span>Retour</span>
+                      </a>
+                  </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
+                          <span>Confirmer la suppression</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/approvals/detail/[PK of Approval]">Confirmer l'annulation</a>
+              </div>
+          </div>
+      </div>
+  </div>
+  
+                          </form>
+                      </div>
+  '''
+# ---

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -34,19 +34,21 @@
           <small class="d-inline-block mb-3">* champs obligatoires</small>
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
-                      <i aria-hidden="true" class="ri-close-line ri-lg"></i>
-                      <span>Annuler</span>
-                  </button>
+                  
+                      <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </button>
+                  
               </div>
               
-                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l'étape précédente" class="btn btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
+                  <div class="form-group col col-lg-auto order-1 order-lg-2">
+                      <a aria-label="Retourner à l'étape précédente" class="btn btn-block btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
                           <span>Retour</span>
                       </a>
                   </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
                           <span>Confirmer la suppression</span>
@@ -60,18 +62,20 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/approvals/detail/[PK of Approval]">Confirmer l'annulation</a>
-              </div>
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/approvals/detail/[PK of Approval]">Confirmer l'annulation</a>
+                  </div>
+              
           </div>
       </div>
   </div>

--- a/tests/www/approvals_views/test_suspend.py
+++ b/tests/www/approvals_views/test_suspend.py
@@ -220,7 +220,7 @@ class ApprovalSuspendViewTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         form = parse_response_to_soup(
-            response, selector="div.c-form", replace_in_href=[suspension, suspension.approval]
+            response, selector="div.c-form", replace_in_attr=[suspension, suspension.approval]
         )
         assert str(form) == self.snapshot(name="delete_suspension_form")
         assert response.context["reset_url"] == redirect_url

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -44,16 +44,64 @@
                                   </ul>
                               
   
-                              <hr/>
-                              <p class="fs-xs">* champ obligatoire</p>
-                              <div class="form-group text-end">
+                              
+                              
                                   
-                                      <button class="btn btn-outline-primary" name="wizard_goto_step" type="submit" value="choose-employee">Retour</button>
                                   
-                                  <button class="btn btn-primary" data-matomo-action="submit" data-matomo-category="fiches-salarié" data-matomo-event="true" data-matomo-option="création">
-                                      Confirmer
-                                  </button>
-                              </div>
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </button>
+                  
+              </div>
+              
+                  <div class="form-group col col-lg-auto order-1 order-lg-2">
+                      <a aria-label="Retourner à l'étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/add/choose-employee" name="wizard_goto_step" value="choose-employee">
+                          <span>Retour</span>
+                      </a>
+                  </div>
+              
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
+                  
+                      <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
+                          <span>Confirmer</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/employee_record/list?status=NEW">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+                              
                           </form>
                       </div>
                   </div>

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -5,7 +5,7 @@
                       
                           <a class="btn btn-sm btn-outline-primary mt-2" href="/employee_record/disable/[PK of EmployeeRecord]">Désactiver la fiche salarié</a>
                       
-                      <a class="btn btn-sm btn-primary mt-2" href="/employee_record/create/[PK of JobApplication]?from_status=NEW">Compléter la fiche salarié</a>
+                      <a class="btn btn-sm btn-primary mt-2" href="/employee_record/create/[PK of JobApplication]?status=NEW">Compléter la fiche salarié</a>
                   </div>
   '''
 # ---
@@ -177,7 +177,7 @@
                       
                           <a class="btn btn-sm btn-outline-primary mt-2" href="/employee_record/disable/[PK of EmployeeRecord]">Désactiver la fiche salarié</a>
                       
-                      <a class="btn btn-sm btn-primary mt-2" href="/employee_record/create/[PK of JobApplication]?from_status=NEW">Compléter la fiche salarié</a>
+                      <a class="btn btn-sm btn-primary mt-2" href="/employee_record/create/[PK of JobApplication]?status=NEW">Compléter la fiche salarié</a>
                   </div>
   '''
 # ---
@@ -187,7 +187,7 @@
                       
                           <a class="btn btn-sm btn-outline-primary mt-2" href="/employee_record/disable/[PK of EmployeeRecord]">Désactiver la fiche salarié</a>
                       
-                      <a class="btn btn-sm btn-primary mt-2" href="/employee_record/create/[PK of JobApplication]?from_status=NEW">Compléter la fiche salarié</a>
+                      <a class="btn btn-sm btn-primary mt-2" href="/employee_record/create/[PK of JobApplication]?status=NEW">Compléter la fiche salarié</a>
                   </div>
   '''
 # ---

--- a/tests/www/employee_record_views/test_add.py
+++ b/tests/www/employee_record_views/test_add.py
@@ -96,7 +96,11 @@ def test_done_step_when_a_new_employee_record_already_exists(client):
 
     choose_employee_url = reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
     choose_approval_url = reverse("employee_record_views:add", kwargs={"step": "choose-approval"})
-    end_url = reverse("employee_record_views:create", kwargs={"job_application_id": job_application.pk})
+    end_url = (
+        reverse("employee_record_views:create", kwargs={"job_application_id": job_application.pk})
+        + "?back_url="
+        + reverse("employee_record_views:add", kwargs={"step": "choose-employee"})
+    )
 
     client.post(
         choose_employee_url,

--- a/tests/www/invitations_views/test_company_send.py
+++ b/tests/www/invitations_views/test_company_send.py
@@ -140,9 +140,12 @@ class TestSendMultipleCompanyInvitation(TestCase):
         response = self.client.get(INVITATION_URL)
 
         assert response.context["formset"]
-        self.client.post(INVITATION_URL, data=self.post_data)
+        response = self.client.post(INVITATION_URL, data=self.post_data)
         invitations = EmployerInvitation.objects.count()
         assert invitations == 2
+
+        assert response.status_code == 302
+        assert response.url == reverse("companies_views:members")
 
     def test_send_multiple_invitations_duplicated_email(self):
         self.client.force_login(self.sender)

--- a/tests/www/prescribers_views/__snapshots__/test_edit.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_edit.ambr
@@ -235,13 +235,15 @@
           <small class="d-inline-block mb-3">* champs obligatoires</small>
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
-                      <i aria-hidden="true" class="ri-close-line ri-lg"></i>
-                      <span>Annuler</span>
-                  </button>
+                  
+                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/dashboard/">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button aria-label="Enregistrer la modification" class="btn btn-block btn-primary" type="submit">
                           <span>Enregistrer</span>
@@ -255,18 +257,20 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
-              </div>
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
+                  </div>
+              
           </div>
       </div>
   </div>

--- a/tests/www/prescribers_views/__snapshots__/test_edit.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_edit.ambr
@@ -227,18 +227,50 @@
   </div><div class="form-group"><label class="form-label" for="id_description">Description</label><textarea class="form-control" cols="40" disabled="" id="id_description" name="description" placeholder="Description" rows="10"></textarea><div class="form-text">Texte de présentation de votre structure.</div>
   </div>
   
-                              <hr/>
-                              <div class="form-row align-items-center gx-3">
-                                  <div class="form-group col-12 col-lg order-2 order-lg-1">
-                                      <a aria-label="Retourner au tableau de bord" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/dashboard/">
-                                          <i class="ri-arrow-go-back-line ri-lg"></i>
-                                          <span>Retour</span>
-                                      </a>
-                                  </div>
-                                  <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                                      <button aria-label="Enregistrer la modification" class="btn btn-primary btn-block">Enregistrer</button>
-                                  </div>
-                              </div>
+                              
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                      <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                      <span>Annuler</span>
+                  </button>
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button aria-label="Enregistrer la modification" class="btn btn-block btn-primary" type="submit">
+                          <span>Enregistrer</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
+              </div>
+          </div>
+      </div>
+  </div>
+  
                           </form>
   '''
 # ---

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -113,13 +113,15 @@
           <small class="d-inline-block mb-3">* champs obligatoires</small>
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
-                      <i aria-hidden="true" class="ri-close-line ri-lg"></i>
-                      <span>Annuler</span>
-                  </button>
+                  
+                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/dashboard/">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
               </div>
               
-              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
                       <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
                           <span>Inscription</span>
@@ -133,18 +135,20 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
-              </div>
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
+                  </div>
+              
           </div>
       </div>
   </div>

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -1,0 +1,156 @@
+# serializer version: 1
+# name: JobSeekerSignupTest.test_job_seeker_signup[job_seeker_signup_form]
+  '''
+  <form action="/signup/job_seeker" class="js-prevent-multiple-submit" method="post" role="form">
+  
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+  
+                              
+  
+                              
+  
+                              <div class="form-group mb-1 form-group-required"><label class="form-label" for="id_email">Adresse e-mail</label><input autocomplete="email" class="form-control" id="id_email" maxlength="320" name="email" placeholder="adresse@email.fr" required="" type="email"/></div>
+                              <div class="text-end small font-italic mb-0">
+  
+  
+  <a data-bs-target="#no-email-modal" data-bs-toggle="modal" href="#">
+      
+          Pas d'adresse e-mail ?
+      
+  </a>
+  
+  <div aria-labelledby="no-email-modal-label" aria-modal="true" class="modal fade text-start" id="no-email-modal" role="dialog" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered modal-lg">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h3 class="modal-title" id="no-email-modal-label">Créer une adresse e-mail</h3>
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+              </div>
+              <div class="modal-body">
+                  <div class="container">
+                      <div class="row">
+                          <div class="col text-center">
+                              <img alt="" src="/static/img/no_email.svg"/>
+                          </div>
+                          <div class="col">
+                              <p class="pt-3">Nous vous conseillons de créer une adresse e-mail avec le service de laposte.net.</p>
+                              <p>Une fois l'adresse e-mail créée, vous pourrez l'utiliser ici.</p>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+              <div class="modal-footer">
+                  <a aria-label="Ouverture dans un nouvel onglet" class="btn btn-sm btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="inscription-candidat" data-matomo-event="true" data-matomo-option="je-n-ai-pas-d-adresse-email" href="https://compte.laposte.net/inscription/index.do?srv_gestion=POLEEMPLOI" rel="noopener" target="_blank">
+                      <span>Créer une adresse e-mail</span>
+                      <i class="ri-external-link-line"></i>
+                  </a>
+              </div>
+          </div>
+      </div>
+  </div>
+  </div>
+  
+                              <div class="form-group mt-1 form-group-required"><label class="form-label" for="id_title">Civilité</label><select class="form-select" id="id_title" name="title" required="">
+    <option value="">---------</option>
+  
+    <option selected="" value="M">Monsieur</option>
+  
+    <option value="MME">Madame</option>
+  
+  </select></div>
+                              <div class="form-group form-group-required"><label class="form-label" for="id_last_name">Nom</label><input class="form-control" id="id_last_name" maxlength="150" name="last_name" placeholder="Durand" required="" type="text"/></div>
+                              <div class="form-group form-group-required"><label class="form-label" for="id_first_name">Prénom</label><input class="form-control" id="id_first_name" maxlength="150" name="first_name" placeholder="Dominique" required="" type="text"/></div>
+                              <div class="form-group form-group-required"><label class="form-label" for="id_password1">Mot de passe</label><div class="input-group">
+      <input autocomplete="new-password" class="form-control" id="id_password1" name="password1" placeholder="**********" required="" type="password"/>
+  
+      <div class="input-group-text p-0">
+          <button class="btn btn-sm btn-link btn-ico" data-it-password="toggle" type="button">
+              <i aria-hidden="true" class="ri-eye-line"></i>
+              <span>Afficher</span>
+          </button>
+      </div>
+  </div><div class="form-text">Le mot de passe doit contenir au moins 3 des 4 types suivants : majuscules, minuscules, chiffres, caractères spéciaux.</div>
+  </div>
+                              <div class="form-group form-group-required"><label class="form-label" for="id_password2">Mot de passe (confirmation)</label><div class="input-group">
+      <input autocomplete="new-password" class="form-control" id="id_password2" name="password2" placeholder="**********" required="" type="password"/>
+  
+      <div class="input-group-text p-0">
+          <button class="btn btn-sm btn-link btn-ico" data-it-password="toggle" type="button">
+              <i aria-hidden="true" class="ri-eye-line"></i>
+              <span>Afficher</span>
+          </button>
+      </div>
+  </div></div>
+  
+                              
+                                  <div class="form-group mt-1"><label class="form-label" for="id_nir">Numéro de sécurité sociale</label><input class="form-control" disabled="" id="id_nir" name="nir" placeholder="Numéro de sécurité sociale" type="text" value="141068078200557"/></div>
+                              
+  
+                              <div class="small pb-4 text-secondary">
+                                  Vous pourrez créer et modifier des informations telles que votre adresse ou un lien vers un CV après votre inscription, à partir de votre tableau de bord.
+                              </div>
+  
+                              
+  
+  
+  <p>
+      Pour plus d'information sur le traitement de vos données personnelles ou pour exercer vos droits, consultez
+      <a aria-label="Consultez la section Protection des données (ouverture dans une nouvel onglet)" href="/legal/privacy/" rel="noopener" target="_blank">
+          la section Protection des données
+      </a><i class="ri-external-link-line ms-1"></i>.
+  </p>
+  <p>
+      En cliquant sur le bouton "Inscription", vous acceptez
+      <a aria-label="Acceptez les conditions générales d'utilisation (ouverture dans une nouvel onglet)" href="/legal/terms/" rel="noopener" target="_blank">
+          les conditions générales d'utilisation
+      </a><i class="ri-external-link-line ms-1"></i>.
+  </p>
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                      <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                      <span>Annuler</span>
+                  </button>
+              </div>
+              
+              <div class="form-group col-12 col-lg-auto order-2 order-lg-3">
+                  
+                      <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
+                          <span>Inscription</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  
+  
+                          </form>
+  '''
+# ---

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -1,5 +1,6 @@
 import uuid
 
+import pytest
 import respx
 from allauth.account.models import EmailConfirmationHMAC
 from django.conf import settings
@@ -15,9 +16,10 @@ from itou.www.signup.forms import JobSeekerSituationForm
 from tests.cities.factories import create_test_cities
 from tests.openid_connect.france_connect.tests import FC_USERINFO, mock_oauth_dance
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
-from tests.utils.test import TestCase, reload_module
+from tests.utils.test import TestCase, parse_response_to_soup, reload_module
 
 
+@pytest.mark.usefixtures("unittest_compatibility")
 class JobSeekerSignupTest(TestCase):
     def setUp(self):
         super().setUp()
@@ -193,7 +195,8 @@ class JobSeekerSignupTest(TestCase):
         url = reverse("signup:job_seeker")
         response = self.client.get(url)
         assert response.status_code == 200
-        self.assertContains(response, '<button type="submit" class="btn btn-primary">Inscription</button>', html=True)
+        form = parse_response_to_soup(response, selector="form.js-prevent-multiple-submit")
+        assert str(form) == self.snapshot(name="job_seeker_signup_form")
 
         address_line_1 = "Test adresse"
         address_line_2 = "Test adresse complémentaire"


### PR DESCRIPTION
### Pourquoi ?

Harmoniser le rendu des boutons de formulaires en préparation de la refonte graphique

### Comment ? 

:safety_vest: définition d'un `simpletag` paramétrable

### Captures d'écran <!-- optionnel -->

formulaire sans bouton secondaire

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/8890d7eb-ebbd-4826-bd4a-5de040e556a5)

formulaire avec bouton secondaire de retour à l'étape précédente

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/54666cd1-9a0c-4c27-a765-4f64c5cce05a)

formulaire en plusieurs étapes, modale de confirmation sur le lien `annuler`

![image](https://github.com/gip-inclusion/les-emplois/assets/11419273/820704b5-3df1-4afd-939e-1968ca35ba82)
