### PR TITLE
Import SIAE : Importer les structures avec une convention validée rétroactivement [GEN-8055]

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -561,6 +561,7 @@ LOGIN_REDIRECT_URL = "/dashboard/"
 
 EXPORT_DIR = os.getenv("SCRIPT_EXPORT_PATH", f"{ROOT_DIR}/exports")
 IMPORT_DIR = os.getenv("SCRIPT_IMPORT_PATH", f"{ROOT_DIR}/imports")
+ASP_FLUX_IAE_DIR = os.getenv("ASP_FLUX_IAE_DIR")
 
 MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")

--- a/itou/companies/management/commands/_import_siae/convention.py
+++ b/itou/companies/management/commands/_import_siae/convention.py
@@ -155,10 +155,6 @@ def get_creatable_conventions():
     return creatable_conventions
 
 
-def get_deletable_conventions():
-    return SiaeConvention.objects.filter(siaes__isnull=True)
-
-
 def check_convention_data_consistency():
     """
     Check data consistency of conventions, not only versus siaes of ASP source,

--- a/itou/companies/management/commands/_import_siae/convention.py
+++ b/itou/companies/management/commands/_import_siae/convention.py
@@ -7,7 +7,6 @@ SiaeConvention object logic used by the import_siae.py script is gathered here.
 from django.utils import timezone
 
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
-from itou.companies.management.commands._import_siae.siae import does_siae_have_an_active_convention
 from itou.companies.management.commands._import_siae.vue_af import (
     get_siae_key_to_convention_end_date,
 )
@@ -38,7 +37,6 @@ def update_existing_conventions(siret_to_siae_row, active_siae_keys):
             # If they still have C1 data they could not be deleted in an earlier step and thus will stay in
             # the C1 database forever, we should leave them untouched.
             if convention.is_active:
-                assert not does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae)
                 conventions_to_deactivate.append(convention)
             continue
 
@@ -68,7 +66,7 @@ def update_existing_conventions(siret_to_siae_row, active_siae_keys):
             convention.siret_signature = row.siret_signature
             convention.save()
 
-        should_be_active = does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae)
+        should_be_active = (row.asp_id, siae.kind) in active_siae_keys
 
         if convention.is_active != should_be_active:
             if should_be_active:
@@ -127,7 +125,7 @@ def get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys):
             continue
 
         row = siret_to_siae_row[siae.siret]
-        is_active = does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae)
+        is_active = (row.asp_id, siae.kind) in active_siae_keys
 
         # convention is to be unique for an asp_id and a SIAE kind
         assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists()

--- a/itou/companies/management/commands/_import_siae/convention.py
+++ b/itou/companies/management/commands/_import_siae/convention.py
@@ -12,7 +12,6 @@ from itou.companies.management.commands._import_siae.vue_af import (
     get_siae_key_to_convention_end_date,
 )
 from itou.companies.models import Company, SiaeConvention
-from itou.utils.python import timeit
 
 
 CONVENTION_DEACTIVATION_THRESHOLD = 200
@@ -192,7 +191,6 @@ def check_convention_data_consistency():
     assert user_created_siaes_without_convention == 0
 
 
-@timeit
 def create_conventions(vue_af_df, siret_to_siae_row, active_siae_keys):
     creatable_conventions = get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
     print(f"will create {len(creatable_conventions)} conventions")
@@ -206,7 +204,6 @@ def create_conventions(vue_af_df, siret_to_siae_row, active_siae_keys):
         assert convention.siaes.filter(source=Company.SOURCE_ASP).count() == 1
 
 
-@timeit
 @transaction.atomic()
 def delete_conventions():
     deletable_conventions = SiaeConvention.objects.filter(siaes__isnull=True)

--- a/itou/companies/management/commands/_import_siae/convention.py
+++ b/itou/companies/management/commands/_import_siae/convention.py
@@ -17,7 +17,7 @@ from itou.companies.models import Company, SiaeConvention
 CONVENTION_DEACTIVATION_THRESHOLD = 200
 
 
-def update_existing_conventions(siret_to_siae_row, siret_to_asp_id, active_siae_keys):
+def update_existing_conventions(siret_to_siae_row, active_siae_keys):
     """
     Update existing conventions, mainly the is_active field,
     and check data integrity on the fly.
@@ -38,7 +38,7 @@ def update_existing_conventions(siret_to_siae_row, siret_to_asp_id, active_siae_
             # If they still have C1 data they could not be deleted in an earlier step and thus will stay in
             # the C1 database forever, we should leave them untouched.
             if convention.is_active:
-                assert not does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae)
+                assert not does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae)
                 conventions_to_deactivate.append(convention)
             continue
 
@@ -68,7 +68,7 @@ def update_existing_conventions(siret_to_siae_row, siret_to_asp_id, active_siae_
             convention.siret_signature = row.siret_signature
             convention.save()
 
-        should_be_active = does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae)
+        should_be_active = does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae)
 
         if convention.is_active != should_be_active:
             if should_be_active:
@@ -105,7 +105,7 @@ def update_existing_conventions(siret_to_siae_row, siret_to_asp_id, active_siae_
     print(f"{len(conventions_to_deactivate)} conventions have been deactivated")
 
 
-def get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys):
+def get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys):
     """
     Get conventions which should be created.
 
@@ -127,7 +127,7 @@ def get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, act
             continue
 
         row = siret_to_siae_row[siae.siret]
-        is_active = does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae)
+        is_active = does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae)
 
         # convention is to be unique for an asp_id and a SIAE kind
         assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists()

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -7,7 +7,6 @@ SiaeFinancialAnnex object logic used by the import_siae.py script is gathered he
 from django.utils import timezone
 
 from itou.companies.models import SiaeConvention, SiaeFinancialAnnex
-from itou.utils.python import timeit
 
 
 def get_creatable_and_deletable_afs(af_number_to_row):
@@ -84,7 +83,6 @@ def build_financial_annex_from_number(row):
         )
 
 
-@timeit
 def manage_financial_annexes(af_number_to_row):
     creatable_afs, deletable_afs = get_creatable_and_deletable_afs(af_number_to_row)
 

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -39,8 +39,8 @@ def get_creatable_and_deletable_afs(af_number_to_row):
             af.save()
 
         # Sometimes an AF end date changes.
-        if af.end_at != timezone.make_aware(row.end_date):
-            af.end_at = timezone.make_aware(row.end_date)
+        if af.end_at != timezone.make_aware(row.end_at):
+            af.end_at = timezone.make_aware(row.end_at)
             af.save()
 
         # Sometimes an AF state changes.
@@ -80,6 +80,6 @@ def build_financial_annex_from_number(af_number_to_row, number):
         number=row.number,
         state=row.state,
         start_at=timezone.make_aware(row.start_at),
-        end_at=timezone.make_aware(row.end_date),
+        end_at=timezone.make_aware(row.end_at),
         convention=convention_query.get(),
     )

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -7,6 +7,7 @@ SiaeFinancialAnnex object logic used by the import_siae.py script is gathered he
 from django.utils import timezone
 
 from itou.companies.models import SiaeConvention, SiaeFinancialAnnex
+from itou.utils.python import timeit
 
 
 def get_creatable_and_deletable_afs(af_number_to_row):
@@ -81,3 +82,16 @@ def build_financial_annex_from_number(row):
             end_at=timezone.make_aware(row.end_at),
             convention=convention,
         )
+
+
+@timeit
+def manage_financial_annexes(af_number_to_row):
+    creatable_afs, deletable_afs = get_creatable_and_deletable_afs(af_number_to_row)
+
+    print(f"will create {len(creatable_afs)} financial annexes")
+    for af in creatable_afs:
+        af.save()
+
+    print(f"will delete {len(deletable_afs)} financial annexes")
+    for af in deletable_afs:
+        af.delete()

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -15,71 +15,69 @@ def get_creatable_and_deletable_afs(af_number_to_row):
 
     Update existing AFs on the fly.
 
-    Output : (creatable_afs, deletable_afs).
+    Output: (creatable_afs, deletable_afs).
     """
-    vue_af_numbers = set(af_number_to_row.keys())
     db_af_numbers = set()
     deletable_afs = []
 
     for af in SiaeFinancialAnnex.objects.select_related("convention"):
         db_af_numbers.add(af.number)
 
-        if af.number not in vue_af_numbers:
+        if af.number not in af_number_to_row:
             deletable_afs.append(af)
             continue
 
         # The AF already exists in db. Let's check if some of its fields have changed.
         row = af_number_to_row[af.number]
-        assert af.number == row.number
         assert af.convention.kind == row.kind
 
-        # Sometimes an AF start date changes.
-        if af.start_at != timezone.make_aware(row.start_at):
-            af.start_at = timezone.make_aware(row.start_at)
-            af.save()
-
-        # Sometimes an AF end date changes.
-        if af.end_at != timezone.make_aware(row.end_at):
-            af.end_at = timezone.make_aware(row.end_at)
-            af.save()
+        updated_fields = set()
+        for field in ["start_at", "end_at"]:
+            row_value = timezone.make_aware(getattr(row, field))
+            if getattr(af, field) != row_value:
+                setattr(af, field, row_value)
+                updated_fields.add(field)
 
         # Sometimes an AF state changes.
         if af.state != row.state:
             af.state = row.state
-            af.save()
+            updated_fields.add("state")
 
         # Sometimes an AF migrates from one convention to another.
         if af.convention.asp_id != row.asp_id:
-            convention_query = SiaeConvention.objects.filter(asp_id=row.asp_id, kind=row.kind)
-            if convention_query.exists():
-                convention = convention_query.get()
-                af.convention = convention
-                af.save()
-            else:
+            try:
+                convention = SiaeConvention.objects.get(asp_id=row.asp_id, kind=row.kind)
+            except SiaeConvention.DoesNotExist:
                 deletable_afs.append(af)
                 continue
-        assert af.convention.asp_id == row.asp_id
+            else:
+                af.convention = convention
+                updated_fields.add("convention")
 
-    creatable_af_numbers = vue_af_numbers - db_af_numbers
+        af.save(update_fields=updated_fields)
 
-    creatable_afs = [build_financial_annex_from_number(af_number_to_row, number) for number in creatable_af_numbers]
+    creatable_af_numbers = set(af_number_to_row) - db_af_numbers
+    creatable_afs = list(
+        filter(
+            None,  # Drop None values (AFs without preexisting convention).
+            [build_financial_annex_from_number(af_number_to_row[number]) for number in creatable_af_numbers],
+        )
+    )
 
-    # Drop None values (AFs without preexisting convention).
-    creatable_afs = [af for af in creatable_afs if af]
-
-    return (creatable_afs, deletable_afs)
+    return creatable_afs, deletable_afs
 
 
-def build_financial_annex_from_number(af_number_to_row, number):
-    row = af_number_to_row[number]
-    convention_query = SiaeConvention.objects.filter(asp_id=row.asp_id, kind=row.kind)
-    if not convention_query.exists():
+def build_financial_annex_from_number(row):
+    try:
+        convention = SiaeConvention.objects.get(asp_id=row.asp_id, kind=row.kind)
+    except SiaeConvention.DoesNotExist:
         # There is no point in storing an AF in db if there is no related convention.
         return None
-    return SiaeFinancialAnnex(
-        number=row.number,
-        state=row.state,
-        start_at=timezone.make_aware(row.start_at),
-        end_at=timezone.make_aware(row.end_at),
-        convention=convention_query.get(),
-    )
+    else:
+        return SiaeFinancialAnnex(
+            number=row.number,
+            state=row.state,
+            start_at=timezone.make_aware(row.start_at),
+            end_at=timezone.make_aware(row.end_at),
+            convention=convention,
+        )

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -11,13 +11,12 @@ from itou.companies.management.commands._import_siae.utils import geocode_siae
 from itou.companies.models import Company
 
 
-def does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae):
-    asp_id = siret_to_asp_id.get(siae.siret)
-    siae_key = (asp_id, siae.kind)
+def does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae):
+    siae_key = (siret_to_siae_row.get(siae.siret).asp_id, siae.kind)
     return siae_key in active_siae_keys
 
 
-def build_siae(active_siae_keys, siret_to_asp_id, row, kind):
+def build_siae(active_siae_keys, siret_to_siae_row, row, kind):
     """
     Build a siae object from a dataframe row.
 
@@ -63,7 +62,7 @@ def build_siae(active_siae_keys, siret_to_asp_id, row, kind):
     siae.post_code = row.post_code
     siae.department = department_from_postcode(siae.post_code)
 
-    if does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae):
+    if does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae):
         siae = geocode_siae(siae)
 
     return siae

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -8,22 +8,20 @@ All these helpers are specific to SIAE logic (not GEIQ, EA, EATT).
 
 from itou.common_apps.address.departments import department_from_postcode
 from itou.companies.management.commands._import_siae.utils import geocode_siae
-from itou.companies.management.commands._import_siae.vue_af import ACTIVE_SIAE_KEYS
-from itou.companies.management.commands._import_siae.vue_structure import SIRET_TO_ASP_ID
 from itou.companies.models import Company
 
 
-def does_siae_have_an_active_convention(siae):
-    asp_id = SIRET_TO_ASP_ID.get(siae.siret)
+def does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae):
+    asp_id = siret_to_asp_id.get(siae.siret)
     siae_key = (asp_id, siae.kind)
-    return siae_key in ACTIVE_SIAE_KEYS
+    return siae_key in active_siae_keys
 
 
-def should_siae_be_created(siae):
-    return does_siae_have_an_active_convention(siae)
+def should_siae_be_created(active_siae_keys, siret_to_asp_id, siae):
+    return does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae)
 
 
-def build_siae(row, kind):
+def build_siae(active_siae_keys, siret_to_asp_id, row, kind):
     """
     Build a siae object from a dataframe row.
 
@@ -69,7 +67,7 @@ def build_siae(row, kind):
     siae.post_code = row.post_code
     siae.department = department_from_postcode(siae.post_code)
 
-    if should_siae_be_created(siae):
+    if should_siae_be_created(active_siae_keys, siret_to_asp_id, siae):
         siae = geocode_siae(siae)
 
     return siae

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -14,7 +14,6 @@ from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
 from itou.companies.management.commands._import_siae.utils import could_siae_be_deleted, geocode_siae
 from itou.companies.models import Company, SiaeConvention
 from itou.utils.emails import send_email_messages
-from itou.utils.python import timeit
 
 
 def build_siae(row, kind, *, is_active):
@@ -71,7 +70,6 @@ def build_siae(row, kind, *, is_active):
     return siae
 
 
-@timeit
 def update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row):
     auth_email_updates, fatal_errors = 0, 0
 
@@ -123,7 +121,6 @@ def update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row):
     return fatal_errors
 
 
-@timeit
 def create_new_siaes(siret_to_siae_row, active_siae_keys):
     creatable_siaes = []
 
@@ -182,7 +179,6 @@ def create_new_siaes(siret_to_siae_row, active_siae_keys):
     print(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")
 
 
-@timeit
 def cleanup_siaes_after_grace_period():
     deletions, blocked_deletions = 0, 0
 
@@ -200,7 +196,6 @@ def cleanup_siaes_after_grace_period():
     print(f"{blocked_deletions} siaes past their grace period cannot be deleted")
 
 
-@timeit
 def delete_user_created_siaes_without_members():
     """
     Siaes created by a user usually have at least one member, their creator.
@@ -227,7 +222,6 @@ def delete_user_created_siaes_without_members():
     return fatal_errors
 
 
-@timeit
 def manage_staff_created_siaes():
     """
     Itou staff regularly creates siaes manually when ASP data lags behind for some specific employers.
@@ -274,7 +268,6 @@ def manage_staff_created_siaes():
     return fatal_errors
 
 
-@timeit
 def check_whether_signup_is_possible_for_all_siaes():
     fatal_errors = 0
 

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -207,7 +207,7 @@ def delete_user_created_siaes_without_members():
     Siaes created by a user usually have at least one member, their creator.
     However in some cases, itou staff deletes some users, leaving
     potentially user created siaes without member.
-    Those siaes cannot be joined by any way and thus are useless.
+    Those siaes cannot be joined by any means and thus are useless.
     Let's clean them up when possible.
     """
     errors = 0

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -17,10 +17,6 @@ def does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae)
     return siae_key in active_siae_keys
 
 
-def should_siae_be_created(active_siae_keys, siret_to_asp_id, siae):
-    return does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae)
-
-
 def build_siae(active_siae_keys, siret_to_asp_id, row, kind):
     """
     Build a siae object from a dataframe row.
@@ -67,7 +63,7 @@ def build_siae(active_siae_keys, siret_to_asp_id, row, kind):
     siae.post_code = row.post_code
     siae.department = department_from_postcode(siae.post_code)
 
-    if should_siae_be_created(active_siae_keys, siret_to_asp_id, siae):
+    if does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae):
         siae = geocode_siae(siae)
 
     return siae

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -58,6 +58,5 @@ def build_siae(active_siae_keys, row, kind):
     siae.department = department_from_postcode(siae.post_code)
 
     if (row.asp_id, siae.kind) in active_siae_keys:
-        siae = geocode_siae(siae)
-
+        geocode_siae(siae)
     return siae

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -6,6 +6,7 @@ All these helpers are specific to SIAE logic (not GEIQ, EA, EATT).
 
 """
 
+from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
 
@@ -173,7 +174,7 @@ def create_new_siaes(siret_to_siae_row, active_siae_keys):
         siae.save()
     print("--- end of CSV output of all creatable_siaes ---")
 
-    send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes)
+    transaction.on_commit(lambda: send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes))
 
     print(f"{len(creatable_siaes)} structures have been created")
     print(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -11,12 +11,7 @@ from itou.companies.management.commands._import_siae.utils import geocode_siae
 from itou.companies.models import Company
 
 
-def does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae):
-    siae_key = (siret_to_siae_row.get(siae.siret).asp_id, siae.kind)
-    return siae_key in active_siae_keys
-
-
-def build_siae(active_siae_keys, siret_to_siae_row, row, kind):
+def build_siae(active_siae_keys, row, kind):
     """
     Build a siae object from a dataframe row.
 
@@ -62,7 +57,7 @@ def build_siae(active_siae_keys, siret_to_siae_row, row, kind):
     siae.post_code = row.post_code
     siae.department = department_from_postcode(siae.post_code)
 
-    if does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae):
+    if (row.asp_id, siae.kind) in active_siae_keys:
         siae = geocode_siae(siae)
 
     return siae

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -11,11 +11,14 @@ from itou.companies.management.commands._import_siae.utils import geocode_siae
 from itou.companies.models import Company
 
 
-def build_siae(active_siae_keys, row, kind):
+def build_siae(row, kind, *, is_active):
     """
     Build a siae object from a dataframe row.
 
     Only for SIAE, not for GEIQ nor EA nor EATT.
+
+    Using `is_active=True` will try to geocode the SIAE's address,
+    if successful it will be visible in search results, hence active.
     """
     siae = Company()
     siae.siret = row.siret
@@ -57,6 +60,6 @@ def build_siae(active_siae_keys, row, kind):
     siae.post_code = row.post_code
     siae.department = department_from_postcode(siae.post_code)
 
-    if (row.asp_id, siae.kind) in active_siae_keys:
+    if is_active:
         geocode_siae(siae)
     return siae

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -6,9 +6,15 @@ All these helpers are specific to SIAE logic (not GEIQ, EA, EATT).
 
 """
 
+from django.db.models import Q
+from django.utils import timezone
+
 from itou.common_apps.address.departments import department_from_postcode
-from itou.companies.management.commands._import_siae.utils import geocode_siae
-from itou.companies.models import Company
+from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
+from itou.companies.management.commands._import_siae.utils import could_siae_be_deleted, geocode_siae
+from itou.companies.models import Company, SiaeConvention
+from itou.utils.emails import send_email_messages
+from itou.utils.python import timeit
 
 
 def build_siae(row, kind, *, is_active):
@@ -63,3 +69,222 @@ def build_siae(row, kind, *, is_active):
     if is_active:
         geocode_siae(siae)
     return siae
+
+
+@timeit
+def update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row):
+    auth_email_updates, fatal_errors = 0, 0
+
+    asp_id_to_siae_row = {row.asp_id: row for row in siret_to_siae_row.values()}
+    for siae in Company.objects.select_related("convention").filter(
+        source=Company.SOURCE_ASP, convention__isnull=False
+    ):
+        assert siae.should_have_convention
+
+        if siae.convention.asp_id not in asp_id_to_siae_row:
+            continue
+        row = asp_id_to_siae_row[siae.convention.asp_id]
+        updated_fields = set()
+
+        auth_email = row.auth_email or siae.auth_email
+        if siae.auth_email != auth_email:
+            siae.auth_email = auth_email
+            updated_fields.add("auth_email")
+            auth_email_updates += 1
+
+        if siae.siret != row.siret:
+            assert siae.siren == row.siret[:9]
+
+            existing_siae = Company.objects.filter(siret=row.siret, kind=siae.kind).first()
+            if existing_siae:
+
+                def fmt(siae):
+                    msg = f"{siae.source} {siae.siret}"
+                    if siae.convention is None:
+                        return f"{msg} convention=None"
+                    return f"{msg} convention.id={siae.convention.id} asp_id={siae.convention.asp_id}"
+
+                print(
+                    f"FATAL ERROR: siae.id={siae.id} ({fmt(siae)}) has changed siret from "
+                    f"{siae.siret} to {row.siret} but new siret is already used by "
+                    f"siae.id={existing_siae.id} ({fmt(existing_siae)}) "
+                )
+                fatal_errors += 1
+                continue
+
+            print(f"siae.id={siae.id} has changed siret from {siae.siret} to {row.siret} (will be updated)")
+            siae.siret = row.siret
+            updated_fields.add("siret")
+
+        if updated_fields:
+            siae.save(update_fields=updated_fields)
+
+    print(f"{auth_email_updates} siae.auth_email fields have been updated")
+    return fatal_errors
+
+
+@timeit
+def create_new_siaes(siret_to_siae_row, active_siae_keys):
+    creatable_siaes = []
+
+    asp_id_to_siae_row = {row.asp_id: row for row in siret_to_siae_row.values()}
+    for asp_id, kind in active_siae_keys:
+        if asp_id not in asp_id_to_siae_row:
+            continue
+        row = asp_id_to_siae_row[asp_id]
+
+        existing_siaes = Company.objects.select_related("convention").filter(convention__asp_id=asp_id, kind=kind)
+        if existing_siaes:
+            # Siaes with this asp_id already exist, no need to create one more.
+            total_existing_siaes_with_asp_source = 0
+            for existing_siae in existing_siaes:
+                assert existing_siae.should_have_convention
+                if existing_siae.source == Company.SOURCE_ASP:
+                    total_existing_siaes_with_asp_source += 1
+                    # Siret should have been fixed by update_siret_and_auth_email_of_existing_siaes().
+                    assert existing_siae.siret == row.siret
+                else:
+                    assert existing_siae.source == Company.SOURCE_USER_CREATED
+
+            # Duplicate siaes should have been deleted.
+            assert total_existing_siaes_with_asp_source == 1
+            continue
+
+        try:
+            existing_siae = Company.objects.get(~Q(source=Company.SOURCE_ASP), siret=row.siret, kind=kind)
+        except Company.DoesNotExist:
+            assert not SiaeConvention.objects.filter(asp_id=asp_id, kind=kind).exists()
+            if (row.asp_id, kind) in active_siae_keys:
+                creatable_siaes.append(build_siae(row, kind, is_active=True))
+        else:
+            # Siae with this siret+kind already exists but with the wrong source.
+            assert existing_siae.source in [Company.SOURCE_USER_CREATED, Company.SOURCE_STAFF_CREATED]
+            assert existing_siae.should_have_convention
+            print(
+                f"siae.id={existing_siae.id} already exists "
+                f"with wrong source={existing_siae.source} "
+                f"(source will be fixed to ASP)"
+            )
+            existing_siae.source = Company.SOURCE_ASP
+            existing_siae.convention = None
+            existing_siae.save(update_fields={"source", "convention"})
+
+    print("--- beginning of CSV output of all creatable_siaes ---")
+    print("siret;kind;department;name;address")
+    for siae in creatable_siaes:
+        print(f"{siae.siret};{siae.kind};{siae.department};{siae.name};{siae.address_on_one_line}")
+        siae.save()
+    print("--- end of CSV output of all creatable_siaes ---")
+
+    send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes)
+
+    print(f"{len(creatable_siaes)} structures have been created")
+    print(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")
+
+
+@timeit
+def cleanup_siaes_after_grace_period():
+    deletions, blocked_deletions = 0, 0
+
+    for siae in Company.objects.select_related("convention"):
+        if not siae.grace_period_has_expired:
+            continue
+
+        if could_siae_be_deleted(siae):
+            siae.delete()
+            deletions += 1
+        else:
+            blocked_deletions += 1
+
+    print(f"{deletions} siaes past their grace period has been deleted")
+    print(f"{blocked_deletions} siaes past their grace period cannot be deleted")
+
+
+@timeit
+def delete_user_created_siaes_without_members():
+    """
+    Siaes created by a user usually have at least one member, their creator.
+    However in some cases, itou staff deletes some users, leaving
+    potentially user created siaes without member.
+    Those siaes cannot be joined by any way and thus are useless.
+    Let's clean them up when possible.
+    """
+    fatal_errors = 0
+    for siae in Company.objects.prefetch_related("memberships").filter(
+        members__isnull=True, source=Company.SOURCE_USER_CREATED
+    ):
+        if not siae.has_members:
+            if could_siae_be_deleted(siae):
+                print(f"siae.id={siae.id} is user created and has no member thus will be deleted")
+                siae.delete()
+            else:
+                print(
+                    f"FATAL ERROR: siae.id={siae.id} is user created and "
+                    f"has no member but has job applications thus cannot be deleted"
+                )
+                fatal_errors += 1
+
+    return fatal_errors
+
+
+@timeit
+def manage_staff_created_siaes():
+    """
+    Itou staff regularly creates siaes manually when ASP data lags behind for some specific employers.
+
+    Normally the SIRET later appears in ASP data then the siae is converted to ASP source by `create_new_siaes`.
+
+    But sometimes a staff created siae's SIRET never appear in ASP data. We wait 90 days (as decided with staff
+    team) before considering it invalid and attempting deleting it.
+
+    If the siae cannot be deleted because it has data, a warning will be shown to supportix.
+    """
+    three_months_ago = timezone.now() - timezone.timedelta(days=90)
+    staff_created_siaes = Company.objects.filter(
+        kind__in=SIAE_WITH_CONVENTION_KINDS,
+        source=Company.SOURCE_STAFF_CREATED,
+    )
+    # Sometimes our staff creates a siae then later attaches it manually to the correct convention. In that
+    # case it should be converted to a regular user created siae so that the usual convention logic applies.
+    for siae in staff_created_siaes.filter(convention__isnull=False):
+        print(f"converted staff created siae.id={siae.id} to user created siae as it has a convention")
+        siae.source = Company.SOURCE_USER_CREATED
+        siae.save(update_fields={"source"})
+
+    recent_unconfirmed_siaes = staff_created_siaes.filter(created_at__gte=three_months_ago)
+    print(
+        f"{recent_unconfirmed_siaes.count()} siaes created recently by staff"
+        " (still waiting for ASP data to be confirmed)"
+    )
+
+    old_unconfirmed_siaes = staff_created_siaes.filter(created_at__lt=three_months_ago)
+    print(f"{len(old_unconfirmed_siaes)} siaes created by staff should be deleted as they are unconfirmed")
+    fatal_errors = 0
+    for siae in old_unconfirmed_siaes:
+        if could_siae_be_deleted(siae):
+            print(f"deleted unconfirmed siae.id={siae.id} created by staff a while ago")
+            siae.delete()
+        else:
+            print(
+                f"FATAL ERROR: Please fix unconfirmed staff created siae.id={siae.id}"
+                f" by either deleting it or attaching it to the correct convention"
+            )
+            fatal_errors += 1
+
+    return fatal_errors
+
+
+@timeit
+def check_whether_signup_is_possible_for_all_siaes():
+    fatal_errors = 0
+
+    no_signup_siaes = Company.objects.filter(auth_email="").exclude(companymembership__is_active=True).distinct()
+    for siae in no_signup_siaes:
+        print(
+            f"FATAL ERROR: signup is impossible for siae.id={siae.id} siret={siae.siret} "
+            f"kind={siae.kind} dpt={siae.department} source={siae.source} "
+            f"created_by={siae.created_by} siae.email={siae.email}"
+        )
+        fatal_errors += 1
+
+    return fatal_errors

--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -117,7 +117,7 @@ def could_siae_be_deleted(siae):
 
 def geocode_siae(siae):
     if siae.geocoding_address is None:
-        return siae
+        return
 
     try:
         geocoding_data = get_geocoding_data(siae.geocoding_address, post_code=siae.post_code)
@@ -136,8 +136,6 @@ def geocode_siae(siae):
         siae.coords = geocoding_data["coords"]
     except GeocodingDataError:
         pass
-
-    return siae
 
 
 def sync_structures(df, source, kinds, build_structure, wet_run=False):

--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -10,6 +10,7 @@ import os
 import zipfile
 
 import pandas as pd
+from django.conf import settings
 from django.utils import timezone
 
 from itou.common_apps.address.models import AddressMixin
@@ -20,17 +21,14 @@ from itou.utils.apis.exceptions import GeocodingDataError
 from itou.utils.apis.geocoding import get_geocoding_data
 
 
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-
-
 def get_fluxiae_referential_filenames():
-    path = f"{CURRENT_DIR}/../data"
+    assert settings.ASP_FLUX_IAE_DIR is not None, "ASP_FLUX_IAE_DIR is not defined"
 
     filename_prefixes = [
         # Example of raw filename: fluxIAE_RefCategorieJuridique_29032021_090124.csv.gz
         # Let's drop the digits and keep the first relevant part only.
         "_".join(filename.split("_")[:2])
-        for filename in os.listdir(path)
+        for filename in os.listdir(settings.ASP_FLUX_IAE_DIR)
         if filename.startswith("fluxIAE_Ref")
     ]
 
@@ -47,13 +45,14 @@ def get_filename(filename_prefix, filename_extension, description=None):
     e.g. fluxIAE_Structure_14122020_075350.csv
     e.g. fluxIAE_AnnexeFinanciere_14122020_063002.csv.gz
     """
+    assert settings.ASP_FLUX_IAE_DIR is not None, "ASP_FLUX_IAE_DIR is not defined"
+
     if description is None:
         description = filename_prefix
 
     filenames = []
     extensions = (filename_extension, f"{filename_extension}.gz")
-    path = f"{CURRENT_DIR}/../data"
-    for filename in os.listdir(path):
+    for filename in os.listdir(settings.ASP_FLUX_IAE_DIR):
         if filename.startswith(f"{filename_prefix}_") and filename.endswith(extensions):
             filenames.append(filename)
 
@@ -65,7 +64,7 @@ def get_filename(filename_prefix, filename_extension, description=None):
 
     filename = filenames[0]
     print(f"Selected file {filename} for {description}.")
-    return os.path.join(path, filename)
+    return os.path.join(settings.ASP_FLUX_IAE_DIR, filename)
 
 
 def clean_string(s):

--- a/itou/companies/management/commands/_import_siae/vue_af.py
+++ b/itou/companies/management/commands/_import_siae/vue_af.py
@@ -23,11 +23,9 @@ from django.utils import timezone
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
 from itou.companies.management.commands._import_siae.utils import get_fluxiae_df, remap_columns
 from itou.companies.models import SiaeFinancialAnnex
-from itou.utils.python import timeit
 from itou.utils.validators import validate_af_number
 
 
-@timeit
 def get_vue_af_df():
     """
     "Vue AF" is short for "Vue Annexes Financières".
@@ -129,7 +127,6 @@ def get_vue_af_df():
     return df
 
 
-@timeit
 def get_af_number_to_row(vue_af_df):
     af_number_to_row = {}
     for _, row in vue_af_df.iterrows():
@@ -139,7 +136,6 @@ def get_af_number_to_row(vue_af_df):
     return af_number_to_row
 
 
-@timeit
 def get_siae_key_to_convention_end_date(vue_af_df):
     """
     For each siae_key (asp_id+kind) we figure out the convention end date.
@@ -159,7 +155,6 @@ def get_siae_key_to_convention_end_date(vue_af_df):
     return siae_key_to_convention_end_date
 
 
-@timeit
 def get_active_siae_keys(vue_af_df):
     return [
         siae_key

--- a/itou/companies/management/commands/_import_siae/vue_af.py
+++ b/itou/companies/management/commands/_import_siae/vue_af.py
@@ -127,15 +127,6 @@ def get_vue_af_df():
     return df
 
 
-def get_af_number_to_row(vue_af_df):
-    af_number_to_row = {}
-    for _, row in vue_af_df.iterrows():
-        af_number = row.number
-        assert af_number not in af_number_to_row
-        af_number_to_row[af_number] = row
-    return af_number_to_row
-
-
 def get_siae_key_to_convention_end_date(vue_af_df):
     """
     For each siae_key (asp_id+kind) we figure out the convention end date.

--- a/itou/companies/management/commands/_import_siae/vue_af.py
+++ b/itou/companies/management/commands/_import_siae/vue_af.py
@@ -129,30 +129,24 @@ def get_vue_af_df():
     return df
 
 
-VUE_AF_DF = get_vue_af_df()
-
-
 @timeit
-def get_af_number_to_row():
+def get_af_number_to_row(vue_af_df):
     af_number_to_row = {}
-    for _, row in VUE_AF_DF.iterrows():
+    for _, row in vue_af_df.iterrows():
         af_number = row.number
         assert af_number not in af_number_to_row
         af_number_to_row[af_number] = row
     return af_number_to_row
 
 
-AF_NUMBER_TO_ROW = get_af_number_to_row()
-
-
 @timeit
-def get_siae_key_to_convention_end_date():
+def get_siae_key_to_convention_end_date(vue_af_df):
     """
     For each siae_key (asp_id+kind) we figure out the convention end date.
     This convention end date (future or past) is eventually stored as siae.convention_end_date.
     """
     siae_key_to_convention_end_date = {}
-    af_df = VUE_AF_DF.copy()  # Leave the main dataframe untouched!
+    af_df = vue_af_df.copy()  # Leave the main dataframe untouched!
     af_df = af_df[af_df.has_active_state]
     for _, row in af_df.iterrows():
         convention_end_date = row.end_date
@@ -165,14 +159,10 @@ def get_siae_key_to_convention_end_date():
     return siae_key_to_convention_end_date
 
 
-ACTIVE_SIAE_KEYS = [
-    siae_key
-    for siae_key, convention_end_date in get_siae_key_to_convention_end_date().items()
-    if timezone.now() < timezone.make_aware(convention_end_date)
-]
-
-INACTIVE_SIAE_LIST = [
-    (siae_key, convention_end_date)
-    for siae_key, convention_end_date in get_siae_key_to_convention_end_date().items()
-    if siae_key not in ACTIVE_SIAE_KEYS
-]
+@timeit
+def get_active_siae_keys(vue_af_df):
+    return [
+        siae_key
+        for siae_key, convention_end_date in get_siae_key_to_convention_end_date(vue_af_df).items()
+        if timezone.now() < timezone.make_aware(convention_end_date)
+    ]

--- a/itou/companies/management/commands/_import_siae/vue_af.py
+++ b/itou/companies/management/commands/_import_siae/vue_af.py
@@ -55,7 +55,7 @@ def get_vue_af_df():
         "af_id_structure": "asp_id",
         "af_mesure_dispositif_code": "kind",
         "af_date_debut_effet": "start_at",
-        "af_date_fin_effet": "end_date",
+        "af_date_fin_effet": "end_at",
         "af_etat_annexe_financiere_code": "state",
     }
     df = remap_columns(df, column_mapping=column_mapping)
@@ -81,7 +81,7 @@ def get_vue_af_df():
     # A ValidationError will be raised if any number is incorrect.
     df.number.apply(validate_af_number)
 
-    df["ends_in_the_future"] = df.end_date.apply(timezone.make_aware) > timezone.now()
+    df["ends_in_the_future"] = df.end_at.apply(timezone.make_aware) > timezone.now()
     df["has_active_state"] = df.state.isin(SiaeFinancialAnnex.STATES_ACTIVE)
     df["is_active"] = df.has_active_state & df.ends_in_the_future
 
@@ -113,7 +113,7 @@ def get_vue_af_df():
         # - the active one if there is one
         # - if there is no active one, the one with an active state and the latest end_date
         # - if there is none with an active state, the one with any state and the latest end_date
-        by=["is_active", "has_active_state", "end_date"],
+        by=["is_active", "has_active_state", "end_at"],
         ascending=[False, False, False],
         inplace=True,
     )
@@ -149,7 +149,7 @@ def get_siae_key_to_convention_end_date(vue_af_df):
     af_df = vue_af_df.copy()  # Leave the main dataframe untouched!
     af_df = af_df[af_df.has_active_state]
     for _, row in af_df.iterrows():
-        convention_end_date = row.end_date
+        convention_end_date = row.end_at
         siae_key = (row.asp_id, row.kind)
         if siae_key in siae_key_to_convention_end_date:
             if convention_end_date > siae_key_to_convention_end_date[siae_key]:

--- a/itou/companies/management/commands/_import_siae/vue_structure.py
+++ b/itou/companies/management/commands/_import_siae/vue_structure.py
@@ -91,24 +91,6 @@ def get_vue_structure_df():
 
 
 @timeit
-def get_siret_to_asp_id(vue_structure_df):
-    """
-    Provide the asp_id from the "Vue Structure" matching the given siret (i.e. siret_actualise).
-
-    Asp_id is a permanent immutable structure ID in ASP exports used to identify a structure à la ASP (an ACI and
-    an EI sharing the same SIRET being considered as a single structure à la ASP). Note that both siret_actualise and
-    siret_signature can change over time thus none of them can act as a good immutable structure ID.
-
-    The SIRET (siret_actualise) => asp_id match is very important to make sure all itou siaes
-    are matched to their correct ASP counterpart.
-    """
-    siret_to_asp_id = {}
-    for _, row in vue_structure_df.iterrows():
-        siret_to_asp_id[row.siret] = row.asp_id
-    return siret_to_asp_id
-
-
-@timeit
 def get_siret_to_siae_row(vue_structure_df):
     """
     Provide the row from the "Vue Structure" matching the given asp_id.

--- a/itou/companies/management/commands/_import_siae/vue_structure.py
+++ b/itou/companies/management/commands/_import_siae/vue_structure.py
@@ -90,41 +90,32 @@ def get_vue_structure_df():
     return df
 
 
-VUE_STRUCTURE_DF = get_vue_structure_df()
-
-
 @timeit
-def get_asp_id_to_siae_row():
+def get_asp_id_to_siae_row(vue_structure_df):
     """
     Provide the row from the "Vue Structure" matching the given asp_id.
     """
     asp_id_to_siae_row = {}
-    for _, row in VUE_STRUCTURE_DF.iterrows():
+    for _, row in vue_structure_df.iterrows():
         assert row.asp_id not in asp_id_to_siae_row
         asp_id_to_siae_row[row.asp_id] = row
     return asp_id_to_siae_row
 
 
-ASP_ID_TO_SIAE_ROW = get_asp_id_to_siae_row()
-
-
 @timeit
-def get_asp_id_to_siret_signature():
+def get_asp_id_to_siret_signature(vue_structure_df):
     """
     Provide the siret_signature from the "Vue Structure" matching the given asp_id.
     """
     asp_id_to_siret_signature = {}
-    for _, row in VUE_STRUCTURE_DF.iterrows():
+    for _, row in vue_structure_df.iterrows():
         assert row.asp_id not in asp_id_to_siret_signature
         asp_id_to_siret_signature[row.asp_id] = row.siret_signature
     return asp_id_to_siret_signature
 
 
-ASP_ID_TO_SIRET_SIGNATURE = get_asp_id_to_siret_signature()
-
-
 @timeit
-def get_siret_to_asp_id():
+def get_siret_to_asp_id(vue_structure_df):
     """
     Provide the asp_id from the "Vue Structure" matching the given siret (i.e. siret_actualise).
 
@@ -136,9 +127,6 @@ def get_siret_to_asp_id():
     are matched to their correct ASP counterpart.
     """
     siret_to_asp_id = {}
-    for _, row in VUE_STRUCTURE_DF.iterrows():
+    for _, row in vue_structure_df.iterrows():
         siret_to_asp_id[row.siret] = row.asp_id
     return siret_to_asp_id
-
-
-SIRET_TO_ASP_ID = get_siret_to_asp_id()

--- a/itou/companies/management/commands/_import_siae/vue_structure.py
+++ b/itou/companies/management/commands/_import_siae/vue_structure.py
@@ -15,11 +15,9 @@ It contains almost all data to build a siae from scratch with 2 exceptions:
 import numpy as np
 
 from itou.companies.management.commands._import_siae.utils import get_fluxiae_df, remap_columns
-from itou.utils.python import timeit
 from itou.utils.validators import validate_naf, validate_siret
 
 
-@timeit
 def get_vue_structure_df():
     """
     The "Vue Structure" export has the following fields:
@@ -90,7 +88,6 @@ def get_vue_structure_df():
     return df
 
 
-@timeit
 def get_siret_to_siae_row(vue_structure_df):
     """
     Provide the row from the "Vue Structure" matching the given asp_id.

--- a/itou/companies/management/commands/_import_siae/vue_structure.py
+++ b/itou/companies/management/commands/_import_siae/vue_structure.py
@@ -103,18 +103,6 @@ def get_asp_id_to_siae_row(vue_structure_df):
 
 
 @timeit
-def get_asp_id_to_siret_signature(vue_structure_df):
-    """
-    Provide the siret_signature from the "Vue Structure" matching the given asp_id.
-    """
-    asp_id_to_siret_signature = {}
-    for _, row in vue_structure_df.iterrows():
-        assert row.asp_id not in asp_id_to_siret_signature
-        asp_id_to_siret_signature[row.asp_id] = row.siret_signature
-    return asp_id_to_siret_signature
-
-
-@timeit
 def get_siret_to_asp_id(vue_structure_df):
     """
     Provide the asp_id from the "Vue Structure" matching the given siret (i.e. siret_actualise).

--- a/itou/companies/management/commands/_import_siae/vue_structure.py
+++ b/itou/companies/management/commands/_import_siae/vue_structure.py
@@ -91,18 +91,6 @@ def get_vue_structure_df():
 
 
 @timeit
-def get_asp_id_to_siae_row(vue_structure_df):
-    """
-    Provide the row from the "Vue Structure" matching the given asp_id.
-    """
-    asp_id_to_siae_row = {}
-    for _, row in vue_structure_df.iterrows():
-        assert row.asp_id not in asp_id_to_siae_row
-        asp_id_to_siae_row[row.asp_id] = row
-    return asp_id_to_siae_row
-
-
-@timeit
 def get_siret_to_asp_id(vue_structure_df):
     """
     Provide the asp_id from the "Vue Structure" matching the given siret (i.e. siret_actualise).
@@ -118,3 +106,11 @@ def get_siret_to_asp_id(vue_structure_df):
     for _, row in vue_structure_df.iterrows():
         siret_to_asp_id[row.siret] = row.asp_id
     return siret_to_asp_id
+
+
+@timeit
+def get_siret_to_siae_row(vue_structure_df):
+    """
+    Provide the row from the "Vue Structure" matching the given asp_id.
+    """
+    return {row.siret: row for _, row in vue_structure_df.iterrows()}

--- a/itou/companies/management/commands/import_ea_eatt.py
+++ b/itou/companies/management/commands/import_ea_eatt.py
@@ -154,8 +154,7 @@ def build_ea_eatt(row):
     company.city = row.city
     company.department = row.department
 
-    company = geocode_siae(company)
-
+    geocode_siae(company)
     return company
 
 

--- a/itou/companies/management/commands/import_geiq.py
+++ b/itou/companies/management/commands/import_geiq.py
@@ -94,8 +94,7 @@ def build_geiq(row):
     company.city = row.city
     company.department = row.department
 
-    company = geocode_siae(company)
-
+    geocode_siae(company)
     return company
 
 

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -44,7 +44,6 @@ from itou.companies.management.commands._import_siae.vue_structure import (
     get_vue_structure_df,
 )
 from itou.utils.command import BaseCommand
-from itou.utils.python import timeit
 
 
 class Command(BaseCommand):
@@ -57,7 +56,6 @@ class Command(BaseCommand):
 
     help = "Update and sync SIAE data based on latest ASP exports."
 
-    @timeit
     def handle(self, **options):
         fatal_errors = 0
 

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
     help = "Update and sync SIAE data based on latest ASP exports."
 
     def handle(self, **options):
-        fatal_errors = 0
+        errors = 0
 
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
 
@@ -66,10 +66,10 @@ class Command(BaseCommand):
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         # Sanitize data from users
-        fatal_errors += delete_user_created_siaes_without_members()
-        fatal_errors += manage_staff_created_siaes()
+        errors += delete_user_created_siaes_without_members()
+        errors += manage_staff_created_siaes()
 
-        fatal_errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
+        errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
         update_existing_conventions(siret_to_siae_row, active_siae_keys)
         create_new_siaes(siret_to_siae_row, active_siae_keys)
         create_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
@@ -79,17 +79,17 @@ class Command(BaseCommand):
 
         # Run some updates a second time.
         update_existing_conventions(siret_to_siae_row, active_siae_keys)
-        fatal_errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
+        errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
         delete_conventions()
 
         # Final checks.
         check_convention_data_consistency()
-        fatal_errors += check_whether_signup_is_possible_for_all_siaes()
+        errors += check_whether_signup_is_possible_for_all_siaes()
 
-        if fatal_errors >= 1:
+        if errors >= 1:
             raise CommandError(
-                "*** FATAL ERROR(S) ***"
-                "The command completed all its actions successfully but at least one fatal error needs "
+                "*** ERROR(S) ***"
+                "The command completed all its actions successfully but at least one error needs "
                 "manual resolution, see command output"
             )
 

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -36,7 +36,7 @@ from itou.companies.management.commands._import_siae.siae import (
     update_siret_and_auth_email_of_existing_siaes,
 )
 from itou.companies.management.commands._import_siae.vue_af import (
-    get_active_siae_keys,
+    get_conventions_by_siae_key,
     get_vue_af_df,
 )
 from itou.companies.management.commands._import_siae.vue_structure import (
@@ -70,22 +70,22 @@ class Command(BaseCommand):
 
         vue_af_df = get_vue_af_df()
         af_number_to_row = {row.number: row for _, row in vue_af_df.iterrows()}
-        active_siae_keys = get_active_siae_keys(vue_af_df)
+        conventions_by_siae_key = get_conventions_by_siae_key(vue_af_df)
 
         # Sanitize data from users
         errors += delete_user_created_siaes_without_members()
         errors += manage_staff_created_siaes()
 
         errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
-        update_existing_conventions(siret_to_siae_row, active_siae_keys)
-        create_new_siaes(siret_to_siae_row, active_siae_keys)
-        create_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
+        update_existing_conventions(siret_to_siae_row, conventions_by_siae_key)
+        create_new_siaes(siret_to_siae_row, conventions_by_siae_key)
+        create_conventions(siret_to_siae_row, conventions_by_siae_key)
         delete_conventions()
         manage_financial_annexes(af_number_to_row)
         cleanup_siaes_after_grace_period()
 
         # Run some updates a second time.
-        update_existing_conventions(siret_to_siae_row, active_siae_keys)
+        update_existing_conventions(siret_to_siae_row, conventions_by_siae_key)
         errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
         delete_conventions()
 

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -37,7 +37,6 @@ from itou.companies.management.commands._import_siae.siae import (
 )
 from itou.companies.management.commands._import_siae.vue_af import (
     get_active_siae_keys,
-    get_af_number_to_row,
     get_vue_af_df,
 )
 from itou.companies.management.commands._import_siae.vue_structure import (
@@ -70,7 +69,7 @@ class Command(BaseCommand):
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
 
         vue_af_df = get_vue_af_df()
-        af_number_to_row = get_af_number_to_row(vue_af_df)
+        af_number_to_row = {row.number: row for _, row in vue_af_df.iterrows()}
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         # Sanitize data from users

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -26,7 +26,10 @@ from itou.companies.management.commands._import_siae.convention import (
     update_existing_conventions,
 )
 from itou.companies.management.commands._import_siae.financial_annex import get_creatable_and_deletable_afs
-from itou.companies.management.commands._import_siae.siae import build_siae, should_siae_be_created
+from itou.companies.management.commands._import_siae.siae import (
+    build_siae,
+    does_siae_have_an_active_convention,
+)
 from itou.companies.management.commands._import_siae.utils import could_siae_be_deleted
 from itou.companies.management.commands._import_siae.vue_af import (
     get_active_siae_keys,
@@ -259,7 +262,7 @@ class Command(BaseCommand):
 
             siae = build_siae(active_siae_keys, siret_to_asp_id, row=row, kind=kind)
 
-            if should_siae_be_created(active_siae_keys, siret_to_asp_id, siae):
+            if does_siae_have_an_active_convention(active_siae_keys, siret_to_asp_id, siae):
                 assert siae not in creatable_siaes
                 creatable_siaes.append(siae)
 

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -56,10 +56,6 @@ class Command(BaseCommand):
     help = "Update and sync SIAE data based on latest ASP exports."
     fatal_errors = 0
 
-    def delete_siae(self, siae):
-        assert could_siae_be_deleted(siae)
-        siae.delete()
-
     @timeit
     def delete_user_created_siaes_without_members(self):
         """
@@ -75,7 +71,7 @@ class Command(BaseCommand):
             if not siae.has_members:
                 if could_siae_be_deleted(siae):
                     self.stdout.write(f"siae.id={siae.id} is user created and has no member thus will be deleted")
-                    self.delete_siae(siae)
+                    siae.delete()
                 else:
                     self.stdout.write(
                         f"FATAL ERROR: siae.id={siae.id} is user created and "
@@ -123,7 +119,7 @@ class Command(BaseCommand):
         for siae in old_unconfirmed_siaes:
             if could_siae_be_deleted(siae):
                 self.stdout.write(f"deleted unconfirmed siae.id={siae.id} created by staff a while ago")
-                self.delete_siae(siae)
+                siae.delete()
             else:
                 self.stdout.write(
                     f"FATAL ERROR: Please fix unconfirmed staff created siae.id={siae.id}"
@@ -198,7 +194,7 @@ class Command(BaseCommand):
             if not siae.grace_period_has_expired:
                 continue
             if could_siae_be_deleted(siae):
-                self.delete_siae(siae)
+                siae.delete()
                 deletions += 1
                 continue
             blocked_deletions += 1

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -28,7 +28,6 @@ from itou.companies.management.commands._import_siae.convention import (
 from itou.companies.management.commands._import_siae.financial_annex import get_creatable_and_deletable_afs
 from itou.companies.management.commands._import_siae.siae import (
     build_siae,
-    does_siae_have_an_active_convention,
 )
 from itou.companies.management.commands._import_siae.utils import could_siae_be_deleted
 from itou.companies.management.commands._import_siae.vue_af import (
@@ -259,9 +258,9 @@ class Command(BaseCommand):
 
             assert not SiaeConvention.objects.filter(asp_id=asp_id, kind=kind).exists()
 
-            siae = build_siae(active_siae_keys, siret_to_siae_row, row=row, kind=kind)
+            siae = build_siae(active_siae_keys, row=row, kind=kind)
 
-            if does_siae_have_an_active_convention(active_siae_keys, siret_to_siae_row, siae):
+            if (row.asp_id, siae.kind) in active_siae_keys:
                 assert siae not in creatable_siaes
                 creatable_siaes.append(siae)
 

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -127,17 +127,6 @@ class Command(BaseCommand):
                 )
                 self.fatal_errors += 1
 
-    def update_siae_auth_email(self, siae, new_auth_email):
-        assert siae.auth_email != new_auth_email
-        siae.auth_email = new_auth_email
-        siae.save()
-
-    def update_siae_siret(self, siae, new_siret):
-        assert siae.siret != new_siret
-        self.stdout.write(f"siae.id={siae.id} has changed siret from {siae.siret} to {new_siret} (will be updated)")
-        siae.siret = new_siret
-        siae.save()
-
     @timeit
     def update_siret_and_auth_email_of_existing_siaes(self, siret_to_siae_row):
         auth_email_updates = 0
@@ -156,7 +145,8 @@ class Command(BaseCommand):
             new_auth_email = row.auth_email
             auth_email_has_changed = new_auth_email and siae.auth_email != new_auth_email
             if auth_email_has_changed:
-                self.update_siae_auth_email(siae, new_auth_email)
+                siae.auth_email = new_auth_email
+                siae.save()
                 auth_email_updates += 1
 
             siret_has_changed = row.siret != siae.siret
@@ -168,7 +158,11 @@ class Command(BaseCommand):
             existing_siae = Company.objects.filter(siret=new_siret, kind=siae.kind).first()
 
             if not existing_siae:
-                self.update_siae_siret(siae, new_siret)
+                self.stdout.write(
+                    f"siae.id={siae.id} has changed siret from {siae.siret} to {new_siret} (will be updated)"
+                )
+                siae.siret = new_siret
+                siae.save()
                 continue
 
             def fmt(siae):

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -45,6 +45,7 @@ from itou.companies.management.commands._import_siae.vue_structure import (
     get_vue_structure_df,
 )
 from itou.utils.command import BaseCommand
+from itou.utils.templatetags.str_filters import pluralizefr
 
 
 class Command(BaseCommand):
@@ -97,10 +98,10 @@ class Command(BaseCommand):
             raise CommandError("DRY RUN mode, use --wet-run to apply changes")
 
         if errors >= 1:
+            s = pluralizefr(errors)
             self.stdout.write(
-                "*** ERROR(S) ***"
-                "The command completed all its actions successfully but at least one error needs "
-                "manual resolution, see command output"
+                f"*** ERROR{s.upper()} *** The command completed all its actions successfully "
+                f"but {errors} error{s} needs manual resolution, see the command's output"
             )
         else:
             self.stdout.write("All done!")

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -258,11 +258,8 @@ class Command(BaseCommand):
 
             assert not SiaeConvention.objects.filter(asp_id=asp_id, kind=kind).exists()
 
-            siae = build_siae(active_siae_keys, row=row, kind=kind)
-
-            if (row.asp_id, siae.kind) in active_siae_keys:
-                assert siae not in creatable_siaes
-                creatable_siaes.append(siae)
+            if (row.asp_id, kind) in active_siae_keys:
+                creatable_siaes.append(build_siae(row, kind, is_active=True))
 
         self.stdout.write("--- beginning of CSV output of all creatable_siaes ---")
         self.stdout.write("siret;kind;department;name;address")

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -16,21 +16,24 @@ name instead of hardcoding column numbers as in `field = row[42]`.
 """
 
 from django.core.management.base import CommandError
-from django.db import transaction
-from django.db.models import Q
-from django.utils import timezone
 
-from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
 from itou.companies.management.commands._import_siae.convention import (
     check_convention_data_consistency,
-    get_creatable_conventions,
+    create_conventions,
+    delete_conventions,
     update_existing_conventions,
 )
-from itou.companies.management.commands._import_siae.financial_annex import get_creatable_and_deletable_afs
-from itou.companies.management.commands._import_siae.siae import (
-    build_siae,
+from itou.companies.management.commands._import_siae.financial_annex import (
+    manage_financial_annexes,
 )
-from itou.companies.management.commands._import_siae.utils import could_siae_be_deleted
+from itou.companies.management.commands._import_siae.siae import (
+    check_whether_signup_is_possible_for_all_siaes,
+    cleanup_siaes_after_grace_period,
+    create_new_siaes,
+    delete_user_created_siaes_without_members,
+    manage_staff_created_siaes,
+    update_siret_and_auth_email_of_existing_siaes,
+)
 from itou.companies.management.commands._import_siae.vue_af import (
     get_active_siae_keys,
     get_af_number_to_row,
@@ -40,9 +43,7 @@ from itou.companies.management.commands._import_siae.vue_structure import (
     get_siret_to_siae_row,
     get_vue_structure_df,
 )
-from itou.companies.models import Company, SiaeConvention
 from itou.utils.command import BaseCommand
-from itou.utils.emails import send_email_messages
 from itou.utils.python import timeit
 
 
@@ -55,250 +56,11 @@ class Command(BaseCommand):
     """
 
     help = "Update and sync SIAE data based on latest ASP exports."
-    fatal_errors = 0
-
-    @timeit
-    def delete_user_created_siaes_without_members(self):
-        """
-        Siaes created by a user usually have at least one member, their creator.
-        However in some cases, itou staff deletes some users, leaving
-        potentially user created siaes without member.
-        Those siaes cannot be joined by any way and thus are useless.
-        Let's clean them up when possible.
-        """
-        for siae in Company.objects.prefetch_related("memberships").filter(
-            members__isnull=True, source=Company.SOURCE_USER_CREATED
-        ):
-            if not siae.has_members:
-                if could_siae_be_deleted(siae):
-                    self.stdout.write(f"siae.id={siae.id} is user created and has no member thus will be deleted")
-                    siae.delete()
-                else:
-                    self.stdout.write(
-                        f"FATAL ERROR: siae.id={siae.id} is user created and "
-                        f"has no member but has job applications thus cannot be deleted"
-                    )
-                    self.fatal_errors += 1
-
-    @timeit
-    def manage_staff_created_siaes(self):
-        """
-        Itou staff regularly creates siaes manually when ASP data lags behind for some specific employers.
-
-        Normally the SIRET later appears in ASP data then the siae is converted to ASP source by `create_new_siaes`.
-
-        But sometimes a staff created siae's SIRET never appear in ASP data. We wait 90 days (as decided with staff
-        team) before considering it invalid and attempting deleting it.
-
-        If the siae cannot be deleted because it has data, a warning will be shown to supportix.
-        """
-        three_months_ago = timezone.now() - timezone.timedelta(days=90)
-        staff_created_siaes = Company.objects.filter(
-            kind__in=SIAE_WITH_CONVENTION_KINDS,
-            source=Company.SOURCE_STAFF_CREATED,
-        )
-        # Sometimes our staff creates a siae then later attaches it manually to the correct convention. In that
-        # case it should be converted to a regular user created siae so that the usual convention logic applies.
-        for siae in staff_created_siaes.filter(convention__isnull=False):
-            self.stdout.write(f"converted staff created siae.id={siae.id} to user created siae as it has a convention")
-            siae.source = Company.SOURCE_USER_CREATED
-            siae.save(update_fields={"source"})
-
-        recent_unconfirmed_siaes = staff_created_siaes.filter(created_at__gte=three_months_ago)
-        self.stdout.write(
-            f"{recent_unconfirmed_siaes.count()} siaes created recently by staff"
-            " (still waiting for ASP data to be confirmed)"
-        )
-
-        old_unconfirmed_siaes = staff_created_siaes.filter(created_at__lt=three_months_ago)
-        self.stdout.write(
-            f"{len(old_unconfirmed_siaes)} siaes created by staff should be deleted as they are unconfirmed"
-        )
-        for siae in old_unconfirmed_siaes:
-            if could_siae_be_deleted(siae):
-                self.stdout.write(f"deleted unconfirmed siae.id={siae.id} created by staff a while ago")
-                siae.delete()
-            else:
-                self.stdout.write(
-                    f"FATAL ERROR: Please fix unconfirmed staff created siae.id={siae.id}"
-                    f" by either deleting it or attaching it to the correct convention"
-                )
-                self.fatal_errors += 1
-
-    @timeit
-    def update_siret_and_auth_email_of_existing_siaes(self, siret_to_siae_row):
-        auth_email_updates = 0
-
-        asp_id_to_siae_row = {row.asp_id: row for row in siret_to_siae_row.values()}
-        for siae in Company.objects.select_related("convention").filter(
-            source=Company.SOURCE_ASP, convention__isnull=False
-        ):
-            assert siae.should_have_convention
-
-            if siae.convention.asp_id not in asp_id_to_siae_row:
-                continue
-            row = asp_id_to_siae_row[siae.convention.asp_id]
-            updated_fields = set()
-
-            auth_email = row.auth_email or siae.auth_email
-            if siae.auth_email != auth_email:
-                siae.auth_email = auth_email
-                updated_fields.add("auth_email")
-                auth_email_updates += 1
-
-            if siae.siret != row.siret:
-                assert siae.siren == row.siret[:9]
-
-                existing_siae = Company.objects.filter(siret=row.siret, kind=siae.kind).first()
-                if existing_siae:
-
-                    def fmt(siae):
-                        msg = f"{siae.source} {siae.siret}"
-                        if siae.convention is None:
-                            return f"{msg} convention=None"
-                        return f"{msg} convention.id={siae.convention.id} asp_id={siae.convention.asp_id}"
-
-                    self.stdout.write(
-                        f"FATAL ERROR: siae.id={siae.id} ({fmt(siae)}) has changed siret from "
-                        f"{siae.siret} to {row.siret} but new siret is already used by "
-                        f"siae.id={existing_siae.id} ({fmt(existing_siae)}) "
-                    )
-                    self.fatal_errors += 1
-                    continue
-
-                self.stdout.write(
-                    f"siae.id={siae.id} has changed siret from {siae.siret} to {row.siret} (will be updated)"
-                )
-                siae.siret = row.siret
-                updated_fields.add("siret")
-
-            if updated_fields:
-                siae.save(update_fields=updated_fields)
-
-        self.stdout.write(f"{auth_email_updates} siae.auth_email fields have been updated")
-
-    @timeit
-    def cleanup_siaes_after_grace_period(self):
-        deletions, blocked_deletions = 0, 0
-
-        for siae in Company.objects.select_related("convention"):
-            if not siae.grace_period_has_expired:
-                continue
-
-            if could_siae_be_deleted(siae):
-                siae.delete()
-                deletions += 1
-            else:
-                blocked_deletions += 1
-
-        self.stdout.write(f"{deletions} siaes past their grace period has been deleted")
-        self.stdout.write(f"{blocked_deletions} siaes past their grace period cannot be deleted")
-
-    @timeit
-    def create_new_siaes(self, siret_to_siae_row, active_siae_keys):
-        creatable_siaes = []
-
-        asp_id_to_siae_row = {row.asp_id: row for row in siret_to_siae_row.values()}
-        for asp_id, kind in active_siae_keys:
-            if asp_id not in asp_id_to_siae_row:
-                continue
-            row = asp_id_to_siae_row[asp_id]
-
-            existing_siaes = Company.objects.select_related("convention").filter(convention__asp_id=asp_id, kind=kind)
-            if existing_siaes:
-                # Siaes with this asp_id already exist, no need to create one more.
-                total_existing_siaes_with_asp_source = 0
-                for existing_siae in existing_siaes:
-                    assert existing_siae.should_have_convention
-                    if existing_siae.source == Company.SOURCE_ASP:
-                        total_existing_siaes_with_asp_source += 1
-                        # Siret should have been fixed by update_siret_and_auth_email_of_existing_siaes().
-                        assert existing_siae.siret == row.siret
-                    else:
-                        assert existing_siae.source == Company.SOURCE_USER_CREATED
-
-                # Duplicate siaes should have been deleted.
-                assert total_existing_siaes_with_asp_source == 1
-                continue
-
-            try:
-                existing_siae = Company.objects.get(~Q(source=Company.SOURCE_ASP), siret=row.siret, kind=kind)
-            except Company.DoesNotExist:
-                assert not SiaeConvention.objects.filter(asp_id=asp_id, kind=kind).exists()
-                if (row.asp_id, kind) in active_siae_keys:
-                    creatable_siaes.append(build_siae(row, kind, is_active=True))
-            else:
-                # Siae with this siret+kind already exists but with the wrong source.
-                assert existing_siae.source in [Company.SOURCE_USER_CREATED, Company.SOURCE_STAFF_CREATED]
-                assert existing_siae.should_have_convention
-                self.stdout.write(
-                    f"siae.id={existing_siae.id} already exists "
-                    f"with wrong source={existing_siae.source} "
-                    f"(source will be fixed to ASP)"
-                )
-                existing_siae.source = Company.SOURCE_ASP
-                existing_siae.convention = None
-                existing_siae.save(update_fields={"source", "convention"})
-
-        self.stdout.write("--- beginning of CSV output of all creatable_siaes ---")
-        self.stdout.write("siret;kind;department;name;address")
-        for siae in creatable_siaes:
-            self.stdout.write(f"{siae.siret};{siae.kind};{siae.department};{siae.name};{siae.address_on_one_line}")
-            siae.save()
-        self.stdout.write("--- end of CSV output of all creatable_siaes ---")
-
-        send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes)
-
-        self.stdout.write(f"{len(creatable_siaes)} structures have been created")
-        self.stdout.write(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")
-
-    @timeit
-    def check_whether_signup_is_possible_for_all_siaes(self):
-        no_signup_siaes = Company.objects.filter(auth_email="").exclude(companymembership__is_active=True).distinct()
-        for siae in no_signup_siaes:
-            self.stdout.write(
-                f"FATAL ERROR: signup is impossible for siae.id={siae.id} siret={siae.siret} "
-                f"kind={siae.kind} dpt={siae.department} source={siae.source} "
-                f"created_by={siae.created_by} siae.email={siae.email}"
-            )
-            self.fatal_errors += 1
-
-    @timeit
-    def create_conventions(self, vue_af_df, siret_to_siae_row, active_siae_keys):
-        creatable_conventions = get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
-        self.stdout.write(f"will create {len(creatable_conventions)} conventions")
-
-        for convention, siae in creatable_conventions:
-            assert not SiaeConvention.objects.filter(asp_id=convention.asp_id, kind=convention.kind).exists()
-            convention.save()
-            assert convention.siaes.count() == 0
-            siae.convention = convention
-            siae.save(update_fields={"convention"})
-            assert convention.siaes.filter(source=Company.SOURCE_ASP).count() == 1
-
-    @timeit
-    @transaction.atomic()
-    def delete_conventions(self):
-        deletable_conventions = SiaeConvention.objects.filter(siaes__isnull=True)
-        self.stdout.write(f"will delete {len(deletable_conventions)} conventions")
-        for convention in deletable_conventions:
-            # This will delete the related financial annexes as well.
-            convention.delete()
-
-    @timeit
-    def manage_financial_annexes(self, af_number_to_row):
-        creatable_afs, deletable_afs = get_creatable_and_deletable_afs(af_number_to_row)
-
-        self.stdout.write(f"will create {len(creatable_afs)} financial annexes")
-        for af in creatable_afs:
-            af.save()
-
-        self.stdout.write(f"will delete {len(deletable_afs)} financial annexes")
-        for af in deletable_afs:
-            af.delete()
 
     @timeit
     def handle(self, **options):
+        fatal_errors = 0
+
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
 
         vue_af_df = get_vue_af_df()
@@ -306,27 +68,27 @@ class Command(BaseCommand):
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         # Sanitize data from users
-        self.delete_user_created_siaes_without_members()
-        self.manage_staff_created_siaes()
+        fatal_errors += delete_user_created_siaes_without_members()
+        fatal_errors += manage_staff_created_siaes()
 
-        self.update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
+        fatal_errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
         update_existing_conventions(siret_to_siae_row, active_siae_keys)
-        self.create_new_siaes(siret_to_siae_row, active_siae_keys)
-        self.create_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
-        self.delete_conventions()
-        self.manage_financial_annexes(af_number_to_row)
-        self.cleanup_siaes_after_grace_period()
+        create_new_siaes(siret_to_siae_row, active_siae_keys)
+        create_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
+        delete_conventions()
+        manage_financial_annexes(af_number_to_row)
+        cleanup_siaes_after_grace_period()
 
         # Run some updates a second time.
         update_existing_conventions(siret_to_siae_row, active_siae_keys)
-        self.update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
-        self.delete_conventions()
+        fatal_errors += update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row)
+        delete_conventions()
 
         # Final checks.
         check_convention_data_consistency()
-        self.check_whether_signup_is_possible_for_all_siaes()
+        fatal_errors += check_whether_signup_is_possible_for_all_siaes()
 
-        if self.fatal_errors >= 1:
+        if fatal_errors >= 1:
             raise CommandError(
                 "*** FATAL ERROR(S) ***"
                 "The command completed all its actions successfully but at least one fatal error needs "

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -16,6 +16,7 @@ name instead of hardcoding column numbers as in `field = row[42]`.
 """
 
 from django.core.management.base import CommandError
+from django.db import transaction
 
 from itou.companies.management.commands._import_siae.convention import (
     check_convention_data_consistency,
@@ -56,7 +57,13 @@ class Command(BaseCommand):
 
     help = "Update and sync SIAE data based on latest ASP exports."
 
-    def handle(self, **options):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+
+    @transaction.atomic
+    def handle(self, wet_run, **options):
         errors = 0
 
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
@@ -86,11 +93,14 @@ class Command(BaseCommand):
         check_convention_data_consistency()
         errors += check_whether_signup_is_possible_for_all_siaes()
 
+        if not wet_run:
+            raise CommandError("DRY RUN mode, use --wet-run to apply changes")
+
         if errors >= 1:
-            raise CommandError(
+            self.stdout.write(
                 "*** ERROR(S) ***"
                 "The command completed all its actions successfully but at least one error needs "
                 "manual resolution, see command output"
             )
-
-        self.stdout.write("All done!")
+        else:
+            self.stdout.write("All done!")

--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -48,7 +48,7 @@ mkdir -p $OUTPUT_PATH/import_siae
 mkdir -p $OUTPUT_PATH/import_ea_eatt
 
 time ./manage.py populate_metabase_fluxiae --verbosity 2 |& tee -a "$OUTPUT_PATH/populate_metabase_fluxiae/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
-time ./manage.py import_siae --verbosity=2 |& tee -a "$OUTPUT_PATH/import_siae/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
+time ./manage.py import_siae --wet-run --verbosity=2 |& tee -a "$OUTPUT_PATH/import_siae/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 time ./manage.py import_ea_eatt --wet-run --verbosity=2 |& tee -a "$OUTPUT_PATH/import_ea_eatt/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 
 # Destroy the cleartext ASP data

--- a/scripts/imports-asp.sh
+++ b/scripts/imports-asp.sh
@@ -31,13 +31,16 @@ if [[ ! -f "$CONTACT_EA_FILE" ]]; then
     exit 0
 fi
 
+FLUX_IAE_DIR=$(realpath "itou/companies/management/commands/data/")
+export FLUX_IAE_DIR
+
 # Create the "data" directory inside of the app and clear it of any previously existing data
-mkdir -p itou/companies/management/commands/data/
-rm -rf itou/companies/management/commands/data/*
+mkdir -p "$FLUX_IAE_DIR"
+rm -rf "$FLUX_IAE_DIR"*
 
 # Unzip ASP files
-unzip -P "$ASP_UNZIP_PASSWORD" "$FLUX_IAE_FILE" -d itou/companies/management/commands/data/
-unzip -P "$ASP_UNZIP_PASSWORD" "$CONTACT_EA_FILE" -d itou/companies/management/commands/data/
+unzip -P "$ASP_UNZIP_PASSWORD" "$FLUX_IAE_FILE" -d "$FLUX_IAE_DIR"
+unzip -P "$ASP_UNZIP_PASSWORD" "$CONTACT_EA_FILE" -d "$FLUX_IAE_DIR"
 
 # Perform the necessary data imports
 mkdir -p $OUTPUT_PATH/populate_metabase_fluxiae
@@ -49,7 +52,7 @@ time ./manage.py import_siae --verbosity=2 |& tee -a "$OUTPUT_PATH/import_siae/o
 time ./manage.py import_ea_eatt --wet-run --verbosity=2 |& tee -a "$OUTPUT_PATH/import_ea_eatt/output_$(date '+%Y-%m-%d_%H-%M-%S').log"
 
 # Destroy the cleartext ASP data
-rm -rf itou/companies/management/commands/data/
+rm -rf "$FLUX_IAE_DIR"
 
 # Remove ASP files older than 3 weeks
 find asp_shared_bucket/ -name '*.zip' -type f -mtime +20 -delete

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -25,7 +25,6 @@ from itou.companies.management.commands._import_siae.vue_af import (
     get_vue_af_df,
 )
 from itou.companies.management.commands._import_siae.vue_structure import (
-    get_siret_to_asp_id,
     get_siret_to_siae_row,
     get_vue_structure_df,
 )
@@ -74,13 +73,12 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
     def test_uncreatable_conventions_for_active_siae_with_active_convention(self):
         vue_structure_df = get_vue_structure_df()
         siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
-        siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP)
         assert company.is_active
-        assert not self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
+        assert not self.mod.get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
 
     def test_uncreatable_conventions_when_convention_exists_for_asp_id_and_kind(self):
         # siae without convention, but a convention already exists for this
@@ -90,7 +88,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         vue_structure_df = get_vue_structure_df()
         siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
-        siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
@@ -98,7 +95,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SiaeConventionFactory(kind=company.kind, asp_id=ASP_ID)
 
         with pytest.raises(AssertionError):
-            self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
+            self.mod.get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
 
     def test_creatable_conventions_for_active_siae_where_siret_equals_siret_signature(self):
         SIRET = SIRET_SIGNATURE = "21540323900019"
@@ -106,12 +103,11 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         vue_structure_df = get_vue_structure_df()
         siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
-        siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
-        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
+        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -132,12 +128,11 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         vue_structure_df = get_vue_structure_df()
         siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
-        siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.AI, convention=None)
-        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
+        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -157,12 +152,11 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         vue_structure_df = get_vue_structure_df()
         siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
-        siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
-        company = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
+        company = self.mod.get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
 
         assert len(company) == 1
 
@@ -259,7 +253,6 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         instance = import_siae.Command()
         instance.create_new_siaes(
             get_siret_to_siae_row(vue_structure_df),
-            get_siret_to_asp_id(vue_structure_df),
             get_active_siae_keys(vue_af_df),
         )
         assert reverse("signup:company_select") in mail.outbox[0].body

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -26,7 +26,6 @@ from itou.companies.management.commands._import_siae.vue_af import (
 )
 from itou.companies.management.commands._import_siae.vue_structure import (
     get_asp_id_to_siae_row,
-    get_asp_id_to_siret_signature,
     get_siret_to_asp_id,
     get_vue_structure_df,
 )
@@ -74,16 +73,14 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
     def test_uncreatable_conventions_for_active_siae_with_active_convention(self):
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siret_signature = get_asp_id_to_siret_signature(vue_structure_df)
+        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP)
         assert company.is_active
-        assert not self.mod.get_creatable_conventions(
-            vue_af_df, siret_to_asp_id, asp_id_to_siret_signature, active_siae_keys
-        )
+        assert not self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
 
     def test_uncreatable_conventions_when_convention_exists_for_asp_id_and_kind(self):
         # siae without convention, but a convention already exists for this
@@ -92,7 +89,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         ASP_ID = 190
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siret_signature = get_asp_id_to_siret_signature(vue_structure_df)
+        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
@@ -101,22 +98,20 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SiaeConventionFactory(kind=company.kind, asp_id=ASP_ID)
 
         with pytest.raises(AssertionError):
-            self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siret_signature, active_siae_keys)
+            self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
 
     def test_creatable_conventions_for_active_siae_where_siret_equals_siret_signature(self):
         SIRET = SIRET_SIGNATURE = "21540323900019"
         ASP_ID = 112
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siret_signature = get_asp_id_to_siret_signature(vue_structure_df)
+        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
-        results = self.mod.get_creatable_conventions(
-            vue_af_df, siret_to_asp_id, asp_id_to_siret_signature, active_siae_keys
-        )
+        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -136,15 +131,13 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         ASP_ID = 768
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siret_signature = get_asp_id_to_siret_signature(vue_structure_df)
+        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.AI, convention=None)
-        results = self.mod.get_creatable_conventions(
-            vue_af_df, siret_to_asp_id, asp_id_to_siret_signature, active_siae_keys
-        )
+        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -163,15 +156,13 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         ASP_ID = 1780
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siret_signature = get_asp_id_to_siret_signature(vue_structure_df)
+        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
-        company = self.mod.get_creatable_conventions(
-            vue_af_df, siret_to_asp_id, asp_id_to_siret_signature, active_siae_keys
-        )
+        company = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
 
         assert len(company) == 1
 

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -39,7 +39,6 @@ from tests.eligibility.factories import EligibilityDiagnosisMadeBySiaeFactory
 @unittest.skipUnless(
     os.getenv("CI", "False"), "Slow and scarcely updated management command, no need for constant testing!"
 )
-@freeze_time("2022-10-10")
 @pytest.mark.usefixtures("unittest_compatibility")
 class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
@@ -89,7 +88,8 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
-        active_siae_keys = get_active_siae_keys(vue_af_df)
+        with freeze_time("2022-10-10"):
+            active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
         results = get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
@@ -113,10 +113,12 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
-        active_siae_keys = get_active_siae_keys(vue_af_df)
+        with freeze_time("2022-10-10"):
+            active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.AI, convention=None)
-        results = get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
+        with freeze_time("2022-10-10"):
+            results = get_creatable_conventions(vue_af_df, siret_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -219,10 +221,11 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
             assert check_whether_signup_is_possible_for_all_siaes() == 0
 
     def test_activate_your_account_email_for_a_siae_without_members_but_with_auth_email(self):
-        create_new_siaes(
-            get_siret_to_siae_row(get_vue_structure_df()),
-            get_active_siae_keys(get_vue_af_df()),
-        )
+        with freeze_time("2022-10-10"):
+            create_new_siaes(
+                get_siret_to_siae_row(get_vue_structure_df()),
+                get_active_siae_keys(get_vue_af_df()),
+            )
         assert reverse("signup:company_select") in mail.outbox[0].body
         assert collections.Counter(mail.subject for mail in mail.outbox) == collections.Counter(
             f"Activez le compte de votre {kind} {name} sur les emplois de l'inclusion"

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -1,15 +1,13 @@
 import collections
 import datetime
-import os
 import shutil
-import unittest
 from pathlib import Path
 
 import pandas as pd
 import pytest
 from django.conf import settings
 from django.core import mail
-from django.test import TransactionTestCase, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from freezegun import freeze_time
 
@@ -34,13 +32,11 @@ from itou.companies.models import Company
 from tests.approvals.factories import ApprovalFactory
 from tests.companies.factories import CompanyFactory, CompanyWith2MembershipsFactory, SiaeConventionFactory
 from tests.eligibility.factories import EligibilityDiagnosisMadeBySiaeFactory
+from tests.utils.test import TestCase
 
 
-@unittest.skipUnless(
-    os.getenv("CI", "False"), "Slow and scarcely updated management command, no need for constant testing!"
-)
 @pytest.mark.usefixtures("unittest_compatibility")
-class ImportSiaeManagementCommandsTest(TransactionTestCase):
+class ImportSiaeManagementCommandsTest(TestCase):
 
     def setUp(self):
         super().setUp()

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -21,7 +21,6 @@ from itou.companies.management.commands._import_siae.siae import (
 from itou.companies.management.commands._import_siae.utils import anonymize_fluxiae_df, could_siae_be_deleted
 from itou.companies.management.commands._import_siae.vue_af import (
     get_active_siae_keys,
-    get_af_number_to_row,
     get_vue_af_df,
 )
 from itou.companies.management.commands._import_siae.vue_structure import (
@@ -152,7 +151,7 @@ class ImportSiaeManagementCommandsTest(TestCase):
         assert (company.source, company.siret, company.kind) == (Company.SOURCE_ASP, SIRET, CompanyKind.ACI)
 
     def test_get_creatable_and_deletable_afs(self):
-        af_number_to_row = get_af_number_to_row(get_vue_af_df())
+        af_number_to_row = {row.number: row for _, row in get_vue_af_df().iterrows()}
 
         existing_convention = SiaeConventionFactory(kind=CompanyKind.ACI, asp_id=2855)
         # Get AF created by SiaeConventionFactory

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -25,8 +25,8 @@ from itou.companies.management.commands._import_siae.vue_af import (
     get_vue_af_df,
 )
 from itou.companies.management.commands._import_siae.vue_structure import (
-    get_asp_id_to_siae_row,
     get_siret_to_asp_id,
+    get_siret_to_siae_row,
     get_vue_structure_df,
 )
 from itou.companies.models import Company
@@ -73,14 +73,14 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
     def test_uncreatable_conventions_for_active_siae_with_active_convention(self):
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP)
         assert company.is_active
-        assert not self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
+        assert not self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
 
     def test_uncreatable_conventions_when_convention_exists_for_asp_id_and_kind(self):
         # siae without convention, but a convention already exists for this
@@ -89,7 +89,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         ASP_ID = 190
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
@@ -98,20 +98,20 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SiaeConventionFactory(kind=company.kind, asp_id=ASP_ID)
 
         with pytest.raises(AssertionError):
-            self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
+            self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
 
     def test_creatable_conventions_for_active_siae_where_siret_equals_siret_signature(self):
         SIRET = SIRET_SIGNATURE = "21540323900019"
         ASP_ID = 112
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
-        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
+        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -131,13 +131,13 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         ASP_ID = 768
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.AI, convention=None)
-        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
+        results = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
 
         assert len(results) == 1
 
@@ -156,13 +156,13 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         ASP_ID = 1780
 
         vue_structure_df = get_vue_structure_df()
-        asp_id_to_siae_row = get_asp_id_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
         siret_to_asp_id = get_siret_to_asp_id(vue_structure_df)
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
         company = CompanyFactory(source=Company.SOURCE_ASP, siret=SIRET, kind=CompanyKind.ACI, convention=None)
-        company = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, asp_id_to_siae_row, active_siae_keys)
+        company = self.mod.get_creatable_conventions(vue_af_df, siret_to_asp_id, siret_to_siae_row, active_siae_keys)
 
         assert len(company) == 1
 
@@ -258,7 +258,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
 
         instance = import_siae.Command()
         instance.create_new_siaes(
-            get_asp_id_to_siae_row(vue_structure_df),
+            get_siret_to_siae_row(vue_structure_df),
             get_siret_to_asp_id(vue_structure_df),
             get_active_siae_keys(vue_af_df),
         )

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -217,11 +217,13 @@ class ImportSiaeManagementCommandsTest(TestCase):
             assert check_whether_signup_is_possible_for_all_siaes() == 0
 
     def test_activate_your_account_email_for_a_siae_without_members_but_with_auth_email(self):
-        with freeze_time("2022-10-10"):
+        with freeze_time("2022-10-10"), self.captureOnCommitCallbacks(execute=True) as commit_callbacks:
             create_new_siaes(
                 get_siret_to_siae_row(get_vue_structure_df()),
                 get_active_siae_keys(get_vue_af_df()),
             )
+        assert len(commit_callbacks) == 1
+        assert len(mail.outbox) == 6
         assert reverse("signup:company_select") in mail.outbox[0].body
         assert collections.Counter(mail.subject for mail in mail.outbox) == collections.Counter(
             f"Activez le compte de votre {kind} {name} sur les emplois de l'inclusion"

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -41,9 +41,9 @@ class ImportSiaeManagementCommandsTest(TestCase):
     def setUp(self):
         super().setUp()
 
-        data_dir = self.tmp_path / "data"
-        data_dir.mkdir()
-        self.mocker.patch("itou.companies.management.commands._import_siae.utils.CURRENT_DIR", data_dir)
+        instance = override_settings(ASP_FLUX_IAE_DIR=self.tmp_path)
+        instance.enable()
+        self.addCleanup(instance.disable)
 
         # Beware : fluxIAE_Structure_22022022_112211.csv.gz ends with .gz but is compressed with pkzip.
         # Since it happened once, and the code now allows it, we also want to test it.
@@ -51,7 +51,7 @@ class ImportSiaeManagementCommandsTest(TestCase):
             x for x in Path(settings.APPS_DIR).joinpath("./companies/fixtures").glob("fluxIAE_*.csv.gz") if x.is_file()
         ]
         for file in files:
-            shutil.copy(file, data_dir)
+            shutil.copy(file, self.tmp_path)
 
     def test_uncreatable_conventions_for_active_siae_with_active_convention(self):
         siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -71,8 +71,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         cls.mod = None
 
     def test_uncreatable_conventions_for_active_siae_with_active_convention(self):
-        vue_structure_df = get_vue_structure_df()
-        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
@@ -86,8 +85,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SIRET = "26290411300061"
         ASP_ID = 190
 
-        vue_structure_df = get_vue_structure_df()
-        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
@@ -101,8 +99,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SIRET = SIRET_SIGNATURE = "21540323900019"
         ASP_ID = 112
 
-        vue_structure_df = get_vue_structure_df()
-        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
@@ -126,8 +123,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SIRET_SIGNATURE = "34950857200048"
         ASP_ID = 768
 
-        vue_structure_df = get_vue_structure_df()
-        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
@@ -150,8 +146,7 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         SIRET = SIRET_SIGNATURE = "41294123900011"
         ASP_ID = 1780
 
-        vue_structure_df = get_vue_structure_df()
-        siret_to_siae_row = get_siret_to_siae_row(vue_structure_df)
+        siret_to_siae_row = get_siret_to_siae_row(get_vue_structure_df())
         vue_af_df = get_vue_af_df()
         active_siae_keys = get_active_siae_keys(vue_af_df)
 
@@ -247,13 +242,10 @@ class ImportSiaeManagementCommandsTest(TransactionTestCase):
         assert instance.fatal_errors == 0
 
     def test_activate_your_account_email_for_a_siae_without_members_but_with_auth_email(self):
-        vue_structure_df = get_vue_structure_df()
-        vue_af_df = get_vue_af_df()
-
         instance = import_siae.Command()
         instance.create_new_siaes(
-            get_siret_to_siae_row(vue_structure_df),
-            get_active_siae_keys(vue_af_df),
+            get_siret_to_siae_row(get_vue_structure_df()),
+            get_active_siae_keys(get_vue_af_df()),
         )
         assert reverse("signup:company_select") in mail.outbox[0].body
         assert collections.Counter(mail.subject for mail in mail.outbox) == collections.Counter(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -181,12 +181,13 @@ def itou_faker_provider(_session_faker):
 
 
 @pytest.fixture(scope="function")
-def unittest_compatibility(request, faker, pdf_file, snapshot, mocker, xlsx_file):
+def unittest_compatibility(request, faker, pdf_file, snapshot, mocker, xlsx_file, tmp_path):
     request.instance.faker = faker
     request.instance.pdf_file = pdf_file
     request.instance.snapshot = snapshot
     request.instance.mocker = mocker
     request.instance.xlsx_file = xlsx_file
+    request.instance.tmp_path = tmp_path
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Pourquoi ?

Il est possible de recevoir des nouvelles AF alors que la date de fin d’effet est dépassée, hors celles-ci sont actuellement ignorées par le script `import_siae`.

### Comment ? <!-- optionnel -->

- Multiple réusinages du script d'import des SIAE, il est possible que certain commit ne soit pas tout à fait iso-fonctionnel mais la globalité oui.
- Ne plus se limiter à la conversion des structures ayant une AF valide au moment de l'import.
- Nous continuons d'ignorer les nouvelles structures non-valide car cela en aurais recréé tout un tas dont on se fiche car n'existant plus physiquement.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
