### PR TITLE
Fiche Salarié : Correction du préremplissage de l'adresse depuis les informations candidats

### DIFF
--- a/itou/asp/fixtures/test_asp_INSEE_communes_factory.json
+++ b/itou/asp/fixtures/test_asp_INSEE_communes_factory.json
@@ -111,6 +111,26 @@
   },
   {
     "model": "asp.Commune",
+    "pk": 47611,
+    "fields": {
+      "code": "58273",
+      "name": "SAUVIGNY-LES-BOIS",
+      "start_date": "1900-01-01",
+      "end_date": "1999-12-31"
+    }
+  },
+  {
+    "model": "asp.Commune",
+    "pk": 47612,
+    "fields": {
+      "code": "58273",
+      "name": "SAUVIGNY-LES-BOIS",
+      "start_date": "2000-01-01",
+      "end_date": null
+    }
+  },
+  {
+    "model": "asp.Commune",
     "pk": 48057,
     "fields": {
       "code": "59183",

--- a/itou/utils/mocks/address_format.py
+++ b/itou/utils/mocks/address_format.py
@@ -3,6 +3,20 @@ import random
 from itou.asp.models import Commune
 
 
+# https://api-adresse.data.gouv.fr/search/?q=42+Rue+du+clos+de+la+Grange%2C+58160+Sauvigny-les-Bois&limit=1
+BAN_GEOCODING_API_RESULTS_FOR_SNAPSHOT_MOCK = {
+    "score": 0.8107390909090908,
+    "address_line_1": "Rue du Clos de la Grange",
+    "number": "42",
+    "lane": "Rue du Clos de la Grange",
+    "address": "Rue du Clos de la Grange",
+    "post_code": "58160",
+    "insee_code": "58273",
+    "city": "Sauvigny-les-Bois",
+    "longitude": 3.271964,
+    "latitude": 46.966611,
+}
+
 BAN_GEOCODING_API_RESULTS_MOCK = [
     {
         "score": 0.8745736363636364,
@@ -293,6 +307,7 @@ BAN_GEOCODING_API_RESULTS_MOCK = [
         "longitude": -1.297749,
         "latitude": 47.012473,
     },
+    BAN_GEOCODING_API_RESULTS_FOR_SNAPSHOT_MOCK,
 ]
 
 # Revert lookup

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -292,12 +292,12 @@ def create_step_2(request, job_application_id, template_name="employee_record/cr
     job_seeker = job_application.job_seeker
     profile = job_seeker.jobseeker_profile
     address_filled = job_seeker.post_code and job_seeker.address_line_1
-    form = NewEmployeeRecordStep2Form(data=request.POST or None, instance=profile)
     query_param = f"?status={request.GET.get('status')}" if request.GET.get("status") else ""
 
     # Perform a geolocation of the user address if possible:
     # - success : prefill form with geolocated data
     # - failure : display actual address and let user fill the form
+    # This need to be done before passing the instance to the form otherwise fields will be shown empty
     if not profile.hexa_address_filled and address_filled:
         try:
             # Attempt to create a job seeker profile with an address prefilled
@@ -307,7 +307,7 @@ def create_step_2(request, job_application_id, template_name="employee_record/cr
             profile.clear_hexa_address()
 
     # At this point, a job seeker profile was created
-
+    form = NewEmployeeRecordStep2Form(data=request.POST or None, instance=profile)
     if request.method == "POST":
         if form.is_valid():
             form.save()

--- a/tests/api/__snapshots__/test_geiq.ambr
+++ b/tests/api/__snapshots__/test_geiq.ambr
@@ -78,10 +78,10 @@
     'previous': None,
     'results': list([
       dict({
-        'adresse_code_postal': '91234',
-        'adresse_ligne_1': 'Rue du clos de la Grange',
+        'adresse_code_postal': '58160',
+        'adresse_ligne_1': '42 Rue du clos de la Grange',
         'adresse_ligne_2': '',
-        'adresse_ville': 'Choufleury',
+        'adresse_ville': 'Sauvigny-les-Bois',
         'auteur_diagnostic': 'GEIQ',
         'civilite': 'F',
         'criteres_eligibilite': list([
@@ -122,10 +122,10 @@
         'type_qualification': 'CQP',
       }),
       dict({
-        'adresse_code_postal': '91234',
-        'adresse_ligne_1': 'Rue du clos de la Grange',
+        'adresse_code_postal': '58160',
+        'adresse_ligne_1': '42 Rue du clos de la Grange',
         'adresse_ligne_2': '',
-        'adresse_ville': 'Choufleury',
+        'adresse_ville': 'Sauvigny-les-Bois',
         'auteur_diagnostic': 'PRESCRIPTEUR',
         'civilite': 'F',
         'criteres_eligibilite': list([

--- a/tests/asp/__snapshots__/test_sync_communes.ambr
+++ b/tests/asp/__snapshots__/test_sync_communes.ambr
@@ -63,6 +63,8 @@
     '\tREMOVED {"code": "37273", "name": "VILLE-AUX-DAMES", "start_date": "2000-01-01", "end_date": null}',
     '\tREMOVED {"code": "41269", "name": "VENDOME", "start_date": "1900-01-01", "end_date": "1999-12-31"}',
     '\tREMOVED {"code": "41269", "name": "VENDOME", "start_date": "2000-01-01", "end_date": null}',
+    '\tREMOVED {"code": "58273", "name": "SAUVIGNY-LES-BOIS", "start_date": "1900-01-01", "end_date": "1999-12-31"}',
+    '\tREMOVED {"code": "58273", "name": "SAUVIGNY-LES-BOIS", "start_date": "2000-01-01", "end_date": null}',
     '\tREMOVED {"code": "59183", "name": "DUNKERQUE", "start_date": "1900-01-01", "end_date": "1999-12-31"}',
     '\tREMOVED {"code": "59183", "name": "DUNKERQUE", "start_date": "2000-01-01", "end_date": null}',
     '\tREMOVED {"code": "59291", "name": "HAUTMONT", "start_date": "1900-01-01", "end_date": "1999-12-31"}',
@@ -102,7 +104,7 @@
     '\tREMOVED {"code": "91432", "name": "MORANGIS", "start_date": "1968-01-01", "end_date": "1999-12-31"}',
     '\tREMOVED {"code": "91432", "name": "MORANGIS", "start_date": "2000-01-01", "end_date": null}',
     '\tREMOVED {"code": "97108", "name": "CAPESTERRE-DE-MARIE-GALANT", "start_date": "1900-01-01", "end_date": null}',
-    '> successfully deleted count=50 communes',
+    '> successfully deleted count=52 communes',
     '> successfully updated count=0 communes',
     '> successfully created count=35 new communes',
   ])

--- a/tests/asp/factories.py
+++ b/tests/asp/factories.py
@@ -14,7 +14,7 @@ from itou.asp import models
 # - `test_asp_INSEE_countries_factory.json`
 # in your Django unit tests (set `fixtures` field).
 
-_COMMUNES_CODES = ["64483", "97108", "97107", "37273", "13200", "67152", "85146"]
+_COMMUNES_CODES = ["64483", "97108", "97107", "37273", "13200", "67152", "85146", "58273"]
 
 _FRANCE_CODES = ["100"]
 _OTHER_FRANCE_CODES = ["714", "737", "812"]

--- a/tests/asp/test_communes.py
+++ b/tests/asp/test_communes.py
@@ -8,7 +8,7 @@ class CommunesFixtureTest(TestCase):
     # INSEE commune with a single entry (1 history entry)
     _CODES_WITHOUT_HISTORY = ["97108", "13200"]
     ## Total number of entries in the file
-    _NUMBER_OF_ENTRIES = 50
+    _NUMBER_OF_ENTRIES = 52
     # No commune registered before this date (end_date)
     _PERIOD_MIN_DATE = datetime.date(1900, 1, 1)
 
@@ -43,7 +43,7 @@ class CommunesFixtureTest(TestCase):
     def test_current_entries(self):
         communes = Commune.objects.filter(end_date__isnull=True)
 
-        assert 26 == communes.count()
+        assert 27 == communes.count()
 
         for commune in communes:
             with self.subTest():

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -177,9 +177,9 @@ class JobSeekerWithAddressFactory(JobSeekerFactory):
             last_name="Dupont",
             birthdate="1990-05-01",
             jobseeker_profile__for_snapshot=True,
-            address_line_1="Rue du clos de la Grange",
-            post_code="91234",
-            city="Choufleury",
+            address_line_1="42 Rue du clos de la Grange",
+            post_code="58160",
+            city="Sauvigny-les-Bois",
         )
 
     address_line_1 = factory.Faker("street_address", locale="fr_FR")
@@ -215,7 +215,7 @@ class JobSeekerWithAddressFactory(JobSeekerFactory):
             # Do nothing
             return
 
-        address = get_random_geocoding_api_result()
+        address = get_random_geocoding_api_result() if extracted is True else extracted
 
         self.address_line_1 = address.get("address_line_1")
         self.post_code = address.get("post_code")

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -1,4 +1,341 @@
 # serializer version: 1
+# name: CreateEmployeeRecordStep2Test.test_job_seeker_address_geolocated
+  '''
+  <form action="/employee_record/create_step_2/[PK of JobApplication]" method="post">
+                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                  <fieldset>
+                      <legend class="h2">Domiciliation du salarié</legend>
+                      <div class="row">
+                          <div class="col-12 col-lg-8">
+                              
+                              <div class="mb-3 mb-md-5">
+                                  <p>
+                                      Merci de bien vouloir vérifier <b>l'adresse qui sera envoyée à l'ASP</b>.
+                                  </p>
+                                  <ul>
+                                      <li>
+                                          Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Suivant»</b> en bas de page.
+                                      </li>
+                                      <li>
+                                          Si elle ne correspond pas, veuillez la modifier à l'aide du formulaire ci-dessous, puis cliquez
+                                          sur le bouton <b>«Valider cette adresse»</b>.
+                                      </li>
+                                  </ul>
+                                  
+                                      <p class="mb-0">
+                                          <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
+                                      </p>
+                                  
+                              </div>
+                          </div>
+                      </div>
+                      <div class="row">
+                          <div class="col-12 col-lg-8">
+                              <div class="form-row">
+                                  <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_lane_number">Numéro</label><input class="form-control" id="id_hexa_lane_number" maxlength="10" name="hexa_lane_number" placeholder="Numéro" type="text"/></div></div>
+                                  <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_std_extension">Extension</label><select class="form-select" id="id_hexa_std_extension" name="hexa_std_extension">
+    <option selected="" value="">---------</option>
+  
+    <option value="B">Bis</option>
+  
+    <option value="T">Ter</option>
+  
+    <option value="Q">Quater</option>
+  
+    <option value="C">Quinquies</option>
+  
+  </select></div></div>
+                              </div>
+                              <div class="form-row">
+                                  <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_type">Type de voie</label><select class="form-select" id="id_hexa_lane_type" name="hexa_lane_type" required="">
+    <option selected="" value="">---------</option>
+  
+    <option value="AER">Aérodrome</option>
+  
+    <option value="AGL">Agglomération</option>
+  
+    <option value="AIRE">Aire</option>
+  
+    <option value="ALL">Allée</option>
+  
+    <option value="ACH">Ancien chemin</option>
+  
+    <option value="ART">Ancienne route</option>
+  
+    <option value="AV">Avenue</option>
+  
+    <option value="BEGI">Beguinage</option>
+  
+    <option value="BD">Boulevard</option>
+  
+    <option value="BRG">Bourg</option>
+  
+    <option value="CPG">Camping</option>
+  
+    <option value="CAR">Carrefour</option>
+  
+    <option value="CTRE">Centre</option>
+  
+    <option value="CCAL">Centre commercial</option>
+  
+    <option value="CHT">Chateau</option>
+  
+    <option value="CHS">Chaussee</option>
+  
+    <option value="CHEM">Chemin</option>
+  
+    <option value="CHV">Chemin vicinal</option>
+  
+    <option value="CITE">Cité</option>
+  
+    <option value="CLOS">Clos</option>
+  
+    <option value="CTR">Contour</option>
+  
+    <option value="COR">Corniche</option>
+  
+    <option value="COTE">Coteaux</option>
+  
+    <option value="COUR">Cour</option>
+  
+    <option value="CRS">Cours</option>
+  
+    <option value="DSC">Descente</option>
+  
+    <option value="DOM">Domaine</option>
+  
+    <option value="ECL">Ecluse</option>
+  
+    <option value="ESC">Escalier</option>
+  
+    <option value="ESPA">Espace</option>
+  
+    <option value="ESP">Esplanade</option>
+  
+    <option value="FG">Faubourg</option>
+  
+    <option value="FRM">Ferme</option>
+  
+    <option value="FON">Fontaine</option>
+  
+    <option value="GAL">Galerie</option>
+  
+    <option value="GARE">Gare</option>
+  
+    <option value="GBD">Grand boulevard</option>
+  
+    <option value="GPL">Grande place</option>
+  
+    <option value="GR">Grande rue</option>
+  
+    <option value="GRI">Grille</option>
+  
+    <option value="HAM">Hameau</option>
+  
+    <option value="IMM">Immeuble(s)</option>
+  
+    <option value="IMP">Impasse</option>
+  
+    <option value="JARD">Jardin</option>
+  
+    <option value="LD">Lieu-dit</option>
+  
+    <option value="LOT">Lotissement</option>
+  
+    <option value="MAIL">Mail</option>
+  
+    <option value="MAIS">Maison</option>
+  
+    <option value="MAS">Mas</option>
+  
+    <option value="MTE">Montee</option>
+  
+    <option value="PARC">Parc</option>
+  
+    <option value="PRV">Parvis</option>
+  
+    <option value="PAS">Passage</option>
+  
+    <option value="PLE">Passerelle</option>
+  
+    <option value="PCH">Petit chemin</option>
+  
+    <option value="PRT">Petite route</option>
+  
+    <option value="PTR">Petite rue</option>
+  
+    <option value="PL">Place</option>
+  
+    <option value="PTTE">Placette</option>
+  
+    <option value="PLN">Plaine</option>
+  
+    <option value="PLAN">Plan</option>
+  
+    <option value="PLT">Plateau</option>
+  
+    <option value="PONT">Pont</option>
+  
+    <option value="PORT">Port</option>
+  
+    <option value="PROM">Promenade</option>
+  
+    <option value="QUAI">Quai</option>
+  
+    <option value="QUAR">Quartier</option>
+  
+    <option value="RPE">Rampe</option>
+  
+    <option value="REMP">Rempart</option>
+  
+    <option value="RES">Residence</option>
+  
+    <option value="ROC">Rocade</option>
+  
+    <option value="RPT">Rond-point</option>
+  
+    <option value="RTD">Rotonde</option>
+  
+    <option value="RTE">Route</option>
+  
+    <option value="RUE">Rue</option>
+  
+    <option value="RLE">Ruelle</option>
+  
+    <option value="SEN">Sente</option>
+  
+    <option value="SENT">Sentier</option>
+  
+    <option value="SQ">Square</option>
+  
+    <option value="TPL">Terre plein</option>
+  
+    <option value="TRAV">Traverse</option>
+  
+    <option value="VEN">Venelle</option>
+  
+    <option value="VTE">Vieille route</option>
+  
+    <option value="VCHE">Vieux chemin</option>
+  
+    <option value="VILL">Villa</option>
+  
+    <option value="VLGE">Village</option>
+  
+    <option value="VOIE">Voie</option>
+  
+    <option value="ZONE">Zone</option>
+  
+    <option value="ZA">Zone d'activite</option>
+  
+    <option value="ZAC">Zone d'amenagement concerte</option>
+  
+    <option value="ZAD">Zone d'amenagement differe</option>
+  
+    <option value="ZI">Zone industrielle</option>
+  
+    <option value="ZUP">Zone urbanisation prio</option>
+  
+  </select></div></div>
+                                  <div class="col-12 col-md-6"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_name">Nom de la voie</label><input class="form-control" id="id_hexa_lane_name" maxlength="120" name="hexa_lane_name" placeholder="Nom de la voie" required="" type="text"/></div></div>
+                              </div>
+                              <div class="form-group"><label class="form-label" for="id_hexa_additional_address">Complément d'adresse</label><input class="form-control" id="id_hexa_additional_address" maxlength="32" name="hexa_additional_address" placeholder="Complément d'adresse" type="text"/></div>
+                              <div class="form-row">
+                                  <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_post_code">Code postal</label><input class="form-control" id="id_hexa_post_code" maxlength="6" name="hexa_post_code" placeholder="Code postal" required="" type="text"/></div></div>
+                                  <div class="col-12 col-md-9"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_commune">Commune</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes?select2=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Nom de la commune" data-theme="bootstrap-5" id="id_hexa_commune" lang="fr" name="hexa_commune" required="">
+  </select></div></div>
+                              </div>
+                          </div>
+                          <div class="col-12 col-lg-4">
+                              <div class="c-form-conseil">
+                                  <div>
+                                      <p>
+                                          <i class="ri-lightbulb-line ri-lg me-1"></i><strong>Rappel de l’adresse du salarié renseignée sur Les emplois de l’inclusion</strong>
+                                      </p>
+                                      
+                                          <ul class="list-unstyled mb-0 mt-2">
+                                              <li>Rue du Clos de la Grange</li>
+                                              
+                                              <li>58160 Sauvigny-les-Bois</li>
+                                          </ul>
+                                      
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </fieldset>
+                  <div class="form-row">
+                      <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
+                          <button class="btn btn-outline-primary">Valider cette adresse</button>
+                      </div>
+                  </div>
+                  <div class="row">
+                      <div class="col-12 col-lg-8">
+                          
+                          
+                          
+                          
+                          
+                              
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </button>
+                  
+              </div>
+              
+                  <div class="form-group col col-lg-auto order-1 order-lg-2">
+                      <a aria-label="Retourner à l'étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/create/[PK of JobApplication]">
+                          <span>Retour</span>
+                      </a>
+                  </div>
+              
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
+                  
+                      <a aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" href="/employee_record/create_step_3/[PK of JobApplication]">
+                          <span>Suivant</span>
+                      </a>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/employee_record/list">Confirmer l'annulation</a>
+                  </div>
+              
+          </div>
+      </div>
+  </div>
+  
+                          
+                      </div>
+                  </div>
+              </form>
+  '''
+# ---
 # name: CreateEmployeeRecordStep5Test.test_employee_record_status
   Message(level=25, message="La création de cette fiche salariée est terminée||Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts.", extra_tags='toast')
 # ---

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -32,7 +32,7 @@
                       <div class="row">
                           <div class="col-12 col-lg-8">
                               <div class="form-row">
-                                  <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_lane_number">Numéro</label><input class="form-control" id="id_hexa_lane_number" maxlength="10" name="hexa_lane_number" placeholder="Numéro" type="text"/></div></div>
+                                  <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_lane_number">Numéro</label><input class="form-control" id="id_hexa_lane_number" maxlength="10" name="hexa_lane_number" placeholder="Numéro" type="text" value="42"/></div></div>
                                   <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_std_extension">Extension</label><select class="form-select" id="id_hexa_std_extension" name="hexa_std_extension">
     <option selected="" value="">---------</option>
   
@@ -48,7 +48,7 @@
                               </div>
                               <div class="form-row">
                                   <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_type">Type de voie</label><select class="form-select" id="id_hexa_lane_type" name="hexa_lane_type" required="">
-    <option selected="" value="">---------</option>
+    <option value="">---------</option>
   
     <option value="AER">Aérodrome</option>
   
@@ -198,7 +198,7 @@
   
     <option value="RTE">Route</option>
   
-    <option value="RUE">Rue</option>
+    <option selected="" value="RUE">Rue</option>
   
     <option value="RLE">Ruelle</option>
   
@@ -237,12 +237,14 @@
     <option value="ZUP">Zone urbanisation prio</option>
   
   </select></div></div>
-                                  <div class="col-12 col-md-6"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_name">Nom de la voie</label><input class="form-control" id="id_hexa_lane_name" maxlength="120" name="hexa_lane_name" placeholder="Nom de la voie" required="" type="text"/></div></div>
+                                  <div class="col-12 col-md-6"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_name">Nom de la voie</label><input class="form-control" id="id_hexa_lane_name" maxlength="120" name="hexa_lane_name" placeholder="Nom de la voie" required="" type="text" value="du Clos de la Grange"/></div></div>
                               </div>
                               <div class="form-group"><label class="form-label" for="id_hexa_additional_address">Complément d'adresse</label><input class="form-control" id="id_hexa_additional_address" maxlength="32" name="hexa_additional_address" placeholder="Complément d'adresse" type="text"/></div>
                               <div class="form-row">
-                                  <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_post_code">Code postal</label><input class="form-control" id="id_hexa_post_code" maxlength="6" name="hexa_post_code" placeholder="Code postal" required="" type="text"/></div></div>
+                                  <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_post_code">Code postal</label><input class="form-control" id="id_hexa_post_code" maxlength="6" name="hexa_post_code" placeholder="Code postal" required="" type="text" value="58160"/></div></div>
                                   <div class="col-12 col-md-9"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_commune">Commune</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes?select2=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Nom de la commune" data-theme="bootstrap-5" id="id_hexa_commune" lang="fr" name="hexa_commune" required="">
+    <option selected="" value="47612">SAUVIGNY-LES-BOIS (058)</option>
+  
   </select></div></div>
                               </div>
                           </div>


### PR DESCRIPTION
### Pourquoi ?

C'est le comportement attendu :), et les utilisateurs vont être content de ne plus avoir à le faire à la main pour les adresses reconnues.

### Comment ? <!-- optionnel -->

J'ai séparé le test de la correction pour avoir une diff propre du _snapshot_.

J'aurais aimé ne pas avoir à passer `BAN_GEOCODING_API_RESULTS_FOR_SNAPSHOT_MOCK` via `with_mocked_address` et l'utiliser automatiquement en fonction de `for_snapshot` mais je pense que ça va demander de bouger des trucs à plein d'endroits donc on verra plus tard :).

### Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/9824c489-841f-484c-89f1-0f56d9bda969)

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
