### PR TITLE
Makefile: Suppression d'une verrue pour le lancement de `shellcheck`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,7 @@ quality: $(VENV_REQUIREMENT)
 fast_fix: $(VENV_REQUIREMENT)
 	black $(LINTER_CHECKED_DIRS)
 	ruff check --fix $(LINTER_CHECKED_DIRS)
-	# Use || true because `git apply` exit with an error ("error: unrecognized input") when the pipe is empty,
-	# this happens when there is nothing to fix or shellcheck can't propose a fix.
-	find * -type f -name '*.sh' -exec shellcheck --external-sources --format=diff {} + | git apply || true
+	find * -type f -name '*.sh' -exec shellcheck --external-sources --format=diff {} + | git apply --allow-empty
 
 fix: fast_fix
 	djlint --reformat itou


### PR DESCRIPTION
### Pourquoi ?

C'est plus propre et ça évite de polluer la sortie avec le commentaire et un message d'erreur.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
