### PR TITLE
Fiches Salarié : Ajout d'une commande afin de renvoyer les fiches salariés pour une SIAE

### DIFF
--- a/itou/employee_record/management/commands/resend_employee_records.py
+++ b/itou/employee_record/management/commands/resend_employee_records.py
@@ -1,0 +1,62 @@
+from django.db import transaction
+
+from itou.companies.models import Company
+from itou.employee_record.enums import Status
+from itou.employee_record.models import EmployeeRecord
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+
+        parser.add_argument("siae_id", type=int)
+        parser.add_argument("--wet-run", action="store_true")
+
+    @transaction.atomic()
+    def handle(self, *, siae_id, wet_run, **options):
+        siae = Company.objects.select_related("convention").get(pk=siae_id)
+        self.stdout.write(
+            f"Marking employee records to be resend: {siae.display_name} - {siae.siret} {siae.kind} - ID {siae.pk}"
+        )
+
+        if not siae.can_use_employee_record:
+            self.stdout.write(f"{siae} can't uses employee records")
+            return
+
+        asp_siret = EmployeeRecord.siret_from_asp_source(siae)
+
+        to_resend = (
+            EmployeeRecord.objects.filter(
+                # Only resend the ones that have been successful
+                status=Status.PROCESSED,
+                # For fine-grained control instead of working on all convention's siaes
+                job_application__to_company=siae,
+            )
+            .exclude(
+                # Only resend the employee records with a "bad" Siret:
+                # - If the Siret match, the employee record should already be on the ASP side,
+                #   resending it will most likely result in a duplicate error.
+                # - If a SIAE is "absorbed" by another one, we only want to resend the employee record
+                #   of the absorbed ones.
+                siret=asp_siret,
+            )
+            .order_by("-created_at")
+        )
+
+        self.stdout.write(f"Found {len(to_resend)} employee record(s) to resend")
+
+        employee_records = []
+        for employee_record in to_resend:
+            self.stdout.write(f"Marking {employee_record} to be resend")
+            employee_record.siret = asp_siret
+            employee_record.status = Status.READY
+            employee_records.append(employee_record)
+
+        if wet_run:
+            updated = EmployeeRecord.objects.bulk_update(employee_records, {"siret", "status"})
+            self.stdout.write(f"{updated}/{len(employee_records)} employee records(s) were marked to be resend")
+        else:
+            self.stdout.write(
+                f"DRY RUN: {len(employee_records)} employee records(s) would have been marked to be resend"
+            )


### PR DESCRIPTION
### Pourquoi ?

Lorsque le Siret d'une SIAE change dans l'Extranet IAE elle doit renvoyer **toutes** ses fiches salariés, les ETTI (et les EITI, mais aussi les grosses structures) en ont souvent des centaines ce qui n'est pas vraiment gérable à faire manuellement.

Les SIAE font donc régulièrement des tickets au support nous demandant si nous pouvons les renvoyer, jusqu'à présent nous refusions à cause des règles de validation de l'ASP et que le nombre n'était pas forcément si énorme (quelques dizaines), en plus que toutes n'avaient pas à être renvoyées non plus.

Suite à un TZ (`#11831`) une ETTI se retrouve à devoir renvoyer ~1500 FS, donc testons la procédure de tout renvoyer et qu'elle fasse le tri a posteriori. Cela devrais aussi éviter des demandes "Je ne trouve pas cet employé" car oublié lors de la reprise, ainsi que réduire le temps passé sur la résolution de ces tickets puisque une seul demande traitera tout.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
