### PR TITLE
Makefile: Afficher la liste des PR déployées pour `deploy_prod`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,4 +117,5 @@ restore_latest_backup:
 .PHONY: deploy_prod
 deploy_prod:
 	git fetch origin  # Update our local to get the latest `master`
+	@echo "Pull request deployed: https://github.com/gip-inclusion/les-emplois/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+`git log --pretty=format:"%h" origin/master_clever..origin/master | tr "\n" "+"`"
 	git push origin origin/master:master_clever  # Deploy by pushing the latest `master` to `master_clever`


### PR DESCRIPTION
### Pourquoi ?

Ça compte la flemme ? :grin: 

Au dessus de 27 commits GH n'affiche rien mais on a rarement des MEP avec autant de commits :see_no_evil:.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
