### PR TITLE
Parcours d'embauche: suppression d'une section dans la vue d'éligibilité

### DIFF
--- a/itou/templates/apply/submit/eligibility_for_hire.html
+++ b/itou/templates/apply/submit/eligibility_for_hire.html
@@ -1,15 +1,9 @@
 {% extends "apply/submit_base.html" %}
 
-{% block content %}
+{% block content_extend %}
 
     {{ block.super }}
 
-    <section class="s-section">
-        <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12 col-lg-8">{% include "apply/includes/eligibility_section.html" %}</div>
-            </div>
-        </div>
-    </section>
+    {% include "apply/includes/eligibility_section.html" %}
 
 {% endblock %}


### PR DESCRIPTION
### Pourquoi ?

`content_extend` est là pour cela.

Et la première section était de toutes façons vide.

Avant:
![Screenshot 2024-02-15 at 12-34-04 Les emplois de l'inclusion](https://github.com/gip-inclusion/les-emplois/assets/1089744/dce230ef-f818-431e-a82a-00271dee933b)

Après:
![Screenshot 2024-02-15 at 12-41-13 Les emplois de l'inclusion](https://github.com/gip-inclusion/les-emplois/assets/1089744/131c4087-9eac-43ac-8a1b-eb01c0d0b33d)
