### PR TITLE
Fast machine : Correction suite à l'ajout de "health check"

### DIFF
--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -30,7 +30,7 @@ clever env set ITOU_ENVIRONMENT "FAST-MACHINE" --alias "$APP_NAME"
 clever service link-addon c1-bucket-config --alias "$APP_NAME"
 clever service link-addon c1-deployment-config --alias "$APP_NAME"
 clever service link-addon c1-imports-config --alias "$APP_NAME"
-clever service link-addon c1-prod-database-encrypted  --alias "$APP_NAME"
+clever service link-addon c1-prod-database-encrypted --alias "$APP_NAME"
 clever service link-addon c1-redis --alias "$APP_NAME"
 clever service link-addon c1-s3 --alias "$APP_NAME"
 


### PR DESCRIPTION
### Pourquoi ?

Sinon le déploiement échoue :
[LES-EMPLOIS-FAST-MACHINES-5W](https://itou.sentry.io/issues/5016488044/)
[LES-EMPLOIS-FAST-MACHINES-5X](https://itou.sentry.io/issues/5016512147/)

Ajouter les liens manuellement corrige le problème.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
