### PR TITLE
Utilisation de la fonctionnalité "Copier dans le presse-papier" du thème

### DIFF
--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -61,18 +61,6 @@ htmx.onLoad((target) => {
     $('a.btn', this).attr("aria-disabled", $(selector).length !== 0 || null)
   })
 
-  /**
-   * JS to copy some text from the DOM into the clipboard.
-   */
-  $(".js-copy-to-clipboard", target).on("click", function(event) {
-    navigator.clipboard.writeText(event.currentTarget.dataset.copyToClipboard).then(function () {
-      $(event.currentTarget).tooltip('show')
-    })
-  })
-  $(".js-copy-to-clipboard", target).on("blur", function (event) {
-    $(event.currentTarget).tooltip('hide')
-  })
-
   /*
    * File selector.
    */

--- a/itou/templates/includes/copy_to_clipboard.html
+++ b/itou/templates/includes/copy_to_clipboard.html
@@ -1,4 +1,4 @@
-<button class="js-copy-to-clipboard {{ css_classes|default:"btn btn-ico" }}" {% if matomo_event_attrs %}{{ matomo_event_attrs }}{% endif %} data-copy-to-clipboard="{{ content }}" data-bs-toggle="tooltip" data-bs-placement="{{ placement|default:"top" }}" data-bs-trigger="manual" data-bs-original-title="Copié !">
+<button class="{{ css_classes|default:"btn btn-ico" }}" {% if matomo_event_attrs %}{{ matomo_event_attrs }}{% endif %} data-it-clipboard-button="copy" data-it-copy-to-clipboard="{{ content }}" data-bs-toggle="tooltip" data-bs-placement="{{ placement|default:"top" }}" data-bs-trigger="manual" data-bs-title="Copié !">
     <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
     <span>{{ text|default:"Copier" }}</span>
 </button>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -789,7 +789,7 @@
                               <p>
                                   <i class="ri-mail-line"></i>
                                   <a class="btn-link me-3" href="mailto:email@example.com">email@example.com</a>
-                                  <button class="js-copy-to-clipboard btn btn-ico btn-secondary" data-bs-original-title="Copié !" data-bs-placement="top" data-bs-toggle="tooltip" data-bs-trigger="manual" data-copy-to-clipboard="email@example.com">
+                                  <button class="btn btn-ico btn-secondary" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="email@example.com">
       <i class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier</span>
   </button>


### PR DESCRIPTION
### Pourquoi ?

Moins de JS, moins de problème (et moins d'erreur Sentry :see_no_evil: )

@hellodeloo Je n'arrive pas à trouver la doc, j'ai juste trouvé pour les input-group: https://zeroheight.com/85c89893b/p/90ca0a-input-group/b/995f63/t/1486d8