### PR TITLE
[GEN-8219] Retirer la bannière promo Mobil Emploi

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -38,36 +38,6 @@
         </div>
     {% endif %}
 
-    {% if show_mobilemploi_prescriber_banner %}
-        <div class="alert alert-info alert-dismissible-once fade show d-none" role="status" id="showMobilEmploiPrescriberBanner">
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-            <div class="row">
-                <div class="col">
-                    <p class="mb-2">
-                        <strong>Mobil’Emploi : dernières places disponibles !</strong>
-                    </p>
-                    <p class="mb-0">
-                        L’équipe Mobil’Emploi propose aux publics éloignés de
-                        l’emploi, un accompagnement gratuit et sur mesure vers
-                        l’emploi durable. Des informations collectives sont prévues
-                        pendant tout le mois de mars.
-                    </p>
-                </div>
-                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                    <a class="btn btn-sm btn-primary btn-ico"
-                       href="https://forms.gle/BdZMLttpjHXsnPKt5"
-                       rel="noopener"
-                       aria-label="Demander à l’équipe Mobil’Emploi de me rappeler"
-                       target="_blank"
-                       {% matomo_event "dashboard" "clic" "mobil-emploi-prescripteur" %}>
-                        <span>En savoir plus</span>
-                        <i class="ri-external-link-line ri-lg"></i>
-                    </a>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-
     <div class="alert alert-info alert-dismissible-once d-none" role="status" id="alertDismissiblOnceUiImprovements">
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
         <div class="row">

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -38,38 +38,6 @@
         </div>
     {% endif %}
 
-    {% if show_mobilemploi_banner %}
-        <div class="alert alert-info alert-dismissible-once fade show d-none" role="status" id="showMobilEmploiBanner">
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-            <div class="row">
-                <div class="col-auto pe-0">
-                    <i class="ri-information-line ri-xl text-info"></i>
-                </div>
-                <div class="col">
-                    <p class="mb-2">
-                        <strong>Mobil’Emploi : dernières places disponibles !</strong>
-                    </p>
-                    <p class="mb-0">
-                        Vous êtes en recherche d’emploi ou de formation ?
-                        <br>
-                        L’équipe Mobil’Emploi vous propose un accompagnement gratuit et sur mesure.
-                    </p>
-                </div>
-                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                    <a class="btn btn-sm btn-primary btn-ico"
-                       href="https://forms.gle/S6FfNXfW3t7jtFyB6"
-                       rel="noopener"
-                       aria-label="Demander à l’équipe Mobil’Emploi de me rappeler"
-                       target="_blank"
-                       {% matomo_event "dashboard" "clic" "mobil-emploi-candidat" %}>
-                        <span>Je souhaite être rappelé(e)</span>
-                        <i class="ri-external-link-line ri-lg"></i>
-                    </a>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-
     {% if show_mobilemploi_prescriber_banner %}
         <div class="alert alert-info alert-dismissible-once fade show d-none" role="status" id="showMobilEmploiPrescriberBanner">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -43,7 +43,7 @@ from itou.www.search.forms import SiaeSearchForm
 from itou.www.stats import utils as stats_utils
 
 
-# Auvergne Rhône Alpes and Île de France
+# Auvergne Rhône Alpes AND Île de France
 MOBILEMPLOI_DEPARTMENTS = (
     "01",
     "03",
@@ -161,7 +161,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "pending_prolongation_requests": None,
         "evaluated_siae_notifications": EvaluatedSiae.objects.none(),
         "show_eiti_webinar_banner": False,
-        "show_mobilemploi_banner": False,
         "show_mobilemploi_prescriber_banner": False,
         "siae_suspension_text_with_dates": None,
         "siae_search_form": SiaeSearchForm(),
@@ -219,7 +218,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         # Force the job seeker to fill its title to use the site
         if not request.user.title:
             return HttpResponseRedirect(reverse("dashboard:edit_user_info"))
-        context["show_mobilemploi_banner"] = request.user.department in MOBILEMPLOI_DEPARTMENTS
 
     return render(request, template_name, context)
 

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -24,7 +24,6 @@ from itou.employee_record.models import EmployeeRecord
 from itou.institutions.models import Institution
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.openid_connect.inclusion_connect import constants as ic_constants
-from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
 from itou.users.enums import MATOMO_ACCOUNT_TYPE, IdentityProvider, UserKind
@@ -41,31 +40,6 @@ from itou.www.dashboard.forms import (
 )
 from itou.www.search.forms import SiaeSearchForm
 from itou.www.stats import utils as stats_utils
-
-
-# Auvergne Rhône Alpes AND Île de France
-MOBILEMPLOI_DEPARTMENTS = (
-    "01",
-    "03",
-    "07",
-    "15",
-    "26",
-    "38",
-    "42",
-    "43",
-    "63",
-    "69",
-    "73",
-    "74",
-    "75",
-    "77",
-    "78",
-    "91",
-    "92",
-    "93",
-    "94",
-    "95",
-)
 
 
 def _employer_dashboard_context(request):
@@ -161,7 +135,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "pending_prolongation_requests": None,
         "evaluated_siae_notifications": EvaluatedSiae.objects.none(),
         "show_eiti_webinar_banner": False,
-        "show_mobilemploi_prescriber_banner": False,
         "siae_suspension_text_with_dates": None,
         "siae_search_form": SiaeSearchForm(),
     }
@@ -175,15 +148,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                     prescriber_organization=current_org,
                     status=ProlongationRequestStatus.PENDING,
                 ).count()
-            context["show_mobilemploi_prescriber_banner"] = (
-                current_org.department in MOBILEMPLOI_DEPARTMENTS
-                and current_org.kind
-                not in (
-                    PrescriberOrganizationKind.CAP_EMPLOI,
-                    PrescriberOrganizationKind.PE,
-                    PrescriberOrganizationKind.ML,
-                )
-            )
         elif request.user.email.endswith("pole-emploi.fr"):
             messages.info(
                 request,


### PR DESCRIPTION
### Pourquoi ?

Il était prévu que cela se termine aujourd'hui.