### PR TITLE
Utiliser un tri déterministe pour PoleEmploiApproval.find_for()

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1794,7 +1794,7 @@ class PoleEmploiApprovalManager(models.Manager):
         if not filters:
             return self.none()
         or_filters = functools.reduce(operator.__or__, filters)
-        return self.filter(or_filters).order_by("-start_at")
+        return self.filter(or_filters).order_by("-start_at", "-number")
 
 
 class PoleEmploiApproval(PENotificationMixin, CommonApprovalMixin):


### PR DESCRIPTION
### Pourquoi ?

Test flaky révélant un problème potentiel https://itou-inclusion.slack.com/archives/C0412CTV63D/p1708356006800829
