### PR TITLE
[GEN-7265] Suppression d'une étape dans le parcours d'acceptation d'une candidature IAE

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -490,7 +490,7 @@ def eligibility(request, job_application_id, template_name="apply/process_eligib
         job_application.to_company,
         job_application.job_seeker,
         cancel_url=reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id}),
-        next_url=reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id}),
+        next_url=reverse("apply:accept", kwargs={"job_application_id": job_application.id}),
         template_name=template_name,
         extra_context={"job_application": job_application},
     )

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1332,7 +1332,7 @@ class ProcessViewsTest(TestCase):
             f"{criterion3.key}": "true",
         }
         response = self.client.post(url, data=post_data)
-        next_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        next_url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
         self.assertRedirects(response, next_url)
 
         has_considered_valid_diagnoses = EligibilityDiagnosis.objects.has_considered_valid(


### PR DESCRIPTION
### Pourquoi ?

Le seul moyen d'accéder à la vue "apply:eligibility" c'est de cliquer sur le bouton "Accepter cette candidature":
il est donc assez logique de toujours rediriger vers la vue d'acceptation une fois le diagnostic validé.

