### PR TITLE
Bannière Dora : correctifs demandés par le métier + la technique

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -244,6 +244,8 @@
                 window._paq = window._paq || [];
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
 
+                _paq.push(['trackVisibleContentImpressions']);
+
                 {% if matomo_user_id %}window._paq.push(['setUserId', '{{ matomo_user_id }}']);{% endif %}
 
                 {% if matomo_custom_url %}

--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -19,6 +19,10 @@ API_THEMATIQUES = [
 ]
 
 
+class DataInclusionApiException(Exception):
+    pass
+
+
 class DataInclusionApiClient:
     def __init__(self, base_url, token):
         self.base_url = base_url
@@ -40,6 +44,8 @@ class DataInclusionApiClient:
             return [r["service"] for r in response.json()["items"]]
         except httpx.RequestError as exc:
             logger.info("data.inclusion request error code_insee=%s error=%s", code_insee, exc)
+            raise DataInclusionApiException()
         except KeyError as exc:
             logger.info("data.inclusion result error code_insee=%s error=%s", code_insee, exc)
+            raise DataInclusionApiException()
         return []

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -66,6 +66,7 @@ def get_data_inclusion_services(code_insee):
             cache.set(cache_key, [], 60 * 15)
             return []
 
+        services = [s for s in services if s["modes_accueil"] == ["en-presentiel"]]
         results = random.sample(services, min(len(services), 3))
         results = [
             r

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -38,7 +38,9 @@ ITOU_SESSION_JOB_DESCRIPTION_KEY = "edit_job_description_key"
 DATA_INCLUSION_API_CACHE_PREFIX = "data_inclusion_api_results"
 
 
-def dora_url(source, id):
+def dora_url(source, id, original_url=None):
+    if source == "dora" and original_url:
+        return original_url
     return urljoin(settings.DORA_BASE_URL, f"/services/di--{source}--{id}")
 
 
@@ -62,7 +64,7 @@ def get_data_inclusion_services(code_insee):
         results = [
             r
             | {
-                "dora_di_url": dora_url(r["source"], r["id"]),
+                "dora_di_url": dora_url(r["source"], r["id"], r.get("lien_source", None)),
                 "thematiques_display": {displayable_thematique(t) for t in r["thematiques"]},
             }
             for r in results

--- a/tests/utils/__snapshots__/tests.ambr
+++ b/tests/utils/__snapshots__/tests.ambr
@@ -33,6 +33,8 @@
                   window._paq = window._paq || [];
                   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
   
+                  _paq.push(['trackVisibleContentImpressions']);
+  
                   window._paq.push(['setUserId', '99999']);
   
                   
@@ -55,6 +57,8 @@
                   /* beautify ignore:start */
                   window._paq = window._paq || [];
                   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  
+                  _paq.push(['trackVisibleContentImpressions']);
   
                   window._paq.push(['setUserId', '99999']);
   

--- a/tests/utils/apis/test_data_inclusion_api.py
+++ b/tests/utils/apis/test_data_inclusion_api.py
@@ -1,4 +1,6 @@
-from itou.utils.apis.data_inclusion import DataInclusionApiClient
+import pytest
+
+from itou.utils.apis.data_inclusion import DataInclusionApiClient, DataInclusionApiException
 
 
 def test_data_inclusion_client(settings, respx_mock):
@@ -36,7 +38,9 @@ def test_data_inclusion_client(settings, respx_mock):
 
     # check exceptions
     api_mock.respond(200, json={"something": "else"})
-    assert client.services("fake-insee-code") == []
+    with pytest.raises(DataInclusionApiException):
+        client.services("fake-insee-code")
 
     api_mock.respond(403, json={"something": "else"})
-    assert client.services("fake-insee-code") == []
+    with pytest.raises(DataInclusionApiException):
+        client.services("fake-insee-code")

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -1060,10 +1060,45 @@ def test_get_data_inclusion_services(settings, respx_mock):
         200,
         json={
             "items": [
-                {"service": {"id": "svc1", "source": "fake", "thematiques": ["a--b"]}, "distance": 1},
-                {"service": {"id": "svc2", "source": "fake", "thematiques": ["a--b"]}, "distance": 3},
-                {"service": {"id": "svc3", "source": "fake", "thematiques": ["a--b"]}, "distance": 2},
-                {"service": {"id": "svc4", "source": "fake", "thematiques": ["a--b"]}, "distance": 5},
+                {
+                    "service": {
+                        "id": "svc1",
+                        "source": "dora",
+                        "thematiques": ["a--b"],
+                        "modes_accueil": ["a-distance"],
+                        "lien_source": "https://fake.api.gouv.fr/services/svc1",
+                    },
+                    "distance": 1,
+                },
+                {
+                    "service": {
+                        "id": "svc2",
+                        "source": "fake",
+                        "thematiques": ["a--b"],
+                        "modes_accueil": ["en-presentiel"],
+                        "lien_source": "https://fake.api.gouv.fr/services/svc2",
+                    },
+                    "distance": 3,
+                },
+                {
+                    "service": {
+                        "id": "svc3",
+                        "source": "dora",
+                        "thematiques": ["a--b"],
+                        "modes_accueil": ["en-presentiel", "a-distance"],
+                    },
+                    "distance": 2,
+                },
+                {
+                    "service": {
+                        "id": "svc4",
+                        "source": "fake",
+                        "thematiques": ["a--b"],
+                        "modes_accueil": ["en-presentiel"],
+                        "lien_source": "https://fake.api.gouv.fr/services/svc4",
+                    },
+                    "distance": 5,
+                },
             ]
         },
     )
@@ -1074,6 +1109,8 @@ def test_get_data_inclusion_services(settings, respx_mock):
         {
             "dora_di_url": "https://dora.inclusion.beta.gouv.fr/services/di--fake--svc4",
             "id": "svc4",
+            "lien_source": "https://fake.api.gouv.fr/services/svc4",
+            "modes_accueil": ["en-presentiel"],
             "source": "fake",
             "thematiques": ["a--b"],
             "thematiques_display": {"A"},
@@ -1081,13 +1118,8 @@ def test_get_data_inclusion_services(settings, respx_mock):
         {
             "dora_di_url": "https://dora.inclusion.beta.gouv.fr/services/di--fake--svc2",
             "id": "svc2",
-            "source": "fake",
-            "thematiques": ["a--b"],
-            "thematiques_display": {"A"},
-        },
-        {
-            "dora_di_url": "https://dora.inclusion.beta.gouv.fr/services/di--fake--svc1",
-            "id": "svc1",
+            "lien_source": "https://fake.api.gouv.fr/services/svc2",
+            "modes_accueil": ["en-presentiel"],
             "source": "fake",
             "thematiques": ["a--b"],
             "thematiques_display": {"A"},

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -1044,6 +1044,8 @@ class CompanyAdminMembersManagementTest(TestCase):
 def test_dora_url(settings):
     settings.DORA_BASE_URL = "https://dora.fake.gouv.fr/"
     assert views.dora_url("toto", "superb-id") == "https://dora.fake.gouv.fr/services/di--toto--superb-id"
+    assert views.dora_url("dora", "superb-id") == "https://dora.fake.gouv.fr/services/di--dora--superb-id"
+    assert views.dora_url("dora", "superb-id", "foobar") == "foobar"
 
 
 def test_displayable_thematique():

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -2,6 +2,7 @@ import random
 from unittest import mock
 
 import freezegun
+import httpcore
 import pytest
 from django.core import mail
 from django.urls import reverse
@@ -1105,3 +1106,7 @@ def test_get_data_inclusion_services(settings, respx_mock):
         random.seed(0)  # ensure the mock data is stable
         assert views.get_data_inclusion_services("75056") == mocked_final_response
         assert api_mock.call_count == 2
+
+    with freezegun.freeze_time("2024-01-01") as frozen_datetime:
+        api_mock.mock(side_effect=httpcore.TimeoutException)
+        assert views.get_data_inclusion_services("89000") == []


### PR DESCRIPTION
### Pourquoi ?
- Nous ne désirons que des services en présentiel (en particulier, retirer les Emplois)
- Certains services, venant de Dora, ont une URL plus "précise" que la canonique data.inclusion.
- Si data.inclusion ne répond pas, il est intéressant de ne pas stocker cette "erreur" en cache pendant 24h.
- Le tracking de contenu Matomo sémantique ne peut pas fonctionner si on ne l'active pas globalement.

### Comment ?
Cf. les commits.
