### PR TITLE
Largueur minimum du dropdown-structure

### DIFF
--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -223,11 +223,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.2.9.zip",
-            "sha256": "61df838f70f212064ace1be79f56b5d93798e6872de37f4a22bc16f715a651a9",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.3.2.zip",
+            "sha256": "9fdff7e7caa31469172671e3428d3bc731899846aca2e11b8e59b2cf5ade451d",
         },
         "extract": {
-            "origin": "itou-theme-1.2.9/dist",
+            "origin": "itou-theme-1.3.2/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
### Pourquoi ?

Parcqu'avec les noms court, le dropdown n'est pas assez large

### Comment ? 

Maj du thème, corrigé dans le css

### Captures d'écran 
Avant
![Untitled](https://github.com/gip-inclusion/les-emplois/assets/3874024/c1376406-9d58-4491-813b-bee8140cc1e8)

Apres
![capture 2024-02-19 à 17 08 22](https://github.com/gip-inclusion/les-emplois/assets/3874024/c046d76b-afde-408c-861a-7d2bef9c8753)
