### PR TITLE
Refonte UX/UI - Mise a jour de la section title / part 01

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -11,6 +11,13 @@
     }
 }
 
+.p-home .s-title-02 {
+    margin-bottom: 0 !important;
+}
+
+.p-home .s-title-02__row::after {
+    display: none !important;
+}
 
 .s-home-search {
     background-position: center left, center right;
@@ -66,7 +73,6 @@
 .input-group-search .select2-selection__rendered {
     white-space: nowrap !important;
 }
-
 
 .input-group-search .select2-container--bootstrap-5 .select2-selection--single {
     border-left: 0 !important;
@@ -237,22 +243,6 @@ an input field being invalid, generating an uncontrolled red box-shadow. */
 
 .home-search :not(output):-moz-ui-invalid:-moz-focusring:not(:focus) {
     box-shadow: none;
-}
-
-/* Old browsers.
---------------------------------------------------------------------------- */
-
-.alert-old-browser {
-    display: none;
-}
-
-/* Target only IE 11. */
-
-/* https://stackoverflow.com/a/27315792 */
-
-_:-ms-fullscreen,
-:root .alert-old-browser {
-    display: block;
 }
 
 /* CSS for js-shroud.

--- a/itou/templates/500.html
+++ b/itou/templates/500.html
@@ -6,7 +6,6 @@
     <h1>Erreur 500</h1>
     <h2>Une erreur technique s'est produite.</h2>
     <p>Notre équipe technique a été informée du problème et s'en occupera le plus rapidement possible.</p>
-
     <p>
         Toutefois, nous vous invitons à contacter
         <a href="{{ ITOU_HELP_CENTER_URL }}">l'assistance de la Plateforme de l'inclusion</a>

--- a/itou/templates/account/account_inactive.html
+++ b/itou/templates/account/account_inactive.html
@@ -3,9 +3,11 @@
 
 {% block title %}Compte inactif {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>Compte inactif</h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-warning">
         <p class="mb-0">Ce compte est inactif.</p>
     </div>
 {% endblock %}
+
+{% block content_title %}<h1>Compte inactif</h1>{% endblock %}

--- a/itou/templates/account/activate_inclusion_connect_account.html
+++ b/itou/templates/account/activate_inclusion_connect_account.html
@@ -10,8 +10,6 @@
 
 {% block body_class %}p-inclusion-connect{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section pt-lg-3">
         <div class="s-section__container container">

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -7,12 +7,14 @@
 
 {% block title %}Confirmer l'adresse e-mail {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>Confirmer l'adresse e-mail</h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-warning">
         <p class="mb-0">Ce compte est inactif.</p>
     </div>
 {% endblock %}
+
+{% block content_title %}<h1>Confirmer l'adresse e-mail</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -6,8 +6,6 @@
 
 {% block title %}Déconnexion {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -2,8 +2,6 @@
 
 {% block title %}API Les emplois de l’inclusion{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/api/openapi.html
+++ b/itou/templates/api/openapi.html
@@ -3,8 +3,6 @@
 
 {% block title %}API ReDoc {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/apply/includes/siae_hiring_actions.html
+++ b/itou/templates/apply/includes/siae_hiring_actions.html
@@ -2,7 +2,7 @@
 {% load format_filters %}
 {% load matomo %}
 
-<div class="c-box c-box--action mb-4 hidden-if-empty" id="transition_buttons_{{ job_application.pk }}"{% if out_of_band_swap %} hx-swap-oob="true"{% endif %} data-disable-btn-if=".editing-prior-action">
+<div class="c-box c-box--action" id="transition_buttons_{{ job_application.pk }}"{% if out_of_band_swap %} hx-swap-oob="true"{% endif %} data-disable-btn-if=".editing-prior-action">
     <h2 class="visually-hidden">Actions rapides</h2>
     <div class="form-row align-items-center gx-3">
         {% if job_application.state.is_new %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -16,9 +16,9 @@
 {% endblock %}
 
 {% block content %}
-    <section class="s-box">
-        <div class="s-box__container container">
-            <div class="s-box__row row">
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
                 <div class="col-12 col-md-4 mb-3 mb-md-5">
                     <aside class="c-aside-filters">
                         <button class="c-aside-filters__btn__collapse" data-bs-toggle="collapse" data-bs-target="#asideFiltersCollapse" aria-expanded="true" aria-controls="asideFiltersCollapse">

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -4,14 +4,8 @@
 
 {% block title %}Export des candidatures {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    {% if export_for == "siae" %}
-        <h1>Exporter toutes les candidatures reçues</h1>
-        <h2>{{ siae.display_name }}</h2>
-    {% else %}
-        <h1>Exporter toutes les candidatures</h1>
-    {% endif %}
-
+{% block messages %}
+    {{ block.super }}
     {% if export_for == "siae" or can_view_stats_pe %}
         <div class="alert alert-info mt-3" id="besoin-dun-chiffre">
             <p class="mb-0">
@@ -39,74 +33,81 @@
     {% endif %}
 {% endblock %}
 
+{% block content_title %}
+    {% if export_for == "siae" %}
+        <h1>Exporter toutes les candidatures reçues</h1>
+        <h2>{{ siae.display_name }}</h2>
+    {% else %}
+        <h1>Exporter toutes les candidatures</h1>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    <div class="c-box">
-                        {% if not job_applications_by_month %}
-                            <h2 class="h4">Aucune candidature pour le moment.</h2>
-                        {% else %}
-                            <h2 class="h4">Candidatures reçues</h2>
-                            <div class="table-responsive-lg mt-3">
-                                <table class="table">
-                                    <caption class="visually-hidden">Liste des candidatures reçues</caption>
-                                    <thead>
+                    {% if not job_applications_by_month %}
+                        <h2 class="h4">Aucune candidature pour le moment.</h2>
+                    {% else %}
+                        <h2 class="h4">Candidatures reçues</h2>
+                        <div class="table-responsive-lg mt-3">
+                            <table class="table">
+                                <caption class="visually-hidden">Liste des candidatures reçues</caption>
+                                <thead>
+                                    <tr>
+                                        <th scope="col">Contenu du fichier</th>
+                                        <th scope="col">Nombre de candidatures</th>
+                                        <th scope="col">Télécharger (.xlsx)</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>Toutes les candidatures</td>
+                                        <td>{{ total_job_applications }}</td>
+                                        <td>
+                                            {% if export_for == "siae" %}
+                                                <a class="btn-link" {% matomo_event "candidature" "exports" "export-siae" %} aria-label="Télécharger cet export SIAE" href="{% url 'apply:list_for_siae_exports_download' %}">
+                                                    <i class="ri-download-line me-1" aria-hidden="true"></i>
+                                                    Télécharger
+                                                </a>
+                                            {% else %}
+                                                <a class="btn-link" {% matomo_event "candidature" "exports" "export-prescripteur" %} aria-label="Télécharger cet export prescripteur" href="{% url 'apply:list_for_prescriber_exports_download' %}">
+                                                    <i class="ri-download-line me-1" aria-hidden="true"></i>
+                                                    Télécharger
+                                                </a>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    {% for month in job_applications_by_month %}
                                         <tr>
-                                            <th scope="col">Contenu du fichier</th>
-                                            <th scope="col">Nombre de candidatures</th>
-                                            <th scope="col">Télécharger (.xlsx)</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr>
-                                            <td>Toutes les candidatures</td>
-                                            <td>{{ total_job_applications }}</td>
+                                            <td>{{ month.month|date:"F Y"|capfirst }}</td>
+                                            <td>{{ month.c }}</td>
                                             <td>
                                                 {% if export_for == "siae" %}
-                                                    <a class="btn-link" {% matomo_event "candidature" "exports" "export-siae" %} aria-label="Télécharger cet export SIAE" href="{% url 'apply:list_for_siae_exports_download' %}">
+                                                    <a class="btn-link"
+                                                       {% matomo_event "candidature" "exports" "export-siae" %}
+                                                       aria-label="Télécharger cet export SIAE"
+                                                       href="{% url 'apply:list_for_siae_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                                         <i class="ri-download-line me-1" aria-hidden="true"></i>
                                                         Télécharger
                                                     </a>
                                                 {% else %}
-                                                    <a class="btn-link" {% matomo_event "candidature" "exports" "export-prescripteur" %} aria-label="Télécharger cet export prescripteur" href="{% url 'apply:list_for_prescriber_exports_download' %}">
+                                                    <a class="btn-link"
+                                                       {% matomo_event "candidature" "exports" "export-prescripteur" %}
+                                                       aria-label="Télécharger cet export prescripteur"
+                                                       href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
                                                         <i class="ri-download-line me-1" aria-hidden="true"></i>
                                                         Télécharger
                                                     </a>
                                                 {% endif %}
                                             </td>
                                         </tr>
-                                        {% for month in job_applications_by_month %}
-                                            <tr>
-                                                <td>{{ month.month|date:"F Y"|capfirst }}</td>
-                                                <td>{{ month.c }}</td>
-                                                <td>
-                                                    {% if export_for == "siae" %}
-                                                        <a class="btn-link"
-                                                           {% matomo_event "candidature" "exports" "export-siae" %}
-                                                           aria-label="Télécharger cet export SIAE"
-                                                           href="{% url 'apply:list_for_siae_exports_download' month_identifier=month.month|date:"Y-m" %}">
-                                                            <i class="ri-download-line me-1" aria-hidden="true"></i>
-                                                            Télécharger
-                                                        </a>
-                                                    {% else %}
-                                                        <a class="btn-link"
-                                                           {% matomo_event "candidature" "exports" "export-prescripteur" %}
-                                                           aria-label="Télécharger cet export prescripteur"
-                                                           href="{% url 'apply:list_for_prescriber_exports_download' month_identifier=month.month|date:"Y-m" %}">
-                                                            <i class="ri-download-line me-1" aria-hidden="true"></i>
-                                                            Télécharger
-                                                        </a>
-                                                    {% endif %}
-                                                </td>
-                                            </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
-                        {% endif %}
-                    </div>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -10,22 +10,18 @@
 {% endblock %}
 
 {% block content_title %}
-    <div class="d-md-flex align-items-center mb-3">
+    <div class="d-md-flex align-items-center">
         <h1 class="mb-1 mb-md-0 me-3">
             Candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
         </h1>
         {% state_badge job_application extra_class="badge-base" %}
     </div>
+    {% block actions %}{% endblock %}
 {% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
-                    {% block actions %}{% endblock %}
-                </div>
-            </div>
             <div class="row">
                 <div class="col-12 col-lg-8">
                     {% if job_application.to_company.is_subject_to_eligibility_rules %}

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -4,6 +4,28 @@
 
 {% block title %}Postuler {{ block.super }}{% endblock %}
 
+{% block messages %}
+    {{ block.super }}
+    {% if new_check_needed %}
+        <div class="alert alert-warning alert-dismissible fade show">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-warning"></i>
+                </div>
+                <div class="col">
+                    <p>
+                        <strong>Veuillez vérifier les informations du candidat</strong>
+                    </p>
+                    <p>
+                        La situation du candidat a peut-être changé depuis le {{ job_seeker.last_checked_at|date }}. Merci de vérifier la validité des informations présentes sur son profil.
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
 {% block content_title %}
     <div class="w-100 w-lg-66">
         <div class="d-flex align-items-center">
@@ -17,24 +39,6 @@
             {% endif %}
             {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning"></i>{% endif %}
         </p>
-        {% if new_check_needed %}
-            <div class="alert alert-warning alert-dismissible fade show">
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-                <div class="row">
-                    <div class="col-auto pe-0">
-                        <i class="ri-information-line ri-xl text-warning"></i>
-                    </div>
-                    <div class="col">
-                        <p>
-                            <strong>Veuillez vérifier les informations du candidat</strong>
-                        </p>
-                        <p>
-                            La situation du candidat a peut-être changé depuis le {{ job_seeker.last_checked_at|date }}. Merci de vérifier la validité des informations présentes sur son profil.
-                        </p>
-                    </div>
-                </div>
-            </div>
-        {% endif %}
     </div>
 {% endblock %}
 

--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -5,7 +5,6 @@
 
 {% block content_title %}
     <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
-    {% block title_messages %}{% endblock %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -6,7 +6,8 @@
 {% load buttons_form %}
 {% load static %}
 
-{% block title_messages %}
+{% block messages %}
+    {{ block.super }}
 
     {% if request.user.is_employer %}
         {% if siae.is_subject_to_eligibility_rules or siae.kind == CompanyKind.GEIQ %}

--- a/itou/templates/apply/submit_step_pending_authorization.html
+++ b/itou/templates/apply/submit_step_pending_authorization.html
@@ -1,8 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -8,9 +8,9 @@
 {% block content_title %}<h1>Salariés et PASS IAE</h1>{% endblock %}
 
 {% block content %}
-    <section class="s-box">
-        <div class="s-box__container container">
-            <div class="s-box__row row">
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
                 <div class="col-12 col-md-4 mb-3 mb-md-5">
                     <aside class="c-aside-filters">
                         <button class="c-aside-filters__btn__collapse" data-bs-toggle="collapse" data-bs-target="#asideFiltersCollapse" aria-expanded="true" aria-controls="asideFiltersCollapse">

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -8,56 +8,52 @@
 {% block content_title %}
     <h1>{{ siae.display_name }}</h1>
     <h2>{{ siae.get_kind_display }}</h2>
+    <div class="c-box c-box--action">
+        <h2 class="visually-hidden">Actions rapides</h2>
+        <div class="form-row align-items-center gx-3">
+            {% if siae.has_active_members and not siae.block_job_applications %}
+                <div class="form-group col col-lg-auto">
+                    <a href="{% url 'apply:start' company_pk=siae.pk %}"
+                       class="btn btn-lg btn-white btn-block btn-ico"
+                       {% matomo_event "candidature" "clic" "start_application" %}
+                       aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
+                        <i class="ri-draft-line font-weight-medium" aria-hidden="true"></i>
+                        <span>Postuler</span>
+                    </a>
+                </div>
+            {% endif %}
+            {% if active_jobs_descriptions or other_jobs_descriptions %}
+                <div class="form-group col col-lg-auto">
+                    <a href="#metiers" class="btn btn-lg btn-outline-white btn-block btn-ico">
+                        <i class="ri-eye-line font-weight-medium" aria-hidden="true"></i>
+                        <span>Voir tous les métiers</span>
+                    </a>
+                </div>
+            {% endif %}
+            <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                <button class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires">
+                    <i class="ri-more-2-line ri-lg font-weight-normal" aria-hidden="true"></i>
+                    <span class="d-lg-none">Autres actions</span>
+                </button>
+                <ul class="dropdown-menu">
+                    <li>
+                        {% include 'includes/copy_to_clipboard.html' with content=siae_card_absolute_url text="Copier le lien de cette fiche entreprise" css_classes="dropdown-item btn-ico btn-link" %}
+                    </li>
+                    <li>
+                        <a href="{{ report_tally_url }}" rel="noopener" class="dropdown-item btn-ico btn-link" target="_blank">
+                            <i class="ri-notification-4-line ri-lg font-weight-normal" aria-hidden="true"></i>
+                            <span>Signaler cette fiche entreprise</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
-                    <div class="c-box c-box--action mb-4 hidden-if-empty">
-                        <h2 class="visually-hidden">Actions rapides</h2>
-                        <div class="form-row align-items-center gx-3">
-                            {% if siae.has_active_members and not siae.block_job_applications %}
-                                <div class="form-group col col-lg-auto">
-                                    <a href="{% url 'apply:start' company_pk=siae.pk %}"
-                                       class="btn btn-lg btn-white btn-block btn-ico"
-                                       {% matomo_event "candidature" "clic" "start_application" %}
-                                       aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line font-weight-medium" aria-hidden="true"></i>
-                                        <span>Postuler</span>
-                                    </a>
-                                </div>
-                            {% endif %}
-                            {% if active_jobs_descriptions or other_jobs_descriptions %}
-                                <div class="form-group col col-lg-auto">
-                                    <a href="#metiers" class="btn btn-lg btn-outline-white btn-block btn-ico">
-                                        <i class="ri-eye-line font-weight-medium" aria-hidden="true"></i>
-                                        <span>Voir tous les métiers</span>
-                                    </a>
-                                </div>
-                            {% endif %}
-                            <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                <button class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires">
-                                    <i class="ri-more-2-line ri-lg font-weight-normal" aria-hidden="true"></i>
-                                    <span class="d-lg-none">Autres actions</span>
-                                </button>
-                                <ul class="dropdown-menu">
-                                    <li>
-                                        {% include 'includes/copy_to_clipboard.html' with content=siae_card_absolute_url text="Copier le lien de cette fiche entreprise" css_classes="dropdown-item btn-ico btn-link" %}
-                                    </li>
-                                    <li>
-                                        <a href="{{ report_tally_url }}" rel="noopener" class="dropdown-item btn-ico btn-link" target="_blank">
-                                            <i class="ri-notification-4-line ri-lg font-weight-normal" aria-hidden="true"></i>
-                                            <span>Signaler cette fiche entreprise</span>
-                                        </a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
             <div class="row">
                 <div class="col-12 col-lg-8 order-2 order-lg-1 mt-3 mt-lg-0 {% if not siae.description and not siae.provided_support %}d-none d-lg-block{% endif %}">
                     <div class="c-box h-100 {% if not siae.description and not siae.provided_support %}d-flex align-items-center justify-content-center{% endif %}">

--- a/itou/templates/companies/create_siae.html
+++ b/itou/templates/companies/create_siae.html
@@ -15,8 +15,7 @@
             connue des services des emplois de l'inclusion mais n’ayant pas encore de membre : <a href="{% url 'signup:company_select' %}">utilisez ce formulaire</a>
         </li>
     </ul>
-    <p class="mb-0">Dans les autres cas, complétez le formulaire ci-dessous.</p>
-
+    <p>Dans les autres cas, complétez le formulaire ci-dessous.</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/companies/deactivate_member.html
+++ b/itou/templates/companies/deactivate_member.html
@@ -2,8 +2,6 @@
 
 {% block title %}Retrait d'un collaborateur {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/edit_job_description.html
+++ b/itou/templates/companies/edit_job_description.html
@@ -9,8 +9,6 @@
     {% include "layout/breadcrumbs_from_dashboard.html" %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/edit_job_description_details.html
+++ b/itou/templates/companies/edit_job_description_details.html
@@ -9,8 +9,6 @@
     {% include "layout/breadcrumbs_from_dashboard.html" %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/edit_job_description_preview.html
+++ b/itou/templates/companies/edit_job_description_preview.html
@@ -8,8 +8,6 @@
     {% include "layout/breadcrumbs_from_dashboard.html" %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/edit_siae.html
+++ b/itou/templates/companies/edit_siae.html
@@ -10,8 +10,6 @@
     {% include 'companies/edit_siae_breadcrumb.html' %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/edit_siae_breadcrumb.html
+++ b/itou/templates/companies/edit_siae_breadcrumb.html
@@ -1,5 +1,5 @@
 <nav class="c-breadcrumb" aria-label="Fil d'Ariane">
-    <ol class="breadcrumb">
+    <ol class="breadcrumb p-0">
         <li class="breadcrumb-item">
             <a href="{% url 'dashboard:index' %}">Tableau de bord</a>
         </li>

--- a/itou/templates/companies/edit_siae_description.html
+++ b/itou/templates/companies/edit_siae_description.html
@@ -10,8 +10,6 @@
     {% include 'companies/edit_siae_breadcrumb.html' %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -11,8 +11,6 @@
     {% include 'companies/edit_siae_breadcrumb.html' %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -58,7 +58,7 @@
                     <a class="btn btn-ico btn-primary"
                        href="{% url 'apply:start' company_pk=siae.pk %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
-                       aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                       aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                         <i class="ri ri-draft-line" aria-hidden="true"></i>
                         <span>Postuler</span>
                     </a>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -15,70 +15,68 @@
 {% block content_title %}
     <h1>{{ job.display_name }}</h1>
     {% if job.is_active %}
-        <span class="badge rounded-pill bg-success">
-            {{ job.open_positions }} poste{{ job.open_positions|pluralizefr }} ouvert{{ job.open_positions|pluralizefr }} au recrutement
-        </span>
+        <p>
+            <span class="badge rounded-pill bg-success">
+                {{ job.open_positions }} poste{{ job.open_positions|pluralizefr }} ouvert{{ job.open_positions|pluralizefr }} au recrutement
+            </span>
+        </p>
     {% endif %}
+    <div class="c-box c-box--action">
+        <h2 class="visually-hidden">Actions rapides</h2>
+        <div class="form-row align-items-center gx-3">
+            {% if can_update_job_description %}
+                <div class="form-group col col-lg-auto">
+                    <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}"
+                       class="btn btn-lg btn-white btn-block btn-ico"
+                       aria-label="Modifier la fiche de poste"
+                       {% matomo_event "employeurs" "clic" "edit-fiche-de-poste" %}>
+                        <i class="ri-pencil-line font-weight-medium" aria-hidden="true"></i>
+                        <span>Modifier</span>
+                    </a>
+                </div>
+                <div class="form-group col col-lg-auto">
+                    <a href="{% url "companies_views:job_description_list" %}" class="btn btn-lg btn-outline-white btn-block btn-ico">
+                        <i class="ri-arrow-go-back-line font-weight-medium" aria-hidden="true"></i>
+                        <span>Retour vers la liste des postes</span>
+                    </a>
+                </div>
+            {% else %}
+                {% if job.is_active and not siae.block_job_applications %}
+                    <div class="form-group col col-lg-auto">
+                        <a href="{% url "apply:start" company_pk=siae.pk %}?job_description_id={{ job.pk }}"
+                           class="btn btn-lg btn-white btn-block btn-ico"
+                           {% matomo_event "candidature" "clic" "start_application" %}
+                           aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
+                            <i class="ri-draft-line font-weight-medium" aria-hidden="true"></i>
+                            <span>Postuler</span>
+                        </a>
+                    </div>
+                {% endif %}
+                <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                    <button class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires">
+                        <i class="ri-more-2-line ri-lg font-weight-normal" aria-hidden="true"></i>
+                        <span class="d-lg-none">Autres actions</span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li>
+                            {% include 'includes/copy_to_clipboard.html' with content=job.get_absolute_url text="Copier le lien de cette fiche de poste" css_classes="dropdown-item btn-ico btn-link" %}
+                        </li>
+                        <li>
+                            <a href="{{ report_tally_url }}" rel="noopener" class="dropdown-item btn-ico btn-link" target="_blank">
+                                <i class="ri-notification-4-line ri-lg font-weight-normal" aria-hidden="true"></i>
+                                <span>Signaler cette fiche de poste</span>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            {% endif %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
-                    <div class="c-box c-box--action mb-4 hidden-if-empty">
-                        <h2 class="visually-hidden">Actions rapides</h2>
-                        <div class="form-row align-items-center gx-3">
-                            {% if can_update_job_description %}
-                                <div class="form-group col col-lg-auto">
-                                    <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}"
-                                       class="btn btn-lg btn-white btn-block btn-ico"
-                                       aria-label="Modifier la fiche de poste"
-                                       {% matomo_event "employeurs" "clic" "edit-fiche-de-poste" %}>
-                                        <i class="ri-pencil-line font-weight-medium" aria-hidden="true"></i>
-                                        <span>Modifier</span>
-                                    </a>
-                                </div>
-                                <div class="form-group col col-lg-auto">
-                                    <a href="{% url "companies_views:job_description_list" %}" class="btn btn-lg btn-outline-white btn-block btn-ico">
-                                        <i class="ri-arrow-go-back-line font-weight-medium" aria-hidden="true"></i>
-                                        <span>Retour vers la liste des postes</span>
-                                    </a>
-                                </div>
-                            {% else %}
-                                {% if job.is_active and not siae.block_job_applications %}
-                                    <div class="form-group col col-lg-auto">
-                                        <a href="{% url "apply:start" company_pk=siae.pk %}?job_description_id={{ job.pk }}"
-                                           class="btn btn-lg btn-white btn-block btn-ico"
-                                           {% matomo_event "candidature" "clic" "start_application" %}
-                                           aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                                            <i class="ri-draft-line font-weight-medium" aria-hidden="true"></i>
-                                            <span>Postuler</span>
-                                        </a>
-                                    </div>
-                                {% endif %}
-                                <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                    <button class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires">
-                                        <i class="ri-more-2-line ri-lg font-weight-normal" aria-hidden="true"></i>
-                                        <span class="d-lg-none">Autres actions</span>
-                                    </button>
-                                    <ul class="dropdown-menu">
-                                        <li>
-                                            {% include 'includes/copy_to_clipboard.html' with content=job.get_absolute_url text="Copier le lien de cette fiche de poste" css_classes="dropdown-item btn-ico btn-link" %}
-                                        </li>
-                                        <li>
-                                            <a href="{{ report_tally_url }}" rel="noopener" class="dropdown-item btn-ico btn-link" target="_blank">
-                                                <i class="ri-notification-4-line ri-lg font-weight-normal" aria-hidden="true"></i>
-                                                <span>Signaler cette fiche de poste</span>
-                                            </a>
-                                        </li>
-                                    </ul>
-                                </div>
-                            {% endif %}
-                        </div>
-                    </div>
-                </div>
-            </div>
             <div class="row">
                 <div class="col-12 col-lg-8 order-2 order-lg-1 mt-3 mt-lg-0">
                     <div class="c-box">{% include "companies/includes/_job_description_details.html" %}</div>

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -8,7 +8,7 @@
 {% block content_title %}
     <h1>Structure</h1>
     <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
-    <p class="mb-0">
+    <p>
         Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
     </p>
 {% endblock %}

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -5,14 +5,8 @@
 
 {% block title %}Annexes financières {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>Structure</h1>
-    <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
-    <p class="mb-0">
-        Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières.
-        <br>
-        La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
-    </p>
+{% block messages %}
+    {{ block.super }}
     {% if not siae.is_active %}
         {% if siae_is_asp %}
             <div class="alert alert-danger" role="status">
@@ -31,6 +25,16 @@
             </div>
         {% endif %}
     {% endif %}
+{% endblock %}
+
+{% block content_title %}
+    <h1>Structure</h1>
+    <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
+    <p>
+        Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières.
+        <br>
+        La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
+    </p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/companies/update_admins.html
+++ b/itou/templates/companies/update_admins.html
@@ -2,8 +2,6 @@
 
 {% block title %}Gestion des administrateurs {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -34,7 +34,7 @@
                                         </li>
                                     </ul>
                                     <p>Listes de vos structures :</p>
-                                    <table class="table table-sm">
+                                    <table class="table">
                                         <thead>
                                             <tr>
                                                 <th scope="col">Nom</th>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -153,11 +153,31 @@
     {% endif %}
 {% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
+{% block content_title %}
+    <h1 class="h1 mb-0">
+        {% if user.is_job_seeker and user.get_full_name %}Tableau de bord - {{ user.get_full_name }}{% endif %}
+        {% if request.current_organization %}{{ request.current_organization.display_name }}{% endif %}
+    </h1>
+    {% if request.current_organization %}
+        <p>
+            {% if user.is_prescriber %}
+                {% if request.current_organization.code_safir_pole_emploi %}
+                    {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
+                    Code SAFIR {{ request.current_organization.code_safir_pole_emploi }}
+                {% elif request.current_organization.siret %}
+                    {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
+                    SIRET {{ request.current_organization.siret|format_siret }}
+                {% endif %}
+            {% elif user.is_employer %}
+                SIRET {{ request.current_organization.siret|format_siret }}
+            {% endif %}
+        </p>
+    {% endif %}
+{% endblock %}
 
 {% block content %}
     {% if ic_activate_url %}
-        <section class="s-banner-01 s-banner-01--ic m-0 pb-0 pt-3 px-0 alert">
+        <section class="s-banner-01 s-banner-01--ic m-0 p-0 alert">
             <div class="s-banner-01__container container">
                 <div class="s-banner-01__row row">
                     <div class="s-banner-01__col col-12">
@@ -201,31 +221,6 @@
 
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
-                    <h1 class="h1 mb-0">
-                        {% if user.is_job_seeker and user.get_full_name %}Tableau de bord - {{ user.get_full_name }}{% endif %}
-                        {% if request.current_organization %}{{ request.current_organization.display_name }}{% endif %}
-                    </h1>
-
-                    {% if request.current_organization %}
-                        <p class="m-0">
-                            {% if user.is_prescriber %}
-                                {% if request.current_organization.code_safir_pole_emploi %}
-                                    {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
-                                    Code SAFIR {{ request.current_organization.code_safir_pole_emploi }}
-                                {% elif request.current_organization.siret %}
-                                    {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
-                                    SIRET {{ request.current_organization.siret|format_siret }}
-                                {% endif %}
-                            {% elif user.is_employer %}
-                                SIRET {{ request.current_organization.siret|format_siret }}
-                            {% endif %}
-                        </p>
-                    {% endif %}
-                </div>
-            </div>
-
             <div class="row my-3 my-md-4">
                 <div class="col-12">
                     <form method="get" action="{% url "search:employers_results" %}" role="search">
@@ -235,7 +230,6 @@
             </div>
 
             <div class="row {% if not user.is_job_seeker %}row-cols-1 row-cols-md-2 row-cols-lg-3{% endif %} mt-3">
-
                 {% if user.is_staff %}
                     {% include "dashboard/includes/admin_card.html" %}
                 {% endif %}

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -4,18 +4,22 @@
 
 {% block title %}Informations personnelles de {{ job_seeker.get_full_name }} {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>
-        Informations personnelles de <span class="text-muted">{{ job_seeker.get_full_name }}</span>
-    </h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-warning">
         <p>
             <b>Vous allez modifier des informations sensibles</b> concernant ce candidat ou cette candidate.
         </p>
-        <p class="mb-0">
+        <p>
             Tout changement entraînera une modification définitive dans notre base de données. <b>Les informations supprimées seront perdues.</b>
         </p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1>
+        Informations personnelles de <span class="text-muted">{{ job_seeker.get_full_name }}</span>
+    </h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/dashboard/edit_user_email.html
+++ b/itou/templates/dashboard/edit_user_email.html
@@ -3,8 +3,8 @@
 
 {% block title %}Modifier mon profil {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>Modifier votre adresse e-mail</h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-warning">
         <p class="mb-0">
             Ce changement entraînera une <b>déconnexion</b>.
@@ -13,6 +13,8 @@
         </p>
     </div>
 {% endblock %}
+
+{% block content_title %}<h1>Modifier votre adresse e-mail</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -5,8 +5,6 @@
 
 {% block title %}Modifier mon profil {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -7,9 +7,11 @@
 {% load buttons_form %}
 
 {% block title %}Créer une fiche salarié {{ block.super }}{% endblock %}
+
 {% block content_title %}
     <h1>Créer une fiche salarié - {{ request.current_organization.display_name }}</h1>
 {% endblock %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -10,7 +10,7 @@
 
 {% block content_title %}
     <h1>Désactiver la fiche salarié ASP</h1>
-    <h2 class="text-muted">{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
+    <h2>{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -7,6 +7,27 @@
 
 {% block title %}Fiches salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}{% endblock %}
 
+{% block messages %}
+    {{ block.super }}
+    {% if need_manual_regularization %}
+        <div class="alert alert-warning">
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-error-warning-line ri-xl text-danger"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-0">
+                        <strong>Une action de votre part est nécessaire</strong>
+                    </p>
+                    <p class="mb-0">
+                        Attention, nous avons détecté une ou plusieurs fiches salarié qui nécessitent une régularisation manuelle de votre part.
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock %}
+
 {% block content_title %}
     <h1>Fiches salarié ASP - {{ request.current_organization.display_name }}</h1>
     <h2 class="h3">Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</h2>
@@ -29,7 +50,7 @@
             Vous trouverez ici les fiches salarié complétées
             <b>en attente d’envoi à l’ASP, qui a lieu automatiquement à intervalles réguliers</b>.
         </p>
-        <p class="mb-0">
+        <p>
             À ce stade, seule la visualisation des informations de la fiche est
             possible.
         </p>
@@ -45,7 +66,7 @@
             Vous trouverez ici les fiches salarié envoyées à l'ASP et retournées avec une
             erreur.
         </p>
-        <p class="mb-0">Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
+        <p>Vous pouvez modifier les fiches en erreur et les envoyer à nouveau.</p>
     {% elif form.status.value == "PROCESSED" %}
         <p class="mb-0">Vous trouverez ici les fiches salarié envoyées et validées par l'ASP.</p>
         <p>
@@ -58,23 +79,6 @@
             En cas de besoin vous pouvez réactiver une fiche, elle sera transférée dans la catégorie
             "Nouvelle".
         </p>
-    {% endif %}
-    {% if need_manual_regularization %}
-        <div class="alert alert-warning">
-            <div class="row">
-                <div class="col-auto pe-0">
-                    <i class="ri-error-warning-line ri-xl text-danger"></i>
-                </div>
-                <div class="col">
-                    <p class="mb-0">
-                        <strong>Une action de votre part est nécessaire</strong>
-                    </p>
-                    <p class="mb-0">
-                        Attention, nous avons détecté une ou plusieurs fiches salarié qui nécessitent une régularisation manuelle de votre part.
-                    </p>
-                </div>
-            </div>
-        </div>
     {% endif %}
 {% endblock %}
 
@@ -90,7 +94,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-12 col-md-3">
+                <div class="col-12 col-md-4 mb-3 mb-md-5">
                     <aside class="c-aside-filters">
                         <button class="c-aside-filters__btn__collapse" data-bs-toggle="collapse" data-bs-target="#asideFiltersCollapse" aria-expanded="true" aria-controls="asideFiltersCollapse">
                             <i class="ri-filter-line" aria-hidden="true"></i>
@@ -125,52 +129,50 @@
                     </aside>
                 </div>
 
-                <div class="col-12 col-md-9">
-                    <div class="c-box p-3 p-md-4">
-                        <div class="d-flex align-items-center">
-                            <div class="flex-grow-1">
-                                {% with navigation_pages.paginator.count as counter %}
-                                    <h3 class="h4 m-0">{{ counter }} résultat{{ counter|pluralizefr }}</h3>
-                                {% endwith %}
-                            </div>
-                            <div>
-                                <span class="fs-sm">Trier par :</span>
-                                <button type="button" class="btn btn-sm btn-link dropdown-toggle p-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    {{ ordered_by_label }}
-                                </button>
-                                <div class="dropdown-menu dropdown-menu-end" id="order-form-group">
-                                    {% for order_value, order_label in form.order.field.choices %}
-                                        <button class="dropdown-item {% if order_value == form.order.value %}active{% endif %}" type="button" value="{{ order_value }}">
-                                            {{ order_label }}
-                                        </button>
-                                    {% endfor %}
-                                </div>
+                <div class="col-12 col-md-8">
+                    <div class="d-flex align-items-center">
+                        <div class="flex-grow-1">
+                            {% with navigation_pages.paginator.count as counter %}
+                                <h3 class="h4 m-0">{{ counter }} résultat{{ counter|pluralizefr }}</h3>
+                            {% endwith %}
+                        </div>
+                        <div>
+                            <span class="fs-sm">Trier par :</span>
+                            <button type="button" class="btn btn-sm btn-link dropdown-toggle p-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                {{ ordered_by_label }}
+                            </button>
+                            <div class="dropdown-menu dropdown-menu-end" id="order-form-group">
+                                {% for order_value, order_label in form.order.field.choices %}
+                                    <button class="dropdown-item {% if order_value == form.order.value %}active{% endif %}" type="button" value="{{ order_value }}">
+                                        {{ order_label }}
+                                    </button>
+                                {% endfor %}
                             </div>
                         </div>
-
-                        {# "Real" employee records objects #}
-                        <div class="employee-records-list">
-                            {% if employee_records_list %}
-                                {% for employee_record in navigation_pages %}
-                                    {% include "employee_record/includes/list_item.html" with employee_record=employee_record item=employee_record.job_application only %}
-                                {% endfor %}
-                                {# New employee records i.e. job applications #}
-                            {% else %}
-                                {% for job_application in navigation_pages %}
-                                    {% include "employee_record/includes/list_item.html" with employee_record=None item=job_application only %}
-                                {% endfor %}
-                            {% endif %}
-                        </div>
-
-                        {% if not navigation_pages %}
-                            <div class="c-box c-box--results my-3 my-md-4">
-                                <div class="c-box--results__body">
-                                    <p class="mb-0">Aucune fiche salarié avec le statut selectionné.</p>
-                                </div>
-                            </div>
-                        {% endif %}
-                        {% include "includes/pagination.html" with page=navigation_pages %}
                     </div>
+
+                    {# "Real" employee records objects #}
+                    <div class="employee-records-list">
+                        {% if employee_records_list %}
+                            {% for employee_record in navigation_pages %}
+                                {% include "employee_record/includes/list_item.html" with employee_record=employee_record item=employee_record.job_application only %}
+                            {% endfor %}
+                            {# New employee records i.e. job applications #}
+                        {% else %}
+                            {% for job_application in navigation_pages %}
+                                {% include "employee_record/includes/list_item.html" with employee_record=None item=job_application only %}
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+
+                    {% if not navigation_pages %}
+                        <div class="c-box c-box--results my-3 my-md-4">
+                            <div class="c-box--results__body">
+                                <p class="mb-0">Aucune fiche salarié avec le statut selectionné.</p>
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% include "includes/pagination.html" with page=navigation_pages %}
                 </div>
             </div>
         </div>

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -10,7 +10,7 @@
 
 {% block content_title %}
     <h1>Réactiver la fiche salarié ASP</h1>
-    <h2 class="text-muted">{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
+    <h2>{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/institutions/deactivate_member.html
+++ b/itou/templates/institutions/deactivate_member.html
@@ -2,8 +2,6 @@
 
 {% block title %}Retrait d'un collaborateur {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -4,7 +4,7 @@
 
 {% block content_title %}
     <h1>Collaborateurs</h1>
-    <p class="mb-0">
+    <p>
         Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
     </p>
 {% endblock %}

--- a/itou/templates/institutions/update_admins.html
+++ b/itou/templates/institutions/update_admins.html
@@ -2,8 +2,6 @@
 
 {% block title %}Gestion des administrateurs {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -8,7 +8,7 @@
 {% block content_title %}
     <h1>Envoyer une invitation</h1>
     <h2>{{ organization.display_name }}</h2>
-    <p class="mb-0">Une fois vos invitations envoyées, vos invités recevront un e-mail contenant un lien de validation</p>
+    <p>Une fois vos invitations envoyées, vos invités recevront un e-mail contenant un lien de validation</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -56,39 +56,20 @@
 
         <main id="main" role="main" class="s-main">
             <div class="toast-container" aria-live="polite" aria-atomic="true">{% include "utils/toasts.html" %}</div>
-            <div class="container container-messages">
-                {% block messages %}
 
-                    {% bootstrap_messages %}
-
-                    {# Display an alert for old browsers #}
-                    <div class="alert alert-secondary alert-old-browser" role="status">
-                        <p class="mb-0">
-                            La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
-                        </p>
-                    </div>
-                {% endblock %}
-            </div>
-
-            <div class="container container-breadcrumb">
-                {% block breadcrumbs %}{% endblock %}
-            </div>
-
-            {% comment %}
-            Si les templates enfants ont besoin d'une section <section .s-title-01>, penser à mettre le contenu dans le {% block content_title %}{% endblock %}
-            Sinon, penser à mettre le {% block content_title_wrapper %}{% endblock %} vide dans ces templates pour vider le DOM "enrobant" ci-dessous
-            {% endcomment %}
-            {% block content_title_wrapper %}
-                <section class="s-title-01">
-                    <div class="s-title-01__container container">
-                        <div class="s-title-01__row row">
-                            <div class="s-title-01__col col-12">
-                                {% block content_title %}{% endblock %}
-                            </div>
+            <section class="s-title-02">
+                <div class="s-title-02__container container">
+                    <div class="s-title-02__row row">
+                        <div class="s-title-02__col col-12">
+                            {% block breadcrumbs %}{% endblock %}
+                            {% block content_title %}{% endblock %}
+                            {% block messages %}
+                                {% bootstrap_messages %}
+                            {% endblock %}
                         </div>
                     </div>
-                </section>
-            {% endblock %}
+                </div>
+            </section>
 
             {% block content %}{% endblock %}
         </main>

--- a/itou/templates/layout/breadcrumbs_from_dashboard.html
+++ b/itou/templates/layout/breadcrumbs_from_dashboard.html
@@ -1,6 +1,6 @@
 {# This template needs a 'breadcrumbs' dict in context, format : {label: url,...} #}
 <nav class="c-breadcrumb" aria-label="Fil d'Ariane">
-    <ol class="breadcrumb">
+    <ol class="breadcrumb p-0">
         <li class="breadcrumb-item">
             <a href="{% url 'dashboard:index' %}">Tableau de bord</a>
         </li>

--- a/itou/templates/prescribers/deactivate_member.html
+++ b/itou/templates/prescribers/deactivate_member.html
@@ -2,8 +2,6 @@
 
 {% block title %}Retrait d'un collaborateur {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -4,9 +4,8 @@
 
 {% block title %}Modifier cette organisation {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>Modifier cette organisation</h1>
-    <h2>{{ organization.display_name }}</h2>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-info">
         <p class="mb-0">
             {% if organization.kind == PrescriberOrganizationKind.PE %}
@@ -17,6 +16,11 @@
             {% endif %}
         </p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1>Modifier cette organisation</h1>
+    <h2>{{ organization.display_name }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -2,39 +2,31 @@
 
 {% block title %}Liste des organisations conventionnées {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
+{% block content_title %}
+    <h1>Liste des organisations conventionnées</h1>
+    <h2>{{ prescriber_org.display_name }}</h2>
+{% endblock %}
+
+{% block messages %}
+    {{ block.super }}
+    <div class="alert alert-info">
+        <p class="mb-0">Seuls les administrateurs peuvent voir cette liste.</p>
+    </div>
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    <h1 class="h1-hero-c1">Liste des organisations conventionnées</h1>
-
-                    <h2 class="h1">
-                        <span class="text-muted">{{ prescriber_org.display_name }}</span>
-                    </h2>
-
-                    <div class="alert alert-info">
-                        <p class="mb-0">Seuls les administrateurs peuvent voir cette liste.</p>
-                    </div>
-
-                    <hr>
-
                     {% if not accredited_orgs %}
-
                         <div class="alert alert-emploi" role="status">
                             <p class="mb-0">Aucun résultat.</p>
                         </div>
-
                     {% else %}
-
                         <ul>
-
                             {% for org in accredited_orgs %}
-
                                 <li>
-
                                     <p>
                                         <b>{{ org.display_name }}</b>
                                         -
@@ -44,11 +36,9 @@
                                             Voir les membres
                                         </a>
                                     </p>
-
                                     <div class="collapse" id="collapse_membership_{{ org.pk }}">
-
                                         <div class="table-responsive">
-                                            <table class="table table-striped table-bordered">
+                                            <table class="table">
                                                 <caption>Liste des organisations conventionnées</caption>
                                                 <thead>
                                                     <tr>
@@ -76,15 +66,10 @@
                                                 </tbody>
                                             </table>
                                         </div>
-
                                     </div>
-
                                 </li>
-
                             {% endfor %}
-
                         </ul>
-
                     {% endif %}
                 </div>
             </div>

--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -4,7 +4,7 @@
 
 {% block content_title %}
     <h1>Collaborateurs</h1>
-    <p class="mb-0">
+    <p>
         Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
     </p>
 {% endblock %}

--- a/itou/templates/prescribers/update_admins.html
+++ b/itou/templates/prescribers/update_admins.html
@@ -2,8 +2,6 @@
 
 {% block title %}Gestion des administrateurs {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/releases/list.html
+++ b/itou/templates/releases/list.html
@@ -2,8 +2,6 @@
 
 {% block title %}Notes de publication {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/search/prescribers_search_home.html
+++ b/itou/templates/search/prescribers_search_home.html
@@ -2,8 +2,6 @@
 
 {% block title %}Rechercher des prescripteurs habilités {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     {% include "search/includes/generic_search_home.html" with form=form title="Rechercher des prescripteurs habilités" url_search="search:prescribers_results" template_form_name="search/includes/prescribers_search_form.html" %}
 {% endblock %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -23,32 +23,21 @@
     <form id="search-form" method="get" class="d-block w-100">
         <section class="s-section mb-0">
             <div class="s-section__container container">
-                <div class="row">
+                <div class="s-section__row row">
                     <div class="col-12">
                         {% include "search/includes/prescribers_search_form.html" with form=form %}
-                        {% if form.is_valid %}
-                            <h2 class="h3 mt-3">
-                                Prescripteurs à <b>{{ distance }} km</b> du centre de <b>{{ city }}</b>
-                            </h2>
-                        {% endif %}
+                        <h2 class="mt-4">Prescripteurs</h2>
+                        <p>
+                            {{ prescriber_orgs_page.paginator.count }} résultat{{ prescriber_orgs_page.paginator.count|pluralizefr }}
+                            {% if form.is_valid %}
+                                - Prescripteur{{ prescriber_orgs_page.paginator.count|pluralizefr }} à <strong>{{ distance }} km</strong> du centre de <strong>{{ city }}</strong>
+                            {% endif %}
+                        </p>
                     </div>
                 </div>
-            </div>
-        </section>
-
-        <section class="s-box mt-3">
-            <div class="s-box__container container">
-                <div class="s-box__row row">
+                <div class="s-section__row row">
                     <div class="col-12 col-md-4">{% include "search/includes/prescribers_search_filters.html" with form=form %}</div>
                     <div class="col-12 col-md-8">
-                        <div class="mb-3 mb-md-4">
-                            <h3 class="h4 mb-0">
-                                {% with prescriber_orgs_page.number as current_page and prescriber_orgs_page.paginator.num_pages as total_pages and prescriber_orgs_page.paginator.count as counter %}
-                                    {{ counter }} résultat{{ counter|pluralizefr }}
-                                    {% if total_pages > 1 %}- Page <b>{{ current_page }}</b>/{{ total_pages }}{% endif %}
-                                {% endwith %}
-                            </h3>
-                        </div>
                         {% for prescriber_org in prescriber_orgs_page %}
                             <div class="c-box c-box--results has-one-link-inside mb-3 mb-md-4">
                                 <div class="c-box--results__header">

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -7,8 +7,6 @@
 
 {% block body_class %}p-home{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
 
     {% include "search/includes/generic_search_home.html" with form=siae_search_form title="Rechercher un emploi inclusif" url_search="search:employers_results" template_form_name="search/includes/siaes_search_form.html" %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -21,7 +21,7 @@
                 <div class="s-tabs-01__col col-12">
                     <form id="search-form" method="get" class="d-block w-100">
                         {% include "search/includes/siaes_search_form.html" with form=form %}
-                        <ul class="s-tabs-01__nav nav nav-tabs mt-3 mt-md-5">
+                        <ul class="s-tabs-01__nav nav nav-tabs mt-3">
                             <li class="nav-item">
                                 <a class="nav-link{% if request.resolver_match.view_name == "search:employers_results" %} active{% endif %}"
                                    {% matomo_event "candidature" "clic" "clic-onglet-employeur" %}

--- a/itou/templates/siae_evaluations/campaign_calendar.html
+++ b/itou/templates/siae_evaluations/campaign_calendar.html
@@ -17,6 +17,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
                     {{ campaign_calendar_html|safe }}
+
                     <p class="my-4">
                         <a href="{{ back_url }}">Retour</a>
                     </p>

--- a/itou/templates/siae_evaluations/default_calendar_html.html
+++ b/itou/templates/siae_evaluations/default_calendar_html.html
@@ -2,8 +2,8 @@
     Retrouvez ci-dessous toutes les dates concernant la campagne de contrôle a posteriori sur les auto-prescriptions du 01/01/2022 au 31/12/2022 (ou du 01/10/2022 au 31/12/2022 pour les DDETS ayant déjà réalisé la campagne optionnelle du 01/01/2022 au 31/09/2022).
 </p>
 
-<table class="table table-bordered bg-white">
-    <thead class="thead-light">
+<table class="table table-hover">
+    <thead>
         <tr>
             <th scope="col"></th>
             <th scope="col" class="font-weight-bold">Dates</th>
@@ -11,7 +11,7 @@
             <th scope="col" class="font-weight-bold">Actions attendues</th>
         </tr>
     </thead>
-    <tbody class="table-hover">
+    <tbody>
         <tr>
             <th scope="row">
                 <span class="d-block">Phase 1</span>

--- a/itou/templates/siae_evaluations/evaluated_siae_sanction.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_sanction.html
@@ -3,18 +3,15 @@
 
 {% block title %}Notification de sanction pour {{ evaluated_siae.siae }} {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
+{% block content_title %}
+    <h1>
+        Notification de sanction pour <span class="text-info">{{ evaluated_siae.siae }}</span>
+    </h1>
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
-                    <h1 class="mb-4">
-                        Notification de sanction pour <span class="text-info">{{ evaluated_siae.siae }}</span>
-                    </h1>
-                </div>
-            </div>
             <div class="row">
                 <div class="col-lg-6 order-2 order-lg-1">
                     <div class="card c-card">

--- a/itou/templates/siae_evaluations/institution_evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_job_application.html
@@ -5,8 +5,6 @@
 
 {% block title %}Contrôler les pièces justificatives {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_detail.html
@@ -5,14 +5,8 @@
 
 {% block title %}Contrôler les pièces justificatives {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1 class="h1">
-        {% if evaluated_siae.evaluation_is_final %}
-            Pièces justificatives
-        {% else %}
-            Contrôler les pièces justificatives
-        {% endif %}
-    </h1>
+{% block messages %}
+    {{ block.super }}
     {% if campaign_closed_before_final_evaluation or accepted_by_default %}
         <div class="alert alert-info">
             <div class="row">
@@ -41,6 +35,16 @@
             </div>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block content_title %}
+    <h1 class="h1">
+        {% if evaluated_siae.evaluation_is_final %}
+            Pièces justificatives
+        {% else %}
+            Contrôler les pièces justificatives
+        {% endif %}
+    </h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/siae_evaluations/sanctions_helper.html
+++ b/itou/templates/siae_evaluations/sanctions_helper.html
@@ -2,8 +2,6 @@
 
 {% block title %}Grille indicative de sanctions proposées par la DGEFP {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
@@ -114,7 +112,7 @@
                             Nouveau contrôle irrégulier constaté pour la même structure dans les 3
                             ans suivant le premier contrôle
                         </h2>
-                        <table class="table table-bordered table-hover">
+                        <table class="table table-hover">
                             <thead>
                                 <tr>
                                     <th class="bg-light" aria-label="Type d’erreur" scope="col"></th>

--- a/itou/templates/siae_evaluations/siae_job_applications_list.html
+++ b/itou/templates/siae_evaluations/siae_job_applications_list.html
@@ -6,11 +6,7 @@
 {% block title %}Liste de mes auto-prescriptions à justifier {{ block.super }}{% endblock %}
 
 {% block messages %}
-    {% bootstrap_messages %}
-{% endblock %}
-
-{% block content_title %}
-    <h1>Justifier mes auto-prescriptions</h1>
+    {{ block.super }}
     <div class="alert alert-info" role="status">
         <p class="font-weight-bold">Précision</p>
         <p>
@@ -19,6 +15,8 @@
         </p>
     </div>
 {% endblock %}
+
+{% block content_title %}<h1>Justifier mes auto-prescriptions</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/siae_evaluations/siae_select_criteria.html
+++ b/itou/templates/siae_evaluations/siae_select_criteria.html
@@ -5,37 +5,26 @@
 
 {% block title %}Auto-prescriptions à justifier pour {{ job_seeker.get_full_name }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row justify-content-center">
-                <div class="col-8">
-
+                <div class="col-12 col-md-8">
                     <div class="card">
-
                         <div class="card-header">
                             {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=job_seeker approval=approval state=state %}
                         </div>
-
                         <div class="card-body">
-
                             <div class="row mt-3">
                                 <div class="col-md-12">{% include "siae_evaluations/includes/criteria_form.html" %}</div>
-
                             </div>
-
-
                         </div>
-
                     </div>
                     {% if back_url %}
                         <p class="mt-4">
                             <a href="{{ back_url }}">Retour</a>
                         </p>
                     {% endif %}
-
                 </div>
             </div>
         </div>

--- a/itou/templates/siae_evaluations/siae_upload_doc.html
+++ b/itou/templates/siae_evaluations/siae_upload_doc.html
@@ -5,27 +5,22 @@
 
 {% block title %}Auto-prescriptions à justifier pour {{ job_seeker.get_full_name }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row justify-content-center">
-                <div class="col-8 ">
+                <div class="col-12 col-md-8">
 
                     <div class="card">
-
                         <div class="card-header">
                             {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=evaluated_administrative_criteria.evaluated_job_application.job_application.job_seeker approval=evaluated_administrative_criteria.evaluated_job_application.job_application.approval state=evaluated_administrative_criteria.evaluated_job_application.compute_state reviewed_at=evaluated_administrative_criteria.evaluated_job_application.evaluated_siae.reviewed_at %}
                         </div>
-
                         <div class="card-body">
                             <div class="row mt-3">
                                 <div class="col-md-12">
                                     {% include "siae_evaluations/includes/criterion_infos.html" with criteria=evaluated_administrative_criteria.administrative_criteria %}
                                 </div>
                             </div>
-
                             {% if evaluated_administrative_criteria.proof_id %}
                                 <div class="row mt-3">
                                     <div class="col-md-12">
@@ -33,8 +28,6 @@
                                     </div>
                                 </div>
                             {% endif %}
-
-
                             <div class="row mt-3">
                                 <div class="col-md-12">
                                     <form method="post" class="js-prevent-multiple-submit"{% if form.is_multipart %} enctype="multipart/form-data"{% endif %}>
@@ -52,7 +45,6 @@
                                                 </div>
                                             </div>
                                         </div>
-
                                         <button class="btn btn-primary float-end">
                                             {% if evaluated_administrative_criteria.proof_id %}
                                                 Enregistrer le nouveau justificatif
@@ -60,12 +52,10 @@
                                                 Enregistrer le justificatif
                                             {% endif %}
                                         </button>
-
                                     </form>
                                 </div>
                             </div>
                         </div>
-
                     </div>
 
                     {% if back_url %}

--- a/itou/templates/signup/choose_user_kind.html
+++ b/itou/templates/signup/choose_user_kind.html
@@ -2,13 +2,13 @@
 {% load django_bootstrap5 %}
 {% load buttons_form %}
 
+{% block content_title %}<h1>Inscription</h1>{% endblock %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12 col-lg-7">
-                    <h1>Inscription</h1>
-
+                <div class="col-12 col-lg-8">
                     <div class="c-form mb-5">
                         <h2>Sélectionnez votre profil *</h2>
 

--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -5,10 +5,8 @@
 {% block title %}Employeur inclusif - Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Employeur inclusif</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Employeur solidaire</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/employer.html
+++ b/itou/templates/signup/employer.html
@@ -4,11 +4,8 @@
 
 {% block title %}Employeur solidaire - Inscription {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Employeur solidaire</small>
-    </h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-emploi">
         <p class="lead mb-0">
             Vous allez rejoindre <b>{{ company.display_name }}</b>
@@ -27,6 +24,11 @@
             {{ company.post_code }} {{ company.city }}
         </p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1 class="mb-0">Inscription</h1>
+    <p>Employeur solidaire</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/facilitator_search.html
+++ b/itou/templates/signup/facilitator_search.html
@@ -6,10 +6,8 @@
 {% block title %}Facilitateur de clauses sociales - Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Facilitateur de clauses sociales</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Facilitateur de clauses sociales</p>
     <h2>Inscrire mon organisation porteuse de la clause sociale d’insertion</h2>
     <p>
         Cette inscription est soumise à des conditions qui ont été définies en lien avec nos partenaires publics et privés nationaux.

--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -7,17 +7,18 @@
 
 {% block title %}Inscription candidat {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
+{% block content_title %}
+    <h1>
+        Inscription <span class="text-muted">candidat</span>
+    </h1>
+{% endblock %}
 
 {% block content %}
-    <section class="s-section m-0">
+    <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 order-md-2 ps-lg-5 col-lg-6">
                     <div class="py-5 py-lg-7">
-                        <h1 class="h1-hero-c1">
-                            Inscription <span class="text-muted">candidat</span>
-                        </h1>
                         <form method="post" action="{% url 'signup:job_seeker_nir' %}" class="js-prevent-multiple-submit js-format-nir">
 
                             {% csrf_token %}

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -5,7 +5,11 @@
 
 {% block title %}Demandeur d'emploi - Inscription {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
+{% block content_title %}
+    <h1>
+        Inscription <span class="text-muted">candidat</span>
+    </h1>
+{% endblock %}
 
 {% block content %}
     <section class="s-section s-section-lg-with-background">
@@ -13,10 +17,6 @@
             <div class="row">
                 <div class="col-12 order-md-2 ps-lg-5 col-lg-6">
                     <div class="py-5 py-lg-7">
-                        <h1>
-                            Inscription <span class="text-muted">candidat</span>
-                        </h1>
-
                         <b class="mb-4">Inscrivez-vous avec un service tiers</b>
                         {% if show_france_connect %}
                             <div>{% include "signup/includes/france_connect_button.html" %}</div>

--- a/itou/templates/signup/job_seeker_situation.html
+++ b/itou/templates/signup/job_seeker_situation.html
@@ -6,7 +6,11 @@
 
 {% block title %}Inscription candidat {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
+{% block content_title %}
+    <h1>
+        Inscription <span class="text-muted">candidat</span>
+    </h1>
+{% endblock %}
 
 {% block content %}
     <section class="s-section s-section-lg-with-background m-0">
@@ -14,9 +18,6 @@
             <div class="row">
                 <div class="col-12 order-md-2 ps-lg-5 col-lg-6">
                     <div class="py-5 py-lg-7">
-                        <h1 class="h1-hero-c1">
-                            Inscription <span class="text-muted">candidat</span>
-                        </h1>
                         <form method="post" action="{% url 'signup:job_seeker_situation' %}" role="form" class="js-prevent-multiple-submit">
 
                             {% csrf_token %}

--- a/itou/templates/signup/job_seeker_situation_not_eligible.html
+++ b/itou/templates/signup/job_seeker_situation_not_eligible.html
@@ -4,10 +4,8 @@
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Candidat</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Candidat</p>
     <p>
         <strong>Vous ne pouvez pas vous inscrire</strong>, veuillez vous rapprocher d’un prescripteur habilité (France Travail, Mission Locale, Cap emploi…)
         pour vous accompagner dans vos démarches. <a href="{% url 'search:prescribers_home' %}">Trouver un prescripteur habilité</a>

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -6,14 +6,13 @@
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur/Orienteur</small>
-    </h1>
-    <h2>Votre organisation est-elle déjà inscrite ?</h2>
-    <p>
-        <a href="{% url 'signup:prescriber_pole_emploi_safir_code' %}">Je travaille pour France Travail</a>
-    </p>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur/Orienteur</p>
+    <div class="alert alert-info">
+        <p class="m-0">
+            <strong>Votre organisation est-elle déjà inscrite ?</strong> <a href="{% url 'signup:prescriber_pole_emploi_safir_code' %}">Je travaille pour France Travail</a>
+        </p>
+    </div>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_check_pe_email.html
+++ b/itou/templates/signup/prescriber_check_pe_email.html
@@ -5,16 +5,18 @@
 
 {% block title %}Prescripteur France Travail - Inscription {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur France Travail</small>
-    </h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-emploi">
         <p class="mb-0">
             Vous allez rejoindre <b>{{ pole_emploi_org.display_name }}</b>
         </p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur France Travail</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -6,10 +6,8 @@
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur/Orienteur</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur/Orienteur</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -5,14 +5,16 @@
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur/Orienteur</small>
-    </h1>
-    <div class="alert alert-secondary">
+{% block messages %}
+    {{ block.super }}
+    <div class="alert alert-warning">
         <p class="mb-0">Votre organisation n'est pas encore inscrite.</p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur/Orienteur</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_confirm_authorization.html
+++ b/itou/templates/signup/prescriber_confirm_authorization.html
@@ -6,10 +6,8 @@
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur habilité</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur habilité</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_is_pole_emploi.html
+++ b/itou/templates/signup/prescriber_is_pole_emploi.html
@@ -6,10 +6,8 @@
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur/Orienteur</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur/Orienteur</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_pole_emploi_safir_code.html
+++ b/itou/templates/signup/prescriber_pole_emploi_safir_code.html
@@ -6,10 +6,8 @@
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur France Travail</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur France Travail</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_pole_emploi_user.html
+++ b/itou/templates/signup/prescriber_pole_emploi_user.html
@@ -3,16 +3,18 @@
 
 {% block title %}Prescripteur France Travail - Inscription {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur France Travail</small>
-    </h1>
-    <div class="alert alert-emploi">
+{% block messages %}
+    {{ block.super }}
+    <div class="alert alert-info">
         <p class="mb-0">
             Vous allez rejoindre <b>{{ pole_emploi_org.display_name }}</b>
         </p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur France Travail</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -6,16 +6,18 @@
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
-{% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur/Orienteur</small>
-    </h1>
+{% block messages %}
+    {{ block.super }}
     <div class="alert alert-info">
         <p class="mb-0">
             Renseignez vos coordonnées afin d'être invité par {{ prescriber.first_name|title }} {{ prescriber.last_name|slice:1|upper }} de l'organisation « {{ organization.display_name }} ».
         </p>
     </div>
+{% endblock %}
+
+{% block content_title %}
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur/Orienteur</p>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_user.html
+++ b/itou/templates/signup/prescriber_user.html
@@ -4,11 +4,18 @@
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
+{% block breadcrumbs %}
+    <div class="c-prevstep">
+        <a href="{{ prev_url }}" class="btn btn-ico btn-link ps-0">
+            <i class="ri-arrow-drop-left-line ri-xl font-weight-medium" aria-hidden="true"></i>
+            <span>Retour</span>
+        </a>
+    </div>
+{% endblock %}
+
 {% block content_title %}
-    <h1>
-        Inscription
-        <small class="text-muted">Prescripteur/Orienteur</small>
-    </h1>
+    <h1 class="mb-0">Inscription</h1>
+    <p>Prescripteur/Orienteur</p>
 {% endblock %}
 
 {% block content %}
@@ -45,10 +52,6 @@
                     {% endif %}
 
                     {% include "inclusion_connect/includes/description.html" %}
-
-                    <div class="mt-3">
-                        <a class="btn btn-outline-secondary" href="{{ prev_url }}">Retour</a>
-                    </div>
                 </div>
             </div>
         </div>

--- a/itou/templates/signup/signup.html
+++ b/itou/templates/signup/signup.html
@@ -4,8 +4,6 @@
 
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/static/legal/terms.html
+++ b/itou/templates/static/legal/terms.html
@@ -5,7 +5,7 @@
 
 {% block content_title %}
     <h1 id="conditions-générales-dutilisation">Conditions Générales d&#39;Utilisation</h1>
-    <h2 class="mt-3 mt-lg-5 h3">
+    <h2 class="h3">
         Les présentes conditions générales d’utilisation (dites « CGU ») définissent les conditions d’accès et d’utilisation des Services par l’Utilisateur.
     </h2>
 {% endblock %}

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -25,21 +25,18 @@
         </div>
     {% endif %}
     <h1>{{ page_title }}</h1>
-
     {% if show_siae_evaluation_message %}
         <p>
             Le tableau ci-dessous comprend 100 % des auto-prescriptions réalisées en année N-1. Vous pouvez affiner les données en utilisant les filtres disponibles.
         </p>
     {% endif %}
-
     {% if is_stats_public %}
-        <div class="mb-4">
+        <p>
             Cette page a pour objectif de présenter l'impact des emplois de l'inclusion. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
-            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" class="has-external-link" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
                 pilotage de l'inclusion
             </a>
-            <i class="ri-external-link-line ri-lg me-1"></i>
-        </div>
+        </p>
     {% endif %}
 {% endblock %}
 

--- a/itou/templates/status/index.html
+++ b/itou/templates/status/index.html
@@ -2,14 +2,12 @@
 
 {% block title %}Status{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    <table class="table table-bordered table-sm text-center">
+                    <table class="table text-center">
                         <thead>
                             <tr>
                                 <th scope="col">Nom</th>

--- a/itou/templates/welcoming_tour/employer.html
+++ b/itou/templates/welcoming_tour/employer.html
@@ -4,8 +4,6 @@
 
 {% block title %}Bienvenue sur les emplois de l'inclusion ! {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/welcoming_tour/job_seeker.html
+++ b/itou/templates/welcoming_tour/job_seeker.html
@@ -4,8 +4,6 @@
 
 {% block title %}Bienvenue sur les emplois de l'inclusion ! {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/itou/templates/welcoming_tour/prescriber.html
+++ b/itou/templates/welcoming_tour/prescriber.html
@@ -4,8 +4,6 @@
 
 {% block title %}Bienvenue sur les emplois de l'inclusion ! {{ block.super }}{% endblock %}
 
-{% block content_title_wrapper %}{% endblock %}
-
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -140,17 +140,23 @@
 # ---
 # name: test_deny_view_for_reasons[DURATION][title]
   '''
-  <section class="s-title-01">
-                      <div class="s-title-01__container container">
-                          <div class="s-title-01__row row">
-                              <div class="s-title-01__col col-12">
-                                  
+  <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
       <h1>Refuser la demande de prolongation pour John DOE</h1>
   
-                              </div>
+                              
+                                  
+  
+  
+                              
                           </div>
                       </div>
-                  </section>
+                  </div>
+              </section>
   '''
 # ---
 # name: test_deny_view_for_reasons[IAE][proposed_actions]
@@ -365,17 +371,23 @@
 # ---
 # name: test_deny_view_for_reasons[IAE][title]
   '''
-  <section class="s-title-01">
-                      <div class="s-title-01__container container">
-                          <div class="s-title-01__row row">
-                              <div class="s-title-01__col col-12">
-                                  
+  <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
       <h1>Refuser la demande de prolongation pour John DOE</h1>
   
-                              </div>
+                              
+                                  
+  
+  
+                              
                           </div>
                       </div>
-                  </section>
+                  </div>
+              </section>
   '''
 # ---
 # name: test_deny_view_for_reasons[REASON][reason]
@@ -519,17 +531,23 @@
 # ---
 # name: test_deny_view_for_reasons[REASON][title]
   '''
-  <section class="s-title-01">
-                      <div class="s-title-01__container container">
-                          <div class="s-title-01__row row">
-                              <div class="s-title-01__col col-12">
-                                  
+  <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
       <h1>Refuser la demande de prolongation pour John DOE</h1>
   
-                              </div>
+                              
+                                  
+  
+  
+                              
                           </div>
                       </div>
-                  </section>
+                  </div>
+              </section>
   '''
 # ---
 # name: test_deny_view_for_reasons[SIAE][reason]
@@ -673,17 +691,23 @@
 # ---
 # name: test_deny_view_for_reasons[SIAE][title]
   '''
-  <section class="s-title-01">
-                      <div class="s-title-01__container container">
-                          <div class="s-title-01__row row">
-                              <div class="s-title-01__col col-12">
-                                  
+  <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
       <h1>Refuser la demande de prolongation pour John DOE</h1>
   
-                              </div>
+                              
+                                  
+  
+  
+                              
                           </div>
                       </div>
-                  </section>
+                  </div>
+              </section>
   '''
 # ---
 # name: test_empty_list_view

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -183,7 +183,7 @@ def test_deny_view_for_reasons(snapshot, client, reason):
     # Starting the tunnel should redirect to the first step
     assertRedirects(client.get(start_url), reason_url)
     # Checking the title at least once
-    assert str(parse_response_to_soup(client.get(reason_url), selector="#main .s-title-01")) == snapshot(name="title")
+    assert str(parse_response_to_soup(client.get(reason_url), selector="#main .s-title-02")) == snapshot(name="title")
 
     # Submit data for the "reason" step
     assert str(parse_response_to_soup(client.get(reason_url), selector="#main .s-section")) == snapshot(name="reason")

--- a/tests/www/companies_views/__snapshots__/test_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_views.ambr
@@ -242,77 +242,57 @@
               <div aria-atomic="true" aria-live="polite" class="toast-container">
   
   </div>
-              <div class="container container-messages">
-                  
   
-                      
-  
-  
-  
-                      
-                      <div class="alert alert-secondary alert-old-browser" role="status">
-                          <p class="mb-0">
-                              La version de votre navigateur n'est plus supportée. Veuillez utiliser une version plus récente pour améliorer votre expérience sur notre site.
-                          </p>
-                      </div>
-                  
-              </div>
-  
-              <div class="container container-breadcrumb">
-                  
-              </div>
-  
-              
-              
-                  <section class="s-title-01">
-                      <div class="s-title-01__container container">
-                          <div class="s-title-01__row row">
-                              <div class="s-title-01__col col-12">
-                                  
+              <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
       <h1>Acme inc.</h1>
       <h2>Entreprise d'insertion</h2>
-  
-                              </div>
-                          </div>
-                      </div>
-                  </section>
+      <div class="c-box c-box--action">
+          <h2 class="visually-hidden">Actions rapides</h2>
+          <div class="form-row align-items-center gx-3">
               
-  
               
-      <section class="s-section">
-          <div class="s-section__container container">
-              <div class="row">
-                  <div class="col-12">
-                      <div class="c-box c-box--action mb-4 hidden-if-empty">
-                          <h2 class="visually-hidden">Actions rapides</h2>
-                          <div class="form-row align-items-center gx-3">
-                              
-                              
-                              <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                  <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
-                                      <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
-                                      <span class="d-lg-none">Autres actions</span>
-                                  </button>
-                                  <ul class="dropdown-menu">
-                                      <li>
-                                          <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/100/card">
+              <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                  <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
+                      <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
+                      <span class="d-lg-none">Autres actions</span>
+                  </button>
+                  <ul class="dropdown-menu">
+                      <li>
+                          <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/100/card">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier le lien de cette fiche entreprise</span>
   </button>
   
-                                      </li>
-                                      <li>
-                                          <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100" rel="noopener" target="_blank">
-                                              <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
-                                              <span>Signaler cette fiche entreprise</span>
-                                          </a>
-                                      </li>
-                                  </ul>
-                              </div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100" rel="noopener" target="_blank">
+                              <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
+                              <span>Signaler cette fiche entreprise</span>
+                          </a>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </div>
+  
+                              
+                                  
+  
+  
+                              
                           </div>
                       </div>
                   </div>
-              </div>
+              </section>
+  
+              
+      <section class="s-section">
+          <div class="s-section__container container">
               <div class="row">
                   <div class="col-12 col-lg-8 order-2 order-lg-1 mt-3 mt-lg-0 d-none d-lg-block">
                       <div class="c-box h-100 d-flex align-items-center justify-content-center">
@@ -474,146 +454,146 @@
 # ---
 # name: CardViewTest.test_card_tally_url_no_user
   '''
-  <div class="c-box c-box--action mb-4 hidden-if-empty">
-                          <h2 class="visually-hidden">Actions rapides</h2>
-                          <div class="form-row align-items-center gx-3">
-                              
-                              
-                              <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                  <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
-                                      <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
-                                      <span class="d-lg-none">Autres actions</span>
-                                  </button>
-                                  <ul class="dropdown-menu">
-                                      <li>
-                                          <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/100/card">
+  <div class="c-box c-box--action">
+          <h2 class="visually-hidden">Actions rapides</h2>
+          <div class="form-row align-items-center gx-3">
+              
+              
+              <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                  <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
+                      <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
+                      <span class="d-lg-none">Autres actions</span>
+                  </button>
+                  <ul class="dropdown-menu">
+                      <li>
+                          <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/100/card">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier le lien de cette fiche entreprise</span>
   </button>
   
-                                      </li>
-                                      <li>
-                                          <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100" rel="noopener" target="_blank">
-                                              <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
-                                              <span>Signaler cette fiche entreprise</span>
-                                          </a>
-                                      </li>
-                                  </ul>
-                              </div>
-                          </div>
-                      </div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100" rel="noopener" target="_blank">
+                              <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
+                              <span>Signaler cette fiche entreprise</span>
+                          </a>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </div>
   '''
 # ---
 # name: CardViewTest.test_card_tally_url_with_user
   '''
-  <div class="c-box c-box--action mb-4 hidden-if-empty">
-                          <h2 class="visually-hidden">Actions rapides</h2>
-                          <div class="form-row align-items-center gx-3">
-                              
-                              
-                              <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                  <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
-                                      <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
-                                      <span class="d-lg-none">Autres actions</span>
-                                  </button>
-                                  <ul class="dropdown-menu">
-                                      <li>
-                                          <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/100/card">
+  <div class="c-box c-box--action">
+          <h2 class="visually-hidden">Actions rapides</h2>
+          <div class="form-row align-items-center gx-3">
+              
+              
+              <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                  <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
+                      <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
+                      <span class="d-lg-none">Autres actions</span>
+                  </button>
+                  <ul class="dropdown-menu">
+                      <li>
+                          <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/100/card">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier le lien de cette fiche entreprise</span>
   </button>
   
-                                      </li>
-                                      <li>
-                                          <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100&amp;UserID=10" rel="noopener" target="_blank">
-                                              <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
-                                              <span>Signaler cette fiche entreprise</span>
-                                          </a>
-                                      </li>
-                                  </ul>
-                              </div>
-                          </div>
-                      </div>
+                      </li>
+                      <li>
+                          <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100&amp;UserID=10" rel="noopener" target="_blank">
+                              <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
+                              <span>Signaler cette fiche entreprise</span>
+                          </a>
+                      </li>
+                  </ul>
+              </div>
+          </div>
+      </div>
   '''
 # ---
 # name: JobDescriptionCardViewTest.test_card_tally_url_no_user
   '''
-  <div class="c-box c-box--action mb-4 hidden-if-empty">
-                          <h2 class="visually-hidden">Actions rapides</h2>
-                          <div class="form-row align-items-center gx-3">
-                              
-                                  
-                                      <div class="form-group col col-lg-auto">
-                                          <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
-                                              <i aria-hidden="true" class="ri-draft-line font-weight-medium"></i>
-                                              <span>Postuler</span>
-                                          </a>
-                                      </div>
-                                  
-                                  <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                      <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
-                                          <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
-                                          <span class="d-lg-none">Autres actions</span>
-                                      </button>
-                                      <ul class="dropdown-menu">
-                                          <li>
-                                              <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/job_description/42/card">
+  <div class="c-box c-box--action">
+          <h2 class="visually-hidden">Actions rapides</h2>
+          <div class="form-row align-items-center gx-3">
+              
+                  
+                      <div class="form-group col col-lg-auto">
+                          <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
+                              <i aria-hidden="true" class="ri-draft-line font-weight-medium"></i>
+                              <span>Postuler</span>
+                          </a>
+                      </div>
+                  
+                  <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                      <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
+                          <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
+                          <span class="d-lg-none">Autres actions</span>
+                      </button>
+                      <ul class="dropdown-menu">
+                          <li>
+                              <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/job_description/42/card">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier le lien de cette fiche de poste</span>
   </button>
   
-                                          </li>
-                                          <li>
-                                              <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100&amp;jobdescriptionID=42" rel="noopener" target="_blank">
-                                                  <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
-                                                  <span>Signaler cette fiche de poste</span>
-                                              </a>
-                                          </li>
-                                      </ul>
-                                  </div>
-                              
-                          </div>
-                      </div>
+                          </li>
+                          <li>
+                              <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100&amp;jobdescriptionID=42" rel="noopener" target="_blank">
+                                  <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
+                                  <span>Signaler cette fiche de poste</span>
+                              </a>
+                          </li>
+                      </ul>
+                  </div>
+              
+          </div>
+      </div>
   '''
 # ---
 # name: JobDescriptionCardViewTest.test_card_tally_url_with_user
   '''
-  <div class="c-box c-box--action mb-4 hidden-if-empty">
-                          <h2 class="visually-hidden">Actions rapides</h2>
-                          <div class="form-row align-items-center gx-3">
-                              
-                                  
-                                      <div class="form-group col col-lg-auto">
-                                          <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
-                                              <i aria-hidden="true" class="ri-draft-line font-weight-medium"></i>
-                                              <span>Postuler</span>
-                                          </a>
-                                      </div>
-                                  
-                                  <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
-                                      <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
-                                          <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
-                                          <span class="d-lg-none">Autres actions</span>
-                                      </button>
-                                      <ul class="dropdown-menu">
-                                          <li>
-                                              <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/job_description/42/card">
+  <div class="c-box c-box--action">
+          <h2 class="visually-hidden">Actions rapides</h2>
+          <div class="form-row align-items-center gx-3">
+              
+                  
+                      <div class="form-group col col-lg-auto">
+                          <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
+                              <i aria-hidden="true" class="ri-draft-line font-weight-medium"></i>
+                              <span>Postuler</span>
+                          </a>
+                      </div>
+                  
+                  <div class="form-group col-12 col-lg d-flex justify-content-center justify-content-lg-end">
+                      <button aria-expanded="false" aria-label="Ouverture et fermeture du menu des actions complémentaires" class="btn btn-lg btn-ico btn-link-white" data-bs-toggle="dropdown">
+                          <i aria-hidden="true" class="ri-more-2-line ri-lg font-weight-normal"></i>
+                          <span class="d-lg-none">Autres actions</span>
+                      </button>
+                      <ul class="dropdown-menu">
+                          <li>
+                              <button class="dropdown-item btn-ico btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="http://localhost:8000/company/job_description/42/card">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span>Copier le lien de cette fiche de poste</span>
   </button>
   
-                                          </li>
-                                          <li>
-                                              <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100&amp;UserID=10&amp;jobdescriptionID=42" rel="noopener" target="_blank">
-                                                  <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
-                                                  <span>Signaler cette fiche de poste</span>
-                                              </a>
-                                          </li>
-                                      </ul>
-                                  </div>
-                              
-                          </div>
-                      </div>
+                          </li>
+                          <li>
+                              <a class="dropdown-item btn-ico btn-link" href="https://tally.so/r/m62GYo?companyID=100&amp;UserID=10&amp;jobdescriptionID=42" rel="noopener" target="_blank">
+                                  <i aria-hidden="true" class="ri-notification-4-line ri-lg font-weight-normal"></i>
+                                  <span>Signaler cette fiche de poste</span>
+                              </a>
+                          </li>
+                      </ul>
+                  </div>
+              
+          </div>
+      </div>
   '''
 # ---
 # name: test_hx_dora_services[Dora service card]

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -123,7 +123,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         response = self.client.get(self.URL + "?status=NEW")
 
         # Global message alert
-        assert str(parse_response_to_soup(response, selector=".s-title-01 .alert")) == self.snapshot(name="alert")
+        assert str(parse_response_to_soup(response, selector=".s-title-02 .alert")) == self.snapshot(name="alert")
 
         # Item message alert
         assert str(
@@ -168,7 +168,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         response = self.client.get(self.URL + "?status=NEW")
 
         # Global message alert
-        assert str(parse_response_to_soup(response, selector=".s-title-01 .alert")) == self.snapshot(name="alert")
+        assert str(parse_response_to_soup(response, selector=".s-title-02 .alert")) == self.snapshot(name="alert")
         # Item message alert
         assert str(
             parse_response_to_soup(
@@ -230,7 +230,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
 
         self.assertContains(response, format_filters.format_approval_number(self.job_application.approval.number))
         # Global message alert
-        assert str(parse_response_to_soup(response, selector=".s-title-01 .alert")) == self.snapshot(name="alert")
+        assert str(parse_response_to_soup(response, selector=".s-title-02 .alert")) == self.snapshot(name="alert")
         # Item message alert
         assert str(
             parse_response_to_soup(
@@ -252,7 +252,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
 
         self.assertContains(response, format_filters.format_approval_number(self.job_application.approval.number))
         # Global message alert
-        assert str(parse_response_to_soup(response, selector=".s-title-01 .alert")) == self.snapshot(name="alert")
+        assert str(parse_response_to_soup(response, selector=".s-title-02 .alert")) == self.snapshot(name="alert")
         # Item message alert
         assert str(
             parse_response_to_soup(

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -353,10 +353,10 @@ class SearchPrescriberTest(TestCase):
         PrescriberOrganizationFactory(authorized=True, coords=vannes.coords)
 
         response = self.client.get(url, {"city": guerande.slug, "distance": 100})
-        self.assertContains(response, "2 résultats", html=True)
+        self.assertContains(response, "2 résultats")
 
         response = self.client.get(url, {"city": guerande.slug, "distance": 15})
-        self.assertContains(response, "1 résultat", html=True)
+        self.assertContains(response, "1 résultat")
 
 
 class JobDescriptionSearchViewTest(TestCase):

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -56,7 +56,7 @@ class EvaluatedSiaeSanctionViewTest(TestCase):
     def assertSanctionContent(self, response):
         self.assertContains(
             response,
-            '<h1 class="mb-4">Notification de sanction pour <span class="text-info">Les petits jardins</span></h1>',
+            '<h1>Notification de sanction pour <span class="text-info">Les petits jardins</span></h1>',
             html=True,
             count=1,
         )


### PR DESCRIPTION
### Pourquoi ?

Mise a jour des zones de titres des pages pour coller au nouveau design

### Comment ?

- remplacement de la section `.s-title-01` par la nouvelle version `.s-title-02`
- si rien dans `.s-title-02`, suppression de l'astuce de masquage de la section par la surcharge `{% block content_title_wrapper %}{% endblock %}` (plus besoin car géré en css maintenant)
- déplacement du `{% block breadcrumbs %}` dans la `.s-title-02`
- déplacement du `{% block messages %}` dans la `.s-title-02`
- déplacement des `.c-box--action` dans la `.s-title-02`
- regroupement des `.alert` dans le `{% block messages %}`

#### En passant
- harmonisation de plusieurs rendu de pages (suppresion des `.c-box` inutiles et mise en forme des `.table`)
- déplacement de titre de pages dans le zone de titre `.s-title-02`
- suppresion de l'alerte old-browser pour IE 11 (63 visites en IE11 sur 1317239 depuis le début d'année)


### Captures d'écran
**Avant**
![capture 2024-04-10 à 12 06 43](https://github.com/gip-inclusion/les-emplois/assets/3874024/539a86f4-0a13-4dc7-9190-f99fbb22559f)

![capture 2024-04-10 à 12 11 53](https://github.com/gip-inclusion/les-emplois/assets/3874024/cc2dd35d-cd6e-45de-9a6c-db6d648ead0e)

---

**Apres**
![capture 2024-04-10 à 12 07 05](https://github.com/gip-inclusion/les-emplois/assets/3874024/f8e8d6f6-aae6-4e1c-9b5f-116c1bcc2be5)

![capture 2024-04-10 à 12 11 59](https://github.com/gip-inclusion/les-emplois/assets/3874024/14e14964-0485-4a6b-9906-c2c976f8778f)
