### PR TITLE
Services Dora : correction du cas où l'adresse structure est manquante

### DIFF
--- a/itou/templates/companies/hx_dora_services.html
+++ b/itou/templates/companies/hx_dora_services.html
@@ -25,9 +25,11 @@
                                                 <a href="{{ service.dora_di_url }}?mtm_campaign=LesEmplois&mtm_kwd=CardServiceFicheDePoste" rel="noopener" target="_blank" class="btn-link mb-2">{{ service.nom | truncatechars:60 }}</a>
                                                 <ul class="list-unstyled list-inline fs-sm">
                                                     <li class="list-inline-item">{{ service.structure.nom | truncatechars:60 }}</li>
-                                                    <li class="list-inline-item">
-                                                        <i class="ri ri-map-pin-2-line me-2" aria-hidden="true"></i>{{ service.structure.code_postal }} {{ service.structure.commune }}
-                                                    </li>
+                                                    {% if service.code_postal and service.commune %}
+                                                        <li class="list-inline-item">
+                                                            <i class="ri ri-map-pin-2-line me-2" aria-hidden="true"></i>{{ service.code_postal }} {{ service.commune }}
+                                                        </li>
+                                                    {% endif %}
                                                 </ul>
                                                 <div class="badge-group">
                                                     {% for thematique in service.thematiques_display %}

--- a/tests/www/companies_views/__snapshots__/test_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_views.ambr
@@ -449,3 +449,39 @@
                       </div>
   '''
 # ---
+# name: test_hx_dora_services[Dora service card with address]
+  '''
+  <div class="card-body">
+                                                  <a class="btn-link mb-2" href="https://fake.api.gouv.fr/services/svc1?mtm_campaign=LesEmplois&amp;mtm_kwd=CardServiceFicheDePoste" rel="noopener" target="_blank">Coupe les cheveux</a>
+                                                  <ul class="list-unstyled list-inline fs-sm">
+                                                      <li class="list-inline-item">Coiffeur</li>
+                                                      
+                                                          <li class="list-inline-item">
+                                                              <i aria-hidden="true" class="ri ri-map-pin-2-line me-2"></i>75056 Paris
+                                                          </li>
+                                                      
+                                                  </ul>
+                                                  <div class="badge-group">
+                                                      
+                                                          <span class="badge badge-sm bg-info-lighter text-info text-uppercase text-decoration-none">A</span>
+                                                      
+                                                  </div>
+                                              </div>
+  '''
+# ---
+# name: test_hx_dora_services[Dora service card]
+  '''
+  <div class="card-body">
+                                                  <a class="btn-link mb-2" href="https://fake.api.gouv.fr/services/svc1?mtm_campaign=LesEmplois&amp;mtm_kwd=CardServiceFicheDePoste" rel="noopener" target="_blank">Coupe les cheveux</a>
+                                                  <ul class="list-unstyled list-inline fs-sm">
+                                                      <li class="list-inline-item">Coiffeur</li>
+                                                      
+                                                  </ul>
+                                                  <div class="badge-group">
+                                                      
+                                                          <span class="badge badge-sm bg-info-lighter text-info text-uppercase text-decoration-none">A</span>
+                                                      
+                                                  </div>
+                                              </div>
+  '''
+# ---


### PR DESCRIPTION
### Pourquoi ?
Dans le jargon DI, il est plus précis de donner l'adresse du service que celle de la structure, la recherche étant faite sur le service "présentiel" on a bien plus de chances d'avoir une adresse correcte ainsi.

Par ailleurs avec cette modification nous testons que si l'adresse est non présente pour le service (a priori pas possible) alors nous n'affichons pas un affreux "None None".

### Captures d'écran
Ce qu'on essaie de corriger:
![image](https://github.com/gip-inclusion/les-emplois/assets/88618/1de926d8-885e-4ddb-a2e9-22c24a354905)


