### PR TITLE
Envoi d'un courriel à l'ajout d'un administrateur : réusinage des tests

### DIFF
--- a/itou/templates/common/emails/add_admin_email_body.txt
+++ b/itou/templates/common/emails/add_admin_email_body.txt
@@ -5,14 +5,17 @@
 Vous êtes administrateur d'une structure sur les emplois de l'inclusion
 
 Un administrateur peut ajouter ou retirer :
-- des collaborateurs 
+- des collaborateurs
 - des administrateurs
 
 Structure :
 
 - Nom : {{ structure.display_name }}
 - Type : {{ structure.kind }}
+{# Institutions don't have a contact email address. #}
+{% if structure.email  %}
 - Email de contact : {{ structure.email }}
+{% endif %}
 
 Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs de cette structure sur les emplois de l'inclusion.
 

--- a/itou/templates/common/emails/remove_admin_email_body.txt
+++ b/itou/templates/common/emails/remove_admin_email_body.txt
@@ -8,7 +8,10 @@ Structure :
 
 - Nom : {{ structure.display_name }}
 - Type : {{ structure.kind }}
+{# Institutions don't have a contact email address. #}
+{% if structure.email  %}
 - Email de contact : {{ structure.email }}
+{% endif %}
 
 Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
 

--- a/tests/common_apps/organizations/tests.py
+++ b/tests/common_apps/organizations/tests.py
@@ -1,0 +1,23 @@
+from django.core import mail
+
+
+def assert_set_admin_role__creation(user, organization):
+    # New admin.
+    assert user in organization.active_admin_members
+
+    # The admin should receive a valid email
+    [email] = mail.outbox
+    assert f"[Activation] Vous êtes désormais administrateur de {organization.display_name}" == email.subject
+    assert "Vous êtes administrateur d'une structure sur les emplois de l'inclusion" in email.body
+    assert email.to[0] == user.email
+
+
+def assert_set_admin_role__removal(user, organization):
+    # Admin removal.
+    assert user not in organization.active_admin_members
+
+    # The admin should receive a valid email
+    [email] = mail.outbox
+    assert f"[Désactivation] Vous n'êtes plus administrateur de {organization.display_name}" == email.subject
+    assert "Un administrateur vous a retiré les droits d'administrateur d'une structure" in email.body
+    assert email.to[0] == user.email

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -17,6 +17,7 @@ from itou.utils import constants as global_constants
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_NO_RESULT_MOCK, BAN_GEOCODING_API_RESULT_MOCK
 from itou.www.companies_views import views
 from tests.cities.factories import create_city_vannes
+from tests.common_apps.organizations.tests import assert_set_admin_role__creation, assert_set_admin_role__removal
 from tests.companies.factories import (
     CompanyFactory,
     CompanyMembershipFactory,
@@ -969,14 +970,7 @@ class CompanyAdminMembersManagementTest(TestCase):
         assert response.status_code == 302
 
         company.refresh_from_db()
-        assert guest in company.active_admin_members
-
-        # The admin should receive a valid email
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert f"[Activation] Vous êtes désormais administrateur de {company.display_name}" == email.subject
-        assert "Vous êtes administrateur d'une structure sur les emplois de l'inclusion" in email.body
-        assert email.to[0] == guest.email
+        assert_set_admin_role__creation(user=guest, organization=company)
 
     def test_remove_admin(self):
         """
@@ -1003,14 +997,7 @@ class CompanyAdminMembersManagementTest(TestCase):
         assert response.status_code == 302
 
         company.refresh_from_db()
-        assert guest not in company.active_admin_members
-
-        # The admin should receive a valid email
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert f"[Désactivation] Vous n'êtes plus administrateur de {company.display_name}" == email.subject
-        assert "Un administrateur vous a retiré les droits d'administrateur d'une structure" in email.body
-        assert email.to[0] == guest.email
+        assert_set_admin_role__removal(user=guest, organization=company)
 
     def test_admin_management_permissions(self):
         """

--- a/tests/www/prescribers_views/test_admins.py
+++ b/tests/www/prescribers_views/test_admins.py
@@ -1,8 +1,8 @@
 import pytest
-from django.core import mail
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 
+from tests.common_apps.organizations.tests import assert_set_admin_role__creation, assert_set_admin_role__removal
 from tests.prescribers.factories import PrescriberOrganizationWith2MembershipFactory
 from tests.utils.test import TestCase
 
@@ -28,14 +28,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         assert response.status_code == 302
 
         organization.refresh_from_db()
-        assert guest in organization.active_admin_members
-
-        # The admin should receive a valid email
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert f"[Activation] Vous êtes désormais administrateur de {organization.display_name}" == email.subject
-        assert "Vous êtes administrateur d'une structure sur les emplois de l'inclusion" in email.body
-        assert email.to[0] == guest.email
+        assert_set_admin_role__creation(user=guest, organization=organization)
 
     def test_remove_admin(self):
         """
@@ -62,14 +55,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         assert response.status_code == 302
 
         organization.refresh_from_db()
-        assert guest not in organization.active_admin_members
-
-        # The admin should receive a valid email
-        assert len(mail.outbox) == 1
-        email = mail.outbox[0]
-        assert f"[Désactivation] Vous n'êtes plus administrateur de {organization.display_name}" == email.subject
-        assert "Un administrateur vous a retiré les droits d'administrateur d'une structure" in email.body
-        assert email.to[0] == guest.email
+        assert_set_admin_role__removal(user=guest, organization=organization)
 
     def test_admin_management_permissions(self):
         """


### PR DESCRIPTION
En préparation de la suite. Antoine prend le relais.
Au passage, correction d'une variable manquante : affichage de « e-mail de contact : {{ email }} » uniquement si la structure en a bien un.