### PR TITLE
Tableau de bord - Pilotage : Changement d'un "Pôle emploi" en "France Travail"

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -77,13 +77,13 @@
                 {% endif %}
                 {% if can_view_stats_pe %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
-                        <a href="https://plateforme-inclusion.notion.site/Guide-d-analyse-des-tableaux-de-bord-P-le-emploi-dad8530e64af47bd99787a6d4e81f6b9"
+                        <a href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9"
                            rel="noopener"
                            target="_blank"
                            aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)"
                            class="btn-link btn-ico">
                             <i class="ri-article-line ri-lg font-weight-normal align-self-start"></i>
-                            <span>Voir le guide d’analyse Pôle emploi</span>
+                            <span>Voir le guide d’analyse France Travail</span>
                         </a>
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">


### PR DESCRIPTION
### Pourquoi ?

Le pilotage à renommer la page de destination donc soyons cohérent :).
Dans la même veine que c425644e1.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
