### PR TITLE
Retirer pytest-timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,23 +151,6 @@ Lancer un test en particulier :
 pytest itou/utils/tests.py::JSONTest::test_encoder
 ```
 
-### MacOS
-
-Les Mac utilisant l’architecture M1 ont besoin d’émuler le jeu d’instructions
-`amd64`, ce qui rend l’exécution de la suite de test plus longue et peut
-rapidement rencontrer les sécurités (_timeout_) configurées.
-
-Pour éviter ces erreurs,
-[pytest-timeout](https://github.com/pytest-dev/pytest-timeout#usage) propose
-deux options :
-
-1. Définir la variable d’environnement `PYTEST_TIMEOUT`, par exemple à une
-   valeur de `60` secondes.
-2. Utiliser `--timeout` lors de l’invocation de `pytest` :
-    ```sh
-    pytest --timeout 60
-    ```
-
 ## Mettre à jour les dépendances Python
 
 La liste des dépendances est consignée dans les fichiers `requirements/*.in`.

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,5 +13,3 @@ addopts =
     --strict-markers
 markers =
     no_django_db: mark tests that should not be marked with django_db.
-timeout = 30
-timeout_method = thread

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -966,7 +966,9 @@ sqlparse==0.4.4 \
 tablib[html,ods,xls,xlsx,yaml]==3.5.0 \
     --hash=sha256:9821caa9eca6062ff7299fa645e737aecff982e6b2b42046928a6413c8dabfd9 \
     --hash=sha256:f6661dfc45e1d4f51fa8a6239f9c8349380859a5bfaa73280645f046d6c96e33
-    # via django-import-export
+    # via
+    #   django-import-export
+    #   tablib
 tenacity==8.2.3 \
     --hash=sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a \
     --hash=sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -950,7 +950,9 @@ prompt-toolkit==3.0.39 \
 psycopg[binary]==3.1.10 \
     --hash=sha256:15b25741494344c24066dc2479b0f383dd1b82fa5e75612fa4fa5bb30726e9b6 \
     --hash=sha256:8bbeddae5075c7890b2fa3e3553440376d3c5e28418335dee3c3656b06fa2b52
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   psycopg
 psycopg-binary==3.1.10 \
     --hash=sha256:0471869e658d0c6b8c3ed53153794739c18d7dad2dd5b8e6ff023a364c20f7df \
     --hash=sha256:0f062f20256708929a58c41d44f350efced4c00a603323d1413f6dc0b84d95a5 \
@@ -1033,6 +1035,7 @@ pyjwt[crypto]==2.7.0 \
     # via
     #   -r requirements/test.txt
     #   django-allauth
+    #   pyjwt
 pynacl==1.5.0 \
     --hash=sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858 \
     --hash=sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d \
@@ -1066,7 +1069,6 @@ pytest==7.4.4 \
     #   pytest-mock
     #   pytest-randomly
     #   pytest-subtests
-    #   pytest-timeout
     #   pytest-xdist
     #   syrupy
 pytest-django==4.8.0 \
@@ -1084,10 +1086,6 @@ pytest-randomly==3.15.0 \
 pytest-subtests==0.12.1 \
     --hash=sha256:100d9f7eb966fc98efba7026c802812ae327e8b5b37181fb260a2ea93226495c \
     --hash=sha256:d6605dcb88647e0b7c1889d027f8ef1c17d7a2c60927ebfdc09c7b0d8120476d
-    # via -r requirements/test.txt
-pytest-timeout==2.3.1 \
-    --hash=sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9 \
-    --hash=sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e
     # via -r requirements/test.txt
 pytest-xdist==3.5.0 \
     --hash=sha256:cbb36f3d67e0c478baa57fa4edc8843887e0f6cfc42d677530a36d7472b32d8a \
@@ -1469,6 +1467,7 @@ tablib[html,ods,xls,xlsx,yaml]==3.5.0 \
     # via
     #   -r requirements/test.txt
     #   django-import-export
+    #   tablib
 tenacity==8.2.3 \
     --hash=sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a \
     --hash=sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -20,7 +20,6 @@ pytest-django # https://github.com/pytest-dev/pytest-django/
 pytest-mock  # https://github.com/pytest-dev/pytest-mock/
 pytest-randomly  # https://github.com/pytest-dev/pytest-randomly
 pytest-subtests  # https://github.com/pytest-dev/pytest-subtests
-pytest-timeout  # https://github.com/pytest-dev/pytest-timeout
 pytest-xdist  # https://pypi.org/project/pytest-xdist/
 respx  # https://lundberg.github.io/respx/
 syrupy  # https://github.com/tophat/syrupy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -836,7 +836,9 @@ pluggy==1.2.0 \
 psycopg[binary]==3.1.10 \
     --hash=sha256:15b25741494344c24066dc2479b0f383dd1b82fa5e75612fa4fa5bb30726e9b6 \
     --hash=sha256:8bbeddae5075c7890b2fa3e3553440376d3c5e28418335dee3c3656b06fa2b52
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   psycopg
 psycopg-binary==3.1.10 \
     --hash=sha256:0471869e658d0c6b8c3ed53153794739c18d7dad2dd5b8e6ff023a364c20f7df \
     --hash=sha256:0f062f20256708929a58c41d44f350efced4c00a603323d1413f6dc0b84d95a5 \
@@ -907,6 +909,7 @@ pyjwt[crypto]==2.7.0 \
     # via
     #   -r requirements/base.txt
     #   django-allauth
+    #   pyjwt
 pynacl==1.5.0 \
     --hash=sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858 \
     --hash=sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d \
@@ -938,7 +941,6 @@ pytest==7.4.4 \
     #   pytest-mock
     #   pytest-randomly
     #   pytest-subtests
-    #   pytest-timeout
     #   pytest-xdist
     #   syrupy
 pytest-django==4.8.0 \
@@ -956,10 +958,6 @@ pytest-randomly==3.15.0 \
 pytest-subtests==0.12.1 \
     --hash=sha256:100d9f7eb966fc98efba7026c802812ae327e8b5b37181fb260a2ea93226495c \
     --hash=sha256:d6605dcb88647e0b7c1889d027f8ef1c17d7a2c60927ebfdc09c7b0d8120476d
-    # via -r requirements/test.in
-pytest-timeout==2.3.1 \
-    --hash=sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9 \
-    --hash=sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e
     # via -r requirements/test.in
 pytest-xdist==3.5.0 \
     --hash=sha256:cbb36f3d67e0c478baa57fa4edc8843887e0f6cfc42d677530a36d7472b32d8a \
@@ -1330,6 +1328,7 @@ tablib[html,ods,xls,xlsx,yaml]==3.5.0 \
     # via
     #   -r requirements/base.txt
     #   django-import-export
+    #   tablib
 tenacity==8.2.3 \
     --hash=sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a \
     --hash=sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c


### PR DESCRIPTION
### Pourquoi ?

Xavier vient de perdre au moins une journée à cause de `pytest-timeout` qui crashait les workers sur GitHub actions sans information par rapport à un setup trop long.

Nous avons déjà augmenté plusieurs fois les timeouts pour essayer de les faire marcher sur les Macs, finalement c’est à chacun de définir sa limite en fonction de sa machine.

D’autres ont rencontré le problème :
- https://github.com/pytest-dev/pytest-timeout/issues/87
- https://github.com/pytest-dev/pytest-timeout/issues/137

L’investissement dev ne vaut la (faible) sécurité ajoutée.
