### PR TITLE
Fiches salarié : Prendre en compte les suspensions dans la détection des notifications ratées

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -86,17 +86,11 @@ class Command(BaseCommand):
                     F("updated_at"),
                     Max(F("update_notifications__created_at")),
                 ),
-                last_approval_change=Greatest(
-                    F("job_application__approval__created_at"),
-                    # We only use prolongations because even if a suspension will postpone the approval's end date
-                    # it's not really useful to the employee on the ASP side, and it significantly speeds up the query.
-                    Max(F("job_application__approval__prolongation__created_at")),
-                ),
             )
             .filter(
                 status=Status.ARCHIVED,
                 job_application__approval__end_at__gte=prolongation_cutoff,  # Take approvals that can still be used
-                last_employee_record_snapshot__lt=F("last_approval_change"),
+                last_employee_record_snapshot__lt=F("job_application__approval__updated_at"),
             )
             .order_by(
                 "job_application__approval__number",

--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -29,12 +29,13 @@ from tests.eligibility.factories import EligibilityDiagnosisFactory
 from tests.files.factories import FileFactory
 from tests.prescribers.factories import PrescriberOrganizationFactory
 from tests.users.factories import JobSeekerFactory, JobSeekerProfileFactory, PrescriberFactory
+from tests.utils.factory_boy import AutoNowOverrideMixin
 
 
 fake = Faker("fr_FR")
 
 
-class ApprovalFactory(factory.django.DjangoModelFactory):
+class ApprovalFactory(AutoNowOverrideMixin, factory.django.DjangoModelFactory):
     class Meta:
         model = Approval
         skip_postgeneration_save = True

--- a/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
@@ -1,0 +1,10 @@
+# serializer version: 1
+# name: test_missed_notifications_limit
+  '''
+  * Checking missing employee records notifications:
+   - found 3 missing notification(s)
+   - 2 notification(s) created
+   - done!
+  
+  '''
+# ---


### PR DESCRIPTION
### Pourquoi ?

Simplification et amélioration suite à #3821.

J'ai ajouté la limite car il y a _un peu_ de backlog :
```
* Checking missing employee records notifications:
 - found 16376 missing notification(s)
 - done!
```

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
