### PR TITLE
Admin - Fiches salarié : Améliorations rapide suite à la journée d'atelier

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -68,7 +68,7 @@ class JobApplicationInline(ItouStackedInline):
     # there is no direct relation between approvals and employee records
     # (YET...)
     @staticmethod
-    @admin.display(description="fiches salariés")
+    @admin.display(description="situation fiches salariés")
     def employee_record_status(obj):
         if obj.employee_record.exists():
             return mark_safe(

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -99,7 +99,7 @@ class JobApplicationInline(ItouStackedInline):
             return "La SIAE ne peut pas utiliser la gestion des fiches salarié"
 
         if not obj.create_employee_record:
-            return "Création désactivée"
+            return "Non proposé à la création"
 
         if obj.hiring_start_at and obj.hiring_start_at < EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date():
             return "Date de début du contrat avant l'interopérabilité"

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -43,10 +43,6 @@ class EmployeeRecordAdminForm(forms.ModelForm):
 class EmployeeRecordAdmin(ItouModelAdmin):
     form = EmployeeRecordAdminForm
 
-    @admin.action(description="Marquer les fiches salarié selectionnées comme COMPLETÉES")
-    def update_employee_record_as_ready(self, _request, queryset):
-        queryset.update(status=Status.READY)
-
     @admin.action(description="Planifier une notification de changement 'PASS IAE' pour ces fiches salarié")
     def schedule_approval_update_notification(self, request, queryset):
         total_created = 0
@@ -68,7 +64,6 @@ class EmployeeRecordAdmin(ItouModelAdmin):
             messages.success(request, f"{total_updated} notification{s} mise{s} à jour")
 
     actions = [
-        update_employee_record_as_ready,
         schedule_approval_update_notification,
     ]
 

--- a/itou/employee_record/management/commands/employee_records_status.py
+++ b/itou/employee_record/management/commands/employee_records_status.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
                     elif job_application.origin == Origin.AI_STOCK:
                         info = "Import AI"
                     elif not job_application.create_employee_record:
-                        info = "Création désactivée"
+                        info = "Non proposé à la création"
                     elif (
                         job_application.hiring_start_at
                         and job_application.hiring_start_at < EMPLOYEE_RECORD_FEATURE_AVAILABILITY_DATE.date()

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1110,7 +1110,7 @@ class CustomApprovalAdminViewsTest(TestCase):
         # When employee record creation is disabled for that job application
         job_application = JobApplicationFactory(create_employee_record=False)
         msg = JobApplicationInline.employee_record_status(job_application)
-        assert msg == "Création désactivée"
+        assert msg == "Non proposé à la création"
 
         # When hiring start date is before employee record availability date
         job_application = JobApplicationFactory(hiring_start_at="2021-09-26")


### PR DESCRIPTION
### Pourquoi ?

Le 6 mars nous avons commencé l'écriture d'un logigramme afin d'aider à la résolution des cas habituels ou simple pour les fiches salarié, lors de cette journée nous avons eu l'occasion de clarifier des incompréhensions et modifications rapides afin d'améliorer le nommage ou la lisibilité pour éviter des erreurs.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
