### PR TITLE
Fiches salarié : Correction d'oublis pour les données statiques des notifications

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -3,7 +3,7 @@ import re
 from rest_framework import serializers
 from unidecode import unidecode
 
-from itou.asp.models import AllocationDuration, LaneExtension, LaneType, SiaeMeasure
+from itou.asp.models import AllocationDuration, EducationLevel, LaneExtension, LaneType, SiaeMeasure
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
 from itou.employee_record.typing import CodeComInsee
 from itou.users.enums import Title
@@ -15,7 +15,7 @@ class _PersonSerializer(serializers.Serializer):
     passIae = serializers.CharField(source="approval_number")  # Required
     idItou = serializers.CharField(source="job_application.job_seeker.jobseeker_profile.asp_uid")  # Required
 
-    civilite = serializers.ChoiceField(choices=Title.choices, source="job_application.job_seeker.title")  # Required
+    civilite = NullIfEmptyChoiceField(choices=Title.choices, source="job_application.job_seeker.title")  # Required
     nomUsage = serializers.SerializerMethodField()  # Required
     nomNaissance = NullField()  # Optional
     prenom = serializers.SerializerMethodField()  # Required
@@ -126,8 +126,8 @@ class _StaticAddressSerializer(_AddressSerializer):
 
 class _SituationSerializer(serializers.Serializer):
     orienteur = serializers.CharField(source="asp_prescriber_type")  # Required
-    niveauFormation = serializers.CharField(
-        source="job_application.job_seeker.jobseeker_profile.education_level"
+    niveauFormation = NullIfEmptyChoiceField(
+        choices=EducationLevel.choices, source="job_application.job_seeker.jobseeker_profile.education_level"
     )  # Required
 
     salarieEnEmploi = serializers.BooleanField(

--- a/tests/employee_record/__snapshots__/test_serializers.ambr
+++ b/tests/employee_record/__snapshots__/test_serializers.ambr
@@ -39,6 +39,30 @@
     'sufPassIae': None,
   })
 # ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[education_level--situationSalarie]
+  ReturnDict({
+    'inscritPoleEmploi': False,
+    'inscritPoleEmploiDepuis': None,
+    'niveauFormation': '00',
+    'numeroIDE': None,
+    'orienteur': '08',
+    'salarieAideSociale': False,
+    'salarieBenefAAH': False,
+    'salarieBenefAAHDepuis': None,
+    'salarieBenefASS': False,
+    'salarieBenefASSDepuis': None,
+    'salarieBenefATA': False,
+    'salarieBenefATADepuis': None,
+    'salarieBenefRSA': 'NON',
+    'salarieBenefRSADepuis': None,
+    'salarieEnEmploi': True,
+    'salarieOETH': False,
+    'salarieRQTH': False,
+    'salarieSansEmploiDepuis': None,
+    'salarieSansRessource': False,
+    'salarieTypeEmployeur': '01',
+  })
+# ---
 # name: test_update_notification_use_static_serializers_on_missing_fields[hexa_commune-None-adresse]
   ReturnDict({
     'adrCpltDistribution': None,
@@ -89,5 +113,29 @@
     'codeinseecom': '57463',
     'codepostalcedex': '57000',
     'codetypevoie': 'AV',
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[pole_emploi_since--situationSalarie]
+  ReturnDict({
+    'inscritPoleEmploi': False,
+    'inscritPoleEmploiDepuis': None,
+    'niveauFormation': '00',
+    'numeroIDE': None,
+    'orienteur': '08',
+    'salarieAideSociale': False,
+    'salarieBenefAAH': False,
+    'salarieBenefAAHDepuis': None,
+    'salarieBenefASS': False,
+    'salarieBenefASSDepuis': None,
+    'salarieBenefATA': False,
+    'salarieBenefATADepuis': None,
+    'salarieBenefRSA': 'NON',
+    'salarieBenefRSADepuis': None,
+    'salarieEnEmploi': True,
+    'salarieOETH': False,
+    'salarieRQTH': False,
+    'salarieSansEmploiDepuis': None,
+    'salarieSansRessource': False,
+    'salarieTypeEmployeur': '01',
   })
 # ---

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -189,6 +189,8 @@ class EmployeeRecordUpdateNotificationSerializerTest(TestCase):
         ("hexa_lane_name", "", "adresse"),
         ("hexa_post_code", "", "adresse"),
         ("hexa_commune", None, "adresse"),
+        ("education_level", "", "situationSalarie"),
+        ("pole_emploi_since", "", "situationSalarie"),
     ],
 )
 def test_update_notification_use_static_serializers_on_missing_fields(snapshot, field, value, key):


### PR DESCRIPTION
### Pourquoi ?

Oubli de `NullIfEmpty*Field()` pour des champs obligatoire dans #3850, ce qui a révélé d'autres champs problématiques :crying_cat_face:.

### À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
