### PR TITLE
Augmenter la limite d’appels sur l’API employee_records

### DIFF
--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -18,18 +18,12 @@ logger = logging.getLogger("api_drf")
 
 
 class EmployeeRecordRateThrottle(UserRateThrottle):
-    # Pulled out for testing
     # For the record, we suspect API calls made by GTA software (used by SIAEs)
     # to be a bit excessive for the least.
-    # We will adapt rates if needed.
-    EMPLOYEE_RECORD_API_REQUESTS_NUMBER = 12
-
-    # For all employee record API endpoints
-    rate = f"{EMPLOYEE_RECORD_API_REQUESTS_NUMBER}/min"
+    rate = "60/min"
 
 
 class AbstractEmployeeRecordViewSet(viewsets.ReadOnlyModelViewSet):
-    # Every employee record endpoint is now throttled
     throttle_classes = [EmployeeRecordRateThrottle]
 
     # Possible authentication frameworks:

--- a/tests/api/employee_record_api/test_throttling.py
+++ b/tests/api/employee_record_api/test_throttling.py
@@ -1,43 +1,19 @@
 from django.urls import reverse
 from rest_framework.test import APIClient, APITestCase
 
-from itou.api.employee_record_api.viewsets import EmployeeRecordRateThrottle
 from tests.companies.factories import CompanyFactory
-from tests.users.factories import DEFAULT_PASSWORD
-
-
-ENDPOINT_URL = reverse("v1:employee-records-list")
 
 
 class EmployeeRecordThrottleTest(APITestCase):
-    # This a simple smoke test, goal is *not* testing DRF throttling
-
-    def test_basic_ko_throttling(self):
+    def test_throttling(self):
         client = APIClient()
         user = CompanyFactory(with_membership=True).members.first()
-
-        client.login(username=user.username, password=DEFAULT_PASSWORD)
-
-        response = client.get(ENDPOINT_URL, format="json")
-        assert response.status_code == 200
-
+        client.force_authenticate(user)
+        url = reverse("v1:employee-records-list")
+        # EmployeeRecordRateThrottle.rate
+        for _ in range(60):
+            response = client.get(url, format="json")
+            assert response.status_code == 200
         # Too fast, Jacky, one too many
-        for _ in range(EmployeeRecordRateThrottle.EMPLOYEE_RECORD_API_REQUESTS_NUMBER):
-            response = client.get(ENDPOINT_URL, format="json")
-
+        response = client.get(url, format="json")
         assert response.status_code == 429
-
-    def test_basic_ok_throttling(self):
-        client = APIClient()
-        user = CompanyFactory(with_membership=True).members.first()
-
-        client.login(username=user.username, password=DEFAULT_PASSWORD)
-
-        response = client.get(ENDPOINT_URL, format="json")
-        assert response.status_code == 200
-
-        # Should hold it : a total of EMPLOYEE_RECORD_API_REQUESTS_NUMBER is sent
-        for _ in range(EmployeeRecordRateThrottle.EMPLOYEE_RECORD_API_REQUESTS_NUMBER - 1):
-            response = client.get(ENDPOINT_URL, format="json")
-
-        assert response.status_code == 200


### PR DESCRIPTION
### Pourquoi ?

Retour utilisateurs.
