### PR TITLE
Refonte UX/UI: Maj du fonctionnement responsif des onglets

### DIFF
--- a/itou/static/js/sliding_tabs.js
+++ b/itou/static/js/sliding_tabs.js
@@ -1,0 +1,24 @@
+// Only for <ul.s-tabs-01__nav.nav.nav-tabs> how has data-it-sliding-tabs="true" attribute
+let slidingTabs = document.querySelector("[data-it-sliding-tabs=true]");
+
+if (slidingTabs) {
+  let slidingTabsStartIndex = 0;
+
+  if (slidingTabs.hasAttribute("data-it-sliding-tabs-startindex")) {
+    slidingTabsStartIndex = slidingTabs.getAttribute("data-it-sliding-tabs-startindex")
+  }
+
+  tns({
+    container: slidingTabs,
+    slideBy: "page",
+    autoWidth: true,
+    arrowKeys: true,
+    loop: false,
+    mouseDrag: true,
+    swipeAngle: false,
+    speed: 300,
+    nav: false,
+    controls: false,
+    startIndex: slidingTabsStartIndex,
+  });
+}

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -1,6 +1,6 @@
 {% extends "layout/base.html" %}
-{% load str_filters %}
 {% load static %}
+{% load str_filters %}
 {% load matomo %}
 
 {% block title %}{{ siae.display_name }} {{ block.super }}{% endblock %}
@@ -125,7 +125,7 @@
             <div class="s-tabs-01__row row">
                 <div class="s-tabs-01__col col-12">
                     <h2 class="visually-hidden" id="metiers-title">Métiers de la structure</h2>
-                    <ul class="s-tabs-01__nav nav nav-tabs" role="tablist" aria-labelledby="metiers-title">
+                    <ul class="s-tabs-01__nav nav nav-tabs" role="tablist" data-it-sliding-tabs="true" aria-labelledby="metiers-title">
                         <li class="nav-item" role="presentation">
                             <a id="recrutements-en-cours-tab" class="nav-link active" role="tab" href="#recrutements-en-cours" data-bs-toggle="tab" aria-selected="true" aria-controls="recrutements-en-cours">
                                 <span>Recrutement{{ active_jobs_descriptions|pluralizefr }} en cours</span>
@@ -182,4 +182,8 @@
     {% if code_insee %}
         <div hx-get="{% url "companies_views:hx_dora_services" code_insee=code_insee %}" hx-trigger="load"></div>
     {% endif %}
+{% endblock %}
+
+{% block script %}
+    <script src="{% static 'js/sliding_tabs.js'%}"></script>
 {% endblock %}

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load static %}
 {% load format_filters %}
 {% load str_filters %}
 {% load matomo %}
@@ -127,7 +128,7 @@
                 <div class="s-tabs-01__row row">
                     <div class="s-tabs-01__col col-12">
                         <h2 class="visually-hidden" id="recrutements-title">Recrutements de la structure</h2>
-                        <ul class="s-tabs-01__nav nav nav-tabs" role="tablist" aria-labelledby="recrutements-title">
+                        <ul class="s-tabs-01__nav nav nav-tabs" role="tablist" data-it-sliding-tabs="true" aria-labelledby="recrutements-title">
                             <li class="nav-item" role="presentation">
                                 <a id="recrutements-en-cours-tab" class="nav-link active" role="tab" href="#recrutements-en-cours" data-bs-toggle="tab" aria-selected="true" aria-controls="recrutements-en-cours">
                                     <span>Recrutement{{ others_active_jobs|pluralizefr }} en cours dans cette structure</span>
@@ -158,4 +159,8 @@
         <div hx-get="{% url "companies_views:hx_dora_services" code_insee=code_insee %}" hx-trigger="load"></div>
     {% endif %}
 
+{% endblock %}
+
+{% block script %}
+    <script src="{% static 'js/sliding_tabs.js'%}"></script>
 {% endblock %}

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -4,7 +4,7 @@
 {% load str_filters %}
 {% load matomo %}
 
-{% block title %}Structure : Métiers et recrutements {{ block.super }}{% endblock %}
+{% block title %}Métiers et recrutements {{ block.super }}{% endblock %}
 
 {% block content_title %}
     <h1>Structure</h1>
@@ -16,7 +16,7 @@
         <div class="s-tabs-01__container container">
             <div class="s-tabs-01__row row">
                 <div class="s-tabs-01__col col-12">
-                    <ul class="s-tabs-01__nav nav nav-tabs" data-it-s-tabs-01="true">
+                    <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true">
                         <li class="nav-item">
                             <a class="nav-link active" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
                                 <span>Métiers et recrutements</span>
@@ -31,12 +31,6 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
-                        </li>
-                        <li class="nav-item-dropdown dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="ri-more-line" aria-hidden="true"></i>
-                            </a>
-                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
                         </li>
                     </ul>
                     <div class="tab-content">
@@ -165,4 +159,8 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    <script src="{% static 'js/sliding_tabs.js'%}"></script>
 {% endblock %}

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -1,8 +1,9 @@
 {% extends "layout/base.html" %}
+{% load static %}
 {% load str_filters %}
 {% load matomo %}
 
-{% block title %}Structure : Collaborateurs {{ block.super }}{% endblock %}
+{% block title %}Collaborateurs {{ block.super }}{% endblock %}
 
 {% block content_title %}
     <h1>Structure</h1>
@@ -17,7 +18,7 @@
         <div class="s-tabs-01__container container">
             <div class="s-tabs-01__row row">
                 <div class="s-tabs-01__col col-12">
-                    <ul class="s-tabs-01__nav nav nav-tabs" data-it-s-tabs-01="true">
+                    <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="1">
                         <li class="nav-item">
                             <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
                                 <span>Métiers et recrutements</span>
@@ -32,12 +33,6 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
-                        </li>
-                        <li class="nav-item-dropdown dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="ri-more-line" aria-hidden="true"></i>
-                            </a>
-                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
                         </li>
                     </ul>
                     <div class="tab-content">
@@ -66,4 +61,8 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    <script src="{% static 'js/sliding_tabs.js'%}"></script>
 {% endblock %}

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -1,8 +1,9 @@
 {% extends "layout/base.html" %}
+{% load static %}
 {% load str_filters %}
 {% load matomo %}
 
-{% block title %}Structure : Annexes financières {{ block.super }}{% endblock %}
+{% block title %}Annexes financières {{ block.super }}{% endblock %}
 
 {% block content_title %}
     <h1>Structure</h1>
@@ -37,7 +38,7 @@
         <div class="s-tabs-01__container container">
             <div class="s-tabs-01__row row">
                 <div class="s-tabs-01__col col-12">
-                    <ul class="s-tabs-01__nav nav nav-tabs" data-it-s-tabs-01="true">
+                    <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="2">
                         <li class="nav-item">
                             <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
                                 <span>Métiers et recrutements</span>
@@ -52,12 +53,6 @@
                         </li>
                         <li class="nav-item">
                             <a class="nav-link active" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
-                        </li>
-                        <li class="nav-item-dropdown dropdown">
-                            <a class="nav-link dropdown-toggle" href="#" role="button" id="sTabs01DropdownMoreLink" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="ri-more-line" aria-hidden="true"></i>
-                            </a>
-                            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="sTabs01DropdownMoreLink"></div>
                         </li>
                     </ul>
                     <div class="tab-content">
@@ -110,4 +105,8 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    <script src="{% static 'js/sliding_tabs.js'%}"></script>
 {% endblock %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -104,6 +104,7 @@
         <script src="{% static "vendor/bootstrap/bootstrap.min.js" %}"></script>
         <script src="{% static "vendor/duetds-date-picker/duet.js" %}"></script>
         <script src="{% static "vendor/tarteaucitron/tarteaucitron.js" %}"></script>
+        <script src="{% static "vendor/tiny-slider/min/tiny-slider.js" %}"></script>
         <script src="{% static "vendor/jquery-ui/jquery-ui.min.js" %}"></script>
         <script src="{% static "vendor/theme-inclusion/javascripts/app.js" %}"></script>
         <script src="{% static "vendor/htmx/htmx.min.js" %}"></script>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -76,6 +76,20 @@ ASSET_INFOS = {
             ],
         },
     },
+    "tiny-slider": {
+        "download": {
+            "url": "https://github.com/ganlanyuan/tiny-slider/archive/refs/tags/v2.9.4.zip",
+            "sha256": "ac906066c097361fd9240ebf7521ee21753ca0740e7b2d31924c8d1ddb91a0ea",
+        },
+        "extract": {
+            "origin": "tiny-slider-2.9.4/dist",
+            "destination": "vendor/tiny-slider",
+            "files": [
+                "min/tiny-slider.js",
+                "sourcemaps/tiny-slider.js.map",
+            ],
+        },
+    },
     "htmx.org": {
         "download": {
             "url": "https://registry.npmjs.org/htmx.org/-/htmx.org-1.9.6.tgz",
@@ -223,11 +237,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.4.6.zip",
-            "sha256": "81af3241ff5d53b1db6b92194c1a95c74dd4f806a77e8b80ddd68c1634b4a996",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.4.7.zip",
+            "sha256": "db7a567cd0e160e74a1ecc867916cb785891f179d7d0008faa18c399acd39a9a",
         },
         "extract": {
-            "origin": "itou-theme-1.4.6/dist",
+            "origin": "itou-theme-1.4.7/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",

--- a/tests/www/companies_views/__snapshots__/test_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_views.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: CardViewTest.test_block_job_applications[nav-tabs]
   '''
-  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" role="tablist">
+  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" role="tablist">
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
@@ -66,7 +66,7 @@
 # ---
 # name: CardViewTest.test_card_active_and_other_jobs[nav-tabs]
   '''
-  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" role="tablist">
+  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" role="tablist">
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
@@ -166,7 +166,7 @@
 # ---
 # name: CardViewTest.test_card_no_active_jobs[nav-tabs]
   '''
-  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" role="tablist">
+  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" role="tablist">
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
@@ -383,7 +383,7 @@
               <div class="s-tabs-01__row row">
                   <div class="s-tabs-01__col col-12">
                       <h2 class="visually-hidden" id="metiers-title">Métiers de la structure</h2>
-                      <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" role="tablist">
+                      <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" role="tablist">
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
@@ -413,7 +413,7 @@
 # ---
 # name: CardViewTest.test_card_no_other_jobs[nav-tabs]
   '''
-  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" role="tablist">
+  <ul aria-labelledby="metiers-title" class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" role="tablist">
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>


### PR DESCRIPTION
### Pourquoi ?

Améliorer le fonctionnement responsif (dropdown avec les items masqués dedans) par un “slider d’onglets”, swipable en mobile

### Comment ? 
- Maj du thème
- Maj du DOM
- Ajout de js

### Captures d'écran 
Avant
![capture 2024-03-22 à 15 54 43](https://github.com/gip-inclusion/les-emplois/assets/3874024/2033a12e-e5de-4c52-a07b-68d614b23e96)

Apres
![capture 2024-03-22 à 15 54 19](https://github.com/gip-inclusion/les-emplois/assets/3874024/a24d0a04-ed74-45bf-88f2-3a716b802f68)



