### PR TITLE
Correction d'une erreur quand une SIAE sans convention voulais accéder aux interfaces des fiches salarié

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -96,7 +96,7 @@ class JobApplicationInline(ItouStackedInline):
             return "Une fiche salarié existe déjà pour ce candidat"
 
         if not obj.to_company.can_use_employee_record:
-            return "La SIAE n'utilise pas les fiches salarié"
+            return "La SIAE ne peut pas utiliser la gestion des fiches salarié"
 
         if not obj.create_employee_record:
             return "Création désactivée"

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -413,8 +413,7 @@ class Company(AddressMixin, OrganizationAbstract):
         """
         Check if this SIAE can use the employee record app
         """
-        # No need to check if convention is active (done by middleware)
-        return self.kind in self.ASP_EMPLOYEE_RECORD_KINDS
+        return self.kind in self.ASP_EMPLOYEE_RECORD_KINDS and self.convention_id
 
     @property
     def can_upload_prolongation_report(self):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1119,7 +1119,7 @@ class CustomApprovalAdminViewsTest(TestCase):
                 job_application = JobApplicationFactory(with_approval=True, to_company__kind=kind)
                 msg = JobApplicationInline.employee_record_status(job_application)
                 if not job_application.to_company.can_use_employee_record:
-                    assert msg == "La SIAE n'utilise pas les fiches salarié"
+                    assert msg == "La SIAE ne peut pas utiliser la gestion des fiches salarié"
                 else:
                     assert msg == "En attente de création"
 


### PR DESCRIPTION
### Pourquoi ?

[LES-EMPLOIS-PROD-1GH](https://itou.sentry.io/issues/4949320866/) et voir le commit :).

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
