### PR TITLE
Filtrer les candidatures des candidats avec HTMX

### DIFF
--- a/itou/static/js/job_applications_filters.js
+++ b/itou/static/js/job_applications_filters.js
@@ -1,7 +1,1 @@
-function submitFiltersForm() {
-    $("#js-job-applications-filters-form").submit();
-}
-$("#js-job-applications-filters-form :input").change(submitFiltersForm);
-$("#js-job-applications-filters-form duet-date-picker").on("duetChange", submitFiltersForm);
-
 $("#js-job-applications-filters-apply-button").hide();

--- a/itou/templates/apply/includes/list_job_applications.html
+++ b/itou/templates/apply/includes/list_job_applications.html
@@ -12,7 +12,8 @@
         <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les candidatures">
             {% include "apply/includes/job_applications_export_button.html" %}
             {% if filters_counter > 0 %}
-                <a href="{% if request.user.is_prescriber %}{% url 'apply:list_for_prescriber' %}{% else %}{% url 'apply:list_for_siae' %}{% endif %}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
+                <a href="{% if request.user.is_prescriber %}{% url 'apply:list_for_prescriber' %}{% elif request.user.is_employer %}{% url 'apply:list_for_siae' %}{% else %}{% url 'apply:list_for_job_seeker' %}{% endif %}"
+                   class="btn btn-secondary btn-ico mt-3 mt-md-0">
                     <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
                     <span>Réinitialiser les filtres ({{ filters_counter }})</span>
                 </a>
@@ -24,7 +25,7 @@
             <img class="img-fluid" src="{% static 'img/illustration-siae-card-no-result.svg' %}" alt="" loading="lazy">
             <p class="mb-1 mt-3">
                 <strong>
-                    {% if request.user.is_prescriber %}
+                    {% if request.user.is_prescriber or request.user.is_job_seeker %}
                         Aucune candidature pour le moment
                     {% elif request.user.is_employer %}
                         {% if pending_states_job_applications_count == 0 %}
@@ -45,6 +46,10 @@
                         Pour recevoir des candidatures, vérifiez que les postes ouverts
                         <br class="d-none d-lg-inline">
                         dans votre structure sont bien à jour.
+                    {% elif request.user.is_job_seeker %}
+                        Vous trouverez ici vos candidatures, émises par un prescripteur
+                        <br class="d-none d-lg-inline">
+                        ou par vous même.
                     {% endif %}
                 </i>
             </p>
@@ -58,6 +63,11 @@
                     <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
                     <span>Gérer les métiers et recrutements</span>
                 </a>
+            {% elif request.user.is_job_seeker %}
+                <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
+                    <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
+                    <span>Rechercher un emploi inclusif</span>
+                </a>
             {% endif %}
         </div>
         {% if request.user.is_employer %}
@@ -66,7 +76,11 @@
     {% else %}
         {% for job_application in job_applications_page %}
             <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                {% include "apply/includes/list_card_body_company.html" %}
+                {% if request.user.is_job_seeker %}
+                    {% include "apply/includes/list_card_body_jobseeker.html" %}
+                {% else %}
+                    {% include "apply/includes/list_card_body_company.html" %}
+                {% endif %}
                 <div class="c-box--results__footer">
                     <div class="d-flex{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} flex-column flex-md-row justify-content-md-between align-items-md-center{% else %} justify-content-end{% endif %}">
                         {% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %}
@@ -87,6 +101,11 @@
                                href="{% url 'apply:details_for_company' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
                                {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>Voir sa candidature</a>
+                        {% elif request.user.is_job_seeker %}
+                            <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
+                               href="{% url 'apply:details_for_jobseeker' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}">
+                                Voir ma candidature
+                            </a>
                         {% endif %}
                     </div>
                 </div>

--- a/itou/templates/apply/list_for_job_seeker.html
+++ b/itou/templates/apply/list_for_job_seeker.html
@@ -17,7 +17,12 @@
                             <span>Filtrer les candidatures</span>
                         </button>
                         <div class="c-aside-filters__card collapse show" id="asideFiltersCollapse">
-                            <form method="get" id="js-job-applications-filters-form">
+                            <form hx-get="{% url 'apply:list_for_job_seeker' %}"
+                                  hx-trigger="change delay:.5s, duetChange delay:.5s"
+                                  hx-indicator="#job-applications-section"
+                                  hx-target="#job-applications-section"
+                                  hx-swap="outerHTML"
+                                  hx-push-url="true">
                                 <div class="c-aside-filters__card__body">
                                     {% include "apply/includes/job_applications_filters/statut.html" %}
                                     <hr>
@@ -30,69 +35,7 @@
                         </div>
                     </aside>
                 </div>
-
-                <div class="col-12 col-md-8">
-                    <section aria-labelledby="results">
-                        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
-                            <h3 class="h4 mb-0" id="results">
-                                {% with job_applications_page.paginator.count as counter %}
-                                    {{ counter }} <strong>résultat{{ counter|pluralizefr }}</strong>
-                                {% endwith %}
-                            </h3>
-                            <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les candidatures">
-                                {% include "apply/includes/job_applications_export_button.html" %}
-                                {% if filters_counter > 0 %}
-                                    <a href="{% url 'apply:list_for_job_seeker' %}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
-                                        <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
-                                        <span>Réinitialiser les filtres ({{ filters_counter }})</span>
-                                    </a>
-                                {% endif %}
-                            </div>
-                        </div>
-
-                        {% if not job_applications_page %}
-                            <div class="text-center my-3 my-md-4">
-                                <img class="img-fluid" src="{% static 'img/illustration-siae-card-no-result.svg' %}" alt="" loading="lazy">
-                                <p class="mb-1 mt-3">
-                                    <strong>Aucune candidature pour le moment</strong>
-                                </p>
-                                <p>
-                                    <i>
-                                        Vous trouverez ici vos candidatures, émises par un prescripteur
-                                        <br class="d-none d-lg-inline">
-                                        ou par vous même.
-                                    </i>
-                                </p>
-                                <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
-                                    <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
-                                    <span>Rechercher un emploi inclusif</span>
-                                </a>
-                            </div>
-                        {% else %}
-                            {% for job_application in job_applications_page %}
-                                <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                    {% include "apply/includes/list_card_body_jobseeker.html" %}
-                                    <div class="c-box--results__footer">
-                                        <div class="d-flex{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} flex-column flex-md-row justify-content-md-between align-items-md-center{% else %} justify-content-end{% endif %}">
-                                            {% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %}
-                                                <p class="text-warning fs-sm mb-3 mb-md-0">
-                                                    <i class="ri-time-line ri-lg me-1" aria-hidden="true"></i>
-                                                    En attente de réponse depuis {{ job_application.pending_for_weeks }} semaines.
-                                                </p>
-                                            {% endif %}
-                                            <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
-                                               href="{% url 'apply:details_for_jobseeker' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}">
-                                                Voir ma candidature
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            {% endfor %}
-
-                            {% include "includes/pagination.html" with page=job_applications_page %}
-                        {% endif %}
-                    </section>
-                </div>
+                <div class="col-12 col-md-8">{% include "apply/includes/list_job_applications.html" %}</div>
             </div>
         </div>
     </section>
@@ -100,5 +43,6 @@
 
 {% block script %}
     {{ block.super }}
+    <script src='{% static "js/htmx_compat.js" %}'></script>
     <script src='{% static "js/job_applications_filters.js" %}'></script>
 {% endblock %}

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -91,7 +91,11 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
         "filters_form": filters_form,
         "filters_counter": filters_counter,
     }
-    return render(request, template_name, context)
+    return render(
+        request,
+        "apply/includes/list_job_applications.html" if request.htmx else template_name,
+        context,
+    )
 
 
 @login_required

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -824,24 +824,24 @@
 # ---
 # name: TestListForSiae.test_warns_about_long_awaiting_applications[JOB SEEKER - no warnings]
   '''
-  <section aria-labelledby="results">
-                          <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
-                              <h3 class="h4 mb-0" id="results">
-                                  
-                                      3 <strong>résultats</strong>
-                                  
-                              </h3>
-                              <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
-                                  
+  <section aria-labelledby="results" id="job-applications-section">
+      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
+          <h3 class="h4 mb-0" id="results">
+              
+                  3 <strong>résultats</strong>
+              
+          </h3>
+          <div aria-label="Actions sur les candidatures" class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group">
+              
   
-                                  
-                              </div>
-                          </div>
-  
-                          
-                              
-                                  <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                      
+              
+          </div>
+      </div>
+      
+          
+              <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+                  
+                      
   
   <div class="c-box--results__header">
       
@@ -889,18 +889,23 @@
       </div>
   </div>
   
-                                      <div class="c-box--results__footer">
-                                          <div class="d-flex justify-content-end">
-                                              
-                                              <a class="btn btn-outline-primary" href="/apply/11111111-1111-1111-1111-111111111111/jobseeker/details?back_url=/apply/job_seeker/list">
-                                                  Voir ma candidature
-                                              </a>
-                                          </div>
-                                      </div>
-                                  </div>
-                              
-                                  <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                      
+                  
+                  <div class="c-box--results__footer">
+                      <div class="d-flex justify-content-end">
+                          
+                          
+                              <a class="btn btn-outline-primary" href="/apply/11111111-1111-1111-1111-111111111111/jobseeker/details?back_url=/apply/job_seeker/list">
+                                  Voir ma candidature
+                              </a>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+          
+              <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+                  
+                      
   
   <div class="c-box--results__header">
       
@@ -948,23 +953,28 @@
       </div>
   </div>
   
-                                      <div class="c-box--results__footer">
-                                          <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
-                                              
-                                                  <p class="text-warning fs-sm mb-3 mb-md-0">
-                                                      <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
-                                                      En attente de réponse depuis 3 semaines.
-                                                  </p>
-                                              
-                                              <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/apply/22222222-2222-2222-2222-222222222222/jobseeker/details?back_url=/apply/job_seeker/list">
-                                                  Voir ma candidature
-                                              </a>
-                                          </div>
-                                      </div>
-                                  </div>
-                              
-                                  <div class="c-box c-box--results has-links-inside my-3 my-md-4">
-                                      
+                  
+                  <div class="c-box--results__footer">
+                      <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
+                          
+                              <p class="text-warning fs-sm mb-3 mb-md-0">
+                                  <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
+                                  En attente de réponse depuis 3 semaines.
+                              </p>
+                          
+                          
+                              <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/apply/22222222-2222-2222-2222-222222222222/jobseeker/details?back_url=/apply/job_seeker/list">
+                                  Voir ma candidature
+                              </a>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+          
+              <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+                  
+                      
   
   <div class="c-box--results__header">
       
@@ -1012,28 +1022,31 @@
       </div>
   </div>
   
-                                      <div class="c-box--results__footer">
-                                          <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
-                                              
-                                                  <p class="text-warning fs-sm mb-3 mb-md-0">
-                                                      <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
-                                                      En attente de réponse depuis 8 semaines.
-                                                  </p>
-                                              
-                                              <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/apply/33333333-3333-3333-3333-333333333333/jobseeker/details?back_url=/apply/job_seeker/list">
-                                                  Voir ma candidature
-                                              </a>
-                                          </div>
-                                      </div>
-                                  </div>
-                              
-  
-                              
-  
-  
-  
+                  
+                  <div class="c-box--results__footer">
+                      <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
                           
-                      </section>
+                              <p class="text-warning fs-sm mb-3 mb-md-0">
+                                  <i aria-hidden="true" class="ri-time-line ri-lg me-1"></i>
+                                  En attente de réponse depuis 8 semaines.
+                              </p>
+                          
+                          
+                              <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/apply/33333333-3333-3333-3333-333333333333/jobseeker/details?back_url=/apply/job_seeker/list">
+                                  Voir ma candidature
+                              </a>
+                          
+                      </div>
+                  </div>
+              </div>
+              
+          
+          
+  
+  
+  
+      
+  </section>
   '''
 # ---
 # name: TestListForSiae.test_warns_about_long_awaiting_applications[PRESCRIBER - warnings for 2222 and 3333]
@@ -1060,6 +1073,7 @@
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
+                      
   
   <div class="c-box--results__header">
       
@@ -1122,6 +1136,7 @@
       </div>
   </div>
   
+                  
                   <div class="c-box--results__footer">
                       <div class="d-flex justify-content-end">
                           
@@ -1137,6 +1152,7 @@
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
+                      
   
   <div class="c-box--results__header">
       
@@ -1199,6 +1215,7 @@
       </div>
   </div>
   
+                  
                   <div class="c-box--results__footer">
                       <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
                           
@@ -1219,6 +1236,7 @@
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
+                      
   
   <div class="c-box--results__header">
       
@@ -1281,6 +1299,7 @@
       </div>
   </div>
   
+                  
                   <div class="c-box--results__footer">
                       <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
                           
@@ -1331,6 +1350,7 @@
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
+                      
   
   <div class="c-box--results__header">
       
@@ -1383,6 +1403,7 @@
       </div>
   </div>
   
+                  
                   <div class="c-box--results__footer">
                       <div class="d-flex justify-content-end">
                           
@@ -1426,6 +1447,7 @@
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
+                      
   
   <div class="c-box--results__header">
       
@@ -1478,6 +1500,7 @@
       </div>
   </div>
   
+                  
                   <div class="c-box--results__footer">
                       <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
                           
@@ -1496,6 +1519,7 @@
           
               <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                   
+                      
   
   <div class="c-box--results__header">
       
@@ -1548,6 +1572,7 @@
       </div>
   </div>
   
+                  
                   <div class="c-box--results__footer">
                       <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
                           


### PR DESCRIPTION
### Pourquoi ?

Limiter les rechargements de la page, pour une meilleure expérience utilisateur.

La construction des filtres étant assez coûteuse, on devrait aussi constater
une légère amélioration de performance.
Comment tester ?

1. Se connecter en tant que candidat (test+de@inclusion.beta.gouv.fr)
2. Aller à la liste des candidatures
3. Filtrer, naviguer entre les pages
