### PR TITLE
MàJ de la doc d’API pour générer un jeton

### DIFF
--- a/itou/api/__init__.py
+++ b/itou/api/__init__.py
@@ -1,0 +1,5 @@
+AUTH_TOKEN_EXPLANATION_TEXT = """\
+1. se connecter en tant qu’administrateur de la structure
+2. dans « Mon espace », se rendre sur la page « Accès aux API »
+3. utiliser l’action « Créer un token d’API »
+"""

--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -1,5 +1,6 @@
 from rest_framework import authentication, generics
 
+from itou.api import AUTH_TOKEN_EXPLANATION_TEXT
 from itou.users.enums import UserKind
 from itou.users.models import User
 
@@ -8,33 +9,6 @@ from .serializers import ApplicantSerializer
 
 
 class ApplicantsView(generics.ListAPIView):
-    """
-    # Liste des candidats par structure
-
-    Cette API retourne la liste de tous les demandeurs d'emploi liés à une candidature pour la structure en cours.
-
-    Les candidats sont triés par date de création dans la base des emplois de l'inclusion,
-    du plus récent au plus ancien.
-
-    # Permissions
-
-    L'utilisation de cette API nécessite un jeton d'autorisation (`token`).
-
-    Pour l'obtention d'un jeton, veuillez utiliser **les identifiants d'un compte administrateur de la structure.**
-
-    Voir l'entrée d'API `token-auth` pour obtenir un jeton.
-
-    Ce compte ne doit être *uniquement membre* de la structure dont on souhaite récupérer la liste de candidats.
-
-    Dans l'idéal, il s'agit d'un compte dédié à l'utilisation de l'API.
-
-
-    # Paramètres
-
-    Cette api ne dispose pas de paramètres de filtrage ou de recherche :
-        elle retourne l'intégralité des candidats de la structure.
-    """
-
     authentication_classes = (
         authentication.TokenAuthentication,
         authentication.SessionAuthentication,
@@ -52,3 +26,30 @@ class ApplicantsView(generics.ListAPIView):
             .prefetch_related("job_applications")
             .order_by("-pk")
         )
+
+
+ApplicantsView.__doc__ = f"""\
+# Liste des candidats par structure
+
+Cette API retourne la liste de tous les demandeurs d'emploi liés à une candidature pour la structure en cours.
+
+Les candidats sont triés par date de création dans la base des emplois de l'inclusion,
+du plus récent au plus ancien.
+
+# Permissions
+
+L'utilisation de cette API nécessite un jeton d'autorisation (`token`) :
+
+{AUTH_TOKEN_EXPLANATION_TEXT}
+
+Le compte administrateur utilisé ne doit être membre **que** de la structure
+dont on souhaite récupérer la liste de candidats, et non membre de plusieurs
+structures.
+
+Dans l'idéal, il s'agit d'un compte dédié à l'utilisation de l'API.
+
+# Paramètres
+
+Cette API ne dispose pas de paramètres de filtrage ou de recherche :
+    elle retourne l'intégralité des candidats de la structure.
+"""

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -6,6 +6,7 @@ from rest_framework import viewsets
 from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.throttling import UserRateThrottle
 
+from itou.api import AUTH_TOKEN_EXPLANATION_TEXT
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification, Status
 from itou.employee_record.serializers import EmployeeRecordUpdateNotificationSerializer
 
@@ -49,64 +50,6 @@ def _annotate_convert_created_at(queryset):
 
 
 class EmployeeRecordViewSet(AbstractEmployeeRecordViewSet):
-    """
-    # API fiches salarié
-
-    Cette API retourne la liste des fiches salarié saisies par les SIAE :
-
-    - dans l'état `PROCESSED` (par défaut)
-    - pour toutes les embauches / candidatures des SIAE liées au token d'identification
-    - classées par date de création (plus récent au plus ancien)
-
-    Il est également possible d'obtenir le détail d'une fiche salarié par son
-    identifiant (dans les mêmes conditions d'autorisation que pour la liste complète)
-
-    # Permissions
-
-    L'utilisation externe de cette API nécessite l'utilisation d'un token d'autorisation
-
-    Ce token peut être généré, et récupéré depuis votre tableau de bord sur le site des emplois.
-    Cliquez sur "Mon espace" puis "Token d'API"
-
-    L'API peut également être utilisée dans un navigateur :
-
-    - seulement dans un environnement de développement
-    - si l'utilisateur connecté est membre d'une ou plusieurs SIAE éligible aux fiches salarié
-
-    # Paramètres
-    Les paramètres suivants sont :
-    - utilisables en paramètres de requête (query string),
-    - chainables : il est possible de préciser un ou plusieurs de ces paramètres pour affiner la recherche.
-
-    Sans paramètre fourni, la liste de résultats contient les fiches salarié en l'état
-
-    - `PROCESSED` (intégrées par l'ASP).
-
-    ## `status` : par statut des fiches salarié
-    Ce paramètre est un tableau permettant de filtrer les fiches retournées par leur statut
-
-    Les valeurs possibles pour ce paramètre sont :
-
-    - `NEW` : nouvelle fiche en cours de saisie,
-    - `READY` : la fiche est prête à être transmise à l'ASP,
-    - `SENT` : la fiche a été transmise et est en attente de traitement,
-    - `PROCESSED` : la fiche a correctement été intégrée par l'ASP,
-    - `REJECTED` : la fiche est retournée en erreur après transmission.
-
-    ### Exemples
-    - ajouter `?status=NEW` à l'URL pour les nouvelles fiches.
-    - ajouter `?status=NEW&status=READY` pour les nouvelles fiches et celles prêtes pour la transmission.
-
-    ## `created` : à date de création
-    Permet de récupérer les fiches salarié créées à la date donnée en paramètre (au format `AAAA-MM-JJ`).
-
-    ## `since` : depuis une certaine date
-    Permet de récupérer les fiches salarié créées depuis date donnée en paramètre (au format `AAAA-MM-JJ`).
-
-    """
-
-    # Above doc section is in French for Swagger / OAS auto doc generation
-
     # If no queryset class parameter is given (f.i. overriding)
     # a `basename` parameter must be set on the router (see local `urls.py` file)
     # See: https://www.django-rest-framework.org/api-guide/routers/
@@ -171,6 +114,70 @@ class EmployeeRecordViewSet(AbstractEmployeeRecordViewSet):
             )
 
 
+# Doc section is in French for Swagger / OAS auto doc generation
+EmployeeRecordViewSet.__doc__ = f"""\
+# API fiches salarié
+
+Cette API retourne la liste des fiches salarié saisies par les SIAE :
+
+- dans l'état `PROCESSED` (par défaut)
+- pour toutes les embauches / candidatures des SIAE liées au token d'identification
+- classées par date de création (plus récent au plus ancien)
+
+Il est également possible d'obtenir le détail d'une fiche salarié par son
+identifiant (dans les mêmes conditions d'autorisation que pour la liste complète).
+
+# Permissions
+
+L'utilisation externe de cette API nécessite un token d'autorisation :
+
+{AUTH_TOKEN_EXPLANATION_TEXT}
+
+L'API peut également être utilisée dans un navigateur :
+
+- seulement dans un environnement de développement
+- si l'utilisateur connecté est membre d'une ou plusieurs SIAE éligible aux fiches salarié
+
+# Paramètres
+
+Les paramètres suivants sont :
+- utilisables en paramètres de requête (query string),
+- chainables : il est possible de préciser un ou plusieurs de ces paramètres pour affiner la recherche.
+
+Sans paramètre fourni, la liste de résultats contient les fiches salarié en l'état
+
+- `PROCESSED` (intégrées par l'ASP).
+
+## `status` : par statut des fiches salarié
+Ce paramètre est un tableau permettant de filtrer les fiches retournées par leur statut
+
+Les valeurs possibles pour ce paramètre sont :
+
+- `NEW` : nouvelle fiche en cours de saisie,
+- `READY` : la fiche est prête à être transmise à l'ASP,
+- `SENT` : la fiche a été transmise et est en attente de traitement,
+- `PROCESSED` : la fiche a correctement été intégrée par l'ASP,
+- `REJECTED` : la fiche est retournée en erreur après transmission.
+
+### Exemples
+- ajouter `?status=NEW` à l'URL pour les nouvelles fiches.
+- ajouter `?status=NEW&status=READY` pour les nouvelles fiches et celles prêtes pour la transmission.
+
+## `created` : à date de création
+Permet de récupérer les fiches salarié créées à la date donnée en paramètre (au format `AAAA-MM-JJ`).
+
+## `since` : depuis une certaine date
+Permet de récupérer les fiches salarié créées depuis date donnée en paramètre (au format `AAAA-MM-JJ`).
+"""
+
+
 class EmployeeRecordUpdateNotificationViewSet(AbstractEmployeeRecordViewSet):
     queryset = EmployeeRecordUpdateNotification.objects.all()
     serializer_class = EmployeeRecordUpdateNotificationSerializer
+
+
+EmployeeRecordUpdateNotificationViewSet.__doc__ = f"""\
+L'utilisation externe de cette API nécessite un token d'autorisation :
+
+{AUTH_TOKEN_EXPLANATION_TEXT}
+"""

--- a/itou/api/token_auth/views.py
+++ b/itou/api/token_auth/views.py
@@ -5,6 +5,8 @@ from rest_framework.authtoken import views as drf_authtoken_views
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 
+from itou.api import AUTH_TOKEN_EXPLANATION_TEXT
+
 
 logger = logging.getLogger(__name__)
 
@@ -30,3 +32,13 @@ class ObtainAuthToken(drf_authtoken_views.ObtainAuthToken):
                 )
 
         return super().post(request, *args, **kwargs)
+
+
+ObtainAuthToken.__doc__ = f"""\
+**Route majoritairement utilisée pour les comptes n’ayant pas activé Inclusion Connect.**
+
+Si vous avez activé Inclusion Connect pour votre compte, vous pouvez obtenir un jeton d’accès aux
+APIs depuis un **compte administrateur de la structure** de la manière suivante :
+
+{AUTH_TOKEN_EXPLANATION_TEXT}
+"""


### PR DESCRIPTION
### Pourquoi ?

Clarifier comment les utilisateurs de l’API peuvent se connecter, l’ancienne documentation étant obsolète depuis la migration à Inclusion Connect.

[GEN-5116]
