### PR TITLE
Retirer les boutons appliquer dans les filtres

### DIFF
--- a/itou/static/js/approvals_filters.js
+++ b/itou/static/js/approvals_filters.js
@@ -2,4 +2,3 @@ function submitFiltersForm() {
   $("#js-job-applications-filters-form").submit();
 }
 $("#js-job-applications-filters-form :input").change(submitFiltersForm);
-$("#js-job-applications-filters-apply-button").hide();

--- a/itou/static/js/job_applications_filters.js
+++ b/itou/static/js/job_applications_filters.js
@@ -1,1 +1,0 @@
-$("#js-job-applications-filters-apply-button").hide();

--- a/itou/templates/apply/list_for_job_seeker.html
+++ b/itou/templates/apply/list_for_job_seeker.html
@@ -27,9 +27,6 @@
                                     {% include "apply/includes/job_applications_filters/statut.html" %}
                                     <hr>
                                     {% include "apply/includes/job_applications_filters/dates.html" %}
-                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
-                                        Appliquer
-                                    </button>
                                 </div>
                             </form>
                         </div>
@@ -44,5 +41,4 @@
 {% block script %}
     {{ block.super }}
     <script src='{% static "js/htmx_compat.js" %}'></script>
-    <script src='{% static "js/job_applications_filters.js" %}'></script>
 {% endblock %}

--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -36,9 +36,6 @@
                                     {% include "apply/includes/job_applications_filters/eligibility_validated.html" %}
                                     {% include "apply/includes/job_applications_filters/criteria.html" %}
                                     {% include "apply/includes/job_applications_filters/departments.html" %}
-                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
-                                        Appliquer
-                                    </button>
                                 </div>
                             </form>
                         </div>
@@ -56,6 +53,5 @@
     {{ block.super }}
     <!-- Needed to use Select2MultipleWidget. -->
     {{ filters_form.media.js }}
-    <script src='{% static "js/job_applications_filters.js" %}'></script>
     <script src='{% static "js/htmx_compat.js" %}'></script>
 {% endblock %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -42,9 +42,6 @@
                                     {% include "apply/includes/job_applications_filters/dates.html" %}
                                     {% include "apply/includes/job_applications_filters/selected_jobs.html" %}
                                     {% include "apply/includes/job_applications_filters/sender.html" %}
-                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
-                                        Appliquer
-                                    </button>
                                 </div>
                             </form>
                         </div>
@@ -63,5 +60,4 @@
     <!-- Needed to use Select2MultipleWidget. -->
     {{ filters_form.media.js }}
     <script src='{% static "js/htmx_compat.js" %}'></script>
-    <script src='{% static "js/job_applications_filters.js" %}'></script>
 {% endblock %}

--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -28,9 +28,6 @@
                                         <legend>Fin du parcours en IAE</legend>
                                         {% bootstrap_field filters_form.expiry layout="inline" %}
                                     </fieldset>
-                                    <button id="js-job-applications-filters-apply-button" class="btn btn-block btn-primary mt-3" aria-label="Appliquer les filtres">
-                                        Appliquer
-                                    </button>
                                 </div>
                             </form>
                         </div>

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -242,9 +242,6 @@
       </fieldset>
   
   
-                                      <button aria-label="Appliquer les filtres" class="btn btn-block btn-primary mt-3" id="js-job-applications-filters-apply-button">
-                                          Appliquer
-                                      </button>
                                   </div>
                               </form>
                           </div>
@@ -433,9 +430,6 @@
   
       </fieldset>
   
-                                      <button aria-label="Appliquer les filtres" class="btn btn-block btn-primary mt-3" id="js-job-applications-filters-apply-button">
-                                          Appliquer
-                                      </button>
                                   </div>
                               </form>
                           </div>
@@ -630,9 +624,6 @@
   
       </fieldset>
   
-                                      <button aria-label="Appliquer les filtres" class="btn btn-block btn-primary mt-3" id="js-job-applications-filters-apply-button">
-                                          Appliquer
-                                      </button>
                                   </div>
                               </form>
                           </div>
@@ -814,9 +805,6 @@
   
       </fieldset>
   
-                                      <button aria-label="Appliquer les filtres" class="btn btn-block btn-primary mt-3" id="js-job-applications-filters-apply-button">
-                                          Appliquer
-                                      </button>
                                   </div>
                               </form>
                           </div>


### PR DESCRIPTION
Ces boutons sont présents dans l’espoir que les utilisateurs sans JS puissent utiliser le site.

Le JavaScript est nécessaire pour que le site fonctionne. Autant le reconnaître et l’assumer. Autrement, on pourrait croire que les utilisateurs sans JS peuvent utiliser le site, alors qu’ils n’ont pas accès au menu déroulant d’authentification, ou au module de recherche d’emploi.