### PR TITLE
Géocodage : Essayer sans le code postal pour les DROM-COM si la BAN ne retourne aucun résultat

### DIFF
--- a/itou/utils/apis/geocoding.py
+++ b/itou/utils/apis/geocoding.py
@@ -73,6 +73,12 @@ def get_geocoding_data(address, post_code=None, limit=1):
     data = call_ban_geocoding_api(address, post_code=post_code, limit=limit)
 
     if not data:
+        if post_code and post_code[:2] in {"97", "98"}:
+            # Try without `post_code` for DROM-COM as the BAN tends to yield no results with that filter.
+            # Example:
+            # - Saint-Martin, COG 97801, CP 97150
+            # TODO(2024-03-21): See if it's still necessary as a future BAN API could handle those cases.
+            return get_geocoding_data(address, post_code=None, limit=limit)
         raise GeocodingDataError("Empty response from BAN API")
 
     if not data.get("properties"):
@@ -87,7 +93,7 @@ def get_geocoding_data(address, post_code=None, limit=1):
         "number": data["properties"].get("housenumber", None),
         "lane": data["properties"].get("street", None),
         "address": data["properties"]["name"],
-        "post_code": data["properties"]["postcode"],
+        "post_code": data["properties"].get("postcode"),
         "insee_code": data["properties"]["citycode"],
         "city": data["properties"]["city"],
         "longitude": longitude,

--- a/itou/utils/mocks/geocoding.py
+++ b/itou/utils/mocks/geocoding.py
@@ -1,37 +1,40 @@
-"""
-Result for a call to:
-https://api-adresse.data.gouv.fr/search/?q=10+PL+5+MARTYRS+LYCEE+BUFFON&limit=1&postcode=75015
-"""
-
+# https://api-adresse.data.gouv.fr/search/?q=10+PL+5+MARTYRS+LYCEE+BUFFON&limit=1&postcode=75015
 BAN_GEOCODING_API_RESULT_MOCK = {
     "type": "Feature",
     "geometry": {"type": "Point", "coordinates": [2.316754, 48.838411]},
     "properties": {
-        "label": "10 Pl des Cinq Martyrs du Lycee Buffon 75015 Paris",
-        "score": 0.587663373207207,
+        "label": "10 Place des Cinq Martyrs du Lycée Buffon 75015 Paris",
+        "score": 0.5197687103594081,
         "housenumber": "10",
         "id": "75115_2048_00010",
-        "type": "housenumber",
-        "name": "10 Pl des Cinq Martyrs du Lycee Buffon",
+        "name": "10 Place des Cinq Martyrs du Lycée Buffon",
         "postcode": "75015",
         "citycode": "75115",
         "x": 649850.81,
-        "y": 6860034.74,
+        "y": 6860034.75,
         "city": "Paris",
         "district": "Paris 15e Arrondissement",
         "context": "75, Paris, Île-de-France",
-        "importance": 0.6950663360485076,
-        "street": "Pl des Cinq Martyrs du Lycee Buffon",
+        "type": "housenumber",
+        "importance": 0.6942,
+        "street": "Place des Cinq Martyrs du Lycée Buffon",
     },
 }
+BAN_GEOCODING_API_WITH_RESULT_RESPONSE = {
+    "type": "FeatureCollection",
+    "version": "draft",
+    "features": [BAN_GEOCODING_API_RESULT_MOCK],
+    "attribution": "BAN",
+    "licence": "ETALAB-2.0",
+    "query": "10 PL 5 MARTYRS LYCEE BUFFON",
+    "filters": {"postcode": "75015"},
+    "limit": 1,
+}
 
-"""
-Result for a call to:
-https://api-adresse.data.gouv.fr/search/?q=10+PL+5+ANATOLE&limit=1&postcode=75010
-"""
-
+# https://api-adresse.data.gouv.fr/search/?q=10+PL+5+ANATOLE&limit=1&postcode=75010
 BAN_GEOCODING_API_NO_RESULT_MOCK = {
     "type": "FeatureCollection",
+    "version": "draft",
     "features": [],
     "attribution": "BAN",
     "licence": "ETALAB-2.0",

--- a/tests/common_apps/address/tests.py
+++ b/tests/common_apps/address/tests.py
@@ -41,7 +41,7 @@ class UtilsAddressMixinTest(TestCase):
         expected_coords = "SRID=4326;POINT (2.316754 48.838411)"
         expected_latitude = 48.838411
         expected_longitude = 2.316754
-        expected_geocoding_score = 0.587663373207207
+        expected_geocoding_score = 0.5197687103594081
 
         assert prescriber.coords == expected_coords
         assert prescriber.geocoding_score == expected_geocoding_score

--- a/tests/utils/apis/__snapshots__/test_geocoding_api.ambr
+++ b/tests/utils/apis/__snapshots__/test_geocoding_api.ambr
@@ -1,0 +1,14 @@
+# serializer version: 1
+# name: test_get_geocoding_data
+  list([
+  ])
+# ---
+# name: test_get_geocoding_data_error
+  list([
+    tuple(
+      'itou.utils.apis.geocoding',
+      20,
+      'Geocoding error, no result found for `https://geo.foo/search/?q=&limit=1`',
+    ),
+  ])
+# ---

--- a/tests/utils/apis/__snapshots__/test_geocoding_api.ambr
+++ b/tests/utils/apis/__snapshots__/test_geocoding_api.ambr
@@ -12,3 +12,31 @@
     ),
   ])
 # ---
+# name: test_get_geocoding_data_try_without_post_code_if_no_results_for_drom_and_com[97000]
+  list([
+    tuple(
+      'itou.utils.apis.geocoding',
+      20,
+      'Geocoding error, no result found for `https://geo.foo/search/?q=HOWELL+CENTER&limit=1&postcode=97000`',
+    ),
+    tuple(
+      'itou.utils.apis.geocoding',
+      20,
+      'Geocoding error, no result found for `https://geo.foo/search/?q=HOWELL+CENTER&limit=1`',
+    ),
+  ])
+# ---
+# name: test_get_geocoding_data_try_without_post_code_if_no_results_for_drom_and_com[98999]
+  list([
+    tuple(
+      'itou.utils.apis.geocoding',
+      20,
+      'Geocoding error, no result found for `https://geo.foo/search/?q=HOWELL+CENTER&limit=1&postcode=98999`',
+    ),
+    tuple(
+      'itou.utils.apis.geocoding',
+      20,
+      'Geocoding error, no result found for `https://geo.foo/search/?q=HOWELL+CENTER&limit=1`',
+    ),
+  ])
+# ---

--- a/tests/utils/apis/test_geocoding_api.py
+++ b/tests/utils/apis/test_geocoding_api.py
@@ -1,38 +1,37 @@
-from unittest import mock
-
 import pytest
 from django.contrib.gis.geos import GEOSGeometry
 
+from itou.utils.apis import geocoding
 from itou.utils.apis.exceptions import GeocodingDataError
-from itou.utils.apis.geocoding import get_geocoding_data
-from itou.utils.mocks.geocoding import BAN_GEOCODING_API_NO_RESULT_MOCK, BAN_GEOCODING_API_RESULT_MOCK
-from tests.utils.test import TestCase
+from itou.utils.mocks.geocoding import BAN_GEOCODING_API_NO_RESULT_MOCK, BAN_GEOCODING_API_WITH_RESULT_RESPONSE
 
 
-class UtilsGeocodingTest(TestCase):
-    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)
-    def test_get_geocoding_data(self, mock_call_ban_geocoding_api):
-        geocoding_data = mock_call_ban_geocoding_api()
-        result = get_geocoding_data(geocoding_data)
-        # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
-        expected = {
-            "score": 0.587663373207207,
-            "address_line_1": "10 Pl des Cinq Martyrs du Lycee Buffon",
-            "number": "10",
-            "lane": "Pl des Cinq Martyrs du Lycee Buffon",
-            "address": "10 Pl des Cinq Martyrs du Lycee Buffon",
-            "post_code": "75015",
-            "insee_code": "75115",
-            "city": "Paris",
-            "longitude": 2.316754,
-            "latitude": 48.838411,
-            "coords": GEOSGeometry("POINT(2.316754 48.838411)"),
-        }
-        assert result == expected
+def test_get_geocoding_data(caplog, snapshot, respx_mock, settings):
+    settings.API_BAN_BASE_URL = "https://geo.foo"
+    respx_mock.get(f"{settings.API_BAN_BASE_URL}/search/").respond(200, json=BAN_GEOCODING_API_WITH_RESULT_RESPONSE)
 
-    @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_NO_RESULT_MOCK)
-    def test_get_geocoding_data_error(self, mock_call_ban_geocoding_api):
-        geocoding_data = mock_call_ban_geocoding_api()
+    result = geocoding.get_geocoding_data("")
+    # Expected data comes from BAN_GEOCODING_API_RESULT_MOCK.
+    assert result == {
+        "score": 0.5197687103594081,
+        "address_line_1": "10 Place des Cinq Martyrs du Lycée Buffon",
+        "number": "10",
+        "lane": "Place des Cinq Martyrs du Lycée Buffon",
+        "address": "10 Place des Cinq Martyrs du Lycée Buffon",
+        "post_code": "75015",
+        "insee_code": "75115",
+        "city": "Paris",
+        "longitude": 2.316754,
+        "latitude": 48.838411,
+        "coords": GEOSGeometry("POINT(2.316754 48.838411)"),
+    }
+    assert [record for record in caplog.record_tuples if record[0] == geocoding.__name__] == snapshot
 
-        with pytest.raises(GeocodingDataError):
-            get_geocoding_data(geocoding_data)
+
+def test_get_geocoding_data_error(caplog, snapshot, respx_mock, settings):
+    settings.API_BAN_BASE_URL = "https://geo.foo"
+    respx_mock.get(f"{settings.API_BAN_BASE_URL}/search/").respond(200, json=BAN_GEOCODING_API_NO_RESULT_MOCK)
+
+    with pytest.raises(GeocodingDataError):
+        geocoding.get_geocoding_data("")
+    assert [record for record in caplog.record_tuples if record[0] == geocoding.__name__] == snapshot

--- a/tests/utils/apis/test_geocoding_api.py
+++ b/tests/utils/apis/test_geocoding_api.py
@@ -35,3 +35,15 @@ def test_get_geocoding_data_error(caplog, snapshot, respx_mock, settings):
     with pytest.raises(GeocodingDataError):
         geocoding.get_geocoding_data("")
     assert [record for record in caplog.record_tuples if record[0] == geocoding.__name__] == snapshot
+
+
+@pytest.mark.parametrize("post_code", ["97000", "98999"])
+def test_get_geocoding_data_try_without_post_code_if_no_results_for_drom_and_com(
+    caplog, snapshot, respx_mock, settings, post_code
+):
+    settings.API_BAN_BASE_URL = "https://geo.foo"
+    respx_mock.get(f"{settings.API_BAN_BASE_URL}/search/").respond(200, json=BAN_GEOCODING_API_NO_RESULT_MOCK)
+
+    with pytest.raises(GeocodingDataError):
+        geocoding.get_geocoding_data("HOWELL CENTER", post_code=post_code)
+    assert [record for record in caplog.record_tuples if record[0] == geocoding.__name__] == snapshot

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -649,7 +649,7 @@ class CreateCompanyViewTest(TestCase):
         assert new_company.coords == "SRID=4326;POINT (2.316754 48.838411)"
         assert new_company.latitude == 48.838411
         assert new_company.longitude == 2.316754
-        assert new_company.geocoding_score == 0.587663373207207
+        assert new_company.geocoding_score == 0.5197687103594081
 
 
 class EditCompanyViewTest(TestCase):
@@ -745,7 +745,7 @@ class EditCompanyViewTest(TestCase):
         assert company.coords == "SRID=4326;POINT (2.316754 48.838411)"
         assert company.latitude == 48.838411
         assert company.longitude == 2.316754
-        assert company.geocoding_score == 0.587663373207207
+        assert company.geocoding_score == 0.5197687103594081
 
     def test_permission(self):
         company = CompanyFactory(with_membership=True)

--- a/tests/www/prescribers_views/test_edit.py
+++ b/tests/www/prescribers_views/test_edit.py
@@ -73,7 +73,7 @@ class TestEditOrganization:
         assert organization.coords == "SRID=4326;POINT (2.316754 48.838411)"
         assert organization.latitude == 48.838411
         assert organization.longitude == 2.316754
-        assert organization.geocoding_score == 0.587663373207207
+        assert organization.geocoding_score == 0.5197687103594081
 
         # Only admins should be able to edit organization details
         membership = organization.prescribermembership_set.first()


### PR DESCRIPTION
### Pourquoi ?

Adresse d'une SIAE impossible a géocoder avec le filtre `postcode` :
- https://api-adresse.data.gouv.fr/search/?q=HOWELL+CENTER&limit=1&postcode=97150
- https://api-adresse.data.gouv.fr/search/?q=HOWELL+CENTER&limit=1

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
