### PR TITLE
Utiliser textContent plutôt que innerHTML

### DIFF
--- a/itou/static/js/siae_evaluations_sample_selection.js
+++ b/itou/static/js/siae_evaluations_sample_selection.js
@@ -4,10 +4,10 @@
   function initSlider() {
     const slider = document.getElementById("chosenPercentRange");
     const output = document.getElementById("showChosenPercentValue");
-    output.innerHTML = slider.value;
+    output.textContent = slider.value;
 
     slider.oninput = function () {
-      output.innerHTML = this.value;
+      output.textContent = this.value;
     }
   }
 


### PR DESCRIPTION
### Pourquoi ?

https://github.com/gip-inclusion/les-emplois/security/code-scanning/19
https://github.com/gip-inclusion/les-emplois/security/code-scanning/20

Il n’y a pas de faille à proprement parler, car l’utilisateur peut bien injecter ce qu’il veut dans le DOM. En revanche, il existe une API plus sûre pour changer le contenu textuel d’un élément, autant l’utiliser. C’est également plus performant.

https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent

### Comment tester

Jouer le script suivant :

```python
>>> from itou.siae_evaluations.models import EvaluationCampaign, create_campaigns_and_calendar
>>> import datetime
>>> EvaluationCampaign.objects.all().delete()
>>> create_campaigns_and_calendar(datetime.date(2023,1,1), datetime.date(2023,12,31), datetime.date(2024,9,1))
```

1. Se connecter en tant que `test+ddets@inclusion.beta.gouv.fr`
2. Aller dans la campagne en cours depuis le tableau de bord
3. Jouer avec le slider de sélection pour le pourcentage de SIAE à contrôler