### PR TITLE
Liste fiches salariés: correction de l'affichage de la ville du candidat [GEN-277]

### DIFF
--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -1,3 +1,4 @@
+{% load job_seekers %}
 {% load format_filters %}
 {% load tally %}
 <div class="c-box c-box--results has-links-inside my-3 my-md-4">
@@ -14,7 +15,7 @@
 
                     <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                         <span>
-                            <i class="ri-map-pin-2-line font-weight-normal me-1" aria-hidden="true"></i>{{ item.job_seeker.jobseeker_profile.hexa_post_code|slice:":2" }} - {{ item.job_seeker.jobseeker_profile.hexa_commune|title }}
+                            <i class="ri-map-pin-2-line font-weight-normal me-1" aria-hidden="true"></i>{% profile_city_display item.job_seeker.jobseeker_profile %}
                         </span>
 
                     </div>

--- a/itou/utils/templatetags/job_seekers.py
+++ b/itou/utils/templatetags/job_seekers.py
@@ -1,0 +1,30 @@
+from django import template
+from django.template.defaultfilters import title
+
+from itou.common_apps.address.departments import department_from_postcode
+
+
+register = template.Library()
+
+
+def display_insee_city(city):
+    return f"{city.department} - {city.name}"
+
+
+@register.simple_tag
+def profile_city_display(profile):
+    if profile.hexa_commune:
+        if profile.hexa_commune.city:
+            return display_insee_city(profile.hexa_commune.city)
+        display_name = title(profile.hexa_commune.name.replace("E__ARRONDISSEMENT", "ᵉ"))
+        return f"{department_from_postcode(profile.hexa_commune.code)} - {display_name}"
+    if profile.user.insee_city:
+        return display_insee_city(profile.user.insee_city)
+    parts = []
+    if profile.user.post_code:
+        parts.append(department_from_postcode(profile.user.post_code))
+    if profile.user.city:
+        parts.append(profile.user.city)
+    if parts:
+        return " - ".join(parts)
+    return "Ville non renseignée"

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -4,10 +4,12 @@ import factory
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.contrib.messages.test import MessagesTestMixin
+from django.template.defaultfilters import title
 from django.test import override_settings
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 
+from itou.common_apps.address.departments import department_from_postcode
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.employee_record.enums import Status
@@ -57,6 +59,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         response = self.client.get(self.URL)
 
         self.assertContains(response, format_filters.format_approval_number(self.job_application.approval.number))
+        self.assertContains(response, "Ville non renseignée")
 
     def test_status_filter(self):
         """
@@ -270,6 +273,9 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         response = self.client.get(self.URL + "?status=REJECTED")
         self.assertContains(response, "Erreur 0012")
         self.assertContains(response, "JSON Invalide")
+
+        hexa_commune = record.job_application.job_seeker.jobseeker_profile.hexa_commune
+        self.assertContains(response, f"{department_from_postcode(hexa_commune.code)} - {title(hexa_commune.name)}")
 
     def test_rejected_custom_messages(self):
         self.client.force_login(self.user)


### PR DESCRIPTION
### Pourquoi ?

Éviter d'afficher des `None`.
