### PR TITLE
Mise à jour de l'adresse du GIP sur la page accessibilité

### DIFF
--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -109,7 +109,9 @@
                             Adresse :
                             <br>
                             <address>
-                                20 avenue de Ségur
+                                Groupement d’intérêt public « Plateforme de l’inclusion »  
+                                <br>
+                                127 rue de Grenelle
                                 <br>
                                 75007 Paris
                             </address>


### PR DESCRIPTION
### Pourquoi ?

Adresse utilisé identique à celle du GIP