### PR TITLE
[GEN-8082] Autocomplétion de l'adresse pour la création d'un candidat

### DIFF
--- a/itou/common_apps/address/forms.py
+++ b/itou/common_apps/address/forms.py
@@ -1,8 +1,14 @@
 import django.forms as forms
+from django.core.exceptions import ValidationError
 from django.urls import reverse_lazy
+from django.utils import timezone
 
 from itou.cities.models import City
+from itou.geo.utils import coords_to_geometry
 from itou.users.models import User
+from itou.utils.apis import geocoding as api_geocoding
+from itou.utils.apis.exceptions import GeocodingDataError
+from itou.utils.widgets import JobSeekerAddressAutocompleteWidget
 
 
 class OptionalAddressFormMixin(forms.Form):
@@ -107,3 +113,132 @@ class MandatoryAddressFormMixin(OptionalAddressFormMixin):
         if self.errors:
             return  # An error here means that some required fields were left blank.
         super().clean()
+
+
+class JobSeekerAddressForm(forms.ModelForm):
+    address_line_1 = forms.CharField(
+        label="Adresse", widget=forms.TextInput(attrs={"placeholder": "102 Quai de Jemmapes"})
+    )
+    address_line_2 = forms.CharField(
+        label="Complément d'adresse", widget=forms.TextInput(attrs={"placeholder": "Appartement 16"}), required=False
+    )
+    post_code = forms.CharField(label="Code postal", widget=forms.TextInput(attrs={"placeholder": "75010"}))
+    insee_code = forms.CharField(widget=forms.HiddenInput(), required=False)
+    ban_api_resolved_address = forms.CharField(widget=forms.HiddenInput(), required=False)
+    fill_mode = forms.CharField(widget=forms.HiddenInput(), required=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        js_handled_fields = [
+            "address_line_1",
+            "address_line_2",
+            "post_code",
+            "city",
+            "insee_code",
+            "ban_api_resolved_address",
+        ]
+
+        for field_name in js_handled_fields:
+            self.fields[field_name].widget.attrs["class"] = f"js-{field_name.replace('_', '-')}"
+            self.fields[field_name].required = False
+
+        initial_data = {}
+
+        # Manage form update/post and creation
+        if "data" in kwargs and kwargs["data"] is not None:
+            initial_data = kwargs["data"]
+        elif "initial" in kwargs and kwargs["initial"] is not None:
+            initial_data = kwargs["initial"]
+
+        self.fields["address_for_autocomplete"] = forms.CharField(
+            label="Adresse",
+            required=True,
+            widget=JobSeekerAddressAutocompleteWidget(initial_data=initial_data, job_seeker=self.instance),
+            initial=0,
+            help_text=(
+                "Si votre adresse ne s’affiche pas, merci de renseigner votre ville uniquement en utilisant "
+                "votre code postal et d’utiliser le Complément d’adresse pour renseigner vos numéro et nom de rue."
+            ),
+        )
+
+    class Meta:
+        model = User
+        fields = [
+            "address_line_1",
+            "address_line_2",
+            "post_code",
+            "city",
+            "ban_api_resolved_address",
+        ]
+
+    def clean_insee_code(self):
+        insee_code = self.cleaned_data["insee_code"]
+        city = None
+
+        if insee_code:
+            try:
+                city = City.objects.get(code_insee=insee_code)
+            except City.DoesNotExist:
+                raise ValidationError("Cette ville n'existe pas dans le référentiel de l'INSEE.")
+
+        if city:
+            self.instance.city = city.name
+            self.instance.insee_city = city
+            self.cleaned_data["city"] = city.name
+
+        return insee_code
+
+    def clean(self):
+        super().clean()
+        address_line_1 = self.cleaned_data.get("address_line_1")
+
+        # Address was filled (manually with fallback or programatically with select2)
+        # the address field should not be required anymore as we don't really use it
+        if address_line_1:
+            if "address_for_autocomplete" in self.errors:
+                del self.errors["address_for_autocomplete"]
+                self.cleaned_data["address_for_autocomplete"] = None
+
+        new_address = self.cleaned_data["ban_api_resolved_address"]
+        fill_mode = self.cleaned_data["fill_mode"]
+
+        address_to_geocode = None
+
+        if fill_mode == "ban_api" and new_address:
+            # If new_address is set the user did a new select2 choice
+
+            self.instance.address_filled_at = timezone.now()
+            self.instance.geocoding_updated_at = timezone.now()
+
+            address_to_geocode = new_address
+        elif fill_mode == "fallback":
+            # we should refill latitude and longitude based on the address provided
+            posted_fields = [
+                self.cleaned_data["address_line_1"],
+                f"{self.cleaned_data['post_code']} {self.cleaned_data['city']}",
+            ]
+            posted_address = ", ".join([field for field in posted_fields if field])
+
+            if posted_address != self.instance.geocoding_address:
+                address_to_geocode = posted_address
+
+        if address_to_geocode is not None:
+            try:
+                geocoding_data = api_geocoding.get_geocoding_data(address_to_geocode)
+
+                if not geocoding_data:
+                    raise ValidationError("Impossible de géolocaliser votre adresse. Veuillez en saisir une autre.")
+            except GeocodingDataError:
+                raise ValidationError(
+                    "Impossible de géolocaliser votre adresse : problème de geométrie. Veuillez en saisir une autre."
+                )
+            else:
+                self.instance.coords = coords_to_geometry(
+                    lat=geocoding_data["latitude"], lon=geocoding_data["longitude"]
+                )
+                self.instance.geocoding_score = geocoding_data["score"]
+
+        if self.cleaned_data["post_code"] is None:
+            self.cleaned_data["post_code"] = ""
+
+        return self.cleaned_data

--- a/itou/static/js/address_autocomplete_fields.js
+++ b/itou/static/js/address_autocomplete_fields.js
@@ -6,7 +6,6 @@ htmx.onLoad(function () {
   let postCodeInput = $("#id_post_code");
   let cityInput = $("#id_city");
   let inseeCodeHiddenInput = $("#id_insee_code");
-  let geocodingScoreHiddenInput = $("#id_geocoding_score");
   let banApiResolvedAddressInput = $("#id_ban_api_resolved_address");
   let fillMode = $("#id_fill_mode");
 
@@ -21,7 +20,6 @@ htmx.onLoad(function () {
     postCodeInput.val(e.params.data.postcode);
     cityInput.val(e.params.data.city);
     inseeCodeHiddenInput.val(e.params.data.citycode);
-    geocodingScoreHiddenInput.val(e.params.data.score);
     banApiResolvedAddressInput.val(e.params.data.label);
     fillMode.val("ban_api");
   });
@@ -72,7 +70,6 @@ htmx.onLoad(function () {
           postCodeInput,
           cityInput,
           inseeCodeHiddenInput,
-          geocodingScoreHiddenInput,
           banApiResolvedAddressInput,
         ];
         fieldstoBeCleaned.forEach((element) => {

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -28,7 +28,15 @@
         {% endif %}
 
         {% if form_user_address %}
-            {% bootstrap_form form_user_address alert_error_type="all" %}
+            {% bootstrap_field form_user_address.address_for_autocomplete %}
+            {% bootstrap_field form_user_address.address_line_1 %}
+            {% bootstrap_field form_user_address.address_line_2 %}
+            {% bootstrap_field form_user_address.post_code %}
+            {% bootstrap_field form_user_address.city %}
+
+            {% bootstrap_field form_user_address.insee_code %}
+            {% bootstrap_field form_user_address.ban_api_resolved_address %}
+            {% bootstrap_field form_user_address.fill_mode %}
         {% endif %}
 
         <hr>

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -88,13 +88,15 @@
                                 <form method="post">
                                     {% csrf_token %}
                                     <fieldset>
+                                        {% bootstrap_field form.address_for_autocomplete %}
                                         {% bootstrap_field form.address_line_1 %}
                                         {% bootstrap_field form.address_line_2 %}
-                                        <div class="form-row">
-                                            {% bootstrap_field form.post_code wrapper_class='form-group col-md-3' %}
-                                            {% bootstrap_field form.city wrapper_class='form-group col-md-9' %}
-                                            {% bootstrap_field form.city_slug %}
-                                        </div>
+                                        {% bootstrap_field form.post_code %}
+                                        {% bootstrap_field form.city %}
+
+                                        {% bootstrap_field form.insee_code %}
+                                        {% bootstrap_field form.ban_api_resolved_address %}
+                                        {% bootstrap_field form.fill_mode %}
                                         {% bootstrap_field form.phone %}
                                     </fieldset>
 
@@ -113,4 +115,10 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {% comment %} Needed for the AddressAutocompleteWidget {% endcomment %}
+    {{ form.media.js }}
 {% endblock %}

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_2.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_2.html
@@ -7,13 +7,20 @@
 {% block form_content %}
     <fieldset>
         <legend class="visually-hidden">Coordonnées du candidat</legend>
+        {% bootstrap_field form.address_for_autocomplete %}
         {% bootstrap_field form.address_line_1 %}
         {% bootstrap_field form.address_line_2 %}
-        <div class="form-row">
-            {% bootstrap_field form.post_code wrapper_class='form-group col-md-3' %}
-            {% bootstrap_field form.city wrapper_class='form-group col-md-9' %}
-            {% bootstrap_field form.city_slug %}
-        </div>
+        {% bootstrap_field form.post_code %}
+        {% bootstrap_field form.city %}
+
+        {% bootstrap_field form.insee_code %}
+        {% bootstrap_field form.ban_api_resolved_address %}
+        {% bootstrap_field form.fill_mode %}
         {% bootstrap_field form.phone %}
     </fieldset>
+{% endblock %}
+{% block script %}
+    {{ block.super }}
+    {% comment %} Needed for the AddressAutocompleteWidget {% endcomment %}
+    {{ form.media.js }}
 {% endblock %}

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -45,4 +45,10 @@
             });
         });
     </script>
+    {{ block.super }}
+
+    {% if form_user_address %}
+        {% comment %} Needed for the AddressAutocompleteWidget {% endcomment %}
+        {{ form_user_address.media.js }}
+    {% endif %}
 {% endblock %}

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -29,7 +29,6 @@
     {% bootstrap_field form.post_code %}
     {% bootstrap_field form.city %}
     {% bootstrap_field form.insee_code %}
-    {% bootstrap_field form.geocoding_score %}
     {% bootstrap_field form.ban_api_resolved_address %}
     {% bootstrap_field form.fill_mode %}
     {% bootstrap_field form.pole_emploi_id %}

--- a/itou/utils/mocks/address_format.py
+++ b/itou/utils/mocks/address_format.py
@@ -318,6 +318,10 @@ for elt in BAN_GEOCODING_API_RESULTS_MOCK:
         RESULTS_BY_BAN_API_RESOLVED_ADDRESS[elt["ban_api_resolved_address"]] = elt
 
 
+def mock_get_first_geocoding_data(_address, **_):
+    return BAN_GEOCODING_API_RESULTS_MOCK[0]
+
+
 def mock_get_geocoding_data(address, **_):
     for result in BAN_GEOCODING_API_RESULTS_MOCK:
         if address.startswith(result["address_line_1"]):

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -615,7 +615,17 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
             k: v
             for k, v in self.job_seeker_session.get("user").items()
             # TODO(xfernandez): remove pole_emploi_id & lack_of_pole_emploi_id_reason in a few weeks
-            if k not in ["city_slug", "lack_of_nir", "pole_emploi_id", "lack_of_pole_emploi_id_reason"]
+            if k
+            not in [
+                "city_slug",
+                "lack_of_nir",
+                "pole_emploi_id",
+                "lack_of_pole_emploi_id_reason",
+                # Address autocomplete fields
+                "fill_mode",
+                "address_for_autocomplete",
+                "insee_code",
+            ]
         }
 
     def _get_profile_data_from_session(self):
@@ -1207,7 +1217,6 @@ class ApplicationEndView(ApplyStepBaseView):
 
 
 class UpdateJobSeekerBaseView(SessionNamespaceRequiredMixin, ApplyStepBaseView):
-
     def __init__(self):
         super().__init__()
         self.job_seeker_session = None
@@ -1461,7 +1470,6 @@ class UpdateJobSeekerStepEndView(UpdateJobSeekerBaseView):
         if self.request.user.can_edit_personal_information(self.job_seeker):
             allowed_user_fields_to_update.extend(CreateOrUpdateJobSeekerStep1Form.Meta.fields)
             allowed_user_fields_to_update.extend(CreateOrUpdateJobSeekerStep2Form.Meta.fields)
-            allowed_user_fields_to_update.remove("city_slug")
 
         for field in allowed_user_fields_to_update:
             if field in self.job_seeker_session.get("user", {}):

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -2,10 +2,8 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.utils import timezone
 
-from itou.cities.models import City
-from itou.common_apps.address.forms import OptionalAddressFormMixin
+from itou.common_apps.address.forms import JobSeekerAddressForm, OptionalAddressFormMixin
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
-from itou.geo.utils import coords_to_geometry
 from itou.job_applications.notifications import (
     NewQualifiedJobAppEmployersNotification,
     NewSpontaneousJobAppEmployersNotification,
@@ -14,9 +12,7 @@ from itou.users.enums import IdentityProvider
 from itou.users.forms import JobSeekerProfileFieldsMixin
 from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
-from itou.utils.apis import geocoding as api_geocoding
-from itou.utils.apis.exceptions import GeocodingDataError
-from itou.utils.widgets import AddressAutocompleteWidget, DuetDatePickerWidget
+from itou.utils.widgets import DuetDatePickerWidget
 
 
 class SSOReadonlyMixin:
@@ -30,149 +26,6 @@ class SSOReadonlyMixin:
             for name in self.fields.keys():
                 if name in disabled_fields:
                     self.fields[name].disabled = True
-
-
-class JobSeekerAddressForm(forms.ModelForm):
-    address_line_1 = forms.CharField(
-        label="Adresse", widget=forms.TextInput(attrs={"placeholder": "102 Quai de Jemmapes"})
-    )
-    address_line_2 = forms.CharField(
-        label="Complément d'adresse", widget=forms.TextInput(attrs={"placeholder": "Appartement 16"}), required=False
-    )
-    post_code = forms.IntegerField(label="Code postal", widget=forms.NumberInput(attrs={"placeholder": "75010"}))
-    insee_code = forms.CharField(widget=forms.HiddenInput(), required=False)
-    latitude = forms.FloatField(widget=forms.HiddenInput(), required=False)
-    longitude = forms.FloatField(widget=forms.HiddenInput(), required=False)
-    geocoding_score = forms.FloatField(widget=forms.HiddenInput(), required=False)
-    ban_api_resolved_address = forms.CharField(widget=forms.HiddenInput(), required=False)
-    fill_mode = forms.CharField(widget=forms.HiddenInput(), required=False)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        js_handled_fields = [
-            "address_line_1",
-            "address_line_2",
-            "post_code",
-            "city",
-            "insee_code",
-            "latitude",
-            "longitude",
-            "geocoding_score",
-            "ban_api_resolved_address",
-        ]
-
-        for field_name in js_handled_fields:
-            self.fields[field_name].widget.attrs["class"] = f"js-{field_name.replace('_', '-')}"
-            self.fields[field_name].required = False
-
-        choices = []
-        address_choice = None
-
-        if kwargs["data"] and "ban_api_resolved_address" in kwargs["data"]:
-            # The user did a select2 choice, we should refill the chosen address if there was a form error
-            address_choice = kwargs["data"]["ban_api_resolved_address"]
-
-        if self.instance and address_choice is None:
-            job_seeker = self.instance
-            if job_seeker.address_line_1:
-                address_choice = job_seeker.geocoding_address
-
-        if address_choice is not None:
-            choices = [(0, address_choice)]
-
-        self.fields["address_for_autocomplete"] = forms.CharField(
-            label="Adresse",
-            required=True,
-            widget=AddressAutocompleteWidget(
-                choices=choices,
-            ),
-            help_text=(
-                "Si votre adresse ne s’affiche pas, merci de renseigner votre ville uniquement en utilisant "
-                "votre code postal et d’utiliser le Complément d’adresse pour renseigner vos numéro et nom de rue."
-            ),
-        )
-
-        if choices:
-            self.initial["address_for_autocomplete"] = 0
-
-    class Meta:
-        model = User
-        fields = [
-            "address_line_1",
-            "address_line_2",
-            "post_code",
-            "city",
-            "geocoding_score",
-            "ban_api_resolved_address",
-        ]
-
-    def clean_insee_code(self):
-        insee_code = self.cleaned_data["insee_code"]
-        city = None
-
-        if insee_code:
-            try:
-                city = City.objects.get(code_insee=insee_code)
-            except City.DoesNotExist:
-                raise ValidationError("Cette ville n'existe pas dans le référentiel de l'INSEE.")
-
-        if city:
-            self.instance.city = city.name
-            self.instance.insee_city = city
-            self.cleaned_data["city"] = city.name
-
-        return insee_code
-
-    def clean(self):
-        super().clean()
-        address_line_1 = self.cleaned_data.get("address_line_1")
-
-        # Address was filled (manually with fallback or programatically with select2)
-        # the address field should not be required anymore as we don't really use it
-        if address_line_1:
-            if "address_for_autocomplete" in self.errors:
-                del self.errors["address_for_autocomplete"]
-                self.cleaned_data["address_for_autocomplete"] = None
-
-        new_address = self.cleaned_data["ban_api_resolved_address"]
-        fill_mode = self.cleaned_data["fill_mode"]
-
-        address_to_geocode = None
-
-        if fill_mode == "ban_api" and new_address:
-            # If new_address is set the user did a new select2 choice
-
-            self.instance.address_filled_at = timezone.now()
-            self.instance.geocoding_updated_at = timezone.now()
-
-            address_to_geocode = new_address
-
-        if fill_mode == "fallback":
-            # we should refill latitude and longitude based on the address provided
-            posted_fields = [
-                self.cleaned_data["address_line_1"],
-                f"{self.cleaned_data['post_code']} {self.cleaned_data['city']}",
-            ]
-            posted_address = ", ".join([field for field in posted_fields if field])
-
-            if posted_address != self.instance.geocoding_address:
-                address_to_geocode = posted_address
-
-        if address_to_geocode is not None:
-            try:
-                geocoding_data = api_geocoding.get_geocoding_data(address_to_geocode)
-            except GeocodingDataError:
-                raise ValidationError("Impossible de géolocaliser votre adresse. Veuillez en saisir une autre.")
-            else:
-                self.instance.coords = coords_to_geometry(
-                    lat=geocoding_data["latitude"], lon=geocoding_data["longitude"]
-                )
-                self.instance.geocoding_score = geocoding_data["score"]
-
-        if self.cleaned_data["post_code"] is None:
-            self.cleaned_data["post_code"] = ""
-
-        return self.cleaned_data
 
 
 class EditJobSeekerInfoForm(

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -139,6 +139,14 @@ class JobSeekerFactory(UserFactory):
             jobseeker_profile__pole_emploi_since=AllocationDuration.MORE_THAN_24_MONTHS,
         )
 
+        with_ban_geoloc_address = factory.Trait(
+            address_line_1="37 B Rue du Général De Gaulle",
+            post_code="67118",
+            city="Geispolsheim",
+            coords="POINT (7.644817 48.515883)",
+            geocoding_score=0.8745736363636364,
+        )
+
     @classmethod
     def _adjust_kwargs(cls, **kwargs):
         # Deactivate automatic creation of JobSeekerProfile in User.save
@@ -170,6 +178,7 @@ class JobSeekerWithAddressFactory(JobSeekerFactory):
             coords=None,
             geocoding_score=None,
         )
+
         for_snapshot = factory.Trait(
             public_id="7614fc4b-aef9-4694-ab17-12324300180a",
             title="MME",

--- a/tests/www/dashboard/__snapshots__/tests.ambr
+++ b/tests/www/dashboard/__snapshots__/tests.ambr
@@ -80,12 +80,6 @@
                                                       
                                                   
                                                       
-                                                  
-                                                      
-                                                  
-                                                      
-                                                  
-                                                      
                                                           <li>
                                                               <strong>Adresse</strong>
                                                           </li>
@@ -140,12 +134,6 @@
                                                           <li>
                                                               <strong>Date de naissance</strong>
                                                           </li>
-                                                      
-                                                  
-                                                      
-                                                  
-                                                      
-                                                  
                                                       
                                                   
                                                       

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -874,7 +874,6 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         self.assertContains(response, 'id="id_post_code"')
         self.assertContains(response, 'id="id_city"')
         self.assertContains(response, 'id="id_insee_code"')
-        self.assertContains(response, 'id="id_geocoding_score"')
         self.assertContains(response, 'id="id_fill_mode"')
         self.assertContains(response, 'id="id_ban_api_resolved_address"')
 


### PR DESCRIPTION
## :thinking: Contexte et problème observé

Maintenant que l'autocomplétion des adresses est possible sur la modification du profil d'un candidat (cf https://github.com/gip-inclusion/les-emplois/pull/3046 ), il est temps de la généraliser à tous les formulaires d'adresse.

Dans cette PR, l'autocomplétion de l'adresse est proposée à la création du candidat.

https://www.notion.so/plateforme-inclusion/Autocomplete-des-adresses-Ajouter-l-autocomplete-dans-le-formulaire-de-cr-ation-du-candidat-9f5f67d17713481bb34767fe0a49dd34?pvs=4

## :cake: Solution

On utilise le même formulaire utilisé pour la modification du candidat.

## :rotating_light:  Points d'attention / Remarques

Du code a été refactoré dans le widget en lui-même pour le rendre réutilisable. Il peut être bon de tester que le fonctionnement attendu lors de la modification de l'adresse du candidat https://github.com/gip-inclusion/les-emplois/pull/3046 fonctionne toujours.

## :desert_island: Comment tester


### Cas numéro 1 - Déclaration d'embauche

- Se connecter avec l'EI
- Déclarer une embauche
- S'assurer que le formulaire d'adresse fonctionne comme souhaité lors de l'étape numéro 2
- Lors de la dernière étape de confirmation d'embauche, vérifier que l'adresse est bien la bonne et la confirmer
Autre possibilité :
- Lors de la dernière étape de confirmation d'embauche, vérifier que changer l'adresse pré-remplie fonctionne correctement

### Cas numéro 2 - Enregistrer une candidature

- Se connecter avec l'EI
- Enregistrer une candidature
- À la fin de l'enregistrement, s'assurer que la modification d'adresse fonctionne comme prévu

