### PR TITLE
Tableau de bord : correction des URLs et trackers Dora

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -168,7 +168,7 @@
                                 <div class="row g-0">
                                     <div class="col-12 col-md-auto mt-2">
                                         <a class="btn btn-primary btn-block btn-ico"
-                                           href="https://dora.fabrique.social.gouv.fr/?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           href="{{ DORA_BASE_URL }}?mtm_campaign=LesEmplois&mtm_kwd=Dashboard"
                                            aria-label="Consulter les services (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
@@ -178,7 +178,7 @@
                                     </div>
                                     <div class="col-12 col-md-auto mt-2">
                                         <a class="btn btn-link btn-block btn-ico"
-                                           href="https://dora.fabrique.social.gouv.fr/contribuer?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           href="{{ DORA_BASE_URL }}/contribuer?mtm_campaign=LesEmplois&mtm_kwd=Dashboard"
                                            aria-label="Suggérer les services de vos partenaires (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
@@ -195,7 +195,7 @@
                                 <div class="row g-0">
                                     <div class="col-12 col-md-auto mt-2">
                                         <a class="btn btn-primary btn-block btn-ico"
-                                           href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ request.current_organization.siret }}&utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           href="{{ DORA_BASE_URL }}/auth/rattachement?siret={{ request.current_organization.siret }}&mtm_campaign=LesEmplois&mtm_kwd=Dashboard"
                                            aria-label="Référencer un service (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
@@ -205,7 +205,7 @@
                                     </div>
                                     <div class="col-12 col-md-auto mt-2">
                                         <a class="btn btn-link btn-block btn-ico"
-                                           href="https://dora.fabrique.social.gouv.fr/?utm_source=LesEmplois&utm_medium=banniereLesEmplois&utm_campaign=dashboard"
+                                           href="{{ DORA_BASE_URL }}?mtm_campaign=LesEmplois&mtm_kwd=Dashboard"
                                            aria-label="Découvrir DORA (ouverture dans un nouvel onglet)"
                                            rel="noopener"
                                            target="_blank">
@@ -307,7 +307,7 @@
                     {% endif %}
 
                     {% if user.is_employer or user.is_prescriber %}
-                        {% include "dashboard/includes/dora_card.html" with siret=request.current_organization.siret|default:"" tracker="utm_source=LesEmplois&utm_medium=blocLesEmplois&utm_campaign=dashboard" only %}
+                        {% include "dashboard/includes/dora_card.html" with siret=request.current_organization.siret|default:"" tracker="mtm_campaign=LesEmplois&mtm_kwd=Dashboard" %}
                         {% include "dashboard/includes/diagoriente_card.html" %}
                     {% endif %}
                 </div>

--- a/itou/templates/dashboard/includes/dora_card.html
+++ b/itou/templates/dashboard/includes/dora_card.html
@@ -6,33 +6,21 @@
         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
-                    <a href="https://dora.fabrique.social.gouv.fr/?{{ tracker }}"
-                       rel="noopener"
-                       target="_blank"
-                       aria-label="Consulter les services d'insertion de votre territoire (ouverture dans un nouvel onglet)"
-                       class="btn-link btn-ico">
+                    <a href="{{ DORA_BASE_URL }}?{{ tracker }}" rel="noopener" target="_blank" aria-label="Consulter les services d'insertion de votre territoire (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
                         <i class="ri-search-eye-line ri-lg font-weight-normal align-self-start"></i>
                         <span>Consulter les services d'insertion de votre territoire</span>
                         <i class="ri-external-link-line font-weight-normal ms-2"></i>
                     </a>
                 </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
-                    <a href="https://dora.fabrique.social.gouv.fr/auth/rattachement?siret={{ siret }}&{{ tracker }}"
-                       rel="noopener"
-                       target="_blank"
-                       aria-label="Référencer vos services (ouverture dans un nouvel onglet)"
-                       class="btn-link btn-ico">
+                    <a href="{{ DORA_BASE_URL }}?siret={{ siret }}&{{ tracker }}" rel="noopener" target="_blank" aria-label="Référencer vos services (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
                         <i class="ri-file-add-line ri-lg font-weight-normal"></i>
                         <span>Référencer vos services</span>
                         <i class="ri-external-link-line font-weight-normal ms-2"></i>
                     </a>
                 </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
-                    <a href="https://dora.fabrique.social.gouv.fr/contribuer?{{ tracker }}"
-                       rel="noopener"
-                       target="_blank"
-                       aria-label="Suggérer un service partenaire (ouverture dans un nouvel onglet)"
-                       class="btn-link btn-ico">
+                    <a href="{{ DORA_BASE_URL }}?{{ tracker }}" rel="noopener" target="_blank" aria-label="Suggérer un service partenaire (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
                         <i class="ri-lightbulb-line ri-lg font-weight-normal"></i>
                         <span>Suggérer un service partenaire</span>
                         <i class="ri-external-link-line font-weight-normal ms-2"></i>

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -21,6 +21,7 @@ def expose_settings(request):
     return {
         "ALLOWED_HOSTS": settings.ALLOWED_HOSTS,
         "API_EMAIL_CONTACT": settings.API_EMAIL_CONTACT,
+        "DORA_BASE_URL": settings.DORA_BASE_URL,
         "ITOU_HELP_CENTER_URL": help_center_url,
         "ITOU_EMAIL_CONTACT": settings.ITOU_EMAIL_CONTACT,
         "ITOU_ENVIRONMENT": settings.ITOU_ENVIRONMENT,


### PR DESCRIPTION
### Pourquoi ?
L'URL "officielle" de Dora n'est plus celle de la fabrique.
Par ailleurs ils transitionnent de Plausible à Matomo, d'où la nécessité de corriger le tracker.

### Comment ? <!-- optionnel -->
Simplement.

