### PR TITLE
Améliorer le comportement responsif du placeholder select2 sur la recherche

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -49,6 +49,11 @@
     }
 }
 
+.input-group-search .select2-selection__rendered {
+    white-space: nowrap !important;
+}
+
+
 .input-group-search .select2-container--bootstrap-5 .select2-selection--single {
     border-left: 0 !important;
 }

--- a/itou/templates/search/includes/prescribers_search_form.html
+++ b/itou/templates/search/includes/prescribers_search_form.html
@@ -11,9 +11,9 @@
             </div>
             {{ form.city }}
             <div class="input-group-text bg-white p-0">
-                <button class="btn btn-ico {% if is_home %}btn-primary{% else %}btn-link{% endif %} js-search-button">
+                <button class="btn btn-ico {% if is_home %}btn-primary{% else %}btn-link{% endif %} js-search-button" aria-label="Rechercher un prescripteur">
                     <i class="ri-search-line font-weight-bold" aria-hidden="true"></i>
-                    <span>Rechercher</span>
+                    <span {% if is_home %}class="d-none d-sm-inline-flex me-0 me-sm-1"{% endif %}>Rechercher</span>
                 </button>
             </div>
         </div>

--- a/itou/templates/search/includes/siaes_search_form.html
+++ b/itou/templates/search/includes/siaes_search_form.html
@@ -12,9 +12,9 @@
             </div>
             {{ form.city }}
             <div class="input-group-text bg-white p-0">
-                <button class="btn btn-ico {% if is_home %}btn-primary{% else %}btn-link{% endif %}">
+                <button class="btn btn-ico {% if is_home %}btn-primary{% else %}btn-link{% endif %}" aria-label="Rechercher un emploi inclusif">
                     <i class="ri-search-line font-weight-bold" aria-hidden="true"></i>
-                    <span>Rechercher</span>
+                    <span {% if is_home %}class="d-none d-sm-inline-flex me-0 me-sm-1"{% endif %}>Rechercher</span>
                 </button>
             </div>
         </div>

--- a/itou/www/search/forms.py
+++ b/itou/www/search/forms.py
@@ -36,7 +36,7 @@ class SiaeSearchForm(forms.Form):
                 "class": "form-control",
                 "data-ajax--url": format_lazy("{}?select2=&slug=", reverse_lazy("autocomplete:cities")),
                 "data-minimum-input-length": 2,
-                "data-placeholder": "Un emploi inclusif autour de…",
+                "data-placeholder": "Rechercher un emploi inclusif autour de…",
             }
         ),
     )
@@ -144,7 +144,7 @@ class PrescriberSearchForm(forms.Form):
                 "class": "form-control",
                 "data-ajax--url": format_lazy("{}?select2=&slug=", reverse_lazy("autocomplete:cities")),
                 "data-minimum-input-length": 2,
-                "data-placeholder": "Un prescripteur autour de…",
+                "data-placeholder": "Rechercher un prescripteur autour de…",
             }
         ),
     )

--- a/tests/www/dashboard/__snapshots__/tests.ambr
+++ b/tests/www/dashboard/__snapshots__/tests.ambr
@@ -14,10 +14,10 @@
               <div class="input-group-text bg-white rounded-start ps-3 pe-2">
                   <i aria-hidden="true" class="ri-map-pin-line ri-lg text-disabled"></i>
               </div>
-              <select class="form-control django-select2" data-ajax--url="/autocomplete/cities?select2=&amp;slug=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Un emploi inclusif autour de…" data-theme="bootstrap-5" id="id_city" lang="fr" name="city" required="">
+              <select class="form-control django-select2" data-ajax--url="/autocomplete/cities?select2=&amp;slug=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Rechercher un emploi inclusif autour de…" data-theme="bootstrap-5" id="id_city" lang="fr" name="city" required="">
   </select>
               <div class="input-group-text bg-white p-0">
-                  <button class="btn btn-ico btn-link">
+                  <button aria-label="Rechercher un emploi inclusif" class="btn btn-ico btn-link">
                       <i aria-hidden="true" class="ri-search-line font-weight-bold"></i>
                       <span>Rechercher</span>
                   </button>


### PR DESCRIPTION
### Pourquoi ?

Améliorer le comportement responsif du placeholder sur le `.input-group-search`
Et aussi modifier le texte des placeholder https://www.notion.so/plateforme-inclusion/Remplacer-le-placeholder-du-champs-de-recherche-d-emploi-8afcfe39718a4155b8f7d50fe2dd3db7?pvs=4

### Captures d'écran
Avant
![capture 2024-03-07 à 16 33 57](https://github.com/gip-inclusion/les-emplois/assets/3874024/02ac2963-36b9-405f-8dbe-4506348d586c)
![capture 2024-03-07 à 16 34 23](https://github.com/gip-inclusion/les-emplois/assets/3874024/6f842895-0728-4020-8376-ea747887aa6b)

Apres
![capture 2024-03-07 à 16 35 09](https://github.com/gip-inclusion/les-emplois/assets/3874024/c8612269-3f48-4b02-bf9f-a44244262784)
![capture 2024-03-07 à 16 34 48](https://github.com/gip-inclusion/les-emplois/assets/3874024/63b47a77-f57f-417e-8644-df15db50f4d2)


