### PR TITLE
Amélioration du template de PR Github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,18 @@
-### Pourquoi ?
+## :thinking: Pourquoi ?
 
-Indiquer le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements.
+> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._
 
-### Comment ? <!-- optionnel -->
+## :cake: Comment ? <!-- optionnel -->
 
-Attirer l'attention sur les décisions d'architecture ou de conception importantes.
+> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._
 
-### Captures d'écran <!-- optionnel -->
+## :computer: Captures d'écran <!-- optionnel -->
 
-### À vérifier
+## :rotating_light: À vérifier
 
 - [ ] Ajouter l'étiquette « no-changelog » ?
 - [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
+
+## :desert_island: Comment tester
+
+> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._


### PR DESCRIPTION
## :thinking:  Pourquoi ?

Suite à un test sur en précédente PR il a été décider de s'inspirer du [template Carnet de Bord](https://github.com/gip-inclusion/carnet-de-bord/blob/main/.github/pull_request_template.md). L'ajout principal est celui de la partie _Comment tester_.

## :computer: Captures d'écran <!-- optionnel -->
Inspiration
![image](https://github.com/gip-inclusion/les-emplois/assets/154904/7a4e1466-0e85-4722-849d-4d234e55a9ce)


## :cake: Comment ? <!-- optionnel -->

On met à jour le template de PR en rajoutant de superbes émojis et une nouvelle section « Comment tester ».
