### PR TITLE
Stats : Correction d'une erreur pour les `DDETS LOG`

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -445,7 +445,9 @@ def render_stats_ddets(request, page_title, extra_context, extend_stats_to_whole
         "department": department,
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(department),
     }
-    context.update(extra_context)
+    if extra_context:
+        context.update(extra_context)
+
     if params is None:
         if extend_stats_to_whole_region:
             params = get_params_for_region(region)
@@ -455,10 +457,6 @@ def render_stats_ddets(request, page_title, extra_context, extend_stats_to_whole
 
 
 def render_stats_ddets_iae(request, page_title, extra_context=None, extend_stats_to_whole_region=False, params=None):
-    if extra_context is None:
-        # Do not use mutable default arguments,
-        # see https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/
-        extra_context = {}
     get_current_institution_or_404(request)
     if not utils.can_view_stats_ddets_iae(request):
         raise PermissionDenied

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -216,7 +216,6 @@ def test_stats_ddets_iae_log_visit(client, settings, view_name):
     )
 
 
-@pytest.mark.xfail
 @freeze_time("2023-03-10")
 @override_settings(METABASE_SITE_URL="http://metabase.fake", METABASE_SECRET_KEY="foobar")
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Pourquoi ?

[LES-EMPLOIS-PROD-1DT](https://itou.sentry.io/issues/4706530465/)

### Comment ? <!-- optionnel -->

Les tests sont _fortement_ dupliqués, mais c'est à l’instar du code j'ai envie de dire ;).
C'est clairement factorisable mais il faudrait le faire en même temps que le code associé afin d'éviter d'avoir des tests ultra-génériques alors que le code ne l'est pas et se retrouver avec des exceptions à gérer.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
