### PR TITLE
Import EA : Correction d'une erreur mineure dans un commentaire

### DIFF
--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -209,7 +209,7 @@ def sync_structures(df, source, kinds, build_structure, wet_run=False):
 
         if siae.source == Company.SOURCE_USER_CREATED:
             # When an employer creates an antenna, it is normal that this antenna cannot be found in official exports.
-            # Thus we never attempt to delete it, as long as it has data.
+            # Thus we never attempt to delete it.
             deletable_skipped_count += 1
             continue
 


### PR DESCRIPTION
### Pourquoi ?

Un commentaire laissait penser à tort que l'import EA supprimait parfois des antennes, ce qui n'est jamais le cas.

Discussion initiale : https://itou-inclusion.slack.com/archives/C01181Y04LT/p1707232064037189?thread_ts=1706024473.600199&cid=C01181Y04LT
