### PR TITLE
[DSP] bascule du lien d'aide vers la communaute

### DIFF
--- a/itou/templates/apply/includes/eligibility_section.html
+++ b/itou/templates/apply/includes/eligibility_section.html
@@ -6,7 +6,7 @@
 
     <ol>
         <li>
-            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733750518161--Diagnostic-socio-professionnel-de-référence/" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
+            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
         </li>
         <li>
             Sélectionner le ou les critères administratifs

--- a/itou/templates/apply/submit/application/eligibility.html
+++ b/itou/templates/apply/submit/application/eligibility.html
@@ -55,7 +55,7 @@
                                     Veuillez vous assurer d’avoir réalisé un diagnostic socio-professionnel dans le cadre d'un entretien individuel.
                                     Vous pouvez vous appuyer sur le document
                                     <a class="text-important"
-                                       href="{{ ITOU_HELP_CENTER_URL }}/articles/14733750518161--Diagnostic-socio-professionnel-de-référence/"
+                                       href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
                                        target="_blank"
                                        rel="noreferrer noopener"
                                        aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -140,7 +140,7 @@
                                     <br />
                                     Vous pouvez vous appuyer sur le document
                                     <a class="text-important"
-                                       href="{{ ITOU_HELP_CENTER_URL }}/articles/14733750518161--Diagnostic-socio-professionnel-de-référence/"
+                                       href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
                                        target="_blank"
                                        rel="noreferrer noopener"
                                        aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
@@ -152,7 +152,7 @@
                                     <br />
                                     Vous pouvez vous appuyer sur le document
                                     <a class="text-important"
-                                       href="{{ ITOU_HELP_CENTER_URL }}/articles/14733750518161--Diagnostic-socio-professionnel-de-référence/"
+                                       href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
                                        target="_blank"
                                        rel="noreferrer noopener"
                                        aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.

--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -49,9 +49,7 @@
                     <li class="mb-2">
                         <span class="fs-sm">
                             <i class="ri-award-line ri-lg ri-lg font-weight-normal me-1"></i>
-                            {{ request.current_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733750518161--Diagnostic-socio-professionnel-de-référence/"
-    target="_blank"
-    aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
+                            {{ request.current_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/" target="_blank" aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.
                         </span>
                     </li>
                 </ul>


### PR DESCRIPTION
### Pourquoi ?

Bascule du lien du Diagnostic Socio Professionel :
* source : helpdesk sur zendesk
* destination : communaute inclusion

### Comment ? <!-- optionnel -->

mise à jour des templates

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
