### PR TITLE
Dépendances : Suppression de `appnope` (et du fichier spécifique Mac) car non-utilisé dans le projet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,7 @@
 PYTHON_VERSION := python3.11
 LINTER_CHECKED_DIRS := config itou tests
 PGDATABASE ?= itou
-ifeq ($(shell uname -s),Linux)
-	REQUIREMENTS_PATH ?= requirements/dev.txt
-else
-	REQUIREMENTS_PATH ?= requirements/dev-mac.txt
-endif
+REQUIREMENTS_PATH ?= requirements/dev.txt
 
 VIRTUAL_ENV ?= .venv
 export PATH := $(VIRTUAL_ENV)/bin:$(PATH)

--- a/requirements/dev-mac.txt
+++ b/requirements/dev-mac.txt
@@ -1,3 +1,0 @@
--r dev.txt
-appnope==0.1.3 \
-  --hash=sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e


### PR DESCRIPTION
### Pourquoi ?

De ce que je comprend de https://github.com/minrk/appnope, il faut importer `appnope` sauf qu'on l'utilise nul part et les utilisateurs de MacOS on _régulièrement_ des problèmes liés à la MAJ de leur venv car seul le fichier `requirements/dev.txt` est modifié donc le timestamp de `requirements/dev-mac.txt` est toujours plus vieux que la dossier du venv.
```
~/betagouv/itou|master> rg appnope
requirements/dev-mac.txt
2:appnope==0.1.3 \
~/betagouv/itou|master>
```

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
