### PR TITLE
templates: suppression du type="button" d'une balise <a>

### DIFF
--- a/itou/templates/layout/_header_nav_primary_items.html
+++ b/itou/templates/layout/_header_nav_primary_items.html
@@ -142,7 +142,7 @@
         </li>
     {% else %}
         <li>
-            <a type="button" class="btn btn-ico btn-outline-primary" href="{% url "signup:choose_user_kind" %}">
+            <a class="btn btn-ico btn-outline-primary" href="{% url "signup:choose_user_kind" %}">
                 <i class="ri-user-add-line" aria-hidden="true"></i>
                 <span>S'inscrire</span>
             </a>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -529,7 +529,7 @@
       </li>
       
           <li>
-              <a class="btn btn-ico btn-outline-primary" href="/signup/" type="button">
+              <a class="btn btn-ico btn-outline-primary" href="/signup/">
                   <i aria-hidden="true" class="ri-user-add-line"></i>
                   <span>S'inscrire</span>
               </a>


### PR DESCRIPTION
### Pourquoi ?

cf https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-type