### PR TITLE
tests: amélioration de nos tests techniques

### DIFF
--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -28,22 +28,22 @@ class TestApprovalAdmin:
 
 @pytest.mark.parametrize("field", ["start_at", "end_at"])
 def test_approval_form_has_warnings_if_suspension_or_prolongation(admin_client, snapshot, field):
+    selector = f"#id_{field}_helptext"
+
     approval = ApprovalFactory()
     response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
-    assertNotContains(
-        response,
-        "En cas de modification, vérifier la cohérence avec " "les périodes de suspension et de prolongation.",
-    )
+    soup = parse_response_to_soup(response)
+    assert soup.select(selector) == []
 
     suspension = SuspensionFactory(approval=approval)
     response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
-    field_helptext = parse_response_to_soup(response, selector=f"#id_{field}_helptext")
+    field_helptext = parse_response_to_soup(response, selector=selector)
     assert str(field_helptext) == snapshot(name="obnoxious start_at and end_at warning")
 
     suspension.delete()
     ProlongationFactory(approval=approval)
     response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
-    field_helptext = parse_response_to_soup(response, selector=f"#id_{field}_helptext")
+    field_helptext = parse_response_to_soup(response, selector=selector)
     assert str(field_helptext) == snapshot(name="obnoxious start_at and end_at warning")
 
 

--- a/tests/settings_viewer/tests.py
+++ b/tests/settings_viewer/tests.py
@@ -6,6 +6,9 @@ from pytest_django.asserts import assertContains, assertNotContains
 from tests.users.factories import ItouStaffFactory
 
 
+APP_VERBOSE_NAME = "Affichage des settings"
+
+
 @pytest.mark.filterwarnings(
     "ignore:"
     "The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.:"
@@ -23,7 +26,7 @@ def test_as_superuser(client):
     admin_user = ItouStaffFactory(is_superuser=True)
     client.force_login(admin_user)
     response = client.get(reverse("admin:index"))
-    assertContains(response, "Affichage des settings")
+    assertContains(response, APP_VERBOSE_NAME)
     response = client.get(reverse("admin:settings_viewer_setting_changelist"))
     assertContains(response, "ALLOWED_HOSTS")
     assertContains(response, "DATABASES")
@@ -35,6 +38,6 @@ def test_as_staff(client):
     admin_user = ItouStaffFactory(is_superuser=False)
     client.force_login(admin_user)
     response = client.get(reverse("admin:index"))
-    assertNotContains(response, "Affichage des settings")
+    assertNotContains(response, APP_VERBOSE_NAME)
     response = client.get(reverse("admin:settings_viewer_setting_changelist"))
     assert response.status_code == 302

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -343,6 +343,7 @@ class JobApplicationAcceptFormWithGEIQFieldsTest(TestCase):
         assert job_application.inverted_vae_contract
 
     def test_apply_with_past_hiring_date(self):
+        CANNOT_BACKDATE_TEXT = "Il n'est pas possible d'antidater un contrat."
         # GEIQ can temporarily accept job applications with a past hiring date
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
 
@@ -372,7 +373,7 @@ class JobApplicationAcceptFormWithGEIQFieldsTest(TestCase):
         response = self.client.post(url_accept, headers={"hx-request": "true"}, data=post_data, follow=True)
 
         assert response.status_code == 200
-        assertContains(response, "Il n'est pas possible d'antidater un contrat.")
+        assertContains(response, CANNOT_BACKDATE_TEXT)
         # Testing a redirect with HTMX is really incomplete, so we also check hiring status
         job_application.refresh_from_db()
         assert job_application.state == JobApplicationWorkflow.STATE_PROCESSING
@@ -387,7 +388,7 @@ class JobApplicationAcceptFormWithGEIQFieldsTest(TestCase):
         response = self.client.post(url_accept, headers={"hx-request": "true"}, data=post_data, follow=True)
 
         assert response.status_code == 200
-        assertNotContains(response, "Il n'est pas possible d'antidater un contrat.")
+        assertNotContains(response, CANNOT_BACKDATE_TEXT)
         job_application.refresh_from_db()
         assert job_application.state == JobApplicationWorkflow.STATE_ACCEPTED
 

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -636,17 +636,19 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
         )
 
     def test_display_placeholder_for_empty_fields(self):
+        PLACE_HOLDER = "La structure n'a pas encore renseigné cette rubrique"
+
         response = self._login(self.user)
 
         # Job description created in setup has empty description fields
-        self.assertContains(response, "La structure n'a pas encore renseigné cette rubrique", count=2)
+        self.assertContains(response, PLACE_HOLDER, count=2)
 
         self.job_description.description = "a job description"
         self.job_description.save()
         response = self.client.get(self.url)
 
         self.assertContains(response, "a job description")
-        self.assertContains(response, "La structure n'a pas encore renseigné cette rubrique")
+        self.assertContains(response, PLACE_HOLDER)
 
         self.job_description.profile_description = "a profile description"
         self.job_description.save()
@@ -654,4 +656,4 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
 
         self.assertContains(response, "a job description")
         self.assertContains(response, "a profile description")
-        self.assertNotContains(response, "La structure n'a pas encore renseigné cette rubrique")
+        self.assertNotContains(response, PLACE_HOLDER)

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -253,6 +253,10 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
 
 
 class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
+
+    NO_ADDRESS_FILLED_IN = "Aucune adresse n'a été saisie sur les emplois de l'inclusion !"
+    ADDRESS_COULD_NOT_BE_AUTO_CHECKED = "L'adresse du salarié n'a pu être vérifiée automatiquement."
+
     def setUp(self):
         super().setUp()
         self.url = reverse("employee_record_views:create_step_2", args=(self.job_application.pk,))
@@ -272,8 +276,8 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         url = reverse("employee_record_views:create_step_2", args=(self.job_application.pk,))
         response = self.client.get(url)
 
-        self.assertContains(response, "Aucune adresse n'a été saisie sur les emplois de l'inclusion !")
-        self.assertContains(response, "L'adresse du salarié n'a pu être vérifiée automatiquement.")
+        self.assertContains(response, self.NO_ADDRESS_FILLED_IN)
+        self.assertContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
 
     @mock.patch(
         "itou.common_apps.address.format.get_geocoding_data",
@@ -285,8 +289,8 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
         url = reverse("employee_record_views:create_step_3", args=(self.job_application.pk,))
         response = self.client.get(url)
 
-        self.assertNotContains(response, "L'adresse du salarié n'a pu être vérifiée automatiquement.")
-        self.assertNotContains(response, "Aucune adresse n'a été saisie sur les emplois de l'inclusion !")
+        self.assertNotContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
+        self.assertNotContains(response, self.NO_ADDRESS_FILLED_IN)
 
     def test_job_seeker_address_not_geolocated(self):
         # Job seeker has an address filled but can't be geolocated
@@ -302,8 +306,8 @@ class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
 
         # Check that when lookup fails, user is properly notified
         # to input employee address manually
-        self.assertContains(response, "L'adresse du salarié n'a pu être vérifiée automatiquement.")
-        self.assertNotContains(response, "Aucune adresse n'a été saisie sur les emplois de l'inclusion !")
+        self.assertContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
+        self.assertNotContains(response, self.NO_ADDRESS_FILLED_IN)
 
         # Force the way without a profile should raise a PermissionDenied
         url = reverse("employee_record_views:create_step_3", args=(self.job_application.pk,))

--- a/tests/www/login/tests.py
+++ b/tests/www/login/tests.py
@@ -26,6 +26,9 @@ from tests.users.factories import (
 from tests.utils.test import TestCase, assertMessages, reload_module
 
 
+CONNECT_WITH_IC = "Se connecter avec Inclusion Connect"
+
+
 class ItouLoginTest(TestCase):
     def test_generic_view(self):
         # If a user type cannot be determined, don't prevent login.
@@ -67,7 +70,7 @@ class PrescriberLoginTest(InclusionConnectBaseTestCase):
     def test_login_options(self):
         url = reverse("login:prescriber")
         response = self.client.get(url)
-        self.assertContains(response, "Se connecter avec Inclusion Connect")
+        self.assertContains(response, CONNECT_WITH_IC)
         params = {
             "user_kind": UserKind.PRESCRIBER,
             "previous_url": url,
@@ -117,10 +120,11 @@ class PrescriberLoginTest(InclusionConnectBaseTestCase):
 
 
 class EmployerLoginTest(InclusionConnectBaseTestCase):
+
     def test_login_options(self):
         url = reverse("login:employer")
         response = self.client.get(url)
-        self.assertContains(response, "Se connecter avec Inclusion Connect")
+        self.assertContains(response, CONNECT_WITH_IC)
         params = {
             "user_kind": UserKind.EMPLOYER,
             "previous_url": url,
@@ -173,7 +177,7 @@ class LaborInspectorLoginTest(TestCase):
     def test_login_options(self):
         url = reverse("login:labor_inspector")
         response = self.client.get(url)
-        self.assertNotContains(response, "S'identifier avec Inclusion Connect")
+        self.assertNotContains(response, CONNECT_WITH_IC)
         self.assertContains(response, "Adresse e-mail")
         self.assertContains(response, "Mot de passe")
 


### PR DESCRIPTION
### Pourquoi ?

Pour s'assurer que nos `assertNotContains` continue de vérifier l'absence de valeur pertinentes.

J'en ai corrigé quelques uns mais il en reste encore pas mal.