### PR TITLE
[GEN-8064] Gérer les membres ITOU se connectant avec FT connect

### DIFF
--- a/itou/openid_connect/pe_connect/views.py
+++ b/itou/openid_connect/pe_connect/views.py
@@ -132,6 +132,9 @@ def pe_connect_callback(request):
             UserKind.PRESCRIBER: reverse("login:prescriber"),
             UserKind.EMPLOYER: reverse("login:employer"),
             UserKind.LABOR_INSPECTOR: reverse("login:labor_inspector"),
+            # Staff members may have created a job seeker account with the same email
+            # as their staff email on the platform for troubleshooting.
+            UserKind.ITOU_STAFF: reverse("login:job_seeker"),
         }[e.user.kind]
         return HttpResponseRedirect(url)
     except MultipleUsersFoundException as e:


### PR DESCRIPTION
### Pourquoi ?

Pôle emploi Connect a été cassé ce matin. Une fois le fix déployé (https://github.com/gip-inclusion/itou-secrets/pull/69), la connexion candidat avec mon compte francetravail.fr affichait une erreur 500. Il a fallu plusieurs minutes (stressantes) pour que l’erreur remonte dans Sentry et que je réalise que la connexion était bien réparée, sauf pour moi.
