### PR TITLE
Retirer “Carte Notion” de pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-**Carte Notion : **
-
 ### Pourquoi ?
 
 Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.


### PR DESCRIPTION
With the `GEN-*` linking, there’s no need for systematic hyperlinks.
