### PR TITLE
CI : Utiliser le même chemin de code que la production

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ quality: $(VENV_REQUIREMENT)
 	djlint --lint --check itou
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
 	python manage.py makemigrations --check --dry-run --noinput || (echo "⚠ Missing migration ⚠"; exit 1)
+	python manage.py collectstatic --no-input
 
 fast_fix: $(VENV_REQUIREMENT)
 	black $(LINTER_CHECKED_DIRS)

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -10,8 +10,11 @@ from .base import *  # noqa: E402,F403
 SECRET_KEY = "foobar"
 ALLOWED_HOSTS = []
 
-# `ManifestStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.
-STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"  # noqa: F405
+# We *want* to do the same `collectstatic` on the CI than on PROD to catch errors early,
+# but we don't want to do it when running the test suite locally for performance reasons.
+if not os.getenv("CI", False):
+    # `ManifestStaticFilesStorage` (used in base settings) requires `collectstatic` to be run.
+    STORAGES["staticfiles"]["BACKEND"] = "django.contrib.staticfiles.storage.StaticFilesStorage"  # noqa: F405
 
 ASP_ITOU_PREFIX = "XXXXX"  # same as in our fixtures
 ITOU_PROTOCOL = "http"

--- a/tests/openid_connect/inclusion_connect/tests.py
+++ b/tests/openid_connect/inclusion_connect/tests.py
@@ -35,6 +35,7 @@ from itou.users import enums as users_enums
 from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants
+from itou.utils.templatetags.theme_inclusion import static_theme_images
 from itou.utils.urls import add_url_params, get_absolute_url
 from tests.job_applications.factories import JobApplicationSentByPrescriberPoleEmploiFactory
 from tests.openid_connect.inclusion_connect.test import InclusionConnectBaseTestCase
@@ -644,7 +645,7 @@ class InclusionConnectLoginTest(InclusionConnectBaseTestCase):
         # Then log in again.
         login_url = reverse("login:prescriber")
         response = self.client.get(login_url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         self.assertContains(response, reverse("inclusion_connect:authorize"))
 
         response = mock_oauth_dance(self.client, UserKind.PRESCRIBER, expected_redirect_url=reverse("dashboard:index"))

--- a/tests/www/approvals_views/test_includes.py
+++ b/tests/www/approvals_views/test_includes.py
@@ -7,6 +7,7 @@ from freezegun import freeze_time
 from tests.approvals.factories import ApprovalFactory
 from tests.eligibility.factories import EligibilityDiagnosisFactory
 from tests.users.factories import EmployerFactory, PrescriberFactory
+from tests.utils.test import remove_static_hash
 
 
 @freeze_time("2022-01-10")
@@ -21,7 +22,7 @@ class TestStatusInclude:
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
-        assert rendered_template == snapshot(name="valid_approval_for_employer")
+        assert remove_static_hash(rendered_template) == snapshot(name="valid_approval_for_employer")
 
     def test_valid_approval_for_prescriber(self, snapshot, db):
         context = Context(
@@ -33,7 +34,7 @@ class TestStatusInclude:
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
-        assert rendered_template == snapshot(name="valid_approval_for_prescriber")
+        assert remove_static_hash(rendered_template) == snapshot(name="valid_approval_for_prescriber")
 
     def test_expired_approval_without_eligibility_diagnosis_for_employer(self, snapshot, db):
         context = Context(
@@ -45,7 +46,9 @@ class TestStatusInclude:
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
-        assert rendered_template == snapshot(name="expired_approval_without_eligibility_diagnosis_for_employer")
+        assert remove_static_hash(rendered_template) == snapshot(
+            name="expired_approval_without_eligibility_diagnosis_for_employer"
+        )
 
     def test_expired_approval_with_eligibility_diagnosis_for_employer(self, snapshot, db):
         approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
@@ -59,7 +62,9 @@ class TestStatusInclude:
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
-        assert rendered_template == snapshot(name="expired_approval_with_eligibility_diagnosis_for_employer")
+        assert remove_static_hash(rendered_template) == snapshot(
+            name="expired_approval_with_eligibility_diagnosis_for_employer"
+        )
 
     def test_expired_approval_with_eligibility_diagnosis_for_prescriber(self, snapshot, db):
         approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
@@ -73,7 +78,9 @@ class TestStatusInclude:
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
-        assert rendered_template == snapshot(name="expired_approval_with_eligibility_diagnosis_for_prescriber")
+        assert remove_static_hash(rendered_template) == snapshot(
+            name="expired_approval_with_eligibility_diagnosis_for_prescriber"
+        )
 
     def test_expired_approval_with_eligibility_diagnosis_for_jobseeker(self, snapshot, db):
         approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
@@ -87,4 +94,6 @@ class TestStatusInclude:
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
-        assert rendered_template == snapshot(name="expired_approval_with_eligibility_diagnosis_for_jobseeker")
+        assert remove_static_hash(rendered_template) == snapshot(
+            name="expired_approval_with_eligibility_diagnosis_for_jobseeker"
+        )

--- a/tests/www/invitations_views/test_company_accept.py
+++ b/tests/www/invitations_views/test_company_accept.py
@@ -12,6 +12,7 @@ from django.utils.html import escape
 from itou.users.enums import KIND_EMPLOYER, UserKind
 from itou.users.models import User
 from itou.utils.perms.company import get_current_company_or_404
+from itou.utils.templatetags.theme_inclusion import static_theme_images
 from itou.utils.urls import add_url_params
 from tests.companies.factories import CompanyFactory
 from tests.invitations.factories import ExpiredEmployerInvitationFactory, SentEmployerInvitationFactory
@@ -48,7 +49,7 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
     def test_accept_invitation_signup(self):
         invitation = SentEmployerInvitationFactory(email=OIDC_USERINFO["email"])
         response = self.client.get(invitation.acceptance_link, follow=True)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # We don't put the full path with the FQDN in the parameters
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]
@@ -88,7 +89,7 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
     def test_accept_invitation_signup_returns_on_other_browser(self):
         invitation = SentEmployerInvitationFactory(email=OIDC_USERINFO["email"])
         response = self.client.get(invitation.acceptance_link, follow=True)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # We don't put the full path with the FQDN in the parameters
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]
@@ -130,7 +131,7 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
     def test_accept_invitation_signup_bad_email_case(self):
         invitation = SentEmployerInvitationFactory(email=OIDC_USERINFO["email"].upper())
         response = self.client.get(invitation.acceptance_link, follow=True)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # We don't put the full path with the FQDN in the parameters
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]
@@ -208,7 +209,7 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
     def test_accept_invitation_signup_wrong_email(self):
         invitation = SentEmployerInvitationFactory()
         response = self.client.get(invitation.acceptance_link, follow=True)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # We don't put the full path with the FQDN in the parameters
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]
@@ -323,7 +324,7 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
         )
         response = self.client.get(invitation.acceptance_link, follow=True)
         self.assertContains(response, escape("La structure que vous souhaitez rejoindre n'est plus active."))
-        self.assertNotContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertNotContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # If the user still manages to signup with IC
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -19,6 +19,7 @@ from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.perms.prescriber import get_current_org_or_404
+from itou.utils.templatetags.theme_inclusion import static_theme_images
 from itou.utils.urls import add_url_params
 from tests.companies.factories import CompanyFactory
 from tests.invitations.factories import PrescriberWithOrgSentInvitationFactory
@@ -262,7 +263,7 @@ class TestAcceptPrescriberWithOrgInvitation(MessagesTestMixin, InclusionConnectB
     def test_accept_prescriber_org_invitation(self):
         invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
         response = self.client.get(invitation.acceptance_link)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # We don't put the full path with the FQDN in the parameters
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]
@@ -325,7 +326,7 @@ class TestAcceptPrescriberWithOrgInvitation(MessagesTestMixin, InclusionConnectB
     def test_accept_prescriber_org_invitation_returns_on_other_browser(self):
         invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
         response = self.client.get(invitation.acceptance_link)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # We don't put the full path with the FQDN in the parameters
         previous_url = invitation.acceptance_link.split(settings.ITOU_FQDN)[1]

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -1,6 +1,7 @@
 import pytest
 from django.contrib.gis.geos import Point
 from django.template.defaultfilters import capfirst
+from django.templatetags.static import static
 from django.test import override_settings
 from django.urls import reverse, reverse_lazy
 from django.utils.html import escape
@@ -844,7 +845,7 @@ class JobDescriptionSearchViewTest(TestCase):
         self.assertContains(response, displayed_job_pec)
 
         self.assertContains(response, "Contrat PEC - Parcours Emploi Compétences")
-        self.assertContains(response, "logo-france-travail.svg")
+        self.assertContains(response, static("img/logo-france-travail.svg"))
         self.assertContains(
             response,
             '<span>Offre proposée et gérée par <span class="visually-hidden">France Travail</span></span>',

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -19,6 +19,7 @@ from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
+from itou.utils.templatetags.theme_inclusion import static_theme_images
 from itou.utils.urls import add_url_params
 from itou.www.signup.forms import PrescriberChooseKindForm
 from tests.openid_connect.inclusion_connect.test import InclusionConnectBaseTestCase
@@ -87,7 +88,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         assert email == session_data.get("email")
 
         response = self.client.get(response.url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_pole_emploi_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -176,7 +177,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         response = self.client.get(url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -253,7 +254,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         response = self.client.get(url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -344,7 +345,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         response = self.client.get(url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -428,7 +429,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         response = self.client.get(url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -568,7 +569,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = reverse("signup:prescriber_user")
         self.assertContains(response, url)
         response = self.client.get(url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         params = {
@@ -640,7 +641,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = reverse("signup:prescriber_user")
         self.assertRedirects(response, url)
         response = self.client.get(url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -748,7 +749,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
 
         # Step 2: register as a simple prescriber (orienteur).
         response = self.client.get(reverse("signup:prescriber_user"))
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         params = {
@@ -814,7 +815,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         signup_url = reverse("signup:prescriber_user")
 
         response = self.client.get(signup_url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:prescriber_user")
         next_url = reverse("signup:prescriber_join_org")
@@ -898,7 +899,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         signup_url = reverse("signup:prescriber_user")
 
         response = self.client.get(signup_url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Connect with Inclusion Connect.
         previous_url = reverse("signup:prescriber_user")
@@ -971,7 +972,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         signup_url = reverse("signup:prescriber_user")
 
         response = self.client.get(signup_url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Connect with Inclusion Connect.
         previous_url = signup_url
@@ -1043,7 +1044,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         signup_url = reverse("signup:prescriber_user")
 
         response = self.client.get(signup_url)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Connect with Inclusion Connect.
         previous_url = reverse("signup:prescriber_user")
@@ -1103,7 +1104,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         check_email_url = reverse("signup:prescriber_check_pe_email")
         post_data = {"email": pe_email}
         response = self.client.post(check_email_url, data=post_data, follow=True)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Connect with Inclusion Connect but, this time, don't use a PE email.
         previous_url = reverse("signup:prescriber_pole_emploi_user")

--- a/tests/www/signup/test_siae.py
+++ b/tests/www/signup/test_siae.py
@@ -20,6 +20,7 @@ from itou.utils import constants as global_constants
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
 from itou.utils.templatetags.format_filters import format_siret
+from itou.utils.templatetags.theme_inclusion import static_theme_images
 from itou.utils.urls import get_tally_form_url
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, CompanyWithMembershipAndJobsFactory
 from tests.openid_connect.inclusion_connect.test import InclusionConnectBaseTestCase
@@ -71,7 +72,7 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
 
         # No error when opening magic link a second time.
         response = self.client.get(magic_link)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Check IC will redirect to the correct url
         token = company.get_token()
@@ -132,7 +133,7 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
 
         magic_link = company.signup_magic_link
         response = self.client.get(magic_link)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Check IC will redirect to the correct url
         token = company.get_token()
@@ -174,7 +175,7 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
 
         magic_link = company.signup_magic_link
         response = self.client.get(magic_link)
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Check IC will redirect to the correct url
         token = company.get_token()
@@ -282,7 +283,7 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
 
         # Now, we're on the second page.
         url = reverse("signup:facilitator_user")
-        self.assertContains(response, "logo-inclusion-connect-one-line.svg")
+        self.assertContains(response, static_theme_images("logo-inclusion-connect-one-line.svg"))
 
         # Check IC will redirect to the correct url
         previous_url = reverse("signup:facilitator_user")


### PR DESCRIPTION
### Pourquoi ?

Pour que ça casse sur la CI plutôt que lors du déploiement en prod ;).

### Comment ? <!-- optionnel -->

Je suis moyennement convaincu par les `re.sub()` sauvage dans `tests/www/approvals_views/test_includes.py`, j'avais l'idée de réutiliser ce qui est fait dans `parse_response_to_soup()` mais je sais pas si ça vaut le coup :thinking:.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
