### PR TITLE
Correction d'un test d'une ancienne PR (#3018)

### DIFF
--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -93,12 +93,12 @@
                   <div class="col-12 col-lg-8">
                       <div class="c-stepper mb-3 mb-lg-5">
                           <div class="progress progress--emploi">
-                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="progress-bar progress-bar-50" role="progressbar">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="progress-bar progress-bar-100" role="progressbar">
                               </div>
                           </div>
                           <p>
                               
-                                  <strong>Étape 1</strong> : Motif du refus
+                                  <strong>Étape 2</strong>/2 : Explications supplémentaires
                               
                           </p>
                       </div>
@@ -107,60 +107,19 @@
                           
                               <form method="post">
                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason_explanation"/>
   
-                                  <div class="form-group form-group-required"><label class="form-label">Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="" id="id_reason-reason" required="">
-      
-          
-          
-              <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_0" name="reason-reason" type="radio" value="IAE"/>
-                  <label class="form-check-label" for="id_reason-reason_0">L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
-              </div>
-          
-      
-          
-          
-              <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_1" name="reason-reason" type="radio" value="SIAE"/>
-                  <label class="form-check-label" for="id_reason-reason_1">La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
-              </div>
-          
-      
-          
-          
-              <div class="form-check">
-                  <input checked="checked" class="form-check-input" id="id_reason-reason_2" name="reason-reason" type="radio" value="DURATION"/>
-                  <label class="form-check-label" for="id_reason-reason_2">La durée de prolongation demandée n’est pas adaptée à la situation du candidat.</label>
-              </div>
-          
-      
-  </div></div>
+                                  <div class="form-group form-group-required"><label class="form-label" for="id_reason_explanation-reason_explanation">Explications du motif de refus</label><textarea class="form-control" cols="40" id="id_reason_explanation-reason_explanation" name="reason_explanation-reason_explanation" placeholder="Message" required="" rows="10"></textarea></div>
   
-                                  
-                                      <div class="c-info mb-4">
-                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#legalInformation" data-bs-toggle="collapse" type="button">
-                                              <span>Contexte légal</span>
-                                          </button>
-                                          <div class="c-info__detail collapse" id="legalInformation">
-                                              <p>
-                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
-                                              </p>
-                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
-                                                  <span>En savoir plus</span>
-                                                  <i class="ri-external-link-line ri-lg"></i>
-                                              </a>
-                                          </div>
-                                      </div>
                                   
   
                                   <hr/>
                                   <p class="fs-xs">* champ obligatoire</p>
                                   <div class="form-group text-end">
                                       
-                                          <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          <button class="btn btn-outline-primary" name="wizard_goto_step" type="submit" value="reason">Retour</button>
                                       
-                                      <button class="btn btn-primary" type="submit">Suivant</button>
+                                      <button class="btn btn-primary" type="submit">Confirmer le refus</button>
                                   </div>
                               </form>
                           
@@ -194,12 +153,12 @@
                   <div class="col-12 col-lg-8">
                       <div class="c-stepper mb-3 mb-lg-5">
                           <div class="progress progress--emploi">
-                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="progress-bar progress-bar-33" role="progressbar">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="progress-bar progress-bar-100" role="progressbar">
                               </div>
                           </div>
                           <p>
                               
-                                  <strong>Étape 1</strong> : Motif du refus
+                                  <strong>Étape 3</strong>/3 : Solution envisagée
                               
                           </p>
                       </div>
@@ -208,60 +167,45 @@
                           
                               <form method="post">
                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="proposed_actions"/>
   
-                                  <div class="form-group form-group-required"><label class="form-label">Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="" id="id_reason-reason" required="">
+                                  <div class="form-group form-group-required"><label class="form-label">Quelle(s) action(s) envisagez-vous de proposer au candidat ?</label><div class="" id="id_proposed_actions-proposed_actions">
       
           
           
               <div class="form-check">
-                  <input checked="checked" class="form-check-input" id="id_reason-reason_0" name="reason-reason" type="radio" value="IAE"/>
-                  <label class="form-check-label" for="id_reason-reason_0">L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
+                  <input class="form-check-input" id="id_proposed_actions-proposed_actions_0" name="proposed_actions-proposed_actions" type="checkbox" value="EXIT_IAE"/>
+                  <label class="form-check-label" for="id_proposed_actions-proposed_actions_0">Accompagnement à la recherche d’emploi hors IAE et mobilisation de l’offre de services disponible au sein de votre structure ou celle d’un partenaire.</label>
               </div>
           
       
           
           
               <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_1" name="reason-reason" type="radio" value="SIAE"/>
-                  <label class="form-check-label" for="id_reason-reason_1">La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
+                  <input class="form-check-input" id="id_proposed_actions-proposed_actions_1" name="proposed_actions-proposed_actions" type="checkbox" value="SOCIAL_PARTNER"/>
+                  <label class="form-check-label" for="id_proposed_actions-proposed_actions_1">Orientation vers un partenaire de l’accompagnement social/professionnel.</label>
               </div>
           
       
           
           
               <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_2" name="reason-reason" type="radio" value="DURATION"/>
-                  <label class="form-check-label" for="id_reason-reason_2">La durée de prolongation demandée n’est pas adaptée à la situation du candidat.</label>
+                  <input class="form-check-input" id="id_proposed_actions-proposed_actions_2" name="proposed_actions-proposed_actions" type="checkbox" value="OTHER"/>
+                  <label class="form-check-label" for="id_proposed_actions-proposed_actions_2">Autre</label>
               </div>
           
       
-  </div></div>
+  </div></div><div class="form-group form-group-required"><label class="form-label" for="id_proposed_actions-proposed_actions_explanation">Précisions</label><textarea class="form-control" cols="40" id="id_proposed_actions-proposed_actions_explanation" name="proposed_actions-proposed_actions_explanation" placeholder="Message" required="" rows="10"></textarea></div>
   
-                                  
-                                      <div class="c-info mb-4">
-                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#legalInformation" data-bs-toggle="collapse" type="button">
-                                              <span>Contexte légal</span>
-                                          </button>
-                                          <div class="c-info__detail collapse" id="legalInformation">
-                                              <p>
-                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
-                                              </p>
-                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
-                                                  <span>En savoir plus</span>
-                                                  <i class="ri-external-link-line ri-lg"></i>
-                                              </a>
-                                          </div>
-                                      </div>
                                   
   
                                   <hr/>
                                   <p class="fs-xs">* champ obligatoire</p>
                                   <div class="form-group text-end">
                                       
-                                          <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          <button class="btn btn-outline-primary" name="wizard_goto_step" type="submit" value="reason_explanation">Retour</button>
                                       
-                                      <button class="btn btn-primary" type="submit">Suivant</button>
+                                      <button class="btn btn-primary" type="submit">Confirmer le refus</button>
                                   </div>
                               </form>
                           
@@ -366,12 +310,12 @@
                   <div class="col-12 col-lg-8">
                       <div class="c-stepper mb-3 mb-lg-5">
                           <div class="progress progress--emploi">
-                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="33" class="progress-bar progress-bar-33" role="progressbar">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="66" class="progress-bar progress-bar-66" role="progressbar">
                               </div>
                           </div>
                           <p>
                               
-                                  <strong>Étape 1</strong> : Motif du refus
+                                  <strong>Étape 2</strong>/3 : Explications supplémentaires
                               
                           </p>
                       </div>
@@ -380,58 +324,17 @@
                           
                               <form method="post">
                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason_explanation"/>
   
-                                  <div class="form-group form-group-required"><label class="form-label">Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="" id="id_reason-reason" required="">
-      
-          
-          
-              <div class="form-check">
-                  <input checked="checked" class="form-check-input" id="id_reason-reason_0" name="reason-reason" type="radio" value="IAE"/>
-                  <label class="form-check-label" for="id_reason-reason_0">L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
-              </div>
-          
-      
-          
-          
-              <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_1" name="reason-reason" type="radio" value="SIAE"/>
-                  <label class="form-check-label" for="id_reason-reason_1">La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
-              </div>
-          
-      
-          
-          
-              <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_2" name="reason-reason" type="radio" value="DURATION"/>
-                  <label class="form-check-label" for="id_reason-reason_2">La durée de prolongation demandée n’est pas adaptée à la situation du candidat.</label>
-              </div>
-          
-      
-  </div></div>
+                                  <div class="form-group form-group-required"><label class="form-label" for="id_reason_explanation-reason_explanation">Explications du motif de refus</label><textarea class="form-control" cols="40" id="id_reason_explanation-reason_explanation" name="reason_explanation-reason_explanation" placeholder="Message" required="" rows="10"></textarea></div>
   
-                                  
-                                      <div class="c-info mb-4">
-                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#legalInformation" data-bs-toggle="collapse" type="button">
-                                              <span>Contexte légal</span>
-                                          </button>
-                                          <div class="c-info__detail collapse" id="legalInformation">
-                                              <p>
-                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
-                                              </p>
-                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
-                                                  <span>En savoir plus</span>
-                                                  <i class="ri-external-link-line ri-lg"></i>
-                                              </a>
-                                          </div>
-                                      </div>
                                   
   
                                   <hr/>
                                   <p class="fs-xs">* champ obligatoire</p>
                                   <div class="form-group text-end">
                                       
-                                          <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          <button class="btn btn-outline-primary" name="wizard_goto_step" type="submit" value="reason">Retour</button>
                                       
                                       <button class="btn btn-primary" type="submit">Suivant</button>
                                   </div>
@@ -553,12 +456,12 @@
                   <div class="col-12 col-lg-8">
                       <div class="c-stepper mb-3 mb-lg-5">
                           <div class="progress progress--emploi">
-                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="50" class="progress-bar progress-bar-50" role="progressbar">
+                              <div aria-valuemax="100" aria-valuemin="0" aria-valuenow="100" class="progress-bar progress-bar-100" role="progressbar">
                               </div>
                           </div>
                           <p>
                               
-                                  <strong>Étape 1</strong> : Motif du refus
+                                  <strong>Étape 2</strong>/2 : Explications supplémentaires
                               
                           </p>
                       </div>
@@ -567,60 +470,19 @@
                           
                               <form method="post">
                                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason"/>
+                                  <input id="id_prolongation_request_deny_view-current_step" name="prolongation_request_deny_view-current_step" type="hidden" value="reason_explanation"/>
   
-                                  <div class="form-group form-group-required"><label class="form-label">Pour quel motif refusez-vous la prolongation du parcours IAE de John DOE ?</label><div class="" id="id_reason-reason" required="">
-      
-          
-          
-              <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_0" name="reason-reason" type="radio" value="IAE"/>
-                  <label class="form-check-label" for="id_reason-reason_0">L’IAE ne correspond plus aux besoins / à la situation de la personne.</label>
-              </div>
-          
-      
-          
-          
-              <div class="form-check">
-                  <input checked="checked" class="form-check-input" id="id_reason-reason_1" name="reason-reason" type="radio" value="SIAE"/>
-                  <label class="form-check-label" for="id_reason-reason_1">La typologie de SIAE ne correspond plus aux besoins / à la situation de la personne.</label>
-              </div>
-          
-      
-          
-          
-              <div class="form-check">
-                  <input class="form-check-input" id="id_reason-reason_2" name="reason-reason" type="radio" value="DURATION"/>
-                  <label class="form-check-label" for="id_reason-reason_2">La durée de prolongation demandée n’est pas adaptée à la situation du candidat.</label>
-              </div>
-          
-      
-  </div></div>
+                                  <div class="form-group form-group-required"><label class="form-label" for="id_reason_explanation-reason_explanation">Explications du motif de refus</label><textarea class="form-control" cols="40" id="id_reason_explanation-reason_explanation" name="reason_explanation-reason_explanation" placeholder="Message" required="" rows="10"></textarea></div>
   
-                                  
-                                      <div class="c-info mb-4">
-                                          <button aria-controls="legalInformation" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#legalInformation" data-bs-toggle="collapse" type="button">
-                                              <span>Contexte légal</span>
-                                          </button>
-                                          <div class="c-info__detail collapse" id="legalInformation">
-                                              <p>
-                                                  Conformément à l’article Art. R. 5132-1-8. du Décret n° 2021-1128 du 30 août 2021 relatif à l'insertion par l'activité économique, le refus de prolongation d'un prescripteur est motivé par écrit et notifié, par tout moyen donnant date certaine à la réception de cette notification, à la structure et à l'intéressé.
-                                              </p>
-                                              <a aria-label="En savoir plus concernant le contexte légal" class="btn btn-link px-0" href="https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000043990367" rel="noopener" target="_blank">
-                                                  <span>En savoir plus</span>
-                                                  <i class="ri-external-link-line ri-lg"></i>
-                                              </a>
-                                          </div>
-                                      </div>
                                   
   
                                   <hr/>
                                   <p class="fs-xs">* champ obligatoire</p>
                                   <div class="form-group text-end">
                                       
-                                          <a class="btn btn-link btn-outline-primary" href="/approvals/prolongation/request/666">Annuler</a>
+                                          <button class="btn btn-outline-primary" name="wizard_goto_step" type="submit" value="reason">Retour</button>
                                       
-                                      <button class="btn btn-primary" type="submit">Suivant</button>
+                                      <button class="btn btn-primary" type="submit">Confirmer le refus</button>
                                   </div>
                               </form>
                           

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -176,11 +176,11 @@ def test_deny_view_for_reasons(snapshot, client, reason):
     assertRedirects(response, reason_explanation_url)
 
     # Submit data for the "reason_explanation" step
-    assert str(parse_response_to_soup(client.get(reason_url), selector="#main .s-section")) == snapshot(
+    assert str(parse_response_to_soup(client.get(reason_explanation_url), selector="#main .s-section")) == snapshot(
         name="reason_explanation"
     )
     response = client.post(
-        reason_url,
+        reason_explanation_url,
         {
             "reason_explanation-reason_explanation": "Lorem ipsum",
             "prolongation_request_deny_view-current_step": "reason_explanation",
@@ -190,12 +190,12 @@ def test_deny_view_for_reasons(snapshot, client, reason):
 
     if reason is ProlongationRequestDenyReason.IAE:
         assertRedirects(response, proposed_actions_url)
-        assert str(parse_response_to_soup(client.get(reason_url), selector="#main .s-section")) == snapshot(
+        assert str(parse_response_to_soup(client.get(proposed_actions_url), selector="#main .s-section")) == snapshot(
             name="proposed_actions"
         )
         # Submit data for the "proposed_actions" step
         response = client.post(
-            reason_url,
+            proposed_actions_url,
             {
                 "proposed_actions-proposed_actions": list(ProlongationRequestDenyProposedAction),
                 "proposed_actions-proposed_actions_explanation": "Lorem ipsum",


### PR DESCRIPTION
### Pourquoi ?

PR d'origine : #3018 
C'est quand même mieux quand le contenu des _snapshots_ est le bon...

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
