### PR TITLE
Admin: ajout de la date de création de la candidature dans le listing de la vue Utilisateur

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -139,7 +139,7 @@ class JobApplicationInline(ItouTabularInline):
     fk_name = "job_seeker"
     extra = 0
     can_delete = False
-    fields = ("pk_link", "sender_kind", "to_company_link", "state")
+    fields = ("pk_link", "created_at", "sender_kind", "to_company_link", "state")
     readonly_fields = fields
     list_select_related = ("to_company", "job_seeker")
 


### PR DESCRIPTION
### Pourquoi ?

Quand on cherche une candidature pouvant correspondre à un évènement cela permet de voir rapidement si cette candidature est pertinente.