### PR TITLE
Retirer du CSS inutilisé pour htmx-indicator

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -427,16 +427,6 @@ _:-ms-fullscreen,
     width: 100px;
 }
 
-/* HTMX
---------------------------------------------------------------------------- */
-.htmx-indicator {
-    display: none;
-}
-
-.htmx-request .htmx-indicator {
-    display: inline-block;
-}
-
 /* Inclusion connect
 --------------------------------------------------------------------------- */
 .p-inclusion-connect .s-main {


### PR DESCRIPTION
### Pourquoi ?

Inutilisé depuis 75e01b341f2b8bfbaea26ad9c783aa8c34ee324a.
