### PR TITLE
[API CANDIDATS] Message générique sur la page api 

### DIFF
--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -17,9 +17,23 @@
                                     <p>
                                         Une API (application programming interface ou « interface de programmation d'application ») est une interface logicielle qui permet de « connecter » le site des emplois de l'inclusion à un autre logiciel ou service afin d'échanger des données et des fonctionnalités.
                                     </p>
-                                    <p>
-                                        En tant qu’administrateur des structures suivantes, vous avez accès à l’API Fiches salarié (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/employee-records" target="_blank">voir la documentation ici</a>):
-                                    </p>
+                                    <p>En tant qu’administrateur des structures suivantes, vous avez accès aux API suivantes :</p>
+                                    <ul>
+                                        <li>
+                                            Fiches salarié (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/employee-records" target="_blank">voir la documentation</a>) : cette API est disponible par défaut pour toutes vos structures.
+                                        </li>
+                                        <li>
+                                            Candidats  (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/candidats" target="_blank">voir la documentation</a>) : cette API est disponible par défaut sur une seule structure mais vous pouvez utiliser
+                                            des paramètres pour accéder aux candidats de toutes vos structures.
+                                            <div class="alert alert-warning">
+                                                <p class="mb-0">
+
+                                                    Important : Votre éditeur de logiciel doit filtrer les données par “SIRET” afin qu’elles soient rattachées dans les bonnes structures.
+                                                </p>
+                                            </div>
+                                        </li>
+                                    </ul>
+                                    <p>Listes de vos structures :</p>
                                     <table class="table table-sm">
                                         <thead>
                                             <tr>
@@ -37,7 +51,7 @@
                                         </tbody>
                                     </table>
                                     <p>
-                                        Pour vous connecter à l'API vous devez utiliser l'identifiant "{{ login_string }}" et comme mot de passe le token suivant.
+                                        Pour vous connecter à l’API vous devez utiliser l’identifiant "{{ login_string }}" et comme mot de passe le token suivant.
                                     </p>
                                 </div>
                                 {% if not token %}


### PR DESCRIPTION
### Pourquoi ?

Pour avertir les utilisateurs de l’option multi-structure est disponible

En attente de https://github.com/gip-inclusion/les-emplois/pull/3527

### À vérifier

- [ ] Ajouter l'étiquette « no-changelog » ?
- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
