### PR TITLE
Makefile: ajout d'une cible fast_fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,13 +52,15 @@ quality: $(VENV_REQUIREMENT)
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
 	python manage.py makemigrations --check --dry-run --noinput || (echo "⚠ Missing migration ⚠"; exit 1)
 
-fix: $(VENV_REQUIREMENT)
+fast_fix: $(VENV_REQUIREMENT)
 	black $(LINTER_CHECKED_DIRS)
 	ruff check --fix $(LINTER_CHECKED_DIRS)
-	djlint --reformat itou
 	# Use || true because `git apply` exit with an error ("error: unrecognized input") when the pipe is empty,
 	# this happens when there is nothing to fix or shellcheck can't propose a fix.
 	find * -type f -name '*.sh' -exec shellcheck --external-sources --format=diff {} + | git apply || true
+
+fix: fast_fix
+	djlint --reformat itou
 
 # Django.
 # =============================================================================


### PR DESCRIPTION
### Pourquoi ?

Souvent, on n'a pas touché aux templates Django et appeler djlint n'est pas nécessaire: autant gagner 10 secondes.

```
❯ time make fix
black config itou tests
All done! ✨ 🍰 ✨
938 files left unchanged.
ruff check --fix config itou tests
# Use || true because `git apply` exit with an error ("error: unrecognized input") when the pipe is empty,
# this happens when there is nothing to fix or shellcheck can't propose a fix.  
find * -type f -name '*.sh' -exec shellcheck --external-sources --format=diff {} + | git apply || true
error: No valid patches in input (allow with "--allow-empty")
djlint --reformat itou

Reformatting 322/322 files ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 00:09    
0 files were updated.                                                                                                  

real    0m10,112s
user    1m33,567s
sys     0m1,980s
```
vs
```
❯ time make fast_fix 
black config itou tests
All done! ✨ 🍰 ✨
938 files left unchanged.
ruff check --fix config itou tests
# Use || true because `git apply` exit with an error ("error: unrecognized input") when the pipe is empty,
# this happens when there is nothing to fix or shellcheck can't propose a fix.
find * -type f -name '*.sh' -exec shellcheck --external-sources --format=diff {} + | git apply || true
error: No valid patches in input (allow with "--allow-empty")

real    0m0,758s
user    0m0,642s
sys     0m0,134s
```

Et voir le commit de @rsebille https://github.com/gip-inclusion/les-emplois/pull/3625/commits/75a5503ea5f575de0b64abd36834ff2e07bed496 m'a fait me dire que je n'étais peut-être pas le seul à souffrir de cela :sweat_smile: .
