### PR TITLE
Modifier mon profil en tant que candidat: meilleure gestion d'un identifiant France Travail/pôle emploi invalide

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1008,8 +1008,8 @@ class JobSeekerProfile(models.Model):
         Only for users with kind == job_seeker.
         It must be used in forms and modelforms that manipulate job seekers.
         """
-        pole_emploi_id = cleaned_data["pole_emploi_id"]
-        lack_of_pole_emploi_id_reason = cleaned_data["lack_of_pole_emploi_id_reason"]
+        pole_emploi_id = cleaned_data.get("pole_emploi_id")
+        lack_of_pole_emploi_id_reason = cleaned_data.get("lack_of_pole_emploi_id_reason")
         # One or the other must be filled.
         if not pole_emploi_id and not lack_of_pole_emploi_id_reason:
             raise ValidationError(

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -993,6 +993,40 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         response = self.client.get(url)
         self.assertNotContains(response, MISSING_INFOS_WARNING_ID)
 
+    def test_edit_with_invalid_pole_emploi_id(self):
+        user = JobSeekerFactory()
+        self.client.force_login(user)
+        url = reverse("dashboard:edit_user_info")
+        response = self.client.get(url)
+        post_data = {
+            "email": user.email,
+            "title": user.title,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "birthdate": "20/12/1978",
+            "phone": user.phone,
+            "pole_emploi_id": "trop long",
+            "lack_of_pole_emploi_id_reason": "",
+            "address_line_1": "10, rue du Gué",
+            "address_line_2": "Sous l'escalier",
+            "post_code": "35400",
+            "city": "Saint-Malo",
+            "lack_of_nir": False,
+            "nir": user.nir,
+        }
+        response = self.client.post(url, data=post_data)
+        assert response.status_code == 200
+        self.assertFormError(
+            response.context["form"],
+            "pole_emploi_id",
+            "Assurez-vous que cette valeur comporte au plus 8 caractères (actuellement 9).",
+        )
+        self.assertFormError(
+            response.context["form"],
+            None,
+            "Renseignez soit un identifiant France Travail (ex pôle emploi), soit la raison de son absence.",
+        )
+
     def test_edit_as_prescriber(self):
         user = PrescriberFactory()
         self.client.force_login(user)


### PR DESCRIPTION
### Pourquoi ?

Éviter facilement des erreurs 500.

cf https://itou.sentry.io/issues/4934484020/
