### PR TITLE
configuration : Suppression de `CLEVER_TOKEN` et `CLEVER_SECRET`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,12 +6,6 @@ PGHOST=localhost
 PGUSER=postgres
 PGPASSWORD=password
 
-# CLEVER_TOKEN and CLEVER_SECRET are to create a machine in
-# ./scripts/create-fast-machine.sh
-# You can find them with "clever login" once you have installed "clever-tools".
-CLEVER_TOKEN=set_me
-CLEVER_SECRET=set_me
-
 # Needed for the ./scripts/restore_latest_backup.sh script.
 # Path to your local itou-backups repository.
 PATH_TO_ITOU_BACKUPS=set_me

--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -1,5 +1,8 @@
 # Journal des changements techniques majeurs
 
+## 2024-01-31
+- Suppression de `CLEVER_TOKEN` et `CLEVER_SECRET`.
+
 ## 2023-11-16
 - Renommage SIAE en Company dans tout le code non spécifique à l'IAE. De nombreux modèles et champs ont été renommés (avec migrations et renommage en base de données) et des urls ont changé. Voir les PR commençant par « Renommage Siae ».
 

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -14,19 +14,10 @@ if [[ ! $RUN_DIRECTORY =~ "scripts" ]]; then
    exit 1
 fi
 
-# If the script is loaded from the root we can import the local environment variables
-# shellcheck source=/dev/null
-source .env
-if [ -z "$CLEVER_TOKEN" ]; then
-  echo "please add 'CLEVER_TOKEN=some_token' in .env at the root of the project in order to run this script. You can find its value with 'clever login'"
+if [ ! -f "$HOME/.config/clever-cloud/clever-tools.json" ]; then
+  echo "clever-tools doesn't seems to be initialized, run 'clever login' to do so."
   exit 1
 fi
-if [ -z "$CLEVER_SECRET" ]; then
-  echo "please add 'CLEVER_SECRET=some_secret' in .env at the root of the project in order to run this script. You can find its value with 'clever login'"
-  exit 1
-fi
-
-clever login --token "$CLEVER_TOKEN" --secret "$CLEVER_SECRET"
 
 APP_NAME=c1-fast-machine-$(date +%y-%m-%d-%Hh-%M)
 


### PR DESCRIPTION
### Pourquoi ?

- Moins d'étape pour avoir le script fonctionnel
- Plus besoin de faire : œuf -> poule -> œuf -> poule
- Pas de duplication de configuration entre le `.env` et le fichier lu nativement par `clever`, ça éviteras des surprises (2 fois, 2 personnes différentes)

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
