### PR TITLE
`parse_response_to_soup()` : Remplacer également les attributs du nœud parent

### DIFF
--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -82,9 +82,14 @@ def parse_response_to_soup(response, selector=None, no_html_body=False, replace_
         unique_attrs = set([replace_tuple[0] for replace_tuple in replacements])
 
         for attr in unique_attrs:
+            # Search and replace in descendant nodes
             for links in soup.find_all(attrs={attr: True}):
                 for _, from_str, to_str in replacements:
                     links.attrs.update({f"{attr}": links.attrs[attr].replace(from_str, to_str)})
+            # Also replace attributes in the top node
+            if attr in soup.attrs:
+                for _, from_str, to_str in replacements:
+                    soup.attrs.update({f"{attr}": soup.attrs[attr].replace(from_str, to_str)})
     return soup
 
 

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1510,6 +1510,11 @@ class UtilsParseResponseToSoupTest(TestCase):
             "</body></html>"
         )
 
+    def test_replace_in_attr_also_replace_on_current_element(self):
+        response = HttpResponse('<html><head></head><body><form action="foo">bar</form></body></html>')
+        soup = parse_response_to_soup(response, selector="form", replace_in_attr=[("action", "foo", "not foo")])
+        assert str(soup) == '<form action="not foo">bar</form>'
+
 
 @pytest.mark.parametrize("model", site._registry)
 def test_all_admin(admin_client, model):


### PR DESCRIPTION
### Pourquoi ?

Voir le test pour le cas rencontré.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
