### PR TITLE
Retirer une surcharge de bloc script inutilisée

### DIFF
--- a/itou/templates/approvals/pe_approval_search_user.html
+++ b/itou/templates/approvals/pe_approval_search_user.html
@@ -38,5 +38,3 @@
         </div>
     </section>
 {% endblock %}
-
-{% block script %}{{ block.super }}{% endblock %}


### PR DESCRIPTION
### Pourquoi ?

Ne sert à rien.
