### PR TITLE
API BAN : Ne pas faire de requête et logué si `API_BAN_BASE_URL` est vide

### DIFF
--- a/itou/utils/apis/geocoding.py
+++ b/itou/utils/apis/geocoding.py
@@ -30,6 +30,10 @@ BATCH_GEOCODE_API_PARAMS = {
 
 
 def call_ban_geocoding_api(address, post_code=None, limit=1):
+    if not settings.API_BAN_BASE_URL:
+        logger.info("API_BAN_BASE_URL is not defined, geocoding will NOT be done")
+        return None
+
     api_url = f"{settings.API_BAN_BASE_URL}/search/"
 
     args = {"q": address, "limit": limit}

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -3,6 +3,7 @@ import io
 import operator
 
 import pytest
+from django.contrib.gis.geos import Point
 from django.core import management
 from freezegun import freeze_time
 
@@ -44,7 +45,20 @@ class TestMoveCompanyData:
         ],
     )
     def test_preserve_to_company_data(self, preserve, predicate):
-        company_1, company_2 = companies_factories.CompanyFactory.create_batch(2, with_informations=True)
+        company_1 = companies_factories.CompanyFactory.create(
+            brand="COMPANY 1",
+            description="COMPANY 1",
+            phone="0000000001",
+            coords=Point(-2.3140436, 47.3618584),
+            geocoding_score=0.1,
+        )
+        company_2 = companies_factories.CompanyFactory.create(
+            brand="COMPANY 2",
+            description="COMPANY 2",
+            phone="0000000002",
+            coords=Point(-2.8186843, 47.657641),
+            geocoding_score=0.2,
+        )
 
         management.call_command(
             "move_company_data",


### PR DESCRIPTION
### Pourquoi ?

Actuellement si `API_BAN_BASE_URL` n'est pas remplis alors on a ce message d'erreur :
> Error while requesting \`None/search/?q=...&limit=1&postcode=...`: Request URL is missing an 'http://' or 'https://' protocol.

Le test est sans rapport, mais celui-ci ayant échoué sur la CI autant s'en occuper tout de suite ;).

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
