### PR TITLE
Délivrer un PASS IAE dans l'admin: remplissage automatique des champs concernant l'origine de la candidature

### DIFF
--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.forms import widgets
 
 from itou.approvals.models import Approval
 from itou.job_applications.enums import Origin
@@ -89,11 +88,8 @@ class ManuallyAddApprovalFromJobApplicationForm(ApprovalFormMixin, forms.ModelFo
         super().__init__(*args, **kwargs)
 
         # Mandatory fields.
-        self.fields["user"].required = True
         self.fields["start_at"].required = True
         self.fields["end_at"].required = True
-        self.fields["created_by"].required = True
-        self.fields["eligibility_diagnosis"].required = True
 
         # Optional fields.
         # The `number` field can be filled in manually by an admin when a Pôle emploi
@@ -103,10 +99,4 @@ class ManuallyAddApprovalFromJobApplicationForm(ApprovalFormMixin, forms.ModelFo
 
     class Meta:
         model = Approval
-        fields = ["user", "start_at", "end_at", "number", "created_by", "origin", "eligibility_diagnosis"]
-        widgets = {
-            "user": widgets.HiddenInput(),
-            "created_by": widgets.HiddenInput(),
-            "origin": widgets.HiddenInput(),
-            "eligibility_diagnosis": widgets.HiddenInput(),
-        }
+        fields = ["start_at", "end_at", "number"]

--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -65,16 +65,16 @@ def manually_add_approval(
     initial = {
         "start_at": job_application.hiring_start_at,
         "end_at": Approval.get_default_end_date(job_application.hiring_start_at),
-        "user": job_application.job_seeker.pk,
-        "created_by": request.user.pk,
-        "origin": Origin.ADMIN,
-        "eligibility_diagnosis": job_application.eligibility_diagnosis,
     }
     form = ManuallyAddApprovalFromJobApplicationForm(initial=initial, data=request.POST or None)
     fieldsets = [(None, {"fields": list(form.base_fields)})]
     adminForm = admin.helpers.AdminForm(form, fieldsets, {})
 
     if request.method == "POST" and form.is_valid():
+        form.instance.user = job_application.job_seeker
+        form.instance.origin = Origin.ADMIN
+        form.instance.created_by = request.user
+        form.instance.eligibility_diagnosis = job_application.eligibility_diagnosis
         approval = form.save()
         job_application.approval = approval
         job_application.manually_deliver_approval(delivered_by=request.user)

--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -75,6 +75,8 @@ def manually_add_approval(
         form.instance.origin = Origin.ADMIN
         form.instance.created_by = request.user
         form.instance.eligibility_diagnosis = job_application.eligibility_diagnosis
+        for field, value in Approval.get_origin_kwargs(job_application).items():
+            setattr(form.instance, field, value)
         approval = form.save()
         job_application.approval = approval
         job_application.manually_deliver_approval(delivered_by=request.user)

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -29,6 +29,7 @@ from itou.approvals.models import Approval, CancelledApproval, PoleEmploiApprova
 from itou.companies.enums import CompanyKind
 from itou.employee_record.enums import Status
 from itou.files.models import File
+from itou.job_applications.enums import SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.users.enums import LackOfPoleEmploiId
 from itou.utils.apis import enums as api_enums
@@ -1077,6 +1078,11 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
         assert approval.user == job_application.job_seeker
         assert approval.origin == Origin.ADMIN
         assert approval.eligibility_diagnosis == job_application.eligibility_diagnosis
+
+        assert approval.origin_sender_kind == SenderKind.JOB_SEEKER
+        assert approval.origin_siae_kind == job_application.to_company.kind
+        assert approval.origin_siae_siret == job_application.to_company.siret
+        assert not approval.origin_prescriber_organization_kind
 
         assert len(mail.outbox) == 1
         email = mail.outbox[0]

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1024,10 +1024,6 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
         assert response.context["form"].initial == {
             "start_at": job_application.hiring_start_at,
             "end_at": Approval.get_default_end_date(job_application.hiring_start_at),
-            "user": job_application.job_seeker.pk,
-            "created_by": user.pk,
-            "origin": Origin.ADMIN,
-            "eligibility_diagnosis": job_application.eligibility_diagnosis,
         }
 
         # Without an eligibility diangosis on the job application.
@@ -1054,11 +1050,7 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
         post_data = {
             "start_at": job_application.hiring_start_at.strftime("%d/%m/%Y"),
             "end_at": job_application.hiring_end_at.strftime("%d/%m/%Y"),
-            "user": job_application.job_seeker.pk,
-            "created_by": user.pk,
-            "origin": Origin.ADMIN,
             "number": f"{Approval.ASP_ITOU_PREFIX}1234567",
-            "eligibility_diagnosis": job_application.eligibility_diagnosis,
         }
         response = self.client.post(url, data=post_data)
         assert response.status_code == 200
@@ -1068,10 +1060,6 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
         post_data = {
             "start_at": job_application.hiring_start_at.strftime("%d/%m/%Y"),
             "end_at": job_application.hiring_end_at.strftime("%d/%m/%Y"),
-            "user": job_application.job_seeker.pk,
-            "created_by": user.pk,
-            "origin": Origin.ADMIN,
-            "eligibility_diagnosis": job_application.eligibility_diagnosis,
         }
         response = self.client.post(url, data=post_data)
         assert response.status_code == 302
@@ -1087,6 +1075,8 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
         approval = job_application.approval
         assert approval.created_by == user
         assert approval.user == job_application.job_seeker
+        assert approval.origin == Origin.ADMIN
+        assert approval.eligibility_diagnosis == job_application.eligibility_diagnosis
 
         assert len(mail.outbox) == 1
         email = mail.outbox[0]


### PR DESCRIPTION
### Pourquoi ?

Pour que ces champs soient toujours remplis et puissent à terme être rendus obligatoires.
