### PR TITLE
Augmenter la fréquence d’accès aux APIs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -506,7 +506,7 @@ REST_FRAMEWORK = {
     # - arbitrary values, update should the need arise.
     "DEFAULT_THROTTLE_RATES": {
         "anon": "12/minute",
-        "user": "12/minute",
+        "user": "120/minute",
     },
 }
 

--- a/tests/api/applicants_api/tests.py
+++ b/tests/api/applicants_api/tests.py
@@ -143,7 +143,7 @@ class ApplicantsAPITest(APITestCase):
         user = company.members.first()
         self.client.force_authenticate(user)
         # settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["user"]
-        for _ in range(12):
+        for _ in range(120):
             response = self.client.get(self.URL, format="json")
             assert response.status_code == 200
         response = self.client.get(self.URL, format="json")

--- a/tests/api/siae_api/tests.py
+++ b/tests/api/siae_api/tests.py
@@ -102,3 +102,12 @@ class SiaeAPIFetchListTest(APITestCase):
         body = json.loads(response.content)
         assert body["count"] == 0
         assert response.status_code == 200
+
+    def test_fetch_siae_list_rate_limits(self):
+        query_params = {"code_insee": self.saint_andre.code_insee, "distance_max_km": 100}
+        # Declared in itou.api.siae_api.viewsets.RestrictedUserRateThrottle.
+        for _ in range(12):
+            self.client.get(ENDPOINT_URL, query_params, format="json")
+        response = self.client.get(ENDPOINT_URL, query_params, format="json")
+        # Rate limited.
+        assert response.status_code == 429


### PR DESCRIPTION
### Pourquoi ?

https://plateforme-inclusion.zendesk.com/agent/tickets/11434

Depuis 9a6c142ccb6834fad7ef7f70d5e5e8246d31f7c4, la limite est descendue d’environ 120/minute à 12/minute.

La nouvelle limite pose problème pour GTA, et probablement d’autres clients. Soyons plus permissifs pour garder le fonctionnement des clients intact, mais protégeons nous contre les usages malveillants des données identifiés.
