### PR TITLE
Retirer du code non utilisé pour js-job-applications-filters-button

### DIFF
--- a/itou/static/js/job_applications_filters.js
+++ b/itou/static/js/job_applications_filters.js
@@ -4,10 +4,3 @@ function submitFiltersForm() {
 $("#js-job-applications-filters-form :input").change(submitFiltersForm);
 $("duet-date-picker").on("duetChange", submitFiltersForm);
 $("#js-job-applications-filters-apply-button").hide();
-
-// If the Filtres button is present, the associated card should be collapsed on display.
-if ($("#js-job-applications-filters-button").is(":visible")) {
-    // The button should be always visible now (on windows resize)
-    $("#js-job-applications-filters-button").removeClass("d-md-none");
-    $('#js-job-applications-filters-form').collapse();
-}


### PR DESCRIPTION
### Pourquoi ?

Retiré avec 7fb0f6b0e2b542b7ea50a567d16dea9c2327ea9d.
