### PR TITLE
Augmenter le délai avant la suppression automatique d’une entreprise (EA / GEIQ) non référencée [GEN-8073]

### DIFF
--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -201,8 +201,8 @@ def sync_structures(df, source, kinds, build_structure, wet_run=False):
     for siret in deletable_sirets:
         siae = Company.objects.get(siret=siret, kind__in=kinds)
 
-        one_week_ago = timezone.now() - timezone.timedelta(days=7)
-        if siae.source == Company.SOURCE_STAFF_CREATED and siae.created_at >= one_week_ago:
+        three_months_ago = timezone.now() - timezone.timedelta(days=90)
+        if siae.source == Company.SOURCE_STAFF_CREATED and siae.created_at >= three_months_ago:
             # When our staff creates a structure, let's give the user sufficient time to join it before deleting it.
             deletable_skipped_count += 1
             continue


### PR DESCRIPTION
### Pourquoi ?

1 semaine c'est un peu court, l'import SIAE est sur 3 mois alors utilisons la même valeur partout.
Nous avons d'ailleurs récemment eu le cas ou une EA créée par le support c'est retrouvé supprimée avant d'être recrée, ce qui n'est pas ouf-ouf.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
