### PR TITLE
Ajout du statut du PASS IAE dans l'export des candidatures (employeurs et prescripteurs)

### DIFF
--- a/itou/job_applications/export.py
+++ b/itou/job_applications/export.py
@@ -100,8 +100,7 @@ def _serialize_job_application(job_application):
     approval_start_date = None
     approval_end_date = None
     approval_state = None
-    if job_seeker.has_valid_common_approval:
-        approval = job_seeker.latest_common_approval
+    if approval := job_seeker.latest_common_approval:
         numero_pass_iae = approval.number
         approval_start_date = approval.start_at
         approval_end_date = approval.end_at

--- a/itou/job_applications/export.py
+++ b/itou/job_applications/export.py
@@ -27,6 +27,7 @@ JOB_APPLICATION_CSV_HEADERS = [
     "Numéro PASS IAE",
     "Début PASS IAE",
     "Fin PASS IAE",
+    "Statut PASS IAE",
 ]
 
 DATE_FMT = "%d/%m/%Y"
@@ -98,11 +99,13 @@ def _serialize_job_application(job_application):
     numero_pass_iae = ""
     approval_start_date = None
     approval_end_date = None
+    approval_state = None
     if job_seeker.has_valid_common_approval:
         approval = job_seeker.latest_common_approval
         numero_pass_iae = approval.number
         approval_start_date = approval.start_at
         approval_end_date = approval.end_at
+        approval_state = approval.get_state_display()
 
     return [
         _resolve_title(job_seeker.title, job_seeker.jobseeker_profile.nir),
@@ -128,6 +131,7 @@ def _serialize_job_application(job_application):
         numero_pass_iae,
         _format_date(approval_start_date),
         _format_date(approval_end_date),
+        approval_state,
     ]
 
 

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1746,6 +1746,7 @@ class JobApplicationXlsxExportTest(TestCase):
                 job_application.approval.number,
                 job_application.approval.start_at.strftime("%d/%m/%Y"),
                 job_application.approval.end_at.strftime("%d/%m/%Y"),
+                "Valide",
             ],
         ]
 
@@ -1785,6 +1786,7 @@ class JobApplicationXlsxExportTest(TestCase):
                 job_application.hiring_end_at.strftime("%d/%m/%Y"),
                 "Candidat non joignable",
                 "oui",
+                "",
                 "",
                 "",
                 "",


### PR DESCRIPTION
### Pourquoi ?

Besoin remonté par les utilisateurs

### Comment ?

Enrichir le tableau excel des candidatures avec la donnée du statut du PASS

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
