### PR TITLE
Metabase : Injection de la vue "Financement" du Flux IAE

### DIFF
--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -275,6 +275,11 @@ def anonymize_fluxiae_df(df):
         "salarie_adr_libelle_voie",
         "salarie_adr_cplt_distribution",
         "salarie_adr_qpv_nom",
+        # Sensitive banking information.
+        "iban",  # International Bank Account Number.
+        "bban",  # Basic Bank Account Number.
+        "bic",  # Bank code.
+        "nom_bqe",  # Bank name.
     ]
 
     for column_name in df.columns.tolist():

--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -276,7 +276,6 @@ def anonymize_fluxiae_df(df):
         "salarie_adr_cplt_distribution",
         "salarie_adr_qpv_nom",
         # Sensitive banking information.
-        "iban",  # International Bank Account Number.
         "bban",  # Basic Bank Account Number.
         "bic",  # Bank code.
         "nom_bqe",  # Bank name.

--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -98,6 +98,7 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_Encadrement")
         self.populate_fluxiae_view(vue_name="fluxIAE_EtatMensuelAgregat")
         self.populate_fluxiae_view(vue_name="fluxIAE_EtatMensuelIndiv")
+        self.populate_fluxiae_view(vue_name="fluxIAE_Financement")
         self.populate_fluxiae_view(vue_name="fluxIAE_Formations")
         self.populate_fluxiae_view(vue_name="fluxIAE_Missions")
         self.populate_fluxiae_view(vue_name="fluxIAE_MissionsEtatMensuelIndiv")


### PR DESCRIPTION
### Pourquoi ?

Nos analystes ont besoin des données de financement afin de calculer correctement le nombre de bRSA cible.

Attention certaines données bancaires sensibles sont soigneusement filtrées.

Testé OK en local avec le dernier flux.

Environ 800k lignes et 40 colonnes quand même.