### PR TITLE
Ajout d'un message pour prévenir les utilisateurs des changements d'interface

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -7,6 +7,19 @@
 {% block messages %}
     {{ block.super }}
 
+    <div class="alert alert-info alert-dismissible fade show" role="status">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+        <div class="row">
+            <div class="col-auto pe-0">
+                <i class="ri-star-s-line ri-xl text-info"></i>
+            </div>
+            <div class="col pl-0">
+                <p class="fw-bold mb-0">Améliorations en cours sur votre espace</p>
+                <p class="mb-0">Un nouveau design va arriver de façon progressive lors des prochains mois.</p>
+            </div>
+        </div>
+    </div>
+
     {% if user.is_employer and request.current_organization and not request.current_organization.jobs.exists %}
         <div class="alert alert-warning alert-dismissible show" role="status">
             <p class="mb-0">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -7,7 +7,7 @@
 {% block messages %}
     {{ block.super }}
 
-    <div class="alert alert-info alert-dismissible fade show" role="status">
+    <div class="alert alert-info alert-dismissible-once d-none" role="status" id="alertDismissiblOnceUiImprovements">
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
         <div class="row">
             <div class="col-auto pe-0">


### PR DESCRIPTION
### Pourquoi ?

Les changements d'interface peuvent dérouter les utilisateurs.

### Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/7eb19037-b124-4ccf-ba46-cd65aa5ea59e)



### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
