### PR TITLE
Calculer la durée d’un PASS avec end_at inclusif [GEN-8200]

### DIFF
--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -525,7 +525,7 @@ class ApprovalModelTest(TestCase):
             start_at=datetime.date(2021, 3, 25),
             end_at=datetime.date(2023, 3, 24),
         )
-        assert approval.remainder == datetime.timedelta(days=122)
+        assert approval.remainder == datetime.timedelta(days=123)
 
         # Futur prolongation, adding 4 days to approval.end_date.
         ProlongationFactory(
@@ -548,7 +548,7 @@ class ApprovalModelTest(TestCase):
 
         del approval.remainder
         approval.refresh_from_db()
-        prolonged_remainder = 122 + 4 + 5 + 30
+        prolonged_remainder = 123 + 4 + 5 + 30
         assert approval.remainder == datetime.timedelta(days=prolonged_remainder)
 
         # Past suspension (ignored), adding 5 days to approval.end_date.
@@ -557,7 +557,7 @@ class ApprovalModelTest(TestCase):
             start_at=datetime.date(2021, 3, 25),
             end_at=datetime.date(2021, 3, 30),
         )
-        # Ongoing suspension, adding 30 days to approval.end_date, but only 9 of them remain.
+        # Ongoing suspension, adding 30 days to approval.end_date, but only 10 of them remain.
         SuspensionFactory(
             approval=approval,
             start_at=datetime.date(2022, 11, 1),
@@ -567,7 +567,7 @@ class ApprovalModelTest(TestCase):
         del approval.remainder
         approval.refresh_from_db()
         # Substract to remainder the remaining suspension time
-        assert approval.remainder == datetime.timedelta(days=(prolonged_remainder + 5 + 30 - 9))
+        assert approval.remainder == datetime.timedelta(days=(prolonged_remainder + 5 + 30 - 10))
 
     @freeze_time("2023-04-26")
     def test_remainder_as_date(self):
@@ -732,7 +732,7 @@ class PoleEmploiApprovalModelTest(TestCase):
             start_at=datetime.date(2021, 3, 25),
             end_at=datetime.date(2023, 3, 24),
         )
-        assert pole_emploi_approval.remainder == datetime.timedelta(days=122)
+        assert pole_emploi_approval.remainder == datetime.timedelta(days=123)
 
 
 class PoleEmploiApprovalManagerTest(TestCase):

--- a/tests/www/approvals_views/__snapshots__/test_includes.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_includes.ambr
@@ -208,7 +208,7 @@
           <p class="mb-1">Date de début : 01/01/2000</p>
           <ul class="list-unstyled">
               <li class="h4 mt-4 mb-2">
-                  Nombre de jours restants sur le PASS IAE : 357198 jours
+                  Nombre de jours restants sur le PASS IAE : 357199 jours
                   <i class="ri-information-line ri-xl text-info"
                      data-bs-toggle="tooltip"
                      title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
@@ -274,7 +274,7 @@
           <p class="mb-1">Date de début : 01/01/2000</p>
           <ul class="list-unstyled">
               <li class="h4 mt-4 mb-2">
-                  Nombre de jours restants sur le PASS IAE : 357198 jours
+                  Nombre de jours restants sur le PASS IAE : 357199 jours
                   <i class="ri-information-line ri-xl text-info"
                      data-bs-toggle="tooltip"
                      title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -233,11 +233,11 @@ class TestApprovalsListView:
         )
 
         # Check IAE pass remainder days
-        assertContains(response, "366 jours")
+        assertContains(response, "367 jours")
 
         assertContains(response, "365 jours")
 
-        assertContains(response, "729 jours")
+        assertContains(response, "730 jours")
 
         assertContains(response, "0 jour")
 

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -745,7 +745,7 @@ class DashboardViewTest(TestCase):
         self.assertContains(response, "Numéro de PASS IAE")
         self.assertContains(response, format_approval_number(approval))
         self.assertContains(response, "Date de début : 21/06/2022")
-        self.assertContains(response, "Nombre de jours restants sur le PASS IAE : 82 jours")
+        self.assertContains(response, "Nombre de jours restants sur le PASS IAE : 83 jours")
         self.assertContains(response, "Date de fin prévisionnelle : 06/12/2022")
 
     @override_settings(TALLY_URL="http://tally.fake")


### PR DESCRIPTION
### Pourquoi ?

Afficher 730 jours de validité pour les nouveaux pass.
