### PR TITLE
Fiches salarié : La clé étrangère vers la candidature est obligatoire

### DIFF
--- a/itou/employee_record/migrations/0010_add_asp_measure_to_unique_constraint.py
+++ b/itou/employee_record/migrations/0010_add_asp_measure_to_unique_constraint.py
@@ -7,19 +7,20 @@ def _fill_asp_measure(apps, schema_editor):
     EmployeeRecord = apps.get_model("employee_record", "EmployeeRecord")
     objects_to_migrate = (
         EmployeeRecord.objects.filter(asp_measure=None)
-        .select_related("job_application__to_siae")
-        .only("job_application__to_siae__kind")
+        .select_related("job_application__to_company")
+        .only("job_application__to_company__kind")
     )
 
     batch = []
     for er in objects_to_migrate:
-        er.asp_measure = SiaeMeasure.from_siae_kind(er.job_application.to_siae.kind)
+        er.asp_measure = SiaeMeasure.from_siae_kind(er.job_application.to_company.kind)
         batch.append(er)
     EmployeeRecord.objects.bulk_update(batch, fields=["asp_measure"])
 
 
 class Migration(migrations.Migration):
     dependencies = [
+        ("job_applications", "0019_rename_to_siae_jobapplication_to_company"),
         ("employee_record", "0009_employeerecord_asp_measure"),
     ]
 

--- a/itou/employee_record/migrations/0014_alter_employeerecord_job_application.py
+++ b/itou/employee_record/migrations/0014_alter_employeerecord_job_application.py
@@ -1,0 +1,23 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("job_applications", "0022_jobapplication_diagoriente_invite_sent_at"),
+        ("employee_record", "0013_change_unique_constraint"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="employeerecord",
+            name="job_application",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="employee_record",
+                to="job_applications.jobapplication",
+                verbose_name="candidature / embauche",
+            ),
+        ),
+    ]

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -177,8 +177,7 @@ class EmployeeRecord(ASPExchangeInformation):
     # - Approval
     job_application = models.ForeignKey(
         "job_applications.jobapplication",
-        on_delete=models.SET_NULL,
-        null=True,
+        on_delete=models.RESTRICT,
         verbose_name="candidature / embauche",
         related_name="employee_record",
     )

--- a/tests/employee_record/factories.py
+++ b/tests/employee_record/factories.py
@@ -6,12 +6,20 @@ from itou.asp import models as asp_models
 from itou.employee_record.enums import NotificationStatus, Status
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
 from tests.job_applications.factories import (
+    JobApplicationFactory,
     JobApplicationWithApprovalNotCancellableFactory,
     JobApplicationWithCompleteJobSeekerProfileFactory,
 )
 
 
 class BareEmployeeRecordFactory(factory.django.DjangoModelFactory):
+    job_application = factory.SubFactory(
+        JobApplicationFactory,
+        sender=None,
+        eligibility_diagnosis=None,
+        to_company__with_membership=False,
+        to_company__convention=None,
+    )
     asp_id = factory.Faker("pyint")
     approval_number = factory.Faker("pystr_format", string_format="#" * 12)
 


### PR DESCRIPTION
### Pourquoi ?

Un objet `EmployeeRecord` ne peux pas fonctionner sans `JobApplication` donc autant que le schéma en DB soit cohérent avec la réalité.

```
SELECT COUNT(*) FROM employee_record_employeerecord WHERE job_application_id IS NULL;
 count 
-------
     0
(1 row)
```

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
