### PR TITLE
Charger les <script>s des gabarits parents

### DIFF
--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -131,6 +131,7 @@
 {% endblock %}
 
 {% block script %}
+    {{ block.super }}
     <script src="{% static 'js/split_nir.js' %}"></script>
     {% if preview_mode %}
         {# Show the confirmation modal after submitting the form. #}

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -90,6 +90,7 @@
 {% endblock %}
 
 {% block script %}
+    {{ block.super }}
     <script src="{% static 'js/split_nir.js' %}"></script>
     {% if preview_mode %}
         {# Show the confirmation modal after submitting the form. #}

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -97,6 +97,7 @@
 {% endblock %}
 
 {% block script %}
+    {{ block.super }}
     <script nonce="{{ CSP_NONCE }}">
         document.getElementById("printButton").addEventListener("click", function print() {
             window.print();

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -63,5 +63,6 @@
 {% endblock %}
 
 {% block script %}
+    {{ block.super }}
     <script src="{% static 'js/split_nir.js' %}"></script>
 {% endblock script %}


### PR DESCRIPTION
### Pourquoi ?

https://itou.sentry.io/issues/4953055957/ est en train de dévorer notre quota d’erreurs.
