### PR TITLE
Pilotage : Résolution d'un cas tordu dans les données candidat qui casse la mise à jour quotidienne

### DIFF
--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -171,7 +171,7 @@ def get_birth_month_from_nir(job_seeker):
 def get_job_seeker_qpv_info(job_seeker):
     if not job_seeker.coords:
         return "Adresse non-géolocalisée"
-    elif job_seeker.geocoding_score < BAN_API_RELIANCE_SCORE:
+    elif job_seeker.geocoding_score is not None and job_seeker.geocoding_score < BAN_API_RELIANCE_SCORE:
         return "Adresse imprécise"
     if job_seeker.pk in get_qpv_job_seeker_pks():
         return "Adresse en QPV"

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -170,10 +170,13 @@ def test_populate_job_seekers():
     #  - multiple eligibility diagnosis
     #  - last eligibility diagnosis from an employer
     #  - not an AI
+    #  - outside QPV but missing geocoding score
     user_3 = JobSeekerFactory(
         pk=26587,
         jobseeker_profile__nir="297016314515713",
         with_pole_emploi_id=True,
+        geocoding_score=None,
+        coords=Point(0, 0),  # QPV utils is mocked
     )
     job_application_3 = JobApplicationFactory(
         job_seeker=user_3,
@@ -342,7 +345,7 @@ def test_populate_job_seekers():
             "",
             None,
             None,
-            "Adresse non-géolocalisée",
+            "Adresse hors QPV",
             2,
             2,
             2,


### PR DESCRIPTION
Fil slack ([ici](https://itou-inclusion.slack.com/archives/C050D9JNJ9Z/p1710497031134269?thread_ts=1710448205.410239&cid=C050D9JNJ9Z)).

### Pourquoi ?

La mise à jour quotidienne Metabase casse depuis quelques jours, sur un nouveau cas tordu (coordonnées GPS présentes mais score de géocoding absent).

### Comment ?

A la TDD. En rajoutant un test qui reproduit le souci puis en corrigeant le code.

Preuve (avant rebase) que c'est rouge puis vert :

![image](https://github.com/gip-inclusion/les-emplois/assets/10533583/ddebc7a3-3257-4e6f-9125-44786641a324)
