### PR TITLE
Fiches salarié : Limiter à 1 fichier par envoi

### DIFF
--- a/itou/employee_record/common_management.py
+++ b/itou/employee_record/common_management.py
@@ -16,6 +16,10 @@ from itou.utils.iterators import chunks
 
 
 class EmployeeRecordTransferCommand(BaseCommand):
+    # Limit confirmed by the ASP after sending 50k+ notifications at the same time, which broke things.
+    # The file naming scheme also disallows creating more than one file in the same seconds.
+    MAX_UPLOADED_FILES = 1
+
     def add_arguments(self, parser):
         """Subclasses have a preflight option to check for serialization errors."""
         parser.add_argument(

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -184,7 +184,9 @@ class Command(EmployeeRecordTransferCommand):
         """
         self.stdout.write("Starting UPLOAD of employee records")
         ready_employee_records = EmployeeRecord.objects.filter(status=Status.READY)
-        for batch in chunks(ready_employee_records, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
+        for batch in chunks(
+            ready_employee_records, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS, max_chunk=self.MAX_UPLOADED_FILES
+        ):
             self._upload_batch_file(sftp, batch, dry_run)
 
     def handle(self, *, upload, download, preflight, wet_run, asp_test=False, debug=False, **options):

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -147,7 +147,9 @@ class Command(EmployeeRecordTransferCommand):
         else:
             self.stdout.write("No new employee record notification found")
 
-        for batch in chunks(new_notifications, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS):
+        for batch in chunks(
+            new_notifications, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS, max_chunk=self.MAX_UPLOADED_FILES
+        ):
             self._upload_batch_file(sftp, batch, dry_run)
 
     def handle(self, *, upload, download, preflight, wet_run, asp_test=False, debug=False, **options):

--- a/itou/utils/iterators.py
+++ b/itou/utils/iterators.py
@@ -2,9 +2,11 @@
 # Misc. utils functions related to list processing and iterators
 
 
-def chunks(lst, n):
+def chunks(lst, n, max_chunk=None):
     """
     Split `lst` in `n` even parts
     """
-    for i in range(0, len(lst), n):
+    for cpt, i in enumerate(range(0, len(lst), n)):
+        if max_chunk is not None and cpt >= max_chunk:
+            return
         yield lst[i : i + n]

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -87,3 +87,13 @@
   
   '''
 # ---
+# name: test_upload_only_create_a_limited_number_of_files
+  '''
+  Connected to "0.0.0.0" as "django_tests"
+  Current remote dir is "/"
+  Starting UPLOAD of employee records
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Employee records processing done!
+  
+  '''
+# ---

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
@@ -86,3 +86,13 @@
   
   '''
 # ---
+# name: test_upload_only_create_a_limited_number_of_files
+  '''
+  Connected to "0.0.0.0" as "django_tests"
+  Current remote dir is "/"
+  Starting UPLOAD of 2 notification(s)
+  Successfully uploaded: RIAE_FS_20210927000000.json
+  Employee record notifications processing done!
+  
+  '''
+# ---

--- a/tests/employee_record/test_transfer_employee_records_updates.py
+++ b/tests/employee_record/test_transfer_employee_records_updates.py
@@ -100,6 +100,27 @@ def test_upload_file_error(faker, snapshot, sftp_directory, command):
     assert command.stdout.getvalue() == snapshot
 
 
+@freezegun.freeze_time("2021-09-27")
+def test_upload_only_create_a_limited_number_of_files(mocker, snapshot, sftp_directory, command):
+    mocker.patch.object(EmployeeRecordBatch, "MAX_EMPLOYEE_RECORDS", 1)
+    EmployeeRecordUpdateNotificationFactory.create_batch(2, ready_for_transfer=True)
+
+    command.handle(upload=True, download=False, preflight=False, wet_run=True)
+    assert len(list(sftp_directory.joinpath("depot").iterdir())) == command.MAX_UPLOADED_FILES
+
+    assert command.stdout.getvalue() == snapshot
+
+
+@freezegun.freeze_time("2021-09-27")
+def test_upload_only_send_a_limited_number_of_rows(mocker, snapshot, sftp_directory, command):
+    mocker.patch.object(EmployeeRecordBatch, "MAX_EMPLOYEE_RECORDS", 1)
+    EmployeeRecordUpdateNotificationFactory.create_batch(2, ready_for_transfer=True)
+
+    command.handle(upload=True, download=False, preflight=False, wet_run=True)
+    for file in sftp_directory.joinpath("depot").iterdir():
+        assert len(file.read_text().splitlines()) == 1
+
+
 def test_download_file_error(faker, snapshot, sftp_directory, command):
     sftp_directory.joinpath("retrait/RIAE_FS_00000000000000_FichierRetour.json").touch(0o000)
 

--- a/tests/utils/test_iterators.py
+++ b/tests/utils/test_iterators.py
@@ -1,0 +1,16 @@
+from itou.utils.iterators import chunks
+
+
+def test_chunks():
+    values = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    assert list(chunks(values, 10)) == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+    assert list(chunks(values, 5)) == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+    assert list(chunks(values, 2)) == [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]]
+
+    assert list(chunks(values, 10, 2)) == [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]
+    assert list(chunks(values, 5, 2)) == [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+    assert list(chunks(values, 2, 2)) == [[0, 1], [2, 3]]
+
+    assert list(chunks([], 2)) == []
+    assert list(chunks([], 2, 2)) == []


### PR DESCRIPTION
### Pourquoi ?

C'est quelque chose qui traîne depuis longtemps (février 2022 de mémoire) et ça permet de faire ceinture-bretelles pour #3872

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
