### PR TITLE
Filtre candidatures sur Mobile

### DIFF
--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -237,11 +237,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.4.7.zip",
-            "sha256": "db7a567cd0e160e74a1ecc867916cb785891f179d7d0008faa18c399acd39a9a",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.4.8.zip",
+            "sha256": "c72154b3e5cb6b80cb0415ab1a7bcac29405f531c777dd23cf14bd70b55e6180",
         },
         "extract": {
-            "origin": "itou-theme-1.4.7/dist",
+            "origin": "itou-theme-1.4.8/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
### Pourquoi ?

Problème de refermerture "automatique".
https://www.notion.so/plateforme-inclusion/1f630a1c1ea54ecdbfd037ca07a7f146?v=6119c6aa4385475a8fbdf8d7f220f19e&p=0218310b60424a7e99110d6e241b8db8&pm=c

### Comment ? 

Mise a jour du js dans le thème et suppression de l'appel de [la function onResize](https://github.com/gip-inclusion/itou-theme/blob/main/src/javascripts/app.js#L35)
Apparemment, à l'ouverture du collapse un élément interne s'affiche et pousse le contenu, donc "resize" le viewport et relance a nouveau la function.


### Solution
Supprimer l'appel de la function au resize
Solution imparfaite, mais temporaire, car les sidebars de filtres disparaitront avec la refonte UI



