### PR TITLE
Corriger le sélecteur data-matomo-event dans matomo.js

### DIFF
--- a/itou/static/js/matomo.js
+++ b/itou/static/js/matomo.js
@@ -9,7 +9,7 @@ htmx.onLoad((target) => {
             <a href="#" data-matomo-event="true" data-matomo-category="MyCategory"
             data-matomo-action="MyAction" data-matomo-option="MyOption" >
     ********************************************************************/
-    $('data-matomo-event="true"', target).on("click", function() {
+    $('[data-matomo-event=true]', target).on("click", function() {
         var category = $(this).data("matomo-category");
         var action = $(this).data("matomo-action");
         var option = $(this).data("matomo-option");


### PR DESCRIPTION
Toutes les pages ont l’erreur JS suivante :

```javascript
Uncaught Error: Syntax error, unrecognized expression: data-matomo-event="true"
    at I.error (jquery.min.2c872dbe60f4.js:2:11769)
    at Y (jquery.min.2c872dbe60f4.js:2:17234)
    at re (jquery.min.2c872dbe60f4.js:2:20008)
    at Function.I [as find] (jquery.min.2c872dbe60f4.js:2:7520)
    at ce.fn.init.find (jquery.min.2c872dbe60f4.js:2:21991)
    at new ce.fn.init (jquery.min.2c872dbe60f4.js:2:22511)
    at ce (jquery.min.2c872dbe60f4.js:2:1077)
    at matomo.691dc1384641.js:12:5
    at HTMLBodyElement.<anonymous> (htmx.min.f78c4167bb3a.js:1:5211)
    at fe (htmx.min.f78c4167bb3a.js:1:25722)
```