### PR TITLE
Confirmation d'embauche: réduction du nombre de requêtes

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -1514,7 +1514,9 @@ def geiq_eligibility_criteria_for_hire(request, company_pk, job_seeker_pk):
 @login_required
 def hire_confirmation(request, company_pk, job_seeker_pk, template_name="apply/submit/hire_confirmation.html"):
     company = get_object_or_404(Company.objects.member_required(request.user), pk=company_pk)
-    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), pk=job_seeker_pk)
+    job_seeker = get_object_or_404(
+        User.objects.filter(kind=UserKind.JOB_SEEKER).select_related("jobseeker_profile"), pk=job_seeker_pk
+    )
     if company.kind == CompanyKind.GEIQ:
         geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(job_seeker, company).first()
         eligibility_diagnosis = None

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -1524,6 +1524,9 @@ def hire_confirmation(request, company_pk, job_seeker_pk, template_name="apply/s
         _check_job_seeker_approval(request, job_seeker, company)
         # General IAE eligibility case
         eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(job_seeker, for_siae=company)
+        if eligibility_diagnosis is not None:
+            # The job_seeker object already contains a lot of information: no need to re-retrieve it
+            eligibility_diagnosis.job_seeker = job_seeker
         geiq_eligibility_diagnosis = None
     return common_views._accept(
         request,

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4066,7 +4066,6 @@ class HireConfirmationTestCase(TestCase):
             + 1  # get company infos (get_object_or_404)
             + 1  # get job seeker infos (get_object_or_404)
             + 1  # get approvals (_check_job_seeker_approval -> has_valid_diagnosis)
-            + 1  # get jobseekerprofile to retrieve pole_emploi_id
             + 1  # get approvals_poleemploiapproval (has_valid_common_approval)
             + 1  # eligibility_eligibilitydiagnosis (_check_job_seeker_approval -> last_considered_valid)
             + 1  # eligibility_eligibilitydiagnosis (EligibilityDiagnosis.objects.last_considered_valid)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4072,10 +4072,6 @@ class HireConfirmationTestCase(TestCase):
             + 1  # cities_city (UserAddressForm)
             + 1  # companies_jobdescription (AcceptForm.__init__)
             + 1  # eligibility_administrativecriteria (/apply/includes/eligibility_diagnosis.html)
-            + 1  # users_user (apply/includes/eligibility_diagnosis.html -> considered_to_expire_at)
-            + 1  # approvals_approval (apply/includes/eligibility_diagnosis.html -> considered_to_expire_at)
-            + 1  # get jobseekerprofile to retrieve pole_emploi_id
-            + 1  # approvals_poleemploiapproval (apply/includes/eligibility_diagnosis.html -> considered_to_expire_at)
             + 3  # update session with savepoint & release
         ):
             response = self.client.get(self._reverse("apply:hire_confirmation"))


### PR DESCRIPTION
### Pourquoi ?

Pour soulager Postgresql et que les pages s'affichent quelques millisecondes plus vite :dash: 
