### PR TITLE
Retirer du JS inutilisé pour #siae-number-results

### DIFF
--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -93,7 +93,5 @@
         $("#asideFiltersCollapse :input").change(function() {
             $("#search-form").submit();
         });
-
-        $("#siae-number-results").focus();
     </script>
 {% endblock %}


### PR DESCRIPTION
### Pourquoi ?

ID retiré dans 9ab58d00895aca7aea48835f1e2e31e95afb5891.