### PR TITLE
Forcer DEBUG=False dans settings.base

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -23,7 +23,7 @@ APPS_DIR = os.path.abspath(os.path.join(ROOT_DIR, "itou"))
 
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
-DEBUG = os.getenv("DJANGO_DEBUG", "False") == "True"
+DEBUG = False
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "inclusion.beta.gouv.fr,emplois.inclusion.beta.gouv.fr").split(",")
 


### PR DESCRIPTION
### Pourquoi ?

On ne veut JAMAIS `DEBUG=True` en prod.
