### PR TITLE
Admin des profils: ajout de la valeur par défaut dans l'help_text

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -813,6 +813,15 @@ class JobSeekerProfileAdmin(InconsistencyCheckMixin, ItouModelAdmin):
                 search_fields.append("user__last_name")
         return search_fields
 
+    def get_form(self, request, obj=None, **kwargs):
+        if obj:
+            help_texts = kwargs.pop("help_texts", {})
+            default_asp_uid = obj._default_asp_uid()
+            warn = "⚠ " if default_asp_uid != obj.asp_uid else ""
+            help_texts["asp_uid"] = f"{warn}Valeur par défaut: {default_asp_uid}"
+            kwargs.update({"help_texts": help_texts})
+        return super().get_form(request, obj, **kwargs)
+
 
 class EmailAddressWithRemarkAdmin(EmailAddressAdmin):
     inlines = (PkSupportRemarkInline,)

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1013,10 +1013,13 @@ class JobSeekerProfile(models.Model):
                     return True
         return False
 
+    def _default_asp_uid(self):
+        return salted_hmac(key_salt="job_seeker.id", value=self.user_id).hexdigest()[:30]
+
     def save(self, force_insert=False, force_update=False, using=None, update_fields=None):
         self.validate_constraints()
         if not self.asp_uid:
-            self.asp_uid = salted_hmac(key_salt="job_seeker.id", value=self.user_id).hexdigest()[:30]
+            self.asp_uid = self._default_asp_uid()
             if update_fields is not None:
                 update_fields = set(update_fields) | {"asp_uid"}
         if self.pe_obfuscated_nir and self.has_data_changed(["nir"]):

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -496,3 +496,15 @@ def test_change_shows_permission_section_on_staff_users(client):
     assertContains(response, "Permissions")
     assertContains(response, group_permissions_markup)
     assertContains(response, user_permissions_markup)
+
+
+def test_asp_uid_help_text(admin_client):
+    profile = JobSeekerFactory().jobseeker_profile
+    default_asp_uid = profile._default_asp_uid()
+    url = reverse("admin:users_jobseekerprofile_change", kwargs={"object_id": profile.pk})
+    response = admin_client.get(url)
+    assertContains(response, f"<div>Valeur par défaut: {default_asp_uid}")
+    profile.asp_uid = "0" * 12
+    profile.save()
+    response = admin_client.get(url)
+    assertContains(response, f"<div>⚠ Valeur par défaut: {default_asp_uid}")


### PR DESCRIPTION
### Pourquoi ?

Pour facilement identifier les asp_uid modifié manuellement (peut-être d'ailleurs qu'on pourrait se passer de la valeur dans le cas où la valeur par défaut est la bonne).

Cf https://github.com/gip-inclusion/les-emplois/pull/3663#discussion_r1489714429