### PR TITLE
Suppression du parcours de bienvenue systématique dans la démo et les recettes jetables

### DIFF
--- a/itou/fixtures/django/05_test_users.json
+++ b/itou/fixtures/django/05_test_users.json
@@ -312,7 +312,7 @@
       "geocoding_score": null,
       "geocoding_updated_at": null,
       "groups": [],
-      "has_completed_welcoming_tour": false,
+      "has_completed_welcoming_tour": true,
       "identity_provider": "IC",
       "is_active": true,
       "is_staff": false,

--- a/itou/users/adapter.py
+++ b/itou/users/adapter.py
@@ -26,9 +26,7 @@ class UserAdapter(DefaultAccountAdapter):
 
     def get_login_redirect_url(self, request):
         url = reverse("dashboard:index")
-        # In demo, false accounts are used by many different persons but never recreated.
-        # The welcoming tour should show up anyway.
-        if not request.user.has_completed_welcoming_tour or settings.ITOU_ENVIRONMENT == "DEMO":
+        if not request.user.has_completed_welcoming_tour:
             url = reverse("welcoming_tour:index")
         return url
 


### PR DESCRIPTION
### Pourquoi ?

Conserver la même règle qu'en production.