### PR TITLE
Filtrer les candidatures des prescripteurs avec HTMX

### DIFF
--- a/itou/templates/apply/includes/job_applications_export_button.html
+++ b/itou/templates/apply/includes/job_applications_export_button.html
@@ -1,9 +1,9 @@
-{% if user.is_prescriber %}
+{% if request.user.is_prescriber %}
     <a href="{% url 'apply:list_for_prescriber_exports' %}" class="btn btn-ico btn-secondary mt-3 mt-md-0" aria-label="Exporter la liste de candidatures">
         <i class="ri-download-2-fill" aria-hidden="true"></i>
         <span>Exporter</span>
     </a>
-{% elif user.is_employer %}
+{% elif request.user.is_employer %}
     <a href="{% url 'apply:list_for_siae_exports' %}" class="btn btn-ico btn-secondary mt-3 mt-md-0" aria-label="Exporter la liste de candidatures">
         <i class="ri-download-2-fill" aria-hidden="true"></i>
         <span>Exporter</span>

--- a/itou/templates/apply/includes/job_applications_export_button.html
+++ b/itou/templates/apply/includes/job_applications_export_button.html
@@ -1,13 +1,11 @@
-{% if user.is_prescriber or user.is_employer %}
-    {% if user.is_prescriber %}
-        <a href="{% url 'apply:list_for_prescriber_exports' %}" class="btn btn-ico btn-secondary mt-3 mt-md-0" aria-label="Exporter la liste de candidatures">
-            <i class="ri-download-2-fill" aria-hidden="true"></i>
-            <span>Exporter</span>
-        </a>
-    {% elif user.is_employer %}
-        <a href="{% url 'apply:list_for_siae_exports' %}" class="btn btn-ico btn-secondary mt-3 mt-md-0" aria-label="Exporter la liste de candidatures">
-            <i class="ri-download-2-fill" aria-hidden="true"></i>
-            <span>Exporter</span>
-        </a>
-    {% endif %}
+{% if user.is_prescriber %}
+    <a href="{% url 'apply:list_for_prescriber_exports' %}" class="btn btn-ico btn-secondary mt-3 mt-md-0" aria-label="Exporter la liste de candidatures">
+        <i class="ri-download-2-fill" aria-hidden="true"></i>
+        <span>Exporter</span>
+    </a>
+{% elif user.is_employer %}
+    <a href="{% url 'apply:list_for_siae_exports' %}" class="btn btn-ico btn-secondary mt-3 mt-md-0" aria-label="Exporter la liste de candidatures">
+        <i class="ri-download-2-fill" aria-hidden="true"></i>
+        <span>Exporter</span>
+    </a>
 {% endif %}

--- a/itou/templates/apply/includes/list_job_applications.html
+++ b/itou/templates/apply/includes/list_job_applications.html
@@ -12,39 +12,57 @@
         <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les candidatures">
             {% include "apply/includes/job_applications_export_button.html" %}
             {% if filters_counter > 0 %}
-                <a href="{% url 'apply:list_for_siae' %}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
+                <a href="{% if request.user.is_prescriber %}{% url 'apply:list_for_prescriber' %}{% else %}{% url 'apply:list_for_siae' %}{% endif %}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
                     <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
                     <span>Réinitialiser les filtres ({{ filters_counter }})</span>
                 </a>
             {% endif %}
         </div>
     </div>
-
     {% if not job_applications_page %}
         <div class="text-center my-3 my-md-4">
             <img class="img-fluid" src="{% static 'img/illustration-siae-card-no-result.svg' %}" alt="" loading="lazy">
             <p class="mb-1 mt-3">
                 <strong>
-                    {% if pending_states_job_applications_count == 0 %}
+                    {% if request.user.is_prescriber %}
                         Aucune candidature pour le moment
-                    {% else %}
-                        Aucune candidature ne correspond aux filtres sélectionnés
+                    {% elif request.user.is_employer %}
+                        {% if pending_states_job_applications_count == 0 %}
+                            Aucune candidature pour le moment
+                        {% else %}
+                            Aucune candidature ne correspond aux filtres sélectionnés
+                        {% endif %}
                     {% endif %}
                 </strong>
             </p>
             <p>
                 <i>
-                    Pour recevoir des candidatures, verifiez que les postes ouverts
-                    <br class="d-none d-lg-inline">
-                    dans votre structure sont bien à jour.
+                    {% if request.user.is_prescriber %}
+                        Vous trouverez ici les candidatures émises par votre organisation
+                        <br class="d-none d-lg-inline">
+                        pour les candidats.
+                    {% elif request.user.is_employer %}
+                        Pour recevoir des candidatures, verifiez que les postes ouverts
+                        <br class="d-none d-lg-inline">
+                        dans votre structure sont bien à jour.
+                    {% endif %}
                 </i>
             </p>
-            <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
-                <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
-                <span>Gérer les métiers et recrutements</span>
-            </a>
+            {% if request.user.is_prescriber %}
+                <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
+                    <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
+                    <span>Postuler pour un candidat</span>
+                </a>
+            {% elif request.user.is_employer %}
+                <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
+                    <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
+                    <span>Gérer les métiers et recrutements</span>
+                </a>
+            {% endif %}
         </div>
-        {% include "apply/includes/rdv_insertion_promo_card.html" %}
+        {% if request.user.is_employer %}
+            {% include "apply/includes/rdv_insertion_promo_card.html" %}
+        {% endif %}
     {% else %}
         {% for job_application in job_applications_page %}
             <div class="c-box c-box--results has-links-inside my-3 my-md-4">
@@ -57,20 +75,26 @@
                                 En attente de réponse depuis {{ job_application.pending_for_weeks }} semaines.
                             </p>
                         {% endif %}
-                        <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
-                           href="{% url 'apply:details_for_company' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
-                           aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
-                           {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>Voir sa candidature</a>
+                        {% if request.user.is_prescriber %}
+                            <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
+                               href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
+                               aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
+                               {% matomo_event "candidature" "clic" "voir_candidature_prescripteur" %}>
+                                Voir sa candidature
+                            </a>
+                        {% elif request.user.is_employer %}
+                            <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
+                               href="{% url 'apply:details_for_company' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
+                               aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
+                               {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>Voir sa candidature</a>
+                        {% endif %}
                     </div>
                 </div>
             </div>
-
-            {% if forloop.counter == 1 %}
+            {% if request.user.is_employer and forloop.counter == 1 %}
                 {% include "apply/includes/rdv_insertion_promo_card.html" %}
             {% endif %}
-
         {% endfor %}
-
         {% include "includes/pagination.html" with page=job_applications_page boost=True boost_target="#job-applications-section" boost_indicator="#job-applications-section" %}
     {% endif %}
 </section>

--- a/itou/templates/apply/includes/list_job_applications.html
+++ b/itou/templates/apply/includes/list_job_applications.html
@@ -42,7 +42,7 @@
                         <br class="d-none d-lg-inline">
                         pour les candidats.
                     {% elif request.user.is_employer %}
-                        Pour recevoir des candidatures, verifiez que les postes ouverts
+                        Pour recevoir des candidatures, vérifiez que les postes ouverts
                         <br class="d-none d-lg-inline">
                         dans votre structure sont bien à jour.
                     {% endif %}

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -19,7 +19,12 @@
                             <span>Filtrer les candidatures</span>
                         </button>
                         <div class="c-aside-filters__card collapse show" id="asideFiltersCollapse">
-                            <form method="get" id="js-job-applications-filters-form">
+                            <form hx-get="{% url 'apply:list_for_prescriber' %}"
+                                  hx-trigger="change delay:.5s, duetChange delay:.5s"
+                                  hx-indicator="#job-applications-section"
+                                  hx-target="#job-applications-section"
+                                  hx-swap="outerHTML"
+                                  hx-push-url="true">
                                 <div class="c-aside-filters__card__body">
                                     {% include "apply/includes/job_applications_filters/statut.html" %}
                                     {% include "apply/includes/job_applications_filters/job_seekers.html" %}
@@ -39,70 +44,8 @@
                         </div>
                     </aside>
                 </div>
-
                 <div class="col-12 col-md-8">
-                    <section aria-labelledby="results">
-                        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
-                            <h3 class="h4 mb-0" id="results">
-                                {% with job_applications_page.paginator.count as counter %}
-                                    {{ counter }} <strong>résultat{{ counter|pluralizefr }}</strong>
-                                {% endwith %}
-                            </h3>
-                            <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les candidatures">
-                                {% include "apply/includes/job_applications_export_button.html" %}
-                                {% if filters_counter > 0 %}
-                                    <a href="{% url 'apply:list_for_prescriber' %}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
-                                        <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
-                                        <span>Réinitialiser les filtres ({{ filters_counter }})</span>
-                                    </a>
-                                {% endif %}
-                            </div>
-                        </div>
-
-                        {% if not job_applications_page %}
-                            <div class="text-center my-3 my-md-4">
-                                <img class="img-fluid" src="{% static 'img/illustration-siae-card-no-result.svg' %}" alt="" loading="lazy">
-                                <p class="mb-1 mt-3">
-                                    <strong>Aucune candidature pour le moment</strong>
-                                </p>
-                                <p>
-                                    <i>
-                                        Vous trouverez ici les candidatures émises par votre organisation
-                                        <br class="d-none d-lg-inline">
-                                        pour les candidats.
-                                    </i>
-                                </p>
-                                <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
-                                    <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
-                                    <span>Postuler pour un candidat</span>
-                                </a>
-                            </div>
-                        {% else %}
-                            {% for job_application in job_applications_page %}
-                                <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                    {% include "apply/includes/list_card_body_company.html" %}
-                                    <div class="c-box--results__footer">
-                                        <div class="d-flex{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} flex-column flex-md-row justify-content-md-between align-items-md-center{% else %} justify-content-end{% endif %}">
-                                            {% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %}
-                                                <p class="text-warning fs-sm mb-3 mb-md-0">
-                                                    <i class="ri-time-line ri-lg me-1" aria-hidden="true"></i>
-                                                    En attente de réponse depuis {{ job_application.pending_for_weeks }} semaines.
-                                                </p>
-                                            {% endif %}
-                                            <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
-                                               href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                               aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
-                                               {% matomo_event "candidature" "clic" "voir_candidature_prescripteur" %}>
-                                                Voir sa candidature
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            {% endfor %}
-
-                            {% include "includes/pagination.html" with page=job_applications_page %}
-                        {% endif %}
-                    </section>
+                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request only %}
                 </div>
             </div>
         </div>
@@ -114,4 +57,5 @@
     <!-- Needed to use Select2MultipleWidget. -->
     {{ filters_form.media.js }}
     <script src='{% static "js/job_applications_filters.js" %}'></script>
+    <script src='{% static "js/htmx_compat.js" %}'></script>
 {% endblock %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -50,7 +50,9 @@
                         </div>
                     </aside>
                 </div>
-                <div class="col-12 col-md-8">{% include "apply/includes/list_job_applications.html" %}</div>
+                <div class="col-12 col-md-8">
+                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request pending_states_job_applications_count=pending_states_job_applications_count only %}
+                </div>
             </div>
         </div>
     </section>

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -122,7 +122,11 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
         "filters_form": filters_form,
         "filters_counter": filters_counter,
     }
-    return render(request, template_name, context)
+    return render(
+        request,
+        "apply/includes/list_job_applications.html" if request.htmx else template_name,
+        context,
+    )
 
 
 @login_required

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -834,12 +834,10 @@
                               </h3>
                               <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
                                   
-      
-          <a aria-label="Exporter la liste de candidatures" class="btn btn-ico btn-secondary mt-3 mt-md-0" href="/apply/prescriber/list/exports">
-              <i aria-hidden="true" class="ri-download-2-fill"></i>
-              <span>Exporter</span>
-          </a>
-      
+      <a aria-label="Exporter la liste de candidatures" class="btn btn-ico btn-secondary mt-3 mt-md-0" href="/apply/prescriber/list/exports">
+          <i aria-hidden="true" class="ri-download-2-fill"></i>
+          <span>Exporter</span>
+      </a>
   
   
                                   
@@ -1100,12 +1098,10 @@
           </h3>
           <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
               
-      
-          <a aria-label="Exporter la liste de candidatures" class="btn btn-ico btn-secondary mt-3 mt-md-0" href="/apply/siae/list/exports">
-              <i aria-hidden="true" class="ri-download-2-fill"></i>
-              <span>Exporter</span>
-          </a>
-      
+      <a aria-label="Exporter la liste de candidatures" class="btn btn-ico btn-secondary mt-3 mt-md-0" href="/apply/siae/list/exports">
+          <i aria-hidden="true" class="ri-download-2-fill"></i>
+          <span>Exporter</span>
+      </a>
   
   
               

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -37,6 +37,219 @@
           </div>
   '''
 # ---
+# name: TestForPrescriber.test_filter_for_prescriber
+  '''
+  <div class="c-aside-filters__card collapse show" id="asideFiltersCollapse">
+                              <form hx-get="/apply/prescriber/list" hx-indicator="#job-applications-section" hx-push-url="true" hx-swap="outerHTML" hx-target="#job-applications-section" hx-trigger="change delay:.5s, duetChange delay:.5s">
+                                  <div class="c-aside-filters__card__body">
+                                      <fieldset>
+      <legend>Statut candidature</legend>
+      <ul>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
+                      <label class="form-check-label" for="id_states_0">Nouvelle candidature</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="processing"/>
+                      <label class="form-check-label" for="id_states_1">Candidature à l'étude</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="postponed"/>
+                      <label class="form-check-label" for="id_states_2">Candidature en attente</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="prior_to_hire"/>
+                      <label class="form-check-label" for="id_states_3">Action préalable à l’embauche</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_4" name="states" type="checkbox" value="accepted"/>
+                      <label class="form-check-label" for="id_states_4">Candidature acceptée</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_5" name="states" type="checkbox" value="refused"/>
+                      <label class="form-check-label" for="id_states_5">Candidature déclinée</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_6" name="states" type="checkbox" value="cancelled"/>
+                      <label class="form-check-label" for="id_states_6">Embauche annulée</label>
+                  </div>
+              </li>
+          
+              <li>
+                  <div class="form-check">
+                      <input class="form-check-input" id="id_states_7" name="states" type="checkbox" value="obsolete"/>
+                      <label class="form-check-label" for="id_states_7">Embauché ailleurs</label>
+                  </div>
+              </li>
+          
+      </ul>
+  </fieldset>
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <div class="form-group"><label class="form-label" for="id_job_seekers">Nom du candidat</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_job_seekers" lang="fr" multiple="" name="job_seekers">
+  </select></div>
+      </fieldset>
+  
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <legend>Structure destinataire</legend>
+          <div class="form-group"><label class="visually-hidden" for="id_to_companies">Structure</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_to_companies" lang="fr" multiple="" name="to_companies">
+  </select></div>
+      </fieldset>
+  
+  
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <legend>Émetteur</legend>
+      
+  
+      
+          <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
+  </select></div>
+      
+  
+      
+  
+      </fieldset>
+  
+                                      
+  
+  <hr/>
+  <fieldset>
+      <legend>Date d'envoi de la candidature</legend>
+      <div class="form-group"><label class="form-label" for="id_start_date">À partir du</label><duet-date-picker class="" identifier="id_start_date" name="start_date" placeholder="À partir du"></duet-date-picker></div>
+      <div class="form-group"><label class="form-label" for="id_end_date">Jusqu'au</label><duet-date-picker class="" identifier="id_end_date" name="end_date" placeholder="Jusqu'au"></duet-date-picker></div>
+  </fieldset>
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <div class="form-group"><label class="form-label" for="id_selected_jobs">Fiches de poste</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_selected_jobs" lang="fr" multiple="" name="selected_jobs">
+  </select></div>
+      </fieldset>
+  
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <legend>Statut du PASS IAE</legend>
+          <div class="mb-2"><div class="form-check"><input class="form-check-input" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/><label class="form-check-label" for="id_pass_iae_active">Actif</label></div></div>
+          <div class=""><div class="form-check"><input class="form-check-input" id="id_pass_iae_suspended" name="pass_iae_suspended" type="checkbox"/><label class="form-check-label" for="id_pass_iae_suspended">Suspendu</label></div></div>
+      </fieldset>
+  
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <legend>Éligibilité IAE</legend>
+          <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_eligibility_validated" name="eligibility_validated" type="checkbox"/><label class="form-check-label" for="id_eligibility_validated">Éligibilité validée</label></div></div>
+      </fieldset>
+  
+  
+                                      
+  
+  
+  
+      <hr/>
+      <fieldset>
+          <legend>Critères administratifs déclarés</legend>
+          <div class=""><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_criteria" lang="fr" multiple="" name="criteria">
+    <option value="1">Bénéficiaire du RSA</option>
+  
+    <option value="2">Allocataire ASS</option>
+  
+    <option value="3">Allocataire AAH</option>
+  
+    <option value="4">DETLD (+ 24 mois)</option>
+  
+    <option value="5">Niveau d'étude 3 (CAP, BEP) ou infra</option>
+  
+    <option value="6">Senior (+50 ans)</option>
+  
+    <option value="7">Jeune (-26 ans)</option>
+  
+    <option value="8">Sortant de l'ASE</option>
+  
+    <option value="9">DELD (12-24 mois)</option>
+  
+    <option value="10">Travailleur handicapé</option>
+  
+    <option value="11">Parent isolé</option>
+  
+    <option value="12">Personne sans hébergement ou hébergée ou ayant un parcours de rue</option>
+  
+    <option value="13">Réfugié statutaire, bénéficiaire d'une protection temporaire, protégé subsidiaire ou demandeur d'asile</option>
+  
+    <option value="14">Résident ZRR</option>
+  
+    <option value="15">Résident QPV</option>
+  
+    <option value="16">Sortant de détention ou personne placée sous main de justice</option>
+  
+    <option value="17">Maîtrise de la langue française</option>
+  
+    <option value="18">Mobilité</option>
+  
+  </select></div>
+      </fieldset>
+  
+  
+                                      
+  
+  
+      <hr/>
+      <fieldset>
+          <div class="form-group"><label class="form-label" for="id_departments">Département du candidat</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_departments" lang="fr" multiple="" name="departments">
+  </select></div>
+      </fieldset>
+  
+  
+                                      <button aria-label="Appliquer les filtres" class="btn btn-block btn-primary mt-3" id="js-job-applications-filters-apply-button">
+                                          Appliquer
+                                      </button>
+                                  </div>
+                              </form>
+                          </div>
+  '''
+# ---
 # name: TestListForSiae.test_filter_for_different_kind[geiq]
   '''
   <div class="c-aside-filters__card collapse show" id="asideFiltersCollapse">
@@ -825,29 +1038,28 @@
 # ---
 # name: TestListForSiae.test_warns_about_long_awaiting_applications[PRESCRIBER - warnings for 2222 and 3333]
   '''
-  <section aria-labelledby="results">
-                          <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
-                              <h3 class="h4 mb-0" id="results">
-                                  
-                                      3 <strong>résultats</strong>
-                                  
-                              </h3>
-                              <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
-                                  
+  <section aria-labelledby="results" id="job-applications-section">
+      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
+          <h3 class="h4 mb-0" id="results">
+              
+                  3 <strong>résultats</strong>
+              
+          </h3>
+          <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
+              
       <a aria-label="Exporter la liste de candidatures" class="btn btn-ico btn-secondary mt-3 mt-md-0" href="/apply/prescriber/list/exports">
           <i aria-hidden="true" class="ri-download-2-fill"></i>
           <span>Exporter</span>
       </a>
   
   
-                                  
-                              </div>
-                          </div>
-  
-                          
-                              
-                                  <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                      
+              
+          </div>
+      </div>
+      
+          
+              <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+                  
   
   <div class="c-box--results__header">
       
@@ -910,18 +1122,21 @@
       </div>
   </div>
   
-                                      <div class="c-box--results__footer">
-                                          <div class="d-flex justify-content-end">
-                                              
-                                              <a aria-label="Gérer la candidature de J… H…" class="btn btn-outline-primary" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/11111111-1111-1111-1111-111111111111/prescriber/details?back_url=/apply/prescriber/list">
-                                                  Voir sa candidature
-                                              </a>
-                                          </div>
-                                      </div>
-                                  </div>
-                              
-                                  <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                      
+                  <div class="c-box--results__footer">
+                      <div class="d-flex justify-content-end">
+                          
+                          
+                              <a aria-label="Gérer la candidature de J… H…" class="btn btn-outline-primary" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/11111111-1111-1111-1111-111111111111/prescriber/details?back_url=/apply/prescriber/list">
+                                  Voir sa candidature
+                              </a>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+          
+              <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+                  
   
   <div class="c-box--results__header">
       
@@ -984,23 +1199,26 @@
       </div>
   </div>
   
-                                      <div class="c-box--results__footer">
-                                          <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
-                                              
-                                                  <p class="text-warning fs-sm mb-3 mb-md-0">
-                                                      <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
-                                                      En attente de réponse depuis 3 semaines.
-                                                  </p>
-                                              
-                                              <a aria-label="Gérer la candidature de J… H…" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/22222222-2222-2222-2222-222222222222/prescriber/details?back_url=/apply/prescriber/list">
-                                                  Voir sa candidature
-                                              </a>
-                                          </div>
-                                      </div>
-                                  </div>
-                              
-                                  <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                      
+                  <div class="c-box--results__footer">
+                      <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
+                          
+                              <p class="text-warning fs-sm mb-3 mb-md-0">
+                                  <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
+                                  En attente de réponse depuis 3 semaines.
+                              </p>
+                          
+                          
+                              <a aria-label="Gérer la candidature de J… H…" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/22222222-2222-2222-2222-222222222222/prescriber/details?back_url=/apply/prescriber/list">
+                                  Voir sa candidature
+                              </a>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+          
+              <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+                  
   
   <div class="c-box--results__header">
       
@@ -1063,28 +1281,30 @@
       </div>
   </div>
   
-                                      <div class="c-box--results__footer">
-                                          <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
-                                              
-                                                  <p class="text-warning fs-sm mb-3 mb-md-0">
-                                                      <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
-                                                      En attente de réponse depuis 8 semaines.
-                                                  </p>
-                                              
-                                              <a aria-label="Gérer la candidature de J… H…" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/33333333-3333-3333-3333-333333333333/prescriber/details?back_url=/apply/prescriber/list">
-                                                  Voir sa candidature
-                                              </a>
-                                          </div>
-                                      </div>
-                                  </div>
-                              
-  
-                              
-  
-  
-  
+                  <div class="c-box--results__footer">
+                      <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
                           
-                      </section>
+                              <p class="text-warning fs-sm mb-3 mb-md-0">
+                                  <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
+                                  En attente de réponse depuis 8 semaines.
+                              </p>
+                          
+                          
+                              <a aria-label="Gérer la candidature de J… H…" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/33333333-3333-3333-3333-333333333333/prescriber/details?back_url=/apply/prescriber/list">
+                                  Voir sa candidature
+                              </a>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+          
+          
+  
+  
+  
+      
+  </section>
   '''
 # ---
 # name: TestListForSiae.test_warns_about_long_awaiting_applications[SIAE - warnings for 2222 and 3333]
@@ -1107,7 +1327,6 @@
               
           </div>
       </div>
-  
       
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
@@ -1119,15 +1338,6 @@
   <div class="d-flex flex-column flex-lg-row gap-1 gap-lg-3 mb-3">
       <p class="fs-sm mb-0 flex-grow-1">
           Émise le 30 mars 2023 par
-          
-              <span class="text-nowrap">
-                  
-                      <strong>Max THROUGHPUT</strong>
-                  
-                  
-                      <i aria-hidden="true" class="ri-home-smile-2-line me-1"></i>Orienteur
-                  
-              </span>
           
           
       </p>
@@ -1176,11 +1386,12 @@
                   <div class="c-box--results__footer">
                       <div class="d-flex justify-content-end">
                           
-                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-outline-primary" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                          
+                              <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-outline-primary" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/11111111-1111-1111-1111-111111111111/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                          
                       </div>
                   </div>
               </div>
-  
               
                   
   
@@ -1212,7 +1423,6 @@
   </div>
   
               
-  
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
@@ -1223,15 +1433,6 @@
   <div class="d-flex flex-column flex-lg-row gap-1 gap-lg-3 mb-3">
       <p class="fs-sm mb-0 flex-grow-1">
           Émise le 18 mars 2023 par
-          
-              <span class="text-nowrap">
-                  
-                      <strong>Max THROUGHPUT</strong>
-                  
-                  
-                      <i aria-hidden="true" class="ri-home-smile-2-line me-1"></i>Orienteur
-                  
-              </span>
           
           
       </p>
@@ -1285,13 +1486,13 @@
                                   En attente de réponse depuis 3 semaines.
                               </p>
                           
-                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                          
+                              <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/22222222-2222-2222-2222-222222222222/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                          
                       </div>
                   </div>
               </div>
-  
               
-  
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
@@ -1302,15 +1503,6 @@
   <div class="d-flex flex-column flex-lg-row gap-1 gap-lg-3 mb-3">
       <p class="fs-sm mb-0 flex-grow-1">
           Émise le 16 février 2023 par
-          
-              <span class="text-nowrap">
-                  
-                      <strong>Max THROUGHPUT</strong>
-                  
-                  
-                      <i aria-hidden="true" class="ri-home-smile-2-line me-1"></i>Orienteur
-                  
-              </span>
           
           
       </p>
@@ -1364,231 +1556,19 @@
                                   En attente de réponse depuis 8 semaines.
                               </p>
                           
-                          <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                          
+                              <a aria-label="Gérer la candidature de Jacques HENRY" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir-candidature-employeur" href="/apply/33333333-3333-3333-3333-333333333333/siae/details?back_url=/apply/siae/list">Voir sa candidature</a>
+                          
                       </div>
                   </div>
               </div>
-  
               
-  
           
-  
           
   
   
   
       
   </section>
-  '''
-# ---
-# name: test_filter_for_prescriber
-  '''
-  <form id="js-job-applications-filters-form" method="get">
-                                  <div class="c-aside-filters__card__body">
-                                      <fieldset>
-      <legend>Statut candidature</legend>
-      <ul>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_0" name="states" type="checkbox" value="new"/>
-                      <label class="form-check-label" for="id_states_0">Nouvelle candidature</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_1" name="states" type="checkbox" value="processing"/>
-                      <label class="form-check-label" for="id_states_1">Candidature à l'étude</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_2" name="states" type="checkbox" value="postponed"/>
-                      <label class="form-check-label" for="id_states_2">Candidature en attente</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_3" name="states" type="checkbox" value="prior_to_hire"/>
-                      <label class="form-check-label" for="id_states_3">Action préalable à l’embauche</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_4" name="states" type="checkbox" value="accepted"/>
-                      <label class="form-check-label" for="id_states_4">Candidature acceptée</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_5" name="states" type="checkbox" value="refused"/>
-                      <label class="form-check-label" for="id_states_5">Candidature déclinée</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_6" name="states" type="checkbox" value="cancelled"/>
-                      <label class="form-check-label" for="id_states_6">Embauche annulée</label>
-                  </div>
-              </li>
-          
-              <li>
-                  <div class="form-check">
-                      <input class="form-check-input" id="id_states_7" name="states" type="checkbox" value="obsolete"/>
-                      <label class="form-check-label" for="id_states_7">Embauché ailleurs</label>
-                  </div>
-              </li>
-          
-      </ul>
-  </fieldset>
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <div class="form-group"><label class="form-label" for="id_job_seekers">Nom du candidat</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_job_seekers" lang="fr" multiple="" name="job_seekers">
-  </select></div>
-      </fieldset>
-  
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <legend>Structure destinataire</legend>
-          <div class="form-group"><label class="visually-hidden" for="id_to_companies">Structure</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_to_companies" lang="fr" multiple="" name="to_companies">
-  </select></div>
-      </fieldset>
-  
-  
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <legend>Émetteur</legend>
-      
-  
-      
-          <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
-  </select></div>
-      
-  
-      
-  
-      </fieldset>
-  
-                                      
-  
-  <hr/>
-  <fieldset>
-      <legend>Date d'envoi de la candidature</legend>
-      <div class="form-group"><label class="form-label" for="id_start_date">À partir du</label><duet-date-picker class="" identifier="id_start_date" name="start_date" placeholder="À partir du"></duet-date-picker></div>
-      <div class="form-group"><label class="form-label" for="id_end_date">Jusqu'au</label><duet-date-picker class="" identifier="id_end_date" name="end_date" placeholder="Jusqu'au"></duet-date-picker></div>
-  </fieldset>
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <div class="form-group"><label class="form-label" for="id_selected_jobs">Fiches de poste</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_selected_jobs" lang="fr" multiple="" name="selected_jobs">
-  </select></div>
-      </fieldset>
-  
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <legend>Statut du PASS IAE</legend>
-          <div class="mb-2"><div class="form-check"><input class="form-check-input" id="id_pass_iae_active" name="pass_iae_active" type="checkbox"/><label class="form-check-label" for="id_pass_iae_active">Actif</label></div></div>
-          <div class=""><div class="form-check"><input class="form-check-input" id="id_pass_iae_suspended" name="pass_iae_suspended" type="checkbox"/><label class="form-check-label" for="id_pass_iae_suspended">Suspendu</label></div></div>
-      </fieldset>
-  
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <legend>Éligibilité IAE</legend>
-          <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_eligibility_validated" name="eligibility_validated" type="checkbox"/><label class="form-check-label" for="id_eligibility_validated">Éligibilité validée</label></div></div>
-      </fieldset>
-  
-  
-                                      
-  
-  
-  
-      <hr/>
-      <fieldset>
-          <legend>Critères administratifs déclarés</legend>
-          <div class=""><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_criteria" lang="fr" multiple="" name="criteria">
-    <option value="1">Bénéficiaire du RSA</option>
-  
-    <option value="2">Allocataire ASS</option>
-  
-    <option value="3">Allocataire AAH</option>
-  
-    <option value="4">DETLD (+ 24 mois)</option>
-  
-    <option value="5">Niveau d'étude 3 (CAP, BEP) ou infra</option>
-  
-    <option value="6">Senior (+50 ans)</option>
-  
-    <option value="7">Jeune (-26 ans)</option>
-  
-    <option value="8">Sortant de l'ASE</option>
-  
-    <option value="9">DELD (12-24 mois)</option>
-  
-    <option value="10">Travailleur handicapé</option>
-  
-    <option value="11">Parent isolé</option>
-  
-    <option value="12">Personne sans hébergement ou hébergée ou ayant un parcours de rue</option>
-  
-    <option value="13">Réfugié statutaire, bénéficiaire d'une protection temporaire, protégé subsidiaire ou demandeur d'asile</option>
-  
-    <option value="14">Résident ZRR</option>
-  
-    <option value="15">Résident QPV</option>
-  
-    <option value="16">Sortant de détention ou personne placée sous main de justice</option>
-  
-    <option value="17">Maîtrise de la langue française</option>
-  
-    <option value="18">Mobilité</option>
-  
-  </select></div>
-      </fieldset>
-  
-  
-                                      
-  
-  
-      <hr/>
-      <fieldset>
-          <div class="form-group"><label class="form-label" for="id_departments">Département du candidat</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_departments" lang="fr" multiple="" name="departments">
-  </select></div>
-      </fieldset>
-  
-  
-                                      <button aria-label="Appliquer les filtres" class="btn btn-block btn-primary mt-3" id="js-job-applications-filters-apply-button">
-                                          Appliquer
-                                      </button>
-                                  </div>
-                              </form>
   '''
 # ---


### PR DESCRIPTION
### Pourquoi ?

Limiter les rechargements de la page, pour une meilleure expérience utilisateur.

La construction des filtres étant assez coûteuse, on devrait aussi constater
une légère amélioration de performance.

#### Comment tester ?

1. Se connecter en tant que prescripteur habilité
1. Aller à la liste des candidatures
1. Filtrer, naviguer entre les pages
