### PR TITLE
Fiches salarié : Utiliser des données statiques dans les envois de notification pour éviter des erreurs

### DIFF
--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -44,7 +44,7 @@ class _API_AddressSerializer(serializers.Serializer):
         # Don't send extended address if it must be truncated:
         # Do not lower quality of data on 'itou' side
         # Check ASP rule : T030_c026_rg002
-        # This rule is badly written, and innacurate (regarding special characters).
+        # This rule is badly written, and inaccurate (regarding special characters).
         # Follows the acceptable format / RE for this field (now validated by ASP).
         additional_address = obj.jobseeker_profile.hexa_additional_address
         if not additional_address:

--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -1,15 +1,25 @@
+import re
+
 from rest_framework import serializers
+from unidecode import unidecode
 
-from itou.employee_record.serializers import EmployeeRecordSerializer, _AddressSerializer, _PersonSerializer
+from itou.employee_record.models import EmployeeRecord
+from itou.employee_record.typing import CodeComInsee
+from itou.users.enums import Title
+from itou.users.models import User
+from itou.utils.serializers import NullField, NullIfEmptyCharField
 
 
-# Employee record serializer is mostly the same as the one used
-# for serialization transfers.
-# Except some fields are "unobfuscated" and added for third-party
-# software connecting to the API.
+# Employee record serializers are mostly the same as the ones used
+# for serialization transfers, except some fields are "unobfuscated"
+# and added for third-party software connecting to the API.
+# For now, we are going to duplicate everything:
+#   - We want to make some changes when serializing for transfer but not break the API
+#   - We could then remove some transfert specific formatting rules
+#   - We rarely ever touch those, so probably not too PITA to maintain, and we can refactor later
 
 
-class _API_AddressSerializer(_AddressSerializer):
+class _API_AddressSerializer(serializers.Serializer):
     """
     This class in only useful for compatibility.
     We decided not to send phone and email (business concerns and bad ASP address filters).
@@ -20,16 +30,128 @@ class _API_AddressSerializer(_AddressSerializer):
     adrTelephone = serializers.CharField(source="phone")
     adrMail = serializers.CharField(source="email")
 
+    adrNumeroVoie = serializers.CharField(source="jobseeker_profile.hexa_lane_number")
+    codeextensionvoie = NullIfEmptyCharField(source="jobseeker_profile.hexa_std_extension", allow_blank=True)
+    codetypevoie = serializers.CharField(source="jobseeker_profile.hexa_lane_type")
 
-class _API_PersonSerializer(_PersonSerializer):
-    """
-    Specific fields added to the API (not used in ASP transfers)
-    """
+    adrLibelleVoie = serializers.SerializerMethodField()
+    adrCpltDistribution = serializers.SerializerMethodField()
 
+    codeinseecom = serializers.CharField(source="jobseeker_profile.hexa_commune.code", allow_null=True)
+    codepostalcedex = serializers.CharField(source="jobseeker_profile.hexa_post_code")
+
+    def get_adrCpltDistribution(self, obj: User) -> str | None:
+        # Don't send extended address if it must be truncated:
+        # Do not lower quality of data on 'itou' side
+        # Check ASP rule : T030_c026_rg002
+        # This rule is badly written, and innacurate (regarding special characters).
+        # Follows the acceptable format / RE for this field (now validated by ASP).
+        additional_address = obj.jobseeker_profile.hexa_additional_address
+        if not additional_address:
+            # Force empty string to be rendered as `null`
+            return None
+        if additional_address and not re.match("^[a-zA-Z0-9@ ]{,32}$", additional_address):
+            return None
+        return additional_address
+
+    def get_adrLibelleVoie(self, obj: User) -> str | None:
+        # Remove diacritics and parenthesis from adrLibelleVoie field fixes ASP error 3330
+        # (parenthesis are not described as invalid characters in specification document).
+        lane = obj.jobseeker_profile.hexa_lane_name
+        if lane:
+            return unidecode(lane.translate({ord(ch): "" for ch in "()"}))
+        return None
+
+
+class _API_PersonSerializer(serializers.Serializer):
+    # Specific field added to the API (not used in ASP transfers)
     NIR = serializers.CharField(source="job_seeker.jobseeker_profile.nir")
 
+    passIae = serializers.CharField(source="approval_number")
+    sufPassIae = NullField()
+    idItou = serializers.CharField(source="job_seeker.jobseeker_profile.asp_uid")
 
-class EmployeeRecordAPISerializer(EmployeeRecordSerializer):
+    civilite = serializers.ChoiceField(choices=Title.choices, source="job_seeker.title")
+    nomUsage = serializers.SerializerMethodField()
+    nomNaissance = NullField()
+    prenom = serializers.SerializerMethodField()
+    dateNaissance = serializers.DateField(format="%d/%m/%Y", source="job_seeker.birthdate")
+
+    codeDpt = serializers.CharField(source="job_seeker.birth_place.department_code", required=False)
+    codeInseePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.code", allow_null=True)
+    codeGroupePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.group", allow_null=True)
+
+    # codeComInsee is only mandatory if birth country is France
+    codeComInsee = serializers.SerializerMethodField(required=False)
+
+    passDateDeb = serializers.DateField(format="%d/%m/%Y", source="approval.start_at")
+    passDateFin = serializers.DateField(format="%d/%m/%Y", source="approval.end_at")
+
+    def get_nomUsage(self, obj: EmployeeRecord) -> str:
+        return unidecode(obj.job_seeker.last_name).upper()
+
+    def get_prenom(self, obj: EmployeeRecord) -> str:
+        return unidecode(obj.job_seeker.first_name).upper()
+
+    def get_codeComInsee(self, obj: EmployeeRecord) -> CodeComInsee:
+        # Another ASP subtlety, making top-level and children with the same name
+        # The commune can be empty if the job seeker is not born in France
+        if birth_place := obj.job_seeker.jobseeker_profile.birth_place:
+            return {
+                "codeComInsee": birth_place.code,
+                "codeDpt": birth_place.department_code,
+            }
+
+        # However, if the employee is not born in France
+        # the department code must be '099' (error 3411)
+        return {
+            "codeComInsee": None,
+            "codeDpt": "099",
+        }
+
+
+class _API_SituationSerializer(serializers.Serializer):
+    niveauFormation = serializers.CharField(source="job_seeker.jobseeker_profile.education_level")
+    salarieEnEmploi = serializers.BooleanField(source="job_seeker.jobseeker_profile.is_employed")
+
+    salarieSansEmploiDepuis = NullIfEmptyCharField(source="job_seeker.jobseeker_profile.unemployed_since")
+    salarieSansRessource = serializers.BooleanField(source="job_seeker.jobseeker_profile.resourceless")
+
+    inscritPoleEmploi = serializers.BooleanField(source="job_seeker.jobseeker_profile.pole_emploi_id")
+    inscritPoleEmploiDepuis = NullIfEmptyCharField(source="job_seeker.jobseeker_profile.pole_emploi_since")
+    numeroIDE = serializers.CharField(source="job_seeker.jobseeker_profile.pole_emploi_id")
+
+    salarieRQTH = serializers.BooleanField(source="job_seeker.jobseeker_profile.rqth_employee")
+    salarieOETH = serializers.BooleanField(source="asp_oeth_employee")
+    salarieAideSociale = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_social_allowance")
+
+    salarieBenefRSA = serializers.CharField(source="job_seeker.jobseeker_profile.has_rsa_allocation")
+    salarieBenefRSADepuis = NullIfEmptyCharField(
+        source="job_seeker.jobseeker_profile.rsa_allocation_since", allow_blank=True
+    )
+
+    salarieBenefASS = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_ass_allocation")
+    salarieBenefASSDepuis = NullIfEmptyCharField(
+        source="job_seeker.jobseeker_profile.ass_allocation_since", allow_blank=True
+    )
+
+    salarieBenefAAH = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_aah_allocation")
+    salarieBenefAAHDepuis = NullIfEmptyCharField(
+        source="job_seeker.jobseeker_profile.aah_allocation_since", allow_blank=True
+    )
+
+    salarieBenefATA = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_ata_allocation")
+    salarieBenefATADepuis = NullIfEmptyCharField(
+        source="job_seeker.jobseeker_profile.ata_allocation_since", allow_blank=True
+    )
+
+    # There is a clear lack of knowledge of ASP business rules on this point.
+    # Without any satisfactory answer, it has been decided to obfuscate / mock these fields.
+    salarieTypeEmployeur = serializers.CharField(source="asp_employer_type", required=False)
+    orienteur = serializers.CharField(source="asp_prescriber_type", required=False)
+
+
+class EmployeeRecordAPISerializer(serializers.Serializer):
     """
     This serializer is a version with the `numeroAnnexe` field added (financial annex number).
 
@@ -37,6 +159,33 @@ class EmployeeRecordAPISerializer(EmployeeRecordSerializer):
     main SFTP serializer but was removed for RGPD concerns.
     """
 
-    numeroAnnexe = serializers.CharField(source="financial_annex_number")
-    adresse = _API_AddressSerializer(source="job_seeker")
+    numLigne = serializers.IntegerField(source="asp_batch_line_number")
+    typeMouvement = serializers.CharField(source="ASP_MOVEMENT_TYPE")
+    siret = serializers.CharField()
+    mesure = serializers.CharField(source="asp_siae_type")
+
+    # See : http://www.tomchristie.com/rest-framework-2-docs/api-guide/fields
     personnePhysique = _API_PersonSerializer(source="*")
+    adresse = _API_AddressSerializer(source="job_seeker")
+    situationSalarie = _API_SituationSerializer(source="*")
+
+    # These fields are null at the beginning of the ASP processing
+    codeTraitement = serializers.CharField(source="asp_processing_code", allow_blank=True)
+    libelleTraitement = serializers.CharField(source="asp_processing_label", allow_blank=True)
+
+    numeroAnnexe = serializers.CharField(source="financial_annex_number")
+
+
+class EmployeeRecordUpdateNotificationAPISerializer(serializers.Serializer):
+    numLigne = serializers.IntegerField(source="asp_batch_line_number")
+    typeMouvement = serializers.CharField(source="ASP_MOVEMENT_TYPE")
+    siret = serializers.CharField(source="employee_record.siret")
+    mesure = serializers.CharField(source="employee_record.asp_siae_type")
+
+    personnePhysique = _API_PersonSerializer(source="employee_record")
+    adresse = _API_AddressSerializer(source="employee_record.job_seeker")
+    situationSalarie = _API_SituationSerializer(source="employee_record")
+
+    # These fields are null at the beginning of the ASP processing
+    codeTraitement = serializers.CharField(source="asp_processing_code", allow_blank=True)
+    libelleTraitement = serializers.CharField(source="asp_processing_label", allow_blank=True)

--- a/itou/api/employee_record_api/serializers.py
+++ b/itou/api/employee_record_api/serializers.py
@@ -65,38 +65,42 @@ class _API_AddressSerializer(serializers.Serializer):
 
 class _API_PersonSerializer(serializers.Serializer):
     # Specific field added to the API (not used in ASP transfers)
-    NIR = serializers.CharField(source="job_seeker.jobseeker_profile.nir")
+    NIR = serializers.CharField(source="job_application.job_seeker.jobseeker_profile.nir")
 
     passIae = serializers.CharField(source="approval_number")
     sufPassIae = NullField()
-    idItou = serializers.CharField(source="job_seeker.jobseeker_profile.asp_uid")
+    idItou = serializers.CharField(source="job_application.job_seeker.jobseeker_profile.asp_uid")
 
-    civilite = serializers.ChoiceField(choices=Title.choices, source="job_seeker.title")
+    civilite = serializers.ChoiceField(choices=Title.choices, source="job_application.job_seeker.title")
     nomUsage = serializers.SerializerMethodField()
     nomNaissance = NullField()
     prenom = serializers.SerializerMethodField()
-    dateNaissance = serializers.DateField(format="%d/%m/%Y", source="job_seeker.birthdate")
+    dateNaissance = serializers.DateField(format="%d/%m/%Y", source="job_application.job_seeker.birthdate")
 
-    codeDpt = serializers.CharField(source="job_seeker.birth_place.department_code", required=False)
-    codeInseePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.code", allow_null=True)
-    codeGroupePays = serializers.CharField(source="job_seeker.jobseeker_profile.birth_country.group", allow_null=True)
+    codeDpt = serializers.CharField(source="job_application.job_seeker.birth_place.department_code", required=False)
+    codeInseePays = serializers.CharField(
+        source="job_application.job_seeker.jobseeker_profile.birth_country.code", allow_null=True
+    )
+    codeGroupePays = serializers.CharField(
+        source="job_application.job_seeker.jobseeker_profile.birth_country.group", allow_null=True
+    )
 
     # codeComInsee is only mandatory if birth country is France
     codeComInsee = serializers.SerializerMethodField(required=False)
 
-    passDateDeb = serializers.DateField(format="%d/%m/%Y", source="approval.start_at")
-    passDateFin = serializers.DateField(format="%d/%m/%Y", source="approval.end_at")
+    passDateDeb = serializers.DateField(format="%d/%m/%Y", source="job_application.approval.start_at")
+    passDateFin = serializers.DateField(format="%d/%m/%Y", source="job_application.approval.end_at")
 
     def get_nomUsage(self, obj: EmployeeRecord) -> str:
-        return unidecode(obj.job_seeker.last_name).upper()
+        return unidecode(obj.job_application.job_seeker.last_name).upper()
 
     def get_prenom(self, obj: EmployeeRecord) -> str:
-        return unidecode(obj.job_seeker.first_name).upper()
+        return unidecode(obj.job_application.job_seeker.first_name).upper()
 
     def get_codeComInsee(self, obj: EmployeeRecord) -> CodeComInsee:
         # Another ASP subtlety, making top-level and children with the same name
         # The commune can be empty if the job seeker is not born in France
-        if birth_place := obj.job_seeker.jobseeker_profile.birth_place:
+        if birth_place := obj.job_application.job_seeker.jobseeker_profile.birth_place:
             return {
                 "codeComInsee": birth_place.code,
                 "codeDpt": birth_place.department_code,
@@ -111,38 +115,50 @@ class _API_PersonSerializer(serializers.Serializer):
 
 
 class _API_SituationSerializer(serializers.Serializer):
-    niveauFormation = serializers.CharField(source="job_seeker.jobseeker_profile.education_level")
-    salarieEnEmploi = serializers.BooleanField(source="job_seeker.jobseeker_profile.is_employed")
+    niveauFormation = serializers.CharField(source="job_application.job_seeker.jobseeker_profile.education_level")
+    salarieEnEmploi = serializers.BooleanField(source="job_application.job_seeker.jobseeker_profile.is_employed")
 
-    salarieSansEmploiDepuis = NullIfEmptyCharField(source="job_seeker.jobseeker_profile.unemployed_since")
-    salarieSansRessource = serializers.BooleanField(source="job_seeker.jobseeker_profile.resourceless")
+    salarieSansEmploiDepuis = NullIfEmptyCharField(
+        source="job_application.job_seeker.jobseeker_profile.unemployed_since"
+    )
+    salarieSansRessource = serializers.BooleanField(source="job_application.job_seeker.jobseeker_profile.resourceless")
 
-    inscritPoleEmploi = serializers.BooleanField(source="job_seeker.jobseeker_profile.pole_emploi_id")
-    inscritPoleEmploiDepuis = NullIfEmptyCharField(source="job_seeker.jobseeker_profile.pole_emploi_since")
-    numeroIDE = serializers.CharField(source="job_seeker.jobseeker_profile.pole_emploi_id")
+    inscritPoleEmploi = serializers.BooleanField(source="job_application.job_seeker.jobseeker_profile.pole_emploi_id")
+    inscritPoleEmploiDepuis = NullIfEmptyCharField(
+        source="job_application.job_seeker.jobseeker_profile.pole_emploi_since"
+    )
+    numeroIDE = serializers.CharField(source="job_application.job_seeker.jobseeker_profile.pole_emploi_id")
 
-    salarieRQTH = serializers.BooleanField(source="job_seeker.jobseeker_profile.rqth_employee")
-    salarieOETH = serializers.BooleanField(source="asp_oeth_employee")
-    salarieAideSociale = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_social_allowance")
+    salarieRQTH = serializers.BooleanField(source="job_application.job_seeker.jobseeker_profile.rqth_employee")
+    salarieOETH = serializers.BooleanField(source="job_application.job_seeker.jobseeker_profile.oeth_employee")
+    salarieAideSociale = serializers.BooleanField(
+        source="job_application.job_seeker.jobseeker_profile.has_social_allowance"
+    )
 
-    salarieBenefRSA = serializers.CharField(source="job_seeker.jobseeker_profile.has_rsa_allocation")
+    salarieBenefRSA = serializers.CharField(source="job_application.job_seeker.jobseeker_profile.has_rsa_allocation")
     salarieBenefRSADepuis = NullIfEmptyCharField(
-        source="job_seeker.jobseeker_profile.rsa_allocation_since", allow_blank=True
+        source="job_application.job_seeker.jobseeker_profile.rsa_allocation_since", allow_blank=True
     )
 
-    salarieBenefASS = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_ass_allocation")
+    salarieBenefASS = serializers.BooleanField(
+        source="job_application.job_seeker.jobseeker_profile.has_ass_allocation"
+    )
     salarieBenefASSDepuis = NullIfEmptyCharField(
-        source="job_seeker.jobseeker_profile.ass_allocation_since", allow_blank=True
+        source="job_application.job_seeker.jobseeker_profile.ass_allocation_since", allow_blank=True
     )
 
-    salarieBenefAAH = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_aah_allocation")
+    salarieBenefAAH = serializers.BooleanField(
+        source="job_application.job_seeker.jobseeker_profile.has_aah_allocation"
+    )
     salarieBenefAAHDepuis = NullIfEmptyCharField(
-        source="job_seeker.jobseeker_profile.aah_allocation_since", allow_blank=True
+        source="job_application.job_seeker.jobseeker_profile.aah_allocation_since", allow_blank=True
     )
 
-    salarieBenefATA = serializers.BooleanField(source="job_seeker.jobseeker_profile.has_ata_allocation")
+    salarieBenefATA = serializers.BooleanField(
+        source="job_application.job_seeker.jobseeker_profile.has_ata_allocation"
+    )
     salarieBenefATADepuis = NullIfEmptyCharField(
-        source="job_seeker.jobseeker_profile.ata_allocation_since", allow_blank=True
+        source="job_application.job_seeker.jobseeker_profile.ata_allocation_since", allow_blank=True
     )
 
     # There is a clear lack of knowledge of ASP business rules on this point.
@@ -166,14 +182,14 @@ class EmployeeRecordAPISerializer(serializers.Serializer):
 
     # See : http://www.tomchristie.com/rest-framework-2-docs/api-guide/fields
     personnePhysique = _API_PersonSerializer(source="*")
-    adresse = _API_AddressSerializer(source="job_seeker")
+    adresse = _API_AddressSerializer(source="job_application.job_seeker")
     situationSalarie = _API_SituationSerializer(source="*")
 
     # These fields are null at the beginning of the ASP processing
     codeTraitement = serializers.CharField(source="asp_processing_code", allow_blank=True)
     libelleTraitement = serializers.CharField(source="asp_processing_label", allow_blank=True)
 
-    numeroAnnexe = serializers.CharField(source="financial_annex_number")
+    numeroAnnexe = serializers.CharField(source="financial_annex.number", allow_null=True)
 
 
 class EmployeeRecordUpdateNotificationAPISerializer(serializers.Serializer):
@@ -183,7 +199,7 @@ class EmployeeRecordUpdateNotificationAPISerializer(serializers.Serializer):
     mesure = serializers.CharField(source="employee_record.asp_siae_type")
 
     personnePhysique = _API_PersonSerializer(source="employee_record")
-    adresse = _API_AddressSerializer(source="employee_record.job_seeker")
+    adresse = _API_AddressSerializer(source="employee_record.job_application.job_seeker")
     situationSalarie = _API_SituationSerializer(source="employee_record")
 
     # These fields are null at the beginning of the ASP processing

--- a/itou/api/employee_record_api/viewsets.py
+++ b/itou/api/employee_record_api/viewsets.py
@@ -8,10 +8,9 @@ from rest_framework.throttling import UserRateThrottle
 
 from itou.api import AUTH_TOKEN_EXPLANATION_TEXT
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification, Status
-from itou.employee_record.serializers import EmployeeRecordUpdateNotificationSerializer
 
 from .perms import EmployeeRecordAPIPermission
-from .serializers import EmployeeRecordAPISerializer
+from .serializers import EmployeeRecordAPISerializer, EmployeeRecordUpdateNotificationAPISerializer
 
 
 logger = logging.getLogger("api_drf")
@@ -167,7 +166,7 @@ Permet de récupérer les fiches salarié créées depuis date donnée en param�
 
 class EmployeeRecordUpdateNotificationViewSet(AbstractEmployeeRecordViewSet):
     queryset = EmployeeRecordUpdateNotification.objects.all()
-    serializer_class = EmployeeRecordUpdateNotificationSerializer
+    serializer_class = EmployeeRecordUpdateNotificationAPISerializer
 
 
 EmployeeRecordUpdateNotificationViewSet.__doc__ = f"""\

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -1,42 +1,13 @@
 import re
-import typing
 
-from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from unidecode import unidecode
 
 from itou.employee_record.models import EmployeeRecord
+from itou.employee_record.typing import CodeComInsee
 from itou.users.enums import Title
 from itou.users.models import User
-
-
-### Notifications
-
-
-class NullIfEmptyCharField(serializers.CharField):
-    def to_representation(self, value):
-        if value == "":
-            return None
-        return super().to_representation(value)
-
-
-@extend_schema_field(OpenApiTypes.NONE)
-class NullField(serializers.Field):
-    def to_representation(self, _):
-        # Field value is always replaced by `None`.
-        # We noticed an erratic processing for sone fields on ASP side (phone, email, ...),
-        # so we simply decided not to send their value anymore.
-        return None
-
-    def get_attribute(self, _):
-        # Do not attempt to match field name in instance
-        return None
-
-
-class CodeComInsee(typing.TypedDict):
-    codeComInsee: str | None
-    codeDpt: str
+from itou.utils.serializers import NullField, NullIfEmptyCharField
 
 
 class _PersonSerializer(serializers.Serializer):

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -100,7 +100,7 @@ class _AddressSerializer(serializers.Serializer):
         # Don't send extended address if it must be truncated:
         # Do not lower quality of data on 'itou' side
         # Check ASP rule : T030_c026_rg002
-        # This rule is badly written, and innacurate (regarding special characters).
+        # This rule is badly written, and inaccurate (regarding special characters).
         # Follows the acceptable format / RE for this field (now validated by ASP).
         additional_address = obj.jobseeker_profile.hexa_additional_address
         if not additional_address:

--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -134,19 +134,6 @@ class _SituationSerializer(serializers.Serializer):
     orienteur = serializers.CharField(source="asp_prescriber_type", required=False)
 
 
-class _BaseEmployeeRecordSerializer(serializers.Serializer):
-    numLigne = serializers.IntegerField(source="asp_batch_line_number")
-    typeMouvement = serializers.CharField(source="ASP_MOVEMENT_TYPE")
-
-    personnePhysique = None
-    adresse = None
-    situationSalarie = None
-
-    # These fields are null at the beginning of the ASP processing
-    codeTraitement = serializers.CharField(source="asp_processing_code", allow_blank=True)
-    libelleTraitement = serializers.CharField(source="asp_processing_label", allow_blank=True)
-
-
 class EmployeeRecordSerializer(serializers.Serializer):
     numLigne = serializers.IntegerField(source="asp_batch_line_number")
     typeMouvement = serializers.CharField(source="ASP_MOVEMENT_TYPE")

--- a/itou/employee_record/typing.py
+++ b/itou/employee_record/typing.py
@@ -1,0 +1,6 @@
+import typing
+
+
+class CodeComInsee(typing.TypedDict):
+    codeComInsee: str | None
+    codeDpt: str

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -10,7 +10,7 @@
 
 {% block content_title %}
     <h1>Désactiver la fiche salarié ASP</h1>
-    <h2 class="text-muted">{{ employee_record.job_seeker.get_full_name }}</h2>
+    <h2 class="text-muted">{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/includes/employee_record_summary.html
+++ b/itou/templates/employee_record/includes/employee_record_summary.html
@@ -1,4 +1,4 @@
-{% with profile=employee_record.job_seeker_profile employee=employee_record.job_seeker %}
+{% with profile=employee_record.job_application.job_seeker.jobseeker_profile employee=employee_record.job_application.job_seeker %}
     <div>
         <p>
             <strong>Etat civil</strong>

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -10,7 +10,7 @@
 
 {% block content_title %}
     <h1>Réactiver la fiche salarié ASP</h1>
-    <h2 class="text-muted">{{ employee_record.job_seeker.get_full_name }}</h2>
+    <h2 class="text-muted">{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content_title %}
-    <h1>Détail fiche salarié ASP: {{ employee_record.job_seeker.get_full_name }}</h1>
+    <h1>Détail fiche salarié ASP: {{ employee_record.job_application.job_seeker.get_full_name }}</h1>
     <p>{% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}</p>
 {% endblock %}
 

--- a/itou/utils/serializers.py
+++ b/itou/utils/serializers.py
@@ -10,6 +10,13 @@ class NullIfEmptyCharField(serializers.CharField):
         return super().to_representation(value)
 
 
+class NullIfEmptyChoiceField(serializers.ChoiceField):
+    def to_representation(self, value):
+        if value == "":
+            return None
+        return super().to_representation(value)
+
+
 @extend_schema_field(OpenApiTypes.NONE)
 class NullField(serializers.Field):
     def to_representation(self, _):

--- a/itou/utils/serializers.py
+++ b/itou/utils/serializers.py
@@ -1,0 +1,21 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+
+class NullIfEmptyCharField(serializers.CharField):
+    def to_representation(self, value):
+        if value == "":
+            return None
+        return super().to_representation(value)
+
+
+@extend_schema_field(OpenApiTypes.NONE)
+class NullField(serializers.Field):
+    def to_representation(self, _):
+        # Always replace by `None`.
+        return None
+
+    def get_attribute(self, _):
+        # Do not attempt to match field name in instance
+        return None

--- a/tests/api/employee_record_api/test_serializers.py
+++ b/tests/api/employee_record_api/test_serializers.py
@@ -1,0 +1,148 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from itou.api.employee_record_api.serializers import (
+    EmployeeRecordAPISerializer,
+    EmployeeRecordUpdateNotificationAPISerializer,
+    _API_AddressSerializer,
+    _API_PersonSerializer,
+)
+from itou.asp.models import SiaeMeasure
+from itou.companies.enums import CompanyKind
+from itou.companies.models import Company
+from itou.employee_record.enums import Status
+from itou.employee_record.models import EmployeeRecordUpdateNotification
+from tests.employee_record.factories import EmployeeRecordFactory, EmployeeRecordWithProfileFactory
+from tests.users.factories import JobSeekerFactory
+
+
+def test_address_serializer_hexa_additional_address():
+    # If additional address contains special characters or is more than 32 characters long
+    # then resulting additional address becomes `None`
+    employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
+    job_seeker = employee_record.job_seeker
+    profile = job_seeker.jobseeker_profile
+    profile.hexa_additional_address = "Bad additional address with %$£"
+
+    serializer = _API_AddressSerializer(job_seeker)
+    data = serializer.data
+
+    assert data is not None
+    assert data["adrCpltDistribution"] is None
+
+    profile.hexa_additional_address = "Bad additional address because it is really over 32 characters"
+    serializer = _API_AddressSerializer(job_seeker)
+    data = serializer.data
+
+    assert data is not None
+    assert data["adrCpltDistribution"] is None
+
+    good_address = "Good additional address"
+    profile.hexa_additional_address = good_address
+
+    serializer = _API_AddressSerializer(job_seeker)
+    data = serializer.data
+
+    assert data is not None
+    assert good_address == data["adrCpltDistribution"]
+
+
+def test_address_serializer_hexa_lane_name():
+    # If lane name contains parens,
+    # then remove them from resulting lane name
+    # (better geolocation)
+    employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
+    job_seeker = employee_record.job_seeker
+    profile = job_seeker.jobseeker_profile
+    profile.hexa_lane_name = "Lane name (with parens)"
+
+    serializer = _API_AddressSerializer(job_seeker)
+    data = serializer.data
+
+    assert data is not None
+    assert "Lane name with parens" == data["adrLibelleVoie"]
+
+    good_lane_name = "Lane name without parens"
+    profile.hexa_lane_name = good_lane_name
+    serializer = _API_AddressSerializer(job_seeker)
+    data = serializer.data
+
+    assert data is not None
+    assert good_lane_name == data["adrLibelleVoie"]
+
+
+def test_address_serializer_with_empty_fields():
+    serializer = _API_AddressSerializer(JobSeekerFactory(phone="", email=None))
+
+    assert serializer.data == {
+        "adrTelephone": "",
+        "adrMail": None,
+        "adrNumeroVoie": "",
+        "codeextensionvoie": None,
+        "codetypevoie": "",
+        "adrLibelleVoie": None,
+        "adrCpltDistribution": None,
+        "codeinseecom": None,
+        "codepostalcedex": "",
+    }
+
+
+def test_person_serializer_with_empty_birth_country():
+    serializer = _API_PersonSerializer(
+        EmployeeRecordFactory(job_application__job_seeker__jobseeker_profile__birth_country=None)
+    )
+
+    assert serializer.data["codeInseePays"] is None
+    assert serializer.data["codeGroupePays"] is None
+
+
+def test_oeth_employee_for_eiti():
+    employee_record = EmployeeRecordWithProfileFactory(
+        status=Status.PROCESSED,
+        job_application__to_company__kind=CompanyKind.EITI,
+    )
+    employee_record.job_application.job_seeker.jobseeker_profile.oeth_employee = True
+    data = EmployeeRecordAPISerializer(employee_record).data
+
+    assert data["mesure"] == "EITI_DC"
+    assert data["situationSalarie"]["salarieOETH"] is False
+
+
+@pytest.mark.parametrize("kind", set(Company.ASP_EMPLOYEE_RECORD_KINDS) - {CompanyKind.EITI})
+def test_oeth_employee_for_non_eiti(kind):
+    employee_record = EmployeeRecordWithProfileFactory(
+        status=Status.PROCESSED,
+        job_application__to_company__kind=kind,
+    )
+    employee_record.job_application.job_seeker.jobseeker_profile.oeth_employee = True
+    data = EmployeeRecordAPISerializer(employee_record).data
+
+    assert data["mesure"] == SiaeMeasure.from_siae_kind(kind)
+    assert data["situationSalarie"]["salarieOETH"] is True
+
+
+def test_notification_serializer():
+    # High-level: check basic information
+    start_at = timezone.localdate()
+    end_at = timezone.localdate() + timedelta(weeks=52)
+    employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
+    approval = employee_record.approval
+    approval.start_at = start_at
+    approval.end_at = end_at
+    employee_record.save()
+
+    data = EmployeeRecordUpdateNotificationAPISerializer(
+        EmployeeRecordUpdateNotification(employee_record=employee_record)
+    ).data
+    assert data is not None
+    assert data.get("siret") == employee_record.siret
+    assert data.get("mesure") == employee_record.asp_siae_type
+    assert data.get("typeMouvement") == EmployeeRecordUpdateNotification.ASP_MOVEMENT_TYPE
+
+    personnal_data = data.get("personnePhysique")
+    assert personnal_data is not None
+    assert personnal_data.get("passIae") == employee_record.approval_number
+    assert personnal_data.get("passDateDeb") == start_at.strftime("%d/%m/%Y")
+    assert personnal_data.get("passDateFin") == end_at.strftime("%d/%m/%Y")

--- a/tests/employee_record/__snapshots__/test_serializers.ambr
+++ b/tests/employee_record/__snapshots__/test_serializers.ambr
@@ -1,0 +1,93 @@
+# serializer version: 1
+# name: test_update_notification_use_static_serializers_on_missing_fields[birth_country-None-personnePhysique]
+  ReturnDict({
+    'civilite': 'MME',
+    'codeComInsee': dict({
+      'codeComInsee': None,
+      'codeDpt': '099',
+    }),
+    'codeGroupePays': '3',
+    'codeInseePays': '102',
+    'dateNaissance': '1990-05-01',
+    'idItou': 'a08dbdb523633cfc59dfdb297307a1',
+    'nomNaissance': None,
+    'nomUsage': 'DUPONT',
+    'passDateDeb': '01/01/2000',
+    'passDateFin': '01/01/3000',
+    'passIae': '999999999999',
+    'prenom': 'SACHA',
+    'sufPassIae': None,
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[birth_place-None-personnePhysique]
+  ReturnDict({
+    'civilite': 'MME',
+    'codeComInsee': dict({
+      'codeComInsee': None,
+      'codeDpt': '099',
+    }),
+    'codeGroupePays': '3',
+    'codeInseePays': '102',
+    'dateNaissance': '1990-05-01',
+    'idItou': 'a08dbdb523633cfc59dfdb297307a1',
+    'nomNaissance': None,
+    'nomUsage': 'DUPONT',
+    'passDateDeb': '01/01/2000',
+    'passDateFin': '01/01/3000',
+    'passIae': '999999999999',
+    'prenom': 'SACHA',
+    'sufPassIae': None,
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[hexa_commune-None-adresse]
+  ReturnDict({
+    'adrCpltDistribution': None,
+    'adrLibelleVoie': 'DE BLIDA',
+    'adrMail': None,
+    'adrNumeroVoie': '3',
+    'adrTelephone': None,
+    'codeextensionvoie': None,
+    'codeinseecom': '57463',
+    'codepostalcedex': '57000',
+    'codetypevoie': 'AV',
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[hexa_lane_name--adresse]
+  ReturnDict({
+    'adrCpltDistribution': None,
+    'adrLibelleVoie': 'DE BLIDA',
+    'adrMail': None,
+    'adrNumeroVoie': '3',
+    'adrTelephone': None,
+    'codeextensionvoie': None,
+    'codeinseecom': '57463',
+    'codepostalcedex': '57000',
+    'codetypevoie': 'AV',
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[hexa_lane_type--adresse]
+  ReturnDict({
+    'adrCpltDistribution': None,
+    'adrLibelleVoie': 'DE BLIDA',
+    'adrMail': None,
+    'adrNumeroVoie': '3',
+    'adrTelephone': None,
+    'codeextensionvoie': None,
+    'codeinseecom': '57463',
+    'codepostalcedex': '57000',
+    'codetypevoie': 'AV',
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[hexa_post_code--adresse]
+  ReturnDict({
+    'adrCpltDistribution': None,
+    'adrLibelleVoie': 'DE BLIDA',
+    'adrMail': None,
+    'adrNumeroVoie': '3',
+    'adrTelephone': None,
+    'codeextensionvoie': None,
+    'codeinseecom': '57463',
+    'codepostalcedex': '57000',
+    'codetypevoie': 'AV',
+  })
+# ---

--- a/tests/employee_record/test_notifications.py
+++ b/tests/employee_record/test_notifications.py
@@ -15,7 +15,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # then exactly *one* 'NEW' notification objects must be created.
         # A normal case
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
         today = timezone.localdate()
 
         approval.start_at = today + timedelta(days=1)
@@ -30,7 +30,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # then exactly *one* 'NEW' notification objects must be created.
         # Another normal case
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
         today = timezone.localdate()
 
         approval.end_at = today + timedelta(days=2)
@@ -45,7 +45,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # then exactly *one* 'NEW' notification objects must be created,
         # (which is the last one)
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
         today = timezone.localdate()
 
         approval.start_at = today + timedelta(days=1)
@@ -66,7 +66,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # And the target fields are not monitored
         # Then there is no creation of an EmployeeRecordUpdateNotification object.
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
 
         approval.created_at = timezone.localtime()
         approval.save()
@@ -91,7 +91,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         for status in [elt for elt in Status.values if elt != Status.PROCESSED]:
             with self.subTest(status):
                 employee_record = EmployeeRecordFactory(status=status)
-                approval = employee_record.approval
+                approval = employee_record.job_application.approval
                 today = timezone.localtime()
 
                 approval.created_at = today + timedelta(days=2)
@@ -126,7 +126,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # Creation of a suspension on an approval linked to an employee record
         # must also create a new employee record update notification.
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
         start_at = timezone.localdate()
 
         SuspensionFactory(
@@ -141,7 +141,7 @@ class EmployeeRecordUpdateNotificationTest(TestCase):
         # Creation of a prolongation on an approval linked to an employee record
         # must also create a new employee record update notification.
         employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
 
         ProlongationFactory(
             approval=approval,

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -13,9 +13,9 @@ from itou.employee_record.serializers import (
     EmployeeRecordUpdateNotificationBatchSerializer,
     EmployeeRecordUpdateNotificationSerializer,
     _AddressSerializer,
-    _PersonSerializer,
 )
-from tests.employee_record.factories import EmployeeRecordFactory, EmployeeRecordWithProfileFactory
+from tests.asp.factories import CommuneFactory
+from tests.employee_record.factories import EmployeeRecordWithProfileFactory
 from tests.users.factories import JobSeekerFactory
 from tests.utils.test import TestCase
 
@@ -76,28 +76,20 @@ class EmployeeRecordAddressSerializerTest(TestCase):
         assert good_lane_name == data["adrLibelleVoie"]
 
     def test_with_empty_fields(self):
-        serializer = _AddressSerializer(JobSeekerFactory())
+        commune = CommuneFactory()
+        serializer = _AddressSerializer(JobSeekerFactory(jobseeker_profile__hexa_commune=commune))
 
         assert serializer.data == {
             "adrTelephone": None,
             "adrMail": None,
-            "adrNumeroVoie": "",
+            "adrNumeroVoie": None,
             "codeextensionvoie": None,
             "codetypevoie": "",
-            "adrLibelleVoie": None,
+            "adrLibelleVoie": "",
             "adrCpltDistribution": None,
-            "codeinseecom": None,
+            "codeinseecom": commune.code,
             "codepostalcedex": "",
         }
-
-
-def test_person_serializer_with_empty_birth_country():
-    serializer = _PersonSerializer(
-        EmployeeRecordFactory(job_application__job_seeker__jobseeker_profile__birth_country=None)
-    )
-
-    assert serializer.data["codeInseePays"] is None
-    assert serializer.data["codeGroupePays"] is None
 
 
 class TestEmployeeRecordSerializer:

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -26,7 +26,7 @@ class EmployeeRecordAddressSerializerTest(TestCase):
         # or is more than 32 charactrs long
         # then resulting additional address becomes `None`
         employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
-        job_seeker = employee_record.job_seeker
+        job_seeker = employee_record.job_application.job_seeker
         profile = job_seeker.jobseeker_profile
         profile.hexa_additional_address = "Bad additional address with %$£"
 
@@ -57,7 +57,7 @@ class EmployeeRecordAddressSerializerTest(TestCase):
         # then remove them from resulting lane name
         # (better geolocation)
         employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
-        job_seeker = employee_record.job_seeker
+        job_seeker = employee_record.job_application.job_seeker
         profile = job_seeker.jobseeker_profile
         profile.hexa_lane_name = "Lane name (with parens)"
 
@@ -123,7 +123,7 @@ class EmployeeRecordUpdateNotificationSerializerTest(TestCase):
         start_at = timezone.localdate()
         end_at = timezone.localdate() + timedelta(weeks=52)
         employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
-        approval = employee_record.approval
+        approval = employee_record.job_application.approval
         approval.start_at = start_at
         approval.end_at = end_at
         employee_record.save()
@@ -154,7 +154,7 @@ class EmployeeRecordUpdateNotificationSerializerTest(TestCase):
         # Add some EmployeeRecordUpdateNotification objects
         for idx in range(10):
             employee_record = EmployeeRecordWithProfileFactory(status=Status.PROCESSED)
-            approval = employee_record.approval
+            approval = employee_record.job_application.approval
             approval.start_at = start_at
             approval.end_at = end_at
             employee_record.save()

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -15,7 +15,7 @@ from itou.employee_record.serializers import (
     _AddressSerializer,
 )
 from tests.asp.factories import CommuneFactory
-from tests.employee_record.factories import EmployeeRecordWithProfileFactory
+from tests.employee_record.factories import EmployeeRecordUpdateNotificationFactory, EmployeeRecordWithProfileFactory
 from tests.users.factories import JobSeekerFactory
 from tests.utils.test import TestCase
 
@@ -178,3 +178,24 @@ class EmployeeRecordUpdateNotificationSerializerTest(TestCase):
                 assert element.get("numLigne") == idx
                 assert element.get("siret") is not None
                 assert element.get("typeMouvement") == EmployeeRecordUpdateNotification.ASP_MOVEMENT_TYPE
+
+
+@pytest.mark.parametrize(
+    "field,value,key",
+    [
+        ("birth_country", None, "personnePhysique"),
+        ("birth_place", None, "personnePhysique"),
+        ("hexa_lane_type", "", "adresse"),
+        ("hexa_lane_name", "", "adresse"),
+        ("hexa_post_code", "", "adresse"),
+        ("hexa_commune", None, "adresse"),
+    ],
+)
+def test_update_notification_use_static_serializers_on_missing_fields(snapshot, field, value, key):
+    notification = EmployeeRecordUpdateNotificationFactory(
+        employee_record__job_application__for_snapshot=True,
+        **{f"employee_record__job_application__job_seeker__jobseeker_profile__{field}": value},
+    )
+
+    data = EmployeeRecordUpdateNotificationSerializer(notification).data
+    assert data[key] == snapshot()

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -39,7 +39,9 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             approval=factory.SubFactory(
                 ApprovalFactory,
                 user=factory.SelfAttribute("..job_seeker"),
-                eligibility_diagnosis=factory.SelfAttribute("..eligibility_diagnosis"),
+                eligibility_diagnosis=factory.Maybe(
+                    "for_snapshot", no_declaration=factory.SelfAttribute("..eligibility_diagnosis")
+                ),
             ),
         )
         # GEIQ diagnosis created by a GEIQ
@@ -85,6 +87,7 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             pk="11111111-1111-1111-1111-111111111111",
             to_company__for_snapshot=True,
             job_seeker__for_snapshot=True,
+            approval__for_snapshot=True,
         )
 
     job_seeker = factory.SubFactory(JobSeekerFactory)

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -241,6 +241,7 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
         )
         for_snapshot = factory.Trait(
             nir="290010101010125",
+            asp_uid="a08dbdb523633cfc59dfdb297307a1",
         )
 
     user = factory.SubFactory(JobSeekerFactory, jobseeker_profile=None)


### PR DESCRIPTION
### Pourquoi ?

La reprise de stock des EITI fait que nous n'avons pas un certain nombre d'informations (pays+commune de naissance et/ou l'adresse postal au format hexa), l'idée originel était qu'il de les faire remplir puis renvoyer par les employeurs mais au vu du nombre (2829+) nous avons décider de réduire la charge pour les employeurs.
Et plutôt que de remplir les `JobSeekerProfile()` pour ces entreprises je me suis dit que c'était mieux de ne pas modifier la données et donc de gérer ça lors de l'envoi.

### Comment ? <!-- optionnel -->

La quasi totalité des données envoyées dans les notifications n'est pas utilisés du coté de l'ASP mais elles sont tout de même validés donc elles doivent être correcte et cohérentes, je modifie donc les _serializers_ afin de passer sur des données statiques si les champs associés sont manquant.

L'adresse "3 Avenue de Blida Metz" est l'adresse d'une agence France Travail qui est connue pour être celle utilisée au moment des problèmes de géocodage, et j'ai pris Islande pour le pays de naissance car j'avais envie et que c'est tout de même assez "exotique" pour que ça soit reconnaissable.

Le commit sur les propriétés superflues est devenu bien plus gros qu'anticipé mais maintenant c'est fait !

Pour vérifier que ça allais fonctionner une fois mis en prod je me suis basé sur ce script :
```python
from itou.asp.models import SiaeMeasure
from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
from itou.employee_record.serializers import EmployeeRecordUpdateNotificationSerializer
from itou.utils.command import BaseCommand


class Command(BaseCommand):

    def add_arguments(self, parser):
        parser.add_argument("--wet-run", dest="wet_run", action="store_true")

    def handle(self, **options):
        success_count = 0

        queryset = EmployeeRecord.objects.full_fetch().filter(asp_measure=SiaeMeasure.EITI)
        total = queryset.count()
        for employee_record in queryset.iterator():
            er_update = EmployeeRecordUpdateNotification(employee_record=employee_record)
            try:
                data = EmployeeRecordUpdateNotificationSerializer(instance=er_update).data
            except Exception as exc:
                self.stderr.write(f"Error serializing {er_update=}: {exc}")
            else:
                success_count += 1
                if success_count % 100 == 0:
                    self.stdout.write(f"Successfully serialized {success_count:5d}/{total} notification(s)")
        self.stdout.write(f"Successfully serialized {success_count:5d}/{total} notification(s)")

```
```
...
Successfully serialized  2800/2831 notification(s)
Successfully serialized  2831/2831 notification(s)
Management command itou.scripts.management.commands.serialize_employee_records succeeded in 8.55 seconds
```

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
