### PR TITLE
Empêcher l’accès anonyme en lecture aux préfixes autres que resume/

### DIFF
--- a/itou/files/management/commands/configure_bucket.py
+++ b/itou/files/management/commands/configure_bucket.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
                 "Effect": "Allow",
                 "Principal": {"AWS": "*"},
                 "Action": "s3:GetObject",
-                "Resource": f"arn:aws:s3:::{bucket}/*",
+                "Resource": f"arn:aws:s3:::{bucket}/resume/*",
             },
         ]
         client.put_bucket_policy(


### PR DESCRIPTION
### Pourquoi ?

L’accès direct à ces fichiers est interdit depuis mi-octobre 2023. Après environ 6 mois d’attente pour éviter que les liens des emails ne cassent, rendons les réellement privés.
