### PR TITLE
Préferer des timedelta aux relativedelta dans les tests de PASS

### DIFF
--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -48,8 +48,8 @@ from tests.utils.test import TestCase, assertMessages
 
 class CommonApprovalQuerySetTest(TestCase):
     def test_valid_for_pole_emploi_approval_model(self):
-        start_at = timezone.localdate() - relativedelta(years=1)
-        end_at = start_at + relativedelta(years=1)
+        start_at = timezone.localdate() - datetime.timedelta(days=365)
+        end_at = start_at + datetime.timedelta(days=365)
         PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
 
         start_at = timezone.localdate() - relativedelta(years=5)
@@ -60,8 +60,8 @@ class CommonApprovalQuerySetTest(TestCase):
         assert 1 == PoleEmploiApproval.objects.valid().count()
 
     def test_valid_for_approval_model(self):
-        start_at = timezone.localdate() - relativedelta(years=1)
-        end_at = start_at + relativedelta(years=1)
+        start_at = timezone.localdate() - datetime.timedelta(days=365)
+        end_at = start_at + datetime.timedelta(days=365)
         ApprovalFactory(start_at=start_at, end_at=end_at)
 
         start_at = timezone.localdate() - relativedelta(years=5)

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -1,3 +1,5 @@
+import datetime
+
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from django.utils import timezone
@@ -126,42 +128,42 @@ class TestApprovalsListView:
         company = CompanyFactory(with_membership=True)
 
         expired_approval = ApprovalFactory(
-            start_at=now - relativedelta(years=3),
-            end_at=now - relativedelta(years=1),
+            start_at=now - datetime.timedelta(days=3 * 365),
+            end_at=now - datetime.timedelta(days=365),
             with_jobapplication=True,
             with_jobapplication__to_company=company,
         )
         future_approval = ApprovalFactory(
-            start_at=now + relativedelta(days=1),
+            start_at=now + datetime.timedelta(days=1),
             with_jobapplication=True,
             with_jobapplication__to_company=company,
         )
         valid_approval = ApprovalFactory(
-            start_at=now - relativedelta(years=1),
+            start_at=now - datetime.timedelta(days=365),
             with_jobapplication=True,
             with_jobapplication__to_company=company,
         )
         suspended_approval = ApprovalFactory(
-            start_at=now - relativedelta(years=1),
+            start_at=now - datetime.timedelta(days=365),
             with_jobapplication=True,
             with_jobapplication__to_company=company,
         )
         SuspensionFactory(
             approval=suspended_approval,
-            start_at=now - relativedelta(days=1),
-            end_at=now + relativedelta(days=1),
+            start_at=now - datetime.timedelta(days=1),
+            end_at=now + datetime.timedelta(days=1),
         )
         # Add 2 suspensions on valid approval because it used to cause duplicates
         # when valid and suspended filters were selected
         SuspensionFactory(
             approval=valid_approval,
-            start_at=now - relativedelta(days=10),
-            end_at=now - relativedelta(days=9),
+            start_at=now - datetime.timedelta(days=10),
+            end_at=now - datetime.timedelta(days=9),
         )
         SuspensionFactory(
             approval=valid_approval,
-            start_at=now - relativedelta(days=3),
-            end_at=now - relativedelta(days=2),
+            start_at=now - datetime.timedelta(days=3),
+            end_at=now - datetime.timedelta(days=2),
         )
 
         employer = company.members.first()


### PR DESCRIPTION
### Pourquoi ?

Réparer la branche master pour le 29 février.
