### PR TITLE
Fiches salarié : Sortir d'archive automatiquement les FS dont on a raté la notification

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -149,6 +149,9 @@ class Command(BaseCommand):
                     defaults={"updated_at": timezone.now},
                 )
                 total_created += int(created)
+                # Unarchive the employee record so next time we don't miss the notification
+                if employee_record.status == Status.ARCHIVED:
+                    employee_record.unarchive()
             self.stdout.write(f" - {total_created} notification(s) created")
         self.stdout.write(" - done!")
 


### PR DESCRIPTION
### Pourquoi ?

Le trigger PG ne crée une notification que si la FS est `NEW` mais auparavant nous archivions les FS 13 mois après leur création, un certain nombre de FS ont donc été archivées mais sont ensuite prolongées ou suspendues après ces 13 mois, la nouvelle date de fin ne sera donc pas transmise à l'ASP.
La commande `sanitize_employee_record` essaie de détecter ces cas (uniquement pour les prolongations) pour créer la notification manquée, il semble donc de bon aloi d'également sortir la FS du statut `ARCHIVED`.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
