### PR TITLE
Suppression du paramètre d'URL back_url des liens vers les fiches entreprises

### DIFF
--- a/itou/templates/apply/includes/list_card_header.html
+++ b/itou/templates/apply/includes/list_card_header.html
@@ -5,9 +5,7 @@
         <b>{{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}</b>
         chez
         <b>
-            <a href="{{ job_application.to_company.get_card_url }}?back_url={{ request.get_full_path|urlencode }}">
-                {{ job_application.to_company.display_name }}
-            </a>
+            <a href="{{ job_application.to_company.get_card_url }}">{{ job_application.to_company.display_name }}</a>
         </b>
         {% if job_application.to_company.grace_period_has_expired %}
             <span class="badge badge-sm rounded-pill bg-danger">

--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -13,7 +13,7 @@
                     {% endif %}
                 {% else %}
                     <a class="btn btn-sm btn-ico btn-link text-start p-0 mh-auto"
-                       href="{{ job_description.company.get_card_url }}?back_url={{ request.get_full_path|urlencode }}"
+                       href="{{ job_description.company.get_card_url }}"
                        {% matomo_event "candidature" "clic" "clic-structure-fichedeposte" %}
                        target="_blank"
                        aria-label="Ouvrir la page de la structure dans un nouvel onglet">

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -16,7 +16,7 @@
             {% endif %}
         </p>
         <h3 class="mb-2">
-            <a href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" {% matomo_event "candidature" "clic" "clic-structure" %}>{{ siae.display_name }}</a>
+            <a href="{{ siae.get_card_url }}" {% matomo_event "candidature" "clic" "clic-structure" %}>{{ siae.display_name }}</a>
             {# Display non-user-edited name too, but only if it's not the same text #}
             {% if siae.brand and siae.brand|lower != siae.name|lower %}
                 <small class="text-muted">({{ siae.name|title }})</small>
@@ -36,7 +36,7 @@
                 <span class="text-muted fs-sm ms-1">de votre lieu de recherche.</span>
             </span>
             {% if siae.active_job_descriptions %}
-                <a class="d-none d-md-inline font-weight-bold mt-3 mt-md-0" href="{{ siae.get_card_url }}?back_url={{ request.get_full_path|urlencode }}#metiers" {% matomo_event "candidature" "clic" "clic-metiers" %}>
+                <a class="d-none d-md-inline font-weight-bold mt-3 mt-md-0" href="{{ siae.get_card_url }}#metiers" {% matomo_event "candidature" "clic" "clic-metiers" %}>
                     Voir tous les métiers ({{ siae.active_job_descriptions|length }})
                 </a>
             {% endif %}

--- a/itou/templates/dashboard/includes/siae_card.html
+++ b/itou/templates/dashboard/includes/siae_card.html
@@ -17,7 +17,7 @@
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
-                    <a href="{{ request.current_organization.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-infos-entreprise" %}>
+                    <a href="{{ request.current_organization.get_card_url }}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-infos-entreprise" %}>
                         <i class="ri-eye-line ri-lg font-weight-normal"></i>
                         <span>Voir la fiche publique</span>
                     </a>

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -484,7 +484,6 @@ def select_financial_annex(request, template_name="companies/select_financial_an
 def card(request, siae_id, template_name="companies/card.html"):
     company = get_object_or_404(Company.objects.with_has_active_members(), pk=siae_id)
     jobs_descriptions = JobDescription.objects.filter(company=company).select_related("appellation", "location")
-    back_url = get_safe_url(request, "back_url")
     active_jobs_descriptions = []
     if company.block_job_applications:
         other_jobs_descriptions = jobs_descriptions
@@ -498,7 +497,6 @@ def card(request, siae_id, template_name="companies/card.html"):
 
     context = {
         "siae": company,
-        "back_url": back_url,
         "active_jobs_descriptions": active_jobs_descriptions,
         "other_jobs_descriptions": other_jobs_descriptions,
         "matomo_custom_title": "Fiche de la structure d'insertion",


### PR DESCRIPTION
### Pourquoi ?

Cette vue n'en fait rien et les liens seront un peu plus léger/lisible/joli.
