### PR TITLE
[GEN-7871] Autoriser les @francetravail.fr à créer un compte PE

### DIFF
--- a/itou/users/forms.py
+++ b/itou/users/forms.py
@@ -1,6 +1,17 @@
 from django.core.exceptions import ValidationError
 
 from itou.users.models import JobSeekerProfile
+from itou.utils import constants as global_constants
+
+
+def validate_francetravail_email(email):
+    allowed_suffixes = (
+        global_constants.POLE_EMPLOI_EMAIL_SUFFIX,
+        global_constants.FRANCE_TRAVAIL_EMAIL_SUFFIX,
+    )
+    if not email.endswith(allowed_suffixes):
+        raise ValidationError("L'adresse e-mail doit être une adresse Pôle emploi ou France Travail.")
+    return email
 
 
 class JobSeekerProfileFieldsMixin:

--- a/itou/www/invitations_views/forms.py
+++ b/itou/www/invitations_views/forms.py
@@ -6,8 +6,8 @@ from django.forms.models import modelformset_factory
 
 from itou.invitations.models import EmployerInvitation, LaborInspectorInvitation, PrescriberWithOrgInvitation
 from itou.prescribers.enums import PrescriberOrganizationKind
+from itou.users.forms import validate_francetravail_email
 from itou.users.models import User
-from itou.utils import constants as global_constants
 
 
 ########################################################################
@@ -45,11 +45,8 @@ class PrescriberWithOrgInvitationForm(forms.ModelForm):
         email = self.cleaned_data["email"]
 
         self._invited_user_exists_error(email)
-        if self.organization.kind == PrescriberOrganizationKind.PE and not email.endswith(
-            global_constants.POLE_EMPLOI_EMAIL_SUFFIX
-        ):
-            error = forms.ValidationError("L'adresse e-mail doit être une adresse Pôle emploi")
-            self.add_error("email", error)
+        if self.organization.kind == PrescriberOrganizationKind.PE:
+            validate_francetravail_email(email)
         return email
 
     def save(self, *args, **kwargs):

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -10,6 +10,7 @@ from itou.common_apps.address.departments import DEPARTMENTS
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import Title, UserKind
+from itou.users.forms import validate_francetravail_email
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.apis import api_entreprise, geocoding as api_geocoding
@@ -355,7 +356,4 @@ class PrescriberCheckPEemail(forms.Form):
     )
 
     def clean_email(self):
-        email = self.cleaned_data["email"]
-        if not email.endswith(global_constants.POLE_EMPLOI_EMAIL_SUFFIX):
-            raise ValidationError("L'adresse e-mail doit être une adresse Pôle emploi.")
-        return email
+        return validate_francetravail_email(self.cleaned_data["email"])

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 from urllib.parse import urlencode
 
+import pytest
 import respx
 from allauth.account.models import EmailAddress
 from django.conf import settings
@@ -151,11 +152,18 @@ class TestSendPrescriberWithOrgInvitationExceptions(TestCase):
 
 
 class TestPEOrganizationInvitation:
-    def test_successful(self, client):
+    @pytest.mark.parametrize(
+        "suffix",
+        [
+            global_constants.POLE_EMPLOI_EMAIL_SUFFIX,
+            global_constants.FRANCE_TRAVAIL_EMAIL_SUFFIX,
+        ],
+    )
+    def test_successful(self, client, suffix):
         organization = PrescriberPoleEmploiFactory()
         organization.members.add(PrescriberFactory())
         sender = organization.members.first()
-        guest = PrescriberFactory.build(email=f"sabine.lagrange{global_constants.POLE_EMPLOI_EMAIL_SUFFIX}")
+        guest = PrescriberFactory.build(email=f"sabine.lagrange{suffix}")
         post_data = POST_DATA | {
             "form-0-first_name": guest.first_name,
             "form-0-last_name": guest.last_name,
@@ -180,7 +188,8 @@ class TestPEOrganizationInvitation:
         # Make sure form is invalid
         assert not response.context["formset"].is_valid()
         assert (
-            response.context["formset"].errors[0]["email"][0] == "L'adresse e-mail doit être une adresse Pôle emploi"
+            response.context["formset"].errors[0]["email"][0]
+            == "L'adresse e-mail doit être une adresse Pôle emploi ou France Travail."
         )
 
 

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -56,12 +56,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         response = self.client.post(url, data={"kind": UserKind.PRESCRIBER})
         self.assertRedirects(response, reverse("signup:prescriber_check_already_exists"))
 
-    @respx.mock
-    def test_create_user_prescriber_member_of_pole_emploi(self):
-        """
-        Test the creation of a user of type prescriber and his joining to a Pole emploi agency.
-        """
-
+    def _test_create_user_prescriber_member_of(self, suffix):
         organization = PrescriberPoleEmploiFactory()
 
         # Go through each step to ensure session data is recorded properly.
@@ -84,7 +79,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         assert response.status_code == 200
         assert response.context["form"].errors.get("email")
 
-        email = f"athos{global_constants.POLE_EMPLOI_EMAIL_SUFFIX}"
+        email = f"athos{suffix}"
         post_data = {"email": email}
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, reverse("signup:prescriber_pole_emploi_user"))
@@ -143,6 +138,17 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
 
         # No email has been sent to support (validation/refusal of authorisation not needed).
         assert len(mail.outbox) == 0
+
+    @respx.mock
+    def test_create_user_prescriber_member_of_france_travail(self):
+        self._test_create_user_prescriber_member_of(global_constants.FRANCE_TRAVAIL_EMAIL_SUFFIX)
+
+    @respx.mock
+    def test_create_user_prescriber_member_of_pole_emploi(self):
+        """
+        Test the creation of a user of type prescriber and his joining to a Pole emploi agency.
+        """
+        self._test_create_user_prescriber_member_of(global_constants.POLE_EMPLOI_EMAIL_SUFFIX)
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)


### PR DESCRIPTION
### Pourquoi ?

`pole-emploi.fr` → `francetravail.fr`
