### PR TITLE
[GEN-8105] Revert "Monitor JavaScript errors with Sentry"

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -605,9 +605,6 @@ CSP_SCRIPT_SRC = [
     "'self'",
     "https://stats.inclusion.beta.gouv.fr",
     "*.hotjar.com",
-    # https://docs.sentry.io/platforms/javascript/install/loader/#content-security-policy
-    "https://browser.sentry-cdn.com",
-    "https://js.sentry-cdn.com",
     "https://tally.so",
 ]
 # Some browsers don't seem to fallback on script-src if script-src-elem is not there

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -37,12 +37,6 @@
         <link rel="stylesheet" href="{% static "vendor/jquery-ui/jquery-ui.min.css" %}">
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}">
         <link rel="stylesheet" href="{% static "css/itou.css" %}">
-        {% if not debug %}
-            {# Sentry loader script, dynamically and lazily loads the Sentry SDK on errors. #}
-            {# Served from Sentry CDN to allows dynamic loading. #}
-            {# The script is not necessary for features on the site. #}
-            <script src="https://js.sentry-cdn.com/d6b350eab2a54e5fab388bade8c9bbad.min.js" crossorigin="anonymous"></script>
-        {% endif %}
         {% block extra_head %}{% endblock %}
     </head>
     <body class="{% block body_class %}{% endblock %}">


### PR DESCRIPTION
### Pourquoi ?

This reverts commit 281ef5617c68ac0fb83b007389ad97f9b391f3ad.

Trop d’erreurs reçues par Sentry. Mettons en pause le temps d’investiguer ce qu’on a eu et réduire le nombre d’erreurs rapportées.
