### PR TITLE
C2 : Mettre à jour les tables de références d'énumérations tout les jours au lieu de tout les mois

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -19,6 +19,7 @@ OUTPUT_LOG="$OUTPUT_PATH/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 # is intended to be automated by a proper tool like Airflow anyway.
 if [[ "$1" == "--daily" ]]; then
     django-admin send_slack_message ":rocket: lancement mise à jour de données C1 -> Metabase"
+    django-admin populate_metabase_emplois --mode=enums |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=analytics |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=siaes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=job_descriptions |& tee -a "$OUTPUT_LOG"
@@ -46,7 +47,6 @@ elif [[ "$1" == "--monthly" ]]; then
     django-admin populate_metabase_emplois --mode=insee_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=insee_codes_vs_post_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=departments |& tee -a "$OUTPUT_LOG"
-    django-admin populate_metabase_emplois --mode=enums |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=dbt_daily |& tee -a "$OUTPUT_LOG"
     django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"
 else

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -12,8 +12,8 @@ DEPARTMENT_FILTER_KEY = "d%C3%A9partement"
 REGION_FILTER_KEY = "r%C3%A9gion"
 PRESCRIBER_FILTER_KEY = "prescripteur"
 JOB_APPLICATION_ORIGIN_FILTER_KEY = "origine_candidature"
-PE_PRESCRIBER_FILTER_VALUE = "Pôle emploi"
-PE_FILTER_VALUE = "Pôle emploi"
+PE_PRESCRIBER_FILTER_VALUE = "France Travail"
+PE_FILTER_VALUE = "France Travail"
 
 METABASE_DASHBOARDS = {
     #


### PR DESCRIPTION
### Pourquoi ?

Les enums peuvent changer n'importe quand, les mettre à jour qu'une fois par mois n'est donc pas suffisant.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
