### PR TITLE
Pilotage : Modifier un intitulé de TB privé des SIAE [GEN-8137]

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -28,7 +28,7 @@
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_siae_hiring' %}" class="btn-link btn-ico">
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
-                            <span>Voir les données de candidatures de mes structures</span>
+                            <span>Suivre le traitement et les résultats des candidatures reçues par ma structure - vision mensuelle</span>
                         </a>
                     </li>
                     <li class="d-flex justify-content-between align-items-center mb-3">

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -298,7 +298,10 @@ class DashboardViewTest(TestCase):
         membership = CompanyMembershipFactory()
         self.client.force_login(membership.user)
         response = self.client.get(reverse("dashboard:index"))
-        self.assertContains(response, "Voir les données de candidatures de mes structures")
+        self.assertContains(
+            response,
+            "Suivre le traitement et les résultats des candidatures reçues par ma structure - vision mensuelle",
+        )
         self.assertContains(response, reverse("stats:stats_siae_hiring"))
         self.assertContains(response, "Focus auto-prescription")
         self.assertContains(response, reverse("stats:stats_siae_auto_prescription"))


### PR DESCRIPTION
### Pourquoi ?

Intitulé qui prête à confusion

### Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/436f68a4-1837-4475-a674-d3cfda12a22b)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
