### PR TITLE
API: correction du log en cas de mot de passe manquant

### DIFF
--- a/itou/api/token_auth/views.py
+++ b/itou/api/token_auth/views.py
@@ -23,7 +23,7 @@ class ObtainAuthToken(drf_authtoken_views.ObtainAuthToken):
                 logger.info(
                     "Auth with special user '%s' failed: unknown token received (len=%s)",
                     TOKEN_ID_STR,
-                    len(password),
+                    len(password) if password is not None else None,
                 )
                 raise serializers.ValidationError(
                     "Impossible de se connecter avec le token fourni.", code="authorization"

--- a/tests/api/token_auth/tests.py
+++ b/tests/api/token_auth/tests.py
@@ -27,3 +27,7 @@ def test_token_auth_with_token(client):
     token.save()
     response = client.post(url, data={"username": "__token__", "password": token.key})
     assert response.json() == {"token": token.key}
+
+    # Don't crash on missing field
+    response = client.post(url, data={"username": "__token__"})
+    assert response.status_code == 400


### PR DESCRIPTION
### Pourquoi ?

Sinon, ça `TypeError: object of type 'NoneType' has no len()`
