### PR TITLE
[GEN-8058] Retirer le NIR de l’API GEIQ

### DIFF
--- a/itou/api/geiq/serializers.py
+++ b/itou/api/geiq/serializers.py
@@ -223,7 +223,6 @@ class GeiqJobApplicationSerializer(serializers.ModelSerializer):
     id_embauche = serializers.UUIDField(source="pk")
     id_utilisateur = serializers.UUIDField(source="job_seeker.public_id")
     siret_employeur = serializers.CharField(source="to_company.siret")
-    nir = serializers.CharField(source="job_seeker.jobseeker_profile.nir")
     nom = serializers.CharField(source="job_seeker.last_name")
     prenom = serializers.CharField(source="job_seeker.first_name")
     date_naissance = serializers.DateField(source="job_seeker.birthdate")
@@ -260,7 +259,6 @@ class GeiqJobApplicationSerializer(serializers.ModelSerializer):
             "id_embauche",
             "id_utilisateur",
             "siret_employeur",
-            "nir",
             "nom",
             "prenom",
             "date_naissance",

--- a/tests/api/__snapshots__/test_geiq.ambr
+++ b/tests/api/__snapshots__/test_geiq.ambr
@@ -103,7 +103,6 @@
           }),
         ]),
         'nb_heures_formation': 1664,
-        'nir': '290010101010125',
         'niveau_formation': 'N3',
         'niveau_qualification': 'SQ',
         'nom': 'Dupont',
@@ -142,7 +141,6 @@
         'mises_en_situation_pro': list([
         ]),
         'nb_heures_formation': 12,
-        'nir': '290010101010125',
         'niveau_formation': 'N3',
         'niveau_qualification': 'N3',
         'nom': 'Dupont',


### PR DESCRIPTION
### Pourquoi ?

Légal, demande métier.
