### PR TITLE
Retirer make deploy_prod

### DIFF
--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -1,5 +1,8 @@
 # Journal des changements techniques majeurs
 
+## 2024-04-08
+- Suppression de la commande `make deploy_prod`, les PRs arrivant sur la branche master sont immédiatement déployées par CleverCloud.
+
 ## 2024-03-14
 - Définition d’`API_BAN_BASE_URL` requise, utiliser la valeur du [`.env.template`](./.env.template).
 

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,3 @@ shell_on_postgres_container:
 
 restore_latest_backup:
 	./scripts/restore_latest_backup.sh $(PGDATABASE)
-
-# Deployment
-# =============================================================================
-
-.PHONY: deploy_prod
-deploy_prod:
-	git fetch origin  # Update our local to get the latest `master`
-	@echo "Pull request deployed: https://github.com/gip-inclusion/les-emplois/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+`git log --pretty=format:"%h" origin/master_clever..origin/master | tr "\n" "+"`"
-	git push origin origin/master:master_clever  # Deploy by pushing the latest `master` to `master_clever`


### PR DESCRIPTION
### Pourquoi ?

CleverCloud suit désormais la branche `master` directement.
