### PR TITLE
Correction de l'option `--preserve-to-company-data` pour `move_company_data`

### DIFF
--- a/itou/companies/management/commands/move_company_data.py
+++ b/itou/companies/management/commands/move_company_data.py
@@ -226,7 +226,7 @@ class Command(BaseCommand):
                 prolongations.update(declared_by_siae_id=to_id)
                 suspensions.update(siae_id=to_id)
                 invitations.update(company_id=to_id)
-                if preserve_to_company_data:
+                if not preserve_to_company_data:
                     to_company_qs.update(
                         brand=from_company.display_name,
                         description=from_company.description,

--- a/itou/utils/faker_providers.py
+++ b/itou/utils/faker_providers.py
@@ -1,8 +1,15 @@
 import random
 
+from django.contrib.gis.geos import Point
 from faker.providers import BaseProvider
 
 
 class ItouProvider(BaseProvider):
+
     def asp_batch_filename(self) -> str:
         return f"RIAE_FS_{random.randint(0, 99999999999999)}.json"
+
+    def geopoint(self) -> Point:
+        return Point(
+            [float(coord) for coord in self.generator.format("local_latlng", country_code="FR", coords_only=True)]
+        )

--- a/tests/companies/factories.py
+++ b/tests/companies/factories.py
@@ -98,6 +98,15 @@ class CompanyFactory(factory.django.DjangoModelFactory):
             membership=factory.RelatedFactory("tests.companies.factories.CompanyMembershipFactory", "company"),
         )
         with_jobs = factory.Trait(romes=factory.PostGeneration(_create_job_from_rome_code))
+        with_geocoding = factory.Trait(
+            coords=factory.Faker("geopoint"),
+            geocoding_score=factory.fuzzy.FuzzyFloat(0.0, 1.0, precision=3),
+        )
+        with_informations = factory.Trait(
+            with_geocoding=True,
+            brand=factory.Faker("company", locale="fr_FR"),
+            description=factory.Faker("paragraph", locale="fr_FR"),
+        )
         for_snapshot = factory.Trait(
             name="ACME Inc.",
             address_line_1="112 rue de la Croix-Nivert",


### PR DESCRIPTION
### Pourquoi ?

Le script fait l'inverse de ce à quoi on s'attend en passant l'option `--preserve-to-company-data`.

### Comment ? <!-- optionnel -->

1. Ajout d'un nouveau _formater_ Faker : `geopoint`
2. Nouveau traits pour `CompanyFactory`
3. Correction avec son test

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
