### PR TITLE
Makefil: ajout de la cible reset_db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,11 @@ shell_on_postgres_container:
 restore_latest_backup:
 	./scripts/restore_latest_backup.sh $(PGDATABASE)
 
+reset_db:
+	dropdb $(PGDATABASE)
+	createdb $(PGDATABASE)
+	python manage.py migrate
+
 # Deployment
 # =============================================================================
 


### PR DESCRIPTION
### Pourquoi ?

Je fais souvent cet enchaînement de commandes (suivi d'un `make populate_db` dans 90 % des cas) et si c'est également le cas d'autres devs, ça faciliterait l'opération.
