### PR TITLE
Admin: amélioration du texte d'explication du champs "ID unique envoyé à l'ASP"

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -818,7 +818,7 @@ class JobSeekerProfileAdmin(InconsistencyCheckMixin, ItouModelAdmin):
             help_texts = kwargs.pop("help_texts", {})
             default_asp_uid = obj._default_asp_uid()
             warn = "⚠ " if default_asp_uid != obj.asp_uid else ""
-            help_texts["asp_uid"] = f"{warn}Valeur par défaut: {default_asp_uid}"
+            help_texts["asp_uid"] = f"{warn}Valeur initiale: {default_asp_uid}"
             kwargs.update({"help_texts": help_texts})
         return super().get_form(request, obj, **kwargs)
 

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -510,8 +510,8 @@ def test_asp_uid_help_text(admin_client):
     default_asp_uid = profile._default_asp_uid()
     url = reverse("admin:users_jobseekerprofile_change", kwargs={"object_id": profile.pk})
     response = admin_client.get(url)
-    assertContains(response, f"<div>Valeur par défaut: {default_asp_uid}")
+    assertContains(response, f"<div>Valeur initiale: {default_asp_uid}")
     profile.asp_uid = "0" * 12
     profile.save()
     response = admin_client.get(url)
-    assertContains(response, f"<div>⚠ Valeur par défaut: {default_asp_uid}")
+    assertContains(response, f"<div>⚠ Valeur initiale: {default_asp_uid}")


### PR DESCRIPTION
### Pourquoi ?

"Valeur par défaut" n'était pas assez clair.
