### PR TITLE
API: ajout d'un log en cas de token invalide

### DIFF
--- a/itou/api/token_auth/views.py
+++ b/itou/api/token_auth/views.py
@@ -1,7 +1,12 @@
+import logging
+
 from rest_framework import serializers
 from rest_framework.authtoken import views as drf_authtoken_views
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
+
+
+logger = logging.getLogger(__name__)
 
 
 TOKEN_ID_STR = "__token__"
@@ -10,11 +15,18 @@ TOKEN_ID_STR = "__token__"
 class ObtainAuthToken(drf_authtoken_views.ObtainAuthToken):
     def post(self, request, *args, **kwargs):
         if request.data.get("username") == TOKEN_ID_STR:
+            password = request.data.get("password")
             try:
-                token = Token.objects.get(key=request.data.get("password"))
+                token = Token.objects.get(key=password)
                 return Response({"token": token.key})
             except Token.DoesNotExist:
-                msg = "Impossible de se connecter avec le token fourni."
-                raise serializers.ValidationError(msg, code="authorization")
+                logger.info(
+                    "Auth with special user '%s' failed: unknown token received (len=%s)",
+                    TOKEN_ID_STR,
+                    len(password),
+                )
+                raise serializers.ValidationError(
+                    "Impossible de se connecter avec le token fourni.", code="authorization"
+                )
 
         return super().post(request, *args, **kwargs)


### PR DESCRIPTION
### Pourquoi ?

Pour pouvoir aider les utilisateurs n'arrivant pas à se connecter à notre API.

À noter que tous nos tokens sont générés automatiquement et ont actuellement la même taille: cette donnée ne dévoile donc rien mais permettrait de détecter des soucis de paramétrage coté utilisateur (si on reçoit des tokens qui ne font pas 40 caractères).