### PR TITLE
Pilotage : Ajouter un encart “enquête” au dessus des tableaux de bord privés [GEN-8251]

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -4,6 +4,26 @@
 {% block title %}Statistiques et pilotage {{ block.super }}{% endblock %}
 
 {% block content_title %}
+    {% if not is_stats_public %}
+        <div class="alert alert-important" role="status">
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-important"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-2">
+                        <strong>Votre satisfaction et votre avis nous sont précieux !</strong>
+                    </p>
+                    <p class="mb-0">
+                        Jusqu’au 2 avril, prenez part à notre enquête sur l'impact des tableaux de bord dans vos missions et partagez vos suggestions d'amélioration pour les mois à venir.
+                    </p>
+                </div>
+                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                    <a href="https://tally.so/r/3N6WkN" class="btn btn-link btn-sm btn-primary has-external-link" rel="noopener" target="_blank" aria-label="Vous rendre sur l'enquête (ouverture dans un nouvel onglet)">Je donne mon avis</a>
+                </div>
+            </div>
+        </div>
+    {% endif %}
     <h1>{{ page_title }}</h1>
 
     {% if show_siae_evaluation_message %}


### PR DESCRIPTION
### Pourquoi ?

Réalisation d’une enquête auprès des utilisateurs entre le 19 mars et le 2 avril : j’ai besoin de communiquer le plus largement possible sur cette enquête pour avoir le maximum de réponses.

### Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/d9b1c2dd-1575-4c81-a73c-1f6a184f7911)


### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
