### PR TITLE
Ajout de collapse sur les filtres departments et districts 

### DIFF
--- a/itou/templates/search/includes/siaes_search_filters.html
+++ b/itou/templates/search/includes/siaes_search_filters.html
@@ -14,7 +14,19 @@
             {% if form.departments %}
                 <hr>
                 <fieldset>
-                    {% bootstrap_field form.departments wrapper_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                    <div class="form-group mb-0">
+                        <legend class="has-collapse-caret mb-0"
+                                data-bs-toggle="collapse"
+                                href="#collapse_{{ form.departments.name }}"
+                                role="button"
+                                aria-expanded="{% if form.departments.value %}true{% else %}false{% endif %}"
+                                aria-controls="collapse_{{ form.departments.name }}">
+                            {{ form.departments.label | capfirst }}
+                        </legend>
+                        <div class="collapse mt-3{% if form.departments.value %} show{% endif %}" id="collapse_{{ form.departments.name }}">
+                            {{ form.departments }}
+                        </div>
+                    </div>
                 </fieldset>
             {% endif %}
 
@@ -22,21 +34,57 @@
             {% if form.districts_13 %}
                 <hr>
                 <fieldset>
-                    {% bootstrap_field form.districts_13 wrapper_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                    <div class="form-group mb-0">
+                        <legend class="has-collapse-caret mb-0"
+                                data-bs-toggle="collapse"
+                                href="#collapse_{{ form.districts_13.name }}"
+                                role="button"
+                                aria-expanded="{% if form.districts_13.value %}true{% else %}false{% endif %}"
+                                aria-controls="collapse_{{ form.districts_13.name }}">
+                            {{ form.districts_13.label | capfirst }}
+                        </legend>
+                        <div class="collapse mt-3{% if form.districts_13.value %} show{% endif %}" id="collapse_{{ form.districts_13.name }}">
+                            {{ form.districts_13 }}
+                        </div>
+                    </div>
                 </fieldset>
             {% endif %}
 
             {% if form.districts_69 %}
                 <hr>
                 <fieldset>
-                    {% bootstrap_field form.districts_69 wrapper_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                    <div class="form-group mb-0">
+                        <legend class="has-collapse-caret mb-0"
+                                data-bs-toggle="collapse"
+                                href="#collapse_{{ form.districts_69.name }}"
+                                role="button"
+                                aria-expanded="{% if form.districts_69.value %}true{% else %}false{% endif %}"
+                                aria-controls="collapse_{{ form.districts_69.name }}">
+                            {{ form.districts_69.label | capfirst }}
+                        </legend>
+                        <div class="collapse mt-3{% if form.districts_69.value %} show{% endif %}" id="collapse_{{ form.districts_69.name }}">
+                            {{ form.districts_69 }}
+                        </div>
+                    </div>
                 </fieldset>
             {% endif %}
 
             {% if form.districts_75 %}
                 <hr>
                 <fieldset>
-                    {% bootstrap_field form.districts_75 wrapper_class="form-group mb-0" label_class="d-block font-weight-bold mb-3" %}
+                    <div class="form-group mb-0">
+                        <legend class="has-collapse-caret mb-0"
+                                data-bs-toggle="collapse"
+                                href="#collapse_{{ form.districts_75.name }}"
+                                role="button"
+                                aria-expanded="{% if form.districts_75.value %}true{% else %}false{% endif %}"
+                                aria-controls="collapse_{{ form.districts_75.name }}">
+                            {{ form.districts_75.label | capfirst }}
+                        </legend>
+                        <div class="collapse mt-3{% if form.districts_75.value %} show{% endif %}" id="collapse_{{ form.districts_75.name }}">
+                            {{ form.districts_75 }}
+                        </div>
+                    </div>
                 </fieldset>
             {% endif %}
 


### PR DESCRIPTION
### Pourquoi ?

Besoin de trop scroller pour accéder aux filtres qui ne concernent pas la localisation

### Captures d'écran
Avant
![capture 2024-02-19 à 17 32 44](https://github.com/gip-inclusion/les-emplois/assets/3874024/a733c156-2439-4dc5-acb0-819c05b00651)

Apres
![capture 2024-02-19 à 17 33 18](https://github.com/gip-inclusion/les-emplois/assets/3874024/ac895dff-153a-4e7a-9aff-575b82d1ca5d)


