### PR TITLE
Fiches salarié : Correction de la création automatique d'une notification en cas de doublon PASS IAE/SIRET (3436)

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -154,6 +154,7 @@ class Command(EmployeeRecordTransferCommand):
                             if approval.suspension_set.exists() or approval.prolongation_set.exists():
                                 # Mimic the SQL trigger function "create_employee_record_notification()"
                                 EmployeeRecordUpdateNotification.objects.update_or_create(
+                                    status=Status.NEW,
                                     employee_record=employee_record,
                                     defaults={"updated_at": timezone.now},
                                 )


### PR DESCRIPTION
### Pourquoi ?

C'est mieux quand ça fonctionne comment c'est supposé fonctionner ;), et ça devrait réduire _un peu_ le nombre de ticket support inutile.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
