### PR TITLE
Candidatures : Retirer le nom de l’employeur pour le statut « Embauché ailleurs » [GEN-230]

### DIFF
--- a/itou/api/geiq/views.py
+++ b/itou/api/geiq/views.py
@@ -8,8 +8,8 @@ from rest_framework import authentication, exceptions, generics, permissions, st
 from itou.api.models import CompanyApiToken
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
-from itou.job_applications.enums import Prequalification, ProfessionalSituationExperience
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow, PriorAction
+from itou.job_applications.enums import JobApplicationState, Prequalification, ProfessionalSituationExperience
+from itou.job_applications.models import JobApplication, PriorAction
 from itou.utils.validators import validate_siren
 
 from .serializers import GeiqJobApplicationSerializer
@@ -69,7 +69,7 @@ class GeiqJobApplicationListView(generics.ListAPIView):
             extra_filters.update({"to_company__siret__startswith": siren[:9]})
         return (
             JobApplication.objects.filter(
-                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                state=JobApplicationState.ACCEPTED,
                 to_company__kind=CompanyKind.GEIQ,
                 **extra_filters,
             )

--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -21,7 +21,8 @@ from django.utils import timezone
 from itou.approvals.admin_forms import ManuallyAddApprovalFromJobApplicationForm
 from itou.approvals.enums import Origin
 from itou.approvals.models import Approval, CancelledApproval
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication
 from itou.utils.apis import enums as api_enums
 from itou.utils.emails import get_email_text_template
 from itou.utils.urls import add_url_params
@@ -49,7 +50,7 @@ def manually_add_approval(
     job_application = get_object_or_404(
         queryset,
         pk=job_application_id,
-        state=JobApplicationWorkflow.STATE_ACCEPTED,
+        state=JobApplicationState.ACCEPTED,
         approval=None,
         approval_manually_refused_at=None,
         approval_manually_refused_by=None,
@@ -121,7 +122,7 @@ def manually_refuse_approval(
     job_application = get_object_or_404(
         queryset,
         pk=job_application_id,
-        state=JobApplicationWorkflow.STATE_ACCEPTED,
+        state=JobApplicationState.ACCEPTED,
         approval=None,
         approval_manually_delivered_by=None,
         approval_number_sent_by_email=False,

--- a/itou/approvals/management/commands/fill_approval_origin_fields.py
+++ b/itou/approvals/management/commands/fill_approval_origin_fields.py
@@ -3,7 +3,7 @@ import time
 from django.core.management.base import BaseCommand
 
 from itou.approvals.models import Approval
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 
 
 BATCH_SIZE = 1000
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     def handle(self, **options):
         objects_to_migrate = Approval.objects.filter(
             origin_sender_kind=None,
-            jobapplication__state=JobApplicationWorkflow.STATE_ACCEPTED,
+            jobapplication__state=JobApplicationState.ACCEPTED,
         ).distinct()
         total_objects = objects_to_migrate.count()
         print(f"Before: {total_objects}")

--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -4,7 +4,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from itou.approvals import models as approvals_models
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 from itou.utils.apis import enums as api_enums
 from itou.utils.command import BaseCommand
 
@@ -39,7 +39,7 @@ class Command(BaseCommand):
             start_at__lte=today,
             # those with no accepted job application would also fail and stay pending.
             # also removes the approvals without any job application yet.
-            jobapplication__state=JobApplicationWorkflow.STATE_ACCEPTED,
+            jobapplication__state=JobApplicationState.ACCEPTED,
         ).exclude(
             Q(user__jobseeker_profile__nir="")
             | Q(user__birthdate=None)

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -680,7 +680,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
     def can_be_deleted(self):
         JobApplication = self.jobapplication_set.model
         try:
-            return self.jobapplication_set.get().state == JobApplication.state.STATE_ACCEPTED
+            return self.jobapplication_set.get().state == job_application_enums.JobApplicationState.ACCEPTED
         except (JobApplication.DoesNotExist, JobApplication.MultipleObjectsReturned):
             return False
 

--- a/itou/companies/management/commands/_import_siae/utils.py
+++ b/itou/companies/management/commands/_import_siae/utils.py
@@ -1,5 +1,4 @@
 """
-
 Various helpers shared by the import_siae, import_geiq and import_ea_eatt scripts.
 
 """
@@ -17,7 +16,7 @@ from py7zr.exceptions import Bad7zFile
 
 from itou.common_apps.address.models import AddressMixin
 from itou.companies.models import Company
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 from itou.metabase.tables.utils import hash_content
 from itou.utils.apis.exceptions import GeocodingDataError
 from itou.utils.apis.geocoding import get_geocoding_data
@@ -105,7 +104,7 @@ def remap_columns(df, column_mapping):
 def could_siae_be_deleted(siae):
     if siae.evaluated_siaes.exists():
         return False
-    if siae.job_applications_received.exclude(state=JobApplicationWorkflow.STATE_NEW).exists():
+    if siae.job_applications_received.exclude(state=JobApplicationState.NEW).exists():
         return False
     # Do not delete SIAE if any approval is linked to one of the elibility diagnosis it has created
     if siae.eligibilitydiagnosis_set.exclude(approval=None).exists():

--- a/itou/employee_record/management/commands/employee_records_status.py
+++ b/itou/employee_record/management/commands/employee_records_status.py
@@ -4,7 +4,8 @@ from itou.approvals.enums import Origin
 from itou.approvals.models import Approval
 from itou.employee_record.constants import get_availability_date_for_kind
 from itou.employee_record.models import EmployeeRecord
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication
 from itou.utils.command import BaseCommand
 
 
@@ -46,7 +47,7 @@ class Command(BaseCommand):
                     info, siret_used = "Plusieurs candidatures", "+".join(siret)
                 else:
                     siret_used = job_application.to_company.siret
-                    if job_application.state != JobApplicationWorkflow.STATE_ACCEPTED:
+                    if job_application.state != JobApplicationState.ACCEPTED:
                         info = "La candidature n'est pas en état 'acceptée'"
                     elif job_application.origin == Origin.AI_STOCK:
                         info = "Import AI"

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -2,8 +2,8 @@ from django import forms
 from django.core.exceptions import ValidationError
 
 from itou.eligibility.models import EligibilityDiagnosis
-from itou.job_applications.enums import SenderKind
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, SenderKind
+from itou.job_applications.models import JobApplication
 
 
 class JobApplicationAdminForm(forms.ModelForm):
@@ -25,12 +25,9 @@ class JobApplicationAdminForm(forms.ModelForm):
 
     def clean(self):
         target_state = self.cleaned_data.get("state")
-        if (
-            target_state == JobApplicationWorkflow.STATE_ACCEPTED
-            and target_state != self._initial_job_application_state
-        ):
+        if target_state == JobApplicationState.ACCEPTED and target_state != self._initial_job_application_state:
             self._job_application_to_accept = True
-            self.cleaned_data["state"] = self._initial_job_application_state or JobApplicationWorkflow.STATE_NEW
+            self.cleaned_data["state"] = self._initial_job_application_state or JobApplicationState.NEW
 
         if self._job_application_to_accept and not self.cleaned_data.get("hiring_start_at"):
             self.add_error("hiring_start_at", "Ce champ est obligatoire pour les candidatures acceptées.")

--- a/itou/job_applications/enums.py
+++ b/itou/job_applications/enums.py
@@ -3,6 +3,18 @@ from django.db import models
 from itou.users import enums as users_enums
 
 
+class JobApplicationState(models.TextChoices):
+    NEW = "new", "Nouvelle candidature"
+    PROCESSING = "processing", "Candidature à l'étude"
+    POSTPONED = "postponed", "Candidature en attente"
+    PRIOR_TO_HIRE = "prior_to_hire", "Action préalable à l’embauche"
+    ACCEPTED = "accepted", "Candidature acceptée"
+    REFUSED = "refused", "Candidature déclinée"
+    CANCELLED = "cancelled", "Embauche annulée"
+    # When a job application is accepted, all other job seeker's pending applications become obsolete.
+    OBSOLETE = "obsolete", "Embauché ailleurs"
+
+
 class SenderKind(models.TextChoices):
     JOB_SEEKER = users_enums.KIND_JOB_SEEKER, "Demandeur d'emploi"
     PRESCRIBER = users_enums.KIND_PRESCRIBER, "Prescripteur"

--- a/itou/job_applications/management/commands/display_missing_eligibility_diagnoses.py
+++ b/itou/job_applications/management/commands/display_missing_eligibility_diagnoses.py
@@ -1,7 +1,7 @@
 from itou.approvals import enums as approvals_enums
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
 from itou.job_applications import enums as job_applications_enums
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.models import JobApplication
 from itou.utils.command import BaseCommand
 
 
@@ -21,7 +21,7 @@ class Command(BaseCommand):
     def handle(self, **options):
         queryset = (
             JobApplication.objects.filter(
-                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                state=job_applications_enums.JobApplicationState.ACCEPTED,
                 eligibility_diagnosis=None,
                 to_company__kind__in=SIAE_WITH_CONVENTION_KINDS,
                 approval__isnull=False,

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -1,4 +1,4 @@
-from itou.job_applications.enums import Origin, SenderKind
+from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.metabase.tables.utils import MetabaseTable, get_choice, get_department_and_region_columns
 from itou.prescribers.enums import PrescriberOrganizationKind
@@ -94,9 +94,7 @@ def get_ja_time_spent_from_new_to_accepted_or_refused(ja):
     # Find the *=>accepted or *=>refused transition log.
     # We have to do all this in python to benefit from prefetch_related.
     logs = [
-        log
-        for log in ja.logs.all()
-        if log.to_state in [JobApplicationWorkflow.STATE_ACCEPTED, JobApplicationWorkflow.STATE_REFUSED]
+        log for log in ja.logs.all() if log.to_state in [JobApplicationState.ACCEPTED, JobApplicationState.REFUSED]
     ]
     return _get_ja_time_spent_in_transition(ja, logs)
 
@@ -136,7 +134,7 @@ TABLE.add_columns(
             "name": "état",
             "type": "varchar",
             "comment": "Etat de la candidature",
-            "fn": lambda o: get_choice(choices=JobApplicationWorkflow.STATE_CHOICES, key=o.state),
+            "fn": lambda o: get_choice(choices=JobApplicationState.choices, key=o.state),
         },
         {
             "name": "origine",

--- a/itou/metabase/tables/organizations.py
+++ b/itou/metabase/tables/organizations.py
@@ -1,5 +1,5 @@
-from itou.job_applications.enums import Origin, SenderKind
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
+from itou.job_applications.models import JobApplication
 from itou.metabase.tables.utils import (
     MetabaseTable,
     get_active_companies_pks,
@@ -55,7 +55,7 @@ def get_org_job_applications_count(org):
 
 def get_org_accepted_job_applications_count(org):
     if org == ORG_OF_PRESCRIBERS_WITHOUT_ORG:
-        return _get_ja_sent_by_prescribers_without_org().filter(state=JobApplicationWorkflow.STATE_ACCEPTED).count()
+        return _get_ja_sent_by_prescribers_without_org().filter(state=JobApplicationState.ACCEPTED).count()
     return org.accepted_job_applications_count
 
 

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -25,7 +25,7 @@ from itou.common_apps.address.models import BAN_API_RELIANCE_SCORE
 from itou.companies.models import Company
 from itou.geo.enums import ZRRStatus
 from itou.geo.models import ZRR
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 from itou.users.models import User
 
 
@@ -116,7 +116,7 @@ def get_hiring_company(job_seeker):
     link yet.
     """
     assert job_seeker.is_job_seeker
-    hirings = [ja for ja in job_seeker.job_applications.all() if ja.state == JobApplicationWorkflow.STATE_ACCEPTED]
+    hirings = [ja for ja in job_seeker.job_applications.all() if ja.state == JobApplicationState.ACCEPTED]
     if hirings:
         latest_hiring = max(hirings, key=attrgetter("created_at"))
         return latest_hiring.to_company

--- a/itou/scripts/management/commands/export_auto_prescriptions.py
+++ b/itou/scripts/management/commands/export_auto_prescriptions.py
@@ -4,7 +4,8 @@ from django.db.models import F
 
 from itou.common_apps.address.departments import DEPARTMENTS
 from itou.companies.enums import CompanyKind
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication
 from itou.users.enums import KIND_EMPLOYER
 from itou.utils.command import BaseCommand
 from itou.utils.management_commands import XlsxExportMixin
@@ -26,7 +27,7 @@ class Command(XlsxExportMixin, BaseCommand):
                 "to_company__convention",
             )
             .filter(
-                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                state=JobApplicationState.ACCEPTED,
                 to_company__kind__in=[CompanyKind.ACI, CompanyKind.EI, CompanyKind.ETTI, CompanyKind.AI],
                 eligibility_diagnosis__author_kind=KIND_EMPLOYER,
                 eligibility_diagnosis__author_siae=F("to_company"),

--- a/itou/siae_evaluations/fixtures.py
+++ b/itou/siae_evaluations/fixtures.py
@@ -21,7 +21,8 @@ from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria
 from itou.eligibility.models.iae import EligibilityDiagnosis
 from itou.institutions.models import Institution
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication
 from itou.siae_evaluations.models import Calendar, EvaluationCampaign, create_campaigns_and_calendar
 from itou.users.models import User
 
@@ -124,7 +125,7 @@ def load_data():
                     sender_company=controlled_siae,
                     sender=employer,
                     sender_kind=users_enums.KIND_EMPLOYER,
-                    state=JobApplicationWorkflow.STATE_ACCEPTED,
+                    state=JobApplicationState.ACCEPTED,
                     to_company=controlled_siae,
                 ).id
             ]

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -13,7 +13,8 @@ from itou.companies.models import Company
 from itou.eligibility.models import AdministrativeCriteria
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.emails import CampaignEmailFactory, SIAEEmailFactory
 from itou.users.enums import KIND_EMPLOYER
@@ -223,7 +224,7 @@ class EvaluationCampaign(models.Model):
             .filter(
                 to_company__department=self.institution.department,
                 to_company__kind__in=evaluation_enums.EvaluationSiaesKind.Evaluable,
-                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                state=JobApplicationState.ACCEPTED,
                 eligibility_diagnosis__author_kind=KIND_EMPLOYER,
                 eligibility_diagnosis__author_siae=F("to_company"),
                 hiring_start_at__gte=self.evaluated_period_start_at,

--- a/itou/templates/apply/includes/transition_logs.html
+++ b/itou/templates/apply/includes/transition_logs.html
@@ -5,7 +5,7 @@
                 <time datetime="{{ log.timestamp.isoformat }}">Le {{ log.timestamp|date:dt_format }}</time>
                 <span>
                     Passé en "{{ log.pretty_to_state }}"
-                    {% if log.user %}par {{ log.user.get_full_name }}{% endif %}
+                    {% if log.user and log.to_state != JobApplicationState.OBSOLETE %}par {{ log.user.get_full_name }}{% endif %}
                 </span>
             </li>
         {% endfor %}

--- a/itou/utils/context_processors.py
+++ b/itou/utils/context_processors.py
@@ -15,6 +15,7 @@ def expose_enums(*args):
     return {
         "ApprovalOrigin": approvals_enums.Origin,
         "JobApplicationOrigin": job_applications_enums.Origin,
+        "JobApplicationState": job_applications_enums.JobApplicationState,
         "PrescriberOrganizationKind": prescribers_enums.PrescriberOrganizationKind,
         "ProlongationRequestStatus": approvals_enums.ProlongationRequestStatus,
         "RefusalReason": job_applications_enums.RefusalReason,

--- a/itou/utils/templatetags/job_applications.py
+++ b/itou/utils/templatetags/job_applications.py
@@ -1,7 +1,7 @@
 from django import template
 from django.utils.safestring import mark_safe
 
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 
 
 register = template.Library()
@@ -10,14 +10,14 @@ register = template.Library()
 @register.simple_tag
 def state_badge(job_application, *, hx_swap_oob=False, extra_class="badge-sm mb-1"):
     state_classes = {
-        JobApplicationWorkflow.STATE_ACCEPTED: "bg-success",
-        JobApplicationWorkflow.STATE_CANCELLED: "bg-primary",
-        JobApplicationWorkflow.STATE_NEW: "bg-info",
-        JobApplicationWorkflow.STATE_OBSOLETE: "bg-primary",
-        JobApplicationWorkflow.STATE_POSTPONED: "bg-accent-03 text-primary",
-        JobApplicationWorkflow.STATE_PRIOR_TO_HIRE: "bg-accent-02 text-primary",
-        JobApplicationWorkflow.STATE_PROCESSING: "bg-accent-03 text-primary",
-        JobApplicationWorkflow.STATE_REFUSED: "bg-danger",
+        JobApplicationState.ACCEPTED: "bg-success",
+        JobApplicationState.CANCELLED: "bg-primary",
+        JobApplicationState.NEW: "bg-info",
+        JobApplicationState.OBSOLETE: "bg-primary",
+        JobApplicationState.POSTPONED: "bg-accent-03 text-primary",
+        JobApplicationState.PRIOR_TO_HIRE: "bg-accent-02 text-primary",
+        JobApplicationState.PROCESSING: "bg-accent-03 text-primary",
+        JobApplicationState.REFUSED: "bg-danger",
     }[job_application.state]
     attrs = [
         f'id="state_{ job_application.pk }"',

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -22,7 +22,7 @@ from itou.companies.models import JobDescription
 from itou.eligibility.models import AdministrativeCriteria
 from itou.files.forms import ItouFileField
 from itou.job_applications import enums as job_applications_enums
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow, PriorAction
+from itou.job_applications.models import JobApplication, PriorAction
 from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.forms import JobSeekerProfileFieldsMixin
 from itou.users.models import JobSeekerProfile, User
@@ -882,7 +882,7 @@ class FilterJobApplicationsForm(forms.Form):
 
     states = forms.MultipleChoiceField(
         required=False,
-        choices=JobApplicationWorkflow.STATE_CHOICES,
+        choices=job_applications_enums.JobApplicationState,
         widget=forms.CheckboxSelectMultiple,
     )
     start_date = forms.DateField(
@@ -1055,7 +1055,9 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
         if not company.can_have_prior_action:
             # Drop "pré-embauche" state from filter for non-GEIQ companies
             self.fields["states"].choices = [
-                (k, v) for k, v in self.fields["states"].choices if k != JobApplicationWorkflow.STATE_PRIOR_TO_HIRE
+                (k, v)
+                for k, v in self.fields["states"].choices
+                if k != job_applications_enums.JobApplicationState.PRIOR_TO_HIRE
             ]
 
     def filter(self, queryset):

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -17,6 +17,7 @@ from itou.companies.enums import CompanyKind, ContractType
 from itou.companies.models import Company
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
+from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow, PriorAction
 from itou.utils.perms.prescriber import get_all_available_job_applications_as_prescriber
 from itou.utils.urls import get_safe_url
@@ -417,9 +418,9 @@ def archive(request, job_application_id):
     job_application = get_object_or_404(queryset, id=job_application_id)
 
     cancelled_states = [
-        JobApplicationWorkflow.STATE_REFUSED,
-        JobApplicationWorkflow.STATE_CANCELLED,
-        JobApplicationWorkflow.STATE_OBSOLETE,
+        JobApplicationState.REFUSED,
+        JobApplicationState.CANCELLED,
+        JobApplicationState.OBSOLETE,
     ]
 
     qs = urlencode({"states": cancelled_states}, doseq=True)

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -25,7 +25,8 @@ from itou.approvals.models import (
     Suspension,
 )
 from itou.files.forms import ItouFileField
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import UserKind
 from itou.users.models import User
@@ -65,7 +66,7 @@ class ApprovalForm(forms.Form):
             JobApplication.objects.filter(
                 approval=OuterRef("pk"),
                 to_company_id=self.siae_pk,
-                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                state=JobApplicationState.ACCEPTED,
             )
         )
 

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -27,8 +27,8 @@ from itou.approvals.models import (
     Suspension,
 )
 from itou.files.models import File
-from itou.job_applications.enums import Origin, SenderKind
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
+from itou.job_applications.models import JobApplication
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.pagination import ItouPaginator, pager
@@ -75,7 +75,7 @@ class ApprovalBaseViewMixin(LoginRequiredMixin):
         return (
             JobApplication.objects.filter(
                 job_seeker=approval.user,
-                state=JobApplicationWorkflow.STATE_ACCEPTED,
+                state=JobApplicationState.ACCEPTED,
                 to_company=self.siae,
                 approval=approval,
             )
@@ -799,7 +799,7 @@ def pe_approval_create(request, pe_approval_id):
     job_application = JobApplication(
         job_seeker=job_seeker,
         to_company=siae,
-        state=JobApplicationWorkflow.STATE_ACCEPTED,
+        state=JobApplicationState.ACCEPTED,
         origin=Origin.PE_APPROVAL,  # This origin is specific to this process.
         sender=request.user,
         sender_kind=SenderKind.EMPLOYER,

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -23,7 +23,7 @@ from itou.companies.models import Company
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.institutions.models import Institution
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 from itou.openid_connect.inclusion_connect import constants as ic_constants
 from itou.prescribers.models import PrescriberOrganization
 from itou.siae_evaluations.models import EvaluatedSiae, EvaluationCampaign
@@ -45,9 +45,9 @@ from itou.www.stats import utils as stats_utils
 
 def _employer_dashboard_context(request):
     current_org = get_current_company_or_404(request)
-    states_to_process = [JobApplicationWorkflow.STATE_NEW, JobApplicationWorkflow.STATE_PROCESSING]
+    states_to_process = [JobApplicationState.NEW, JobApplicationState.PROCESSING]
     if current_org.can_have_prior_action:
-        states_to_process.append(JobApplicationWorkflow.STATE_PRIOR_TO_HIRE)
+        states_to_process.append(JobApplicationState.PRIOR_TO_HIRE)
 
     job_applications_categories = [
         {
@@ -58,7 +58,7 @@ def _employer_dashboard_context(request):
         },
         {
             "name": "En attente",
-            "states": [JobApplicationWorkflow.STATE_POSTPONED],
+            "states": [JobApplicationState.POSTPONED],
             "icon": "ri-time-line",
             "badge": "bg-info-lighter",
         },

--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -23,8 +23,7 @@ from itou.approvals.models import (
     Suspension,
 )
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS, CompanyKind
-from itou.job_applications.enums import SenderKind
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, SenderKind
 from tests.companies.factories import CompanyFactory
 from tests.eligibility.factories import EligibilityDiagnosisFactory
 from tests.files.factories import FileFactory
@@ -75,7 +74,7 @@ class ApprovalFactory(factory.django.DjangoModelFactory):
         if extracted:
             from tests.job_applications.factories import JobApplicationFactory
 
-            state = kwargs.pop("state", JobApplicationWorkflow.STATE_ACCEPTED)
+            state = kwargs.pop("state", JobApplicationState.ACCEPTED)
             self.jobapplication_set.add(JobApplicationFactory(state=state, job_seeker=self.user, **kwargs))
 
 

--- a/tests/approvals/test_notify_pole_emploi.py
+++ b/tests/approvals/test_notify_pole_emploi.py
@@ -12,8 +12,7 @@ from freezegun import freeze_time
 
 from itou.approvals.models import Approval, CancelledApproval
 from itou.companies.enums import CompanyKind, siae_kind_to_pe_type_siae
-from itou.job_applications.enums import SenderKind
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, SenderKind
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.utils.apis import enums as api_enums
 from itou.utils.mocks.pole_emploi import (
@@ -62,7 +61,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
     def test_invalid_job_application(self):
         approval = ApprovalFactory(
             with_jobapplication=True,
-            with_jobapplication__state=JobApplicationWorkflow.STATE_CANCELLED,
+            with_jobapplication__state=JobApplicationState.CANCELLED,
         )
         with freeze_time() as frozen_now:
             approval.notify_pole_emploi()
@@ -275,7 +274,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         job_seeker = JobSeekerFactory()
         company = CompanyFactory(kind="FOO")  # unknown kind
         approval = ApprovalFactory(user=job_seeker)
-        JobApplicationFactory(to_company=company, approval=approval, state=JobApplicationWorkflow.STATE_ACCEPTED)
+        JobApplicationFactory(to_company=company, approval=approval, state=JobApplicationState.ACCEPTED)
         with freeze_time() as frozen_now:
             approval.notify_pole_emploi()
         approval.refresh_from_db()
@@ -293,7 +292,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         job_seeker = JobSeekerFactory()
         company = CompanyFactory(kind="FOO")  # unknown kind
         approval = ApprovalFactory(user=job_seeker)
-        JobApplicationFactory(to_company=company, approval=approval, state=JobApplicationWorkflow.STATE_POSTPONED)
+        JobApplicationFactory(to_company=company, approval=approval, state=JobApplicationState.POSTPONED)
         with freeze_time() as frozen_now:
             approval.notify_pole_emploi()
         approval.refresh_from_db()
@@ -313,7 +312,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         job_seeker = JobSeekerFactory()
         siae = CompanyFactory(kind="FOO")  # unknown kind
         approval = ApprovalFactory(user=job_seeker, with_origin_values=True, origin_siae_kind=CompanyKind.ETTI)
-        JobApplicationFactory(to_company=siae, approval=approval, state=JobApplicationWorkflow.STATE_ACCEPTED)
+        JobApplicationFactory(to_company=siae, approval=approval, state=JobApplicationState.ACCEPTED)
         approval.notify_pole_emploi()
         approval.refresh_from_db()
         payload = json.loads(respx.calls.last.request.content)

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -29,8 +29,8 @@ from itou.approvals.models import Approval, CancelledApproval, PoleEmploiApprova
 from itou.companies.enums import CompanyKind
 from itou.employee_record.enums import Status
 from itou.files.models import File
-from itou.job_applications.enums import SenderKind
-from itou.job_applications.models import JobApplication, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, SenderKind
+from itou.job_applications.models import JobApplication
 from itou.users.enums import LackOfPoleEmploiId
 from itou.utils.apis import enums as api_enums
 from tests.approvals.factories import (
@@ -614,7 +614,7 @@ class ApprovalModelTest(TestCase):
 
     def test_deleting_an_approval_prefer_origin_values(self):
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=JobApplicationState.PROCESSING,
             to_company__kind=CompanyKind.EI,
         )
         job_application.accept(user=job_application.to_company.members.first())
@@ -624,7 +624,7 @@ class ApprovalModelTest(TestCase):
         assert approval.origin_siae_siret == job_application.to_company.siret
 
         other_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=JobApplicationState.PROCESSING,
             to_company__kind=CompanyKind.ETTI,
             job_seeker_id=job_application.job_seeker_id,  # Use pk to avoid cached_property invalidations
         )
@@ -644,7 +644,7 @@ class ApprovalModelTest(TestCase):
 
     def test_deleting_an_approval_without_application_linked(self):
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=JobApplicationState.PROCESSING,
         )
         job_application.accept(user=job_application.to_company.members.first())
 
@@ -997,7 +997,7 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
         )
         job_application = JobApplicationSentByJobSeekerFactory(
             job_seeker=job_seeker,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=JobApplicationState.PROCESSING,
             approval=None,
             approval_number_sent_by_email=False,
         )
@@ -1097,7 +1097,7 @@ class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
 
         # When the job application will lead to a duplicate employee record but is still proposed
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             to_company=employee_record.job_application.to_company,
             approval=employee_record.job_application.approval,
         )

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -12,7 +12,7 @@ from freezegun import freeze_time
 
 from itou.companies.enums import CompanyKind, ContractType
 from itou.companies.models import Company, JobDescription
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 from tests.companies.factories import (
     CompanyAfterGracePeriodFactory,
     CompanyFactory,
@@ -361,7 +361,7 @@ class JobDescriptionQuerySetTest(TestCase):
             to_company=company,
             job_seeker=job_seeker,
             selected_jobs=[popular_job_description],
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
         )
 
         assert not JobDescription.objects.with_annotation_is_popular().get(pk=job_description.pk).is_popular

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -14,6 +14,7 @@ from itou.companies.models import Company
 from itou.employee_record.enums import Status
 from itou.employee_record.exceptions import InvalidStatusError
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, validate_asp_batch_filename
+from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.utils.mocks.address_format import mock_get_geocoding_data
 from tests.approvals.factories import ApprovalFactory
@@ -59,9 +60,7 @@ class EmployeeRecordModelTest(TestCase):
 
     def test_creation_with_bad_job_application_status(self):
         for state in [
-            state.name
-            for state in list(JobApplicationWorkflow.states)
-            if state.name != JobApplicationWorkflow.STATE_ACCEPTED
+            state.name for state in list(JobApplicationWorkflow.states) if state.name != JobApplicationState.ACCEPTED
         ]:
             with self.subTest(state):
                 with self.assertRaisesMessage(ValidationError, EmployeeRecord.ERROR_JOB_APPLICATION_MUST_BE_ACCEPTED):

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -8,7 +8,11 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import JobDescription
 from itou.eligibility.enums import AuthorKind
 from itou.job_applications import models
-from itou.job_applications.enums import Prequalification, ProfessionalSituationExperience, SenderKind
+from itou.job_applications.enums import (
+    Prequalification,
+    ProfessionalSituationExperience,
+    SenderKind,
+)
 from itou.jobs.models import Appellation
 from itou.utils.types import InclusiveDateRange
 from tests.approvals.factories import ApprovalFactory
@@ -35,7 +39,7 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             job_seeker=factory.SubFactory(JobSeekerWithAddressFactory, with_mocked_address=True)
         )
         with_approval = factory.Trait(
-            state=models.JobApplicationWorkflow.STATE_ACCEPTED,
+            state=models.JobApplicationState.ACCEPTED,
             approval=factory.SubFactory(
                 ApprovalFactory,
                 user=factory.SelfAttribute("..job_seeker"),
@@ -185,7 +189,7 @@ class JobApplicationSentByPrescriberPoleEmploiFactory(JobApplicationSentByPrescr
 class JobApplicationWithoutApprovalFactory(JobApplicationSentByPrescriberFactory):
     """Generates a JobApplication() object without an Approval() object."""
 
-    state = models.JobApplicationWorkflow.STATE_ACCEPTED
+    state = models.JobApplicationState.ACCEPTED
     hiring_without_approval = True
 
 

--- a/tests/job_applications/test_admin.py
+++ b/tests/job_applications/test_admin.py
@@ -16,7 +16,7 @@ from tests.users.factories import JobSeekerFactory
 
 def test_create_employee_record(admin_client):
     job_application = factories.JobApplicationFactory(
-        state=models.JobApplicationWorkflow.STATE_ACCEPTED,
+        state=models.JobApplicationState.ACCEPTED,
         with_approval=True,
     )
 
@@ -206,7 +206,7 @@ def test_accept_existing_job_application(admin_client):
     job_application = factories.JobApplicationFactory(
         eligibility_diagnosis=None,
         to_company__subject_to_eligibility=True,
-        state=models.JobApplicationWorkflow.STATE_REFUSED,
+        state=models.JobApplicationState.REFUSED,
     )
     change_url = reverse("admin:job_applications_jobapplication_change", args=[job_application.pk])
     post_data = {

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -14,7 +14,8 @@ from itou.companies.enums import CompanyKind
 from itou.eligibility.enums import AdministrativeCriteriaLevel, AuthorKind
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.institutions.enums import InstitutionKind
-from itou.job_applications.models import JobApplication, JobApplicationQuerySet, JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.models import JobApplication, JobApplicationQuerySet
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.models import (
     Calendar,
@@ -164,7 +165,7 @@ def campaign_eligible_job_app_objects():
         sender_company=company,
         eligibility_diagnosis=diag,
         hiring_start_at=timezone.now() - relativedelta(months=2),
-        state=JobApplicationWorkflow.STATE_ACCEPTED,
+        state=JobApplicationState.ACCEPTED,
     )
     return {
         "approval": approval,
@@ -207,7 +208,7 @@ class TestEvaluationCampaignManagerEligibleJobApplication:
     def test_job_application_not_accepted(self, campaign_eligible_job_app_objects):
         evaluation_campaign = EvaluationCampaignFactory()
         job_app = campaign_eligible_job_app_objects["job_app"]
-        job_app.state = JobApplicationWorkflow.STATE_REFUSED
+        job_app.state = JobApplicationState.REFUSED
         job_app.save()
         assert [] == list(evaluation_campaign.eligible_job_applications())
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -17,8 +17,7 @@ import tests.asp.factories as asp
 from itou.approvals.models import Approval
 from itou.asp.models import AllocationDuration, EducationLevel
 from itou.companies.enums import CompanyKind
-from itou.job_applications.enums import Origin
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, Origin
 from itou.users.enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploiId, Title, UserKind
 from itou.users.models import JobSeekerProfile, User
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, mock_get_geocoding_data
@@ -365,7 +364,7 @@ class ModelTest(TestCase):
         ]
 
     def test_last_hire_was_made_by_company(self):
-        job_application = JobApplicationSentByJobSeekerFactory(state=JobApplicationWorkflow.STATE_ACCEPTED)
+        job_application = JobApplicationSentByJobSeekerFactory(state=JobApplicationState.ACCEPTED)
         user = job_application.job_seeker
         company_1 = job_application.to_company
         assert user.last_hire_was_made_by_company(company_1)
@@ -379,7 +378,7 @@ class ModelTest(TestCase):
         # `last_accepted_job_application` is the one with the greater `created_at`
         now = timezone.now()
         job_application_1 = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             origin=Origin.PE_APPROVAL,
             created_at=now + relativedelta(days=1),
         )
@@ -388,7 +387,7 @@ class ModelTest(TestCase):
 
         job_application_2 = JobApplicationFactory(
             job_seeker=user,
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             origin=Origin.PE_APPROVAL,
             created_at=now,
         )
@@ -404,7 +403,7 @@ class ModelTest(TestCase):
         # `last_accepted_job_application` is the one with the greater `hiring_start_at`
         now = timezone.now()
         job_application_1 = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             origin=Origin.PE_APPROVAL,
             created_at=now,
             hiring_start_at=now + relativedelta(days=1),
@@ -414,7 +413,7 @@ class ModelTest(TestCase):
 
         job_application_2 = JobApplicationFactory(
             job_seeker=user,
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             origin=Origin.PE_APPROVAL,
             created_at=now,
             hiring_start_at=now,

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -36,7 +36,7 @@ from itou.asp.models import Commune
 from itou.cities.models import City
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company, CompanyMembership
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState
 from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants, pagination
@@ -1464,7 +1464,7 @@ def test_matomo_context_processor(client, settings, snapshot):
     assert str(script_content) == snapshot(name="matomo custom init siae card")
 
 
-@pytest.mark.parametrize("state", [s[0] for s in JobApplicationWorkflow.STATE_CHOICES])
+@pytest.mark.parametrize("state", JobApplicationState.values)
 def test_job_application_state_badge_processing(state, snapshot):
     job_application = JobApplicationFactory(id="00000000-0000-0000-0000-000000000000", state=state)
     assert job_applications.state_badge(job_application) == snapshot

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -2,6 +2,27 @@
 # name: ProcessTransferJobApplicationTest.test_job_application_transfer_redirection[job application transfer message]
   'La candidature de <>Html Escaped<> DOE a bien été transférée à Acme inc.||Pour la consulter, rendez-vous sur son tableau de bord en changeant de structure'
 # ---
+# name: ProcessViewsTest.test_details_for_company_transition_logs_hides_hired_by_other
+  '''
+  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
+      
+          
+              <li>
+                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
+                  <span>
+                      Passé en "Embauché ailleurs"
+                      
+                  </span>
+              </li>
+          
+          <li>
+              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
+              <span>Nouvelle candidature</span>
+          </li>
+      
+  </ul>
+  '''
+# ---
 # name: ProcessViewsTest.test_details_for_company_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -7,8 +7,7 @@ from pytest_django.asserts import assertContains, assertNotContains
 
 from itou.cities.models import City
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS, CompanyKind, ContractType
-from itou.job_applications.enums import QualificationLevel, QualificationType
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, QualificationLevel, QualificationType
 from itou.www.apply import forms as apply_forms
 from tests.cities.factories import create_test_cities
 from tests.companies.factories import JobDescriptionFactory
@@ -377,7 +376,7 @@ class JobApplicationAcceptFormWithGEIQFieldsTest(TestCase):
         assertContains(response, CANNOT_BACKDATE_TEXT)
         # Testing a redirect with HTMX is really incomplete, so we also check hiring status
         job_application.refresh_from_db()
-        assert job_application.state == JobApplicationWorkflow.STATE_PROCESSING
+        assert job_application.state == JobApplicationState.PROCESSING
 
         # with a GEIQ
         job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ, state="processing")
@@ -391,7 +390,7 @@ class JobApplicationAcceptFormWithGEIQFieldsTest(TestCase):
         assert response.status_code == 200
         assertNotContains(response, CANNOT_BACKDATE_TEXT)
         job_application.refresh_from_db()
-        assert job_application.state == JobApplicationWorkflow.STATE_ACCEPTED
+        assert job_application.state == JobApplicationState.ACCEPTED
 
     HELP_START_AT = (
         "La date est modifiable jusqu'à la veille de la date saisie. "

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -483,7 +483,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
     def test_details_for_job_seeker_when_refused(self, *args, **kwargs):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
-            state=JobApplicationWorkflow.STATE_REFUSED,
+            state=job_applications_enums.JobApplicationState.REFUSED,
             answer="abc",
             answer_to_prescriber="undisclosed",
             refusal_reason="other",
@@ -504,7 +504,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
     def test_details_for_prescriber_when_refused(self, *args, **kwargs):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
-            state=JobApplicationWorkflow.STATE_REFUSED,
+            state=job_applications_enums.JobApplicationState.REFUSED,
             answer="abc",
             answer_to_prescriber="undisclosed",
             refusal_reason="other",
@@ -533,7 +533,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             to_company__with_membership=True,
             to_company__email="refused_job_application@example.com",
             sent_by_authorized_prescriber_organisation=True,
-            state=JobApplicationWorkflow.STATE_REFUSED,
+            state=job_applications_enums.JobApplicationState.REFUSED,
             answer="abc",
             answer_to_prescriber="undisclosed",
             refusal_reason=job_applications_enums.RefusalReason.OTHER,
@@ -554,8 +554,8 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             company_user = job_application.to_company.members.first()
             job_application.logs.create(
                 transition=JobApplicationWorkflow.TRANSITION_REFUSE,
-                from_state=JobApplicationWorkflow.STATE_NEW,
-                to_state=JobApplicationWorkflow.STATE_REFUSED,
+                from_state=job_applications_enums.JobApplicationState.NEW,
+                to_state=job_applications_enums.JobApplicationState.REFUSED,
                 user=company_user,
             )
             url = reverse("apply:details_for_prescriber", kwargs={"job_application_id": job_application.pk})
@@ -588,7 +588,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             to_company__with_membership=True,
             to_company__email="refused_job_application@example.com",
             sent_by_authorized_prescriber_organisation=True,
-            state=JobApplicationWorkflow.STATE_REFUSED,
+            state=job_applications_enums.JobApplicationState.REFUSED,
             answer="abc",
             answer_to_prescriber="undisclosed",
             refusal_reason=job_applications_enums.RefusalReason.OTHER,
@@ -609,7 +609,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             to_company__with_membership=True,
             to_company__email="refused_job_application@example.com",
             sent_by_authorized_prescriber_organisation=True,
-            state=JobApplicationWorkflow.STATE_REFUSED,
+            state=job_applications_enums.JobApplicationState.REFUSED,
             answer="abc",
             answer_to_prescriber="undisclosed",
             refusal_reason=job_applications_enums.RefusalReason.OTHER,
@@ -642,10 +642,10 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         """Ensure that the `refuse` transition is triggered."""
 
         states = [
-            JobApplicationWorkflow.STATE_NEW,
-            JobApplicationWorkflow.STATE_PROCESSING,
-            JobApplicationWorkflow.STATE_PRIOR_TO_HIRE,
-            JobApplicationWorkflow.STATE_POSTPONED,
+            job_applications_enums.JobApplicationState.NEW,
+            job_applications_enums.JobApplicationState.PROCESSING,
+            job_applications_enums.JobApplicationState.PRIOR_TO_HIRE,
+            job_applications_enums.JobApplicationState.POSTPONED,
         ]
 
         for state in states:
@@ -674,8 +674,8 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         """Ensure that the `postpone` transition is triggered."""
 
         states = [
-            JobApplicationWorkflow.STATE_PROCESSING,
-            JobApplicationWorkflow.STATE_PRIOR_TO_HIRE,
+            job_applications_enums.JobApplicationState.PROCESSING,
+            job_applications_enums.JobApplicationState.PRIOR_TO_HIRE,
         ]
 
         for state in states:
@@ -811,7 +811,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
 
         # No address provided.
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             to_company=company,
         )
 
@@ -834,7 +834,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
 
         # No eligibility diagnosis -> if job_seeker has a valid eligibility diagnosis, it's OK
         job_application = JobApplicationSentByJobSeekerFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=job_seeker,
             to_company=company,
             eligibility_diagnosis=None,
@@ -851,7 +851,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
 
         # if no, should not see the confirm button, nor accept posted data
         job_application = JobApplicationSentByJobSeekerFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=job_seeker,
             to_company=company,
             eligibility_diagnosis=None,
@@ -909,7 +909,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         other_company = CompanyFactory(with_membership=True)
         job_application = JobApplicationFactory(
             approval=approval_job_seeker,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=job_seeker_user,
             to_company=other_company,
         )
@@ -955,7 +955,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         city = self.get_random_city()
 
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             # The state of the 3 `pole_emploi_*` fields will trigger a manual delivery.
             job_seeker__jobseeker_profile__nir="",
             job_seeker__jobseeker_profile__pole_emploi_id="",
@@ -1017,15 +1017,15 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         # Send 3 job applications to 3 different structures
         job_application = JobApplicationFactory(
             job_seeker=job_seeker,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
         job_app_starting_earlier = JobApplicationFactory(
             job_seeker=job_seeker,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
         job_app_starting_later = JobApplicationFactory(
             job_seeker=job_seeker,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
 
         # company 1 logs in and accepts the first job application.
@@ -1107,7 +1107,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             with_ban_geoloc_address=True,
         )
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=job_seeker,
             to_company=company,
         )
@@ -1136,7 +1136,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             birthdate=job_seeker.birthdate,
         )
         another_job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=almost_same_job_seeker,
             to_company=company,
         )
@@ -1151,7 +1151,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
     @override_settings(TALLY_URL="https://tally.so")
     def test_accept_nir_readonly(self, *args, **kwargs):
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
 
         employer = job_application.to_company.members.first()
@@ -1187,7 +1187,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         city = self.get_random_city()
 
         job_application = JobApplicationSentByJobSeekerFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker__jobseeker_profile__nir="",
             job_seeker__with_pole_emploi_id=True,
             job_seeker__with_ban_geoloc_address=True,
@@ -1245,7 +1245,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         city = self.get_random_city()
 
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker__jobseeker_profile__nir="",
             job_seeker__with_pole_emploi_id=True,
         )
@@ -1286,7 +1286,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         city = self.get_random_city()
 
         job_application = JobApplicationSentByJobSeekerFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker__jobseeker_profile__nir="",
             job_seeker__with_pole_emploi_id=True,
             job_seeker__with_ban_geoloc_address=True,
@@ -1334,7 +1334,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         city = self.get_random_city()
 
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker__jobseeker_profile__nir="",
             job_seeker__jobseeker_profile__lack_of_nir_reason=LackOfNIRReason.TEMPORARY_NUMBER,
             job_seeker__with_pole_emploi_id=True,
@@ -1384,7 +1384,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
     @override_settings(TALLY_URL="https://tally.so")
     def test_accept_lack_of_nir_reason_other_user(self, *args, **kwargs):
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker__jobseeker_profile__nir="",
             job_seeker__jobseeker_profile__lack_of_nir_reason=LackOfNIRReason.NIR_ASSOCIATED_TO_OTHER,
         )
@@ -1412,7 +1412,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
     def test_eligibility(self, *args, **kwargs):
         """Test eligibility."""
         job_application = JobApplicationSentByPrescriberOrganizationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=JobSeekerWithAddressFactory(with_address_in_qpv=True),
             eligibility_diagnosis=None,
         )
@@ -1476,7 +1476,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
 
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             to_company__kind=CompanyKind.GEIQ,
         )
         employer = job_application.to_company.members.first()
@@ -1490,7 +1490,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         """Test eligibility for an Siae that has been suspended."""
 
         job_application = JobApplicationSentByPrescriberOrganizationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker=JobSeekerWithAddressFactory(),
         )
         Sanctions.objects.create(
@@ -1527,7 +1527,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             self.client.logout()
 
         # Wrong state
-        job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
+        job_application.state = job_applications_enums.JobApplicationState.ACCEPTED
         job_application.save()
         self.client.force_login(employer)
         url = reverse("apply:eligibility", kwargs={"job_application_id": job_application.pk})
@@ -1604,7 +1604,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         city = self.get_random_city()
         job_seeker = JobSeekerWithAddressFactory(city=city.name, with_pole_emploi_id=True)
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_CANCELLED,
+            state=job_applications_enums.JobApplicationState.CANCELLED,
             job_seeker=job_seeker,
         )
         employer = job_application.to_company.members.first()
@@ -1622,7 +1622,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         """Ensure that when a company archives a job_application, the hidden_for_company flag is updated."""
 
         job_application = JobApplicationFactory(
-            sent_by_authorized_prescriber_organisation=True, state=JobApplicationWorkflow.STATE_CANCELLED
+            sent_by_authorized_prescriber_organisation=True, state=job_applications_enums.JobApplicationState.CANCELLED
         )
         assert job_application.state.is_cancelled
         employer = job_application.to_company.members.first()
@@ -1631,9 +1631,9 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         url = reverse("apply:archive", kwargs={"job_application_id": job_application.pk})
 
         cancelled_states = [
-            JobApplicationWorkflow.STATE_REFUSED,
-            JobApplicationWorkflow.STATE_CANCELLED,
-            JobApplicationWorkflow.STATE_OBSOLETE,
+            job_applications_enums.JobApplicationState.REFUSED,
+            job_applications_enums.JobApplicationState.CANCELLED,
+            job_applications_enums.JobApplicationState.OBSOLETE,
         ]
 
         response = self.client.post(url)
@@ -1984,7 +1984,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_processing(self):
         """Test actions available when the state is processing."""
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_PROCESSING
+        self.job_application.state = job_applications_enums.JobApplicationState.PROCESSING
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -1997,7 +1997,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_prior_to_hire(self):
         """Test actions available when the state is prior_to_hire."""
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_PRIOR_TO_HIRE
+        self.job_application.state = job_applications_enums.JobApplicationState.PRIOR_TO_HIRE
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2014,7 +2014,7 @@ class ProcessTemplatesTest(TestCase):
             suspension_dates=InclusiveDateRange(timezone.localdate() - relativedelta(days=1)),
         )
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_PROCESSING
+        self.job_application.state = job_applications_enums.JobApplicationState.PROCESSING
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2034,7 +2034,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_postponed(self):
         """Test actions available when the state is postponed."""
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_POSTPONED
+        self.job_application.state = job_applications_enums.JobApplicationState.POSTPONED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2048,7 +2048,7 @@ class ProcessTemplatesTest(TestCase):
         """Test actions available when the state is postponed."""
         self.client.force_login(self.employer)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
-        self.job_application.state = JobApplicationWorkflow.STATE_POSTPONED
+        self.job_application.state = job_applications_enums.JobApplicationState.POSTPONED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2060,7 +2060,7 @@ class ProcessTemplatesTest(TestCase):
 
     def test_details_template_for_state_obsolete(self):
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_OBSOLETE
+        self.job_application.state = job_applications_enums.JobApplicationState.OBSOLETE
         self.job_application.save()
 
         response = self.client.get(self.url_details)
@@ -2075,7 +2075,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_obsolete_valid_diagnosis(self):
         self.client.force_login(self.employer)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
-        self.job_application.state = JobApplicationWorkflow.STATE_OBSOLETE
+        self.job_application.state = job_applications_enums.JobApplicationState.OBSOLETE
         self.job_application.save()
 
         response = self.client.get(self.url_details)
@@ -2090,7 +2090,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_refused(self):
         """Test actions available for other states."""
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_REFUSED
+        self.job_application.state = job_applications_enums.JobApplicationState.REFUSED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2104,7 +2104,7 @@ class ProcessTemplatesTest(TestCase):
         """Test actions available for other states."""
         self.client.force_login(self.employer)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
-        self.job_application.state = JobApplicationWorkflow.STATE_REFUSED
+        self.job_application.state = job_applications_enums.JobApplicationState.REFUSED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2117,7 +2117,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_canceled(self):
         """Test actions available for other states."""
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_CANCELLED
+        self.job_application.state = job_applications_enums.JobApplicationState.CANCELLED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2131,7 +2131,7 @@ class ProcessTemplatesTest(TestCase):
         """Test actions available for other states."""
         self.client.force_login(self.employer)
         EligibilityDiagnosisFactory(job_seeker=self.job_application.job_seeker)
-        self.job_application.state = JobApplicationWorkflow.STATE_CANCELLED
+        self.job_application.state = job_applications_enums.JobApplicationState.CANCELLED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2144,7 +2144,7 @@ class ProcessTemplatesTest(TestCase):
     def test_details_template_for_state_accepted(self):
         """Test actions available for other states."""
         self.client.force_login(self.employer)
-        self.job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
+        self.job_application.state = job_applications_enums.JobApplicationState.ACCEPTED
         self.job_application.save()
         response = self.client.get(self.url_details)
         # Test template content.
@@ -2167,7 +2167,7 @@ class ProcessTransferJobApplicationTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             to_company=company,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
 
         self.client.force_login(user)
@@ -2183,12 +2183,14 @@ class ProcessTransferJobApplicationTest(TestCase):
         company = CompanyFactory(with_membership=True)
         user = company.members.first()
         job_application_1 = JobApplicationFactory(
-            sent_by_authorized_prescriber_organisation=True, to_company=company, state=JobApplicationWorkflow.STATE_NEW
+            sent_by_authorized_prescriber_organisation=True,
+            to_company=company,
+            state=job_applications_enums.JobApplicationState.NEW,
         )
         job_application_2 = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             to_company=company,
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=job_applications_enums.JobApplicationState.ACCEPTED,
         )
 
         self.client.force_login(user)
@@ -2212,7 +2214,7 @@ class ProcessTransferJobApplicationTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             to_company=company,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
 
         assert 2 == user.companymembership_set.count()
@@ -2234,7 +2236,7 @@ class ProcessTransferJobApplicationTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             to_company=company,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
             job_seeker__for_snapshot=True,
             job_seeker__first_name="<>html escaped<>",
         )
@@ -2267,7 +2269,7 @@ class ProcessTransferJobApplicationTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             to_company=company,
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=job_applications_enums.JobApplicationState.PROCESSING,
         )
         # Forge query
         self.client.force_login(user)
@@ -2281,7 +2283,7 @@ class ProcessTransferJobApplicationTest(TestCase):
 def test_refuse_jobapplication_geiq_reasons(client, reason):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         to_company__kind=CompanyKind.GEIQ,
     )
     assert job_application.state.is_processing
@@ -2306,7 +2308,7 @@ def test_details_for_prescriber_not_can_have_prior_actions(client):
     kind = random.choice(list(set(CompanyKind) - {CompanyKind.GEIQ}))
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         to_company__kind=kind,
     )
     client.force_login(job_application.sender)
@@ -2319,7 +2321,7 @@ def test_details_for_prescriber_not_can_have_prior_actions(client):
 def test_details_for_prescriber_geiq_without_prior_actions(client):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         with_geiq_eligibility_diagnosis_from_prescriber=True,
     )
     prescriber = job_application.sender_prescriber_organization.members.first()
@@ -2336,7 +2338,7 @@ def test_details_for_prescriber_geiq_without_prior_actions(client):
 def test_details_for_prescriber_geiq_with_prior_actions(client):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         with_geiq_eligibility_diagnosis_from_prescriber=True,
     )
     prior_action = PriorActionFactory(
@@ -2360,7 +2362,7 @@ def test_details_for_prescriber_geiq_with_prior_actions(client):
 def test_details_for_jobseeker_geiq_with_prior_actions(client):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         with_geiq_eligibility_diagnosis_from_prescriber=True,
     )
     prior_action = PriorActionFactory(
@@ -2384,7 +2386,7 @@ def test_details_for_jobseeker_geiq_with_prior_actions(client):
 
 def test_accept_button(client):
     job_application = JobApplicationFactory(
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         to_company__kind=CompanyKind.GEIQ,
     )
     accept_url = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
@@ -2430,7 +2432,7 @@ def test_add_prior_action_processing(client, snapshot):
     job_application = JobApplicationFactory(
         for_snapshot=True,
         to_company__kind=CompanyKind.GEIQ,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         created_at=datetime.datetime(2023, 12, 10, 10, 11, 11, tzinfo=datetime.timezone.utc),
     )
     client.force_login(job_application.to_company.members.first())
@@ -2455,7 +2457,7 @@ def test_add_prior_action_processing(client, snapshot):
     assert str(soup) == snapshot
 
     # State is accepted
-    job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
+    job_application.state = job_applications_enums.JobApplicationState.ACCEPTED
     job_application.save(update_fields=("state",))
     response = client.post(
         add_prior_action_url,
@@ -2470,7 +2472,7 @@ def test_add_prior_action_processing(client, snapshot):
 
     # State is processing but company is not a GEIQ
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.AI, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.AI, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     client.force_login(job_application.to_company.members.first())
     response = client.post(
@@ -2487,7 +2489,7 @@ def test_add_prior_action_processing(client, snapshot):
 
 def test_modify_prior_action(client):
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.GEIQ, state=JobApplicationWorkflow.STATE_POSTPONED
+        to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.POSTPONED
     )
     prior_action = PriorActionFactory(
         job_application=job_application, action=job_applications_enums.Prequalification.AFPR
@@ -2513,7 +2515,7 @@ def test_modify_prior_action(client):
     assert prior_action.dates.upper == new_end_date
     assert prior_action.action == job_applications_enums.ProfessionalSituationExperience.PMSMP
 
-    job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
+    job_application.state = job_applications_enums.JobApplicationState.ACCEPTED
     job_application.save(update_fields=("state",))
     response = client.post(
         modify_prior_action_url,
@@ -2530,7 +2532,7 @@ def test_modify_prior_action(client):
 
 def test_delete_prior_action_accepted(client):
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.GEIQ, state=JobApplicationWorkflow.STATE_ACCEPTED
+        to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.ACCEPTED
     )
     prior_action = PriorActionFactory(
         job_application=job_application, action=job_applications_enums.Prequalification.AFPR
@@ -2552,7 +2554,7 @@ def test_delete_prior_action(client, snapshot, with_geiq_diagnosis):
     job_application = JobApplicationFactory(
         for_snapshot=True,
         to_company__kind=CompanyKind.GEIQ,
-        state=JobApplicationWorkflow.STATE_PROCESSING,
+        state=job_applications_enums.JobApplicationState.PROCESSING,
         created_at=datetime.datetime(2023, 12, 10, 10, 11, 11, tzinfo=datetime.timezone.utc),
     )
     prior_action1 = PriorActionFactory(
@@ -2621,7 +2623,7 @@ def test_delete_prior_action(client, snapshot, with_geiq_diagnosis):
 
 def test_htmx_add_prior_action_and_cancel(client):
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.GEIQ, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     client.force_login(job_application.to_company.members.first())
     details_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
@@ -2651,7 +2653,7 @@ def test_htmx_add_prior_action_and_cancel(client):
 
 def test_htmx_modify_prior_action_and_cancel(client):
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.GEIQ, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     prior_action = PriorActionFactory(job_application=job_application)
     client.force_login(job_application.to_company.members.first())
@@ -2700,7 +2702,7 @@ def test_details_for_company_with_prior_action(client, with_geiq_diagnosis):
     response = client.post(reverse("apply:process", kwargs={"job_application_id": job_application.pk}))
     assertRedirects(response, details_url)
     job_application.refresh_from_db()
-    assert job_application.state == JobApplicationWorkflow.STATE_PROCESSING
+    assert job_application.state == job_applications_enums.JobApplicationState.PROCESSING
 
     END_AT_LABEL = "Date de fin prévisionnelle"
     MISSING_FIELD_MESSAGE = "Ce champ est obligatoire"
@@ -2763,7 +2765,7 @@ def test_details_for_company_with_prior_action(client, with_geiq_diagnosis):
     update_page_with_htmx(simulated_page, "#add_prior_action > form", response)
 
     job_application.refresh_from_db()
-    assert job_application.state == JobApplicationWorkflow.STATE_PRIOR_TO_HIRE
+    assert job_application.state == job_applications_enums.JobApplicationState.PRIOR_TO_HIRE
     prior_action = job_application.prior_actions.get()
     assert prior_action.action == job_applications_enums.Prequalification.AFPR
 
@@ -2813,7 +2815,7 @@ def test_precriber_details_with_older_valid_approval(client, faker):
 def test_details_for_geiq_with_inverted_vae_contract(client, inverted_vae_contract, expected_predicate):
     # GEIQ: check that contract type is displayed in details
     job_application = JobApplicationFactory(
-        state=JobApplicationWorkflow.STATE_ACCEPTED,
+        state=job_applications_enums.JobApplicationState.ACCEPTED,
         to_company__kind=CompanyKind.GEIQ,
         contract_type=ContractType.PROFESSIONAL_TRAINING,
         inverted_vae_contract=inverted_vae_contract,
@@ -2928,7 +2930,7 @@ def test_reload_contract_type_and_options_404(client):
 
 def test_htmx_reload_contract_type_and_options(client, snapshot):
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.GEIQ, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     employer = job_application.to_company.members.first()
     client.force_login(employer)
@@ -2976,7 +2978,7 @@ JOB_DETAILS_LABEL = "Préciser le nom du poste (code ROME)"
 def test_select_job_description_for_job_application(client):
     create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.EI, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.EI, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     user = job_application.to_company.members.first()
 
@@ -3014,7 +3016,7 @@ def test_select_other_job_description_for_job_application(client, mocker):
     create_test_cities(["54", "57"], num_per_department=2)
 
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.EI, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.EI, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     user = job_application.to_company.members.first()
     JobDescriptionFactory(company=job_application.to_company, is_active=True)
@@ -3082,7 +3084,7 @@ def test_select_other_job_description_for_job_application(client, mocker):
 def test_no_job_description_for_job_application(client):
     create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
     job_application = JobApplicationFactory(
-        to_company__kind=CompanyKind.EI, state=JobApplicationWorkflow.STATE_PROCESSING
+        to_company__kind=CompanyKind.EI, state=job_applications_enums.JobApplicationState.PROCESSING
     )
     user = job_application.to_company.members.first()
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -22,7 +22,7 @@ from itou.eligibility.models import (
     GEIQAdministrativeCriteria,
     GEIQEligibilityDiagnosis,
 )
-from itou.job_applications.enums import QualificationLevel, QualificationType, SenderKind
+from itou.job_applications.enums import JobApplicationState, QualificationLevel, QualificationType, SenderKind
 from itou.job_applications.models import JobApplication
 from itou.siae_evaluations.models import Sanctions
 from itou.users.enums import LackOfNIRReason, LackOfPoleEmploiId
@@ -456,7 +456,7 @@ class ApplyAsJobSeekerTest(TestCase):
         assert job_application.sender_kind == SenderKind.JOB_SEEKER
         assert job_application.sender_company is None
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_NEW
+        assert job_application.state == JobApplicationState.NEW
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [company.job_description_through.first()]
         assert job_application.resume_link == (
@@ -952,7 +952,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         assert job_application.sender_kind == SenderKind.PRESCRIBER
         assert job_application.sender_company is None
         assert job_application.sender_prescriber_organization == prescriber_organization
-        assert job_application.state == job_application.state.workflow.STATE_NEW
+        assert job_application.state == JobApplicationState.NEW
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [
             company.job_description_through.first(),
@@ -1227,7 +1227,7 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
         assert job_application.sender_kind == SenderKind.PRESCRIBER
         assert job_application.sender_company is None
         assert job_application.sender_prescriber_organization == prescriber_organization
-        assert job_application.state == job_application.state.workflow.STATE_NEW
+        assert job_application.state == JobApplicationState.NEW
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [
             company.job_description_through.first(),
@@ -1570,7 +1570,7 @@ class ApplyAsPrescriberTest(MessagesTestMixin, TestCase):
         assert job_application.sender_kind == SenderKind.PRESCRIBER
         assert job_application.sender_company is None
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_NEW
+        assert job_application.state == JobApplicationState.NEW
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [
             company.job_description_through.first(),
@@ -2035,7 +2035,7 @@ class ApplyAsCompanyTest(TestCase):
         assert job_application.sender_kind == SenderKind.EMPLOYER
         assert job_application.sender_company == company
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_NEW
+        assert job_application.state == JobApplicationState.NEW
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert list(job_application.selected_jobs.all()) == [
             company.job_description_through.first(),
@@ -2370,7 +2370,7 @@ class DirectHireFullProcessTest(TestCase):
         assert job_application.sender_kind == SenderKind.EMPLOYER
         assert job_application.sender_company == company
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_ACCEPTED
+        assert job_application.state == JobApplicationState.ACCEPTED
         assert job_application.message == ""
         assert list(job_application.selected_jobs.all()) == []
         assert job_application.resume_link == ""
@@ -2504,7 +2504,7 @@ class DirectHireFullProcessTest(TestCase):
         assert job_application.sender_kind == SenderKind.EMPLOYER
         assert job_application.sender_company == company
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_ACCEPTED
+        assert job_application.state == JobApplicationState.ACCEPTED
         assert job_application.message == ""
         assert list(job_application.selected_jobs.all()) == []
         assert job_application.resume_link == ""
@@ -4311,7 +4311,7 @@ class HireConfirmationTestCase(TestCase):
         assert job_application.sender_kind == SenderKind.EMPLOYER
         assert job_application.sender_company == self.company
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_ACCEPTED
+        assert job_application.state == JobApplicationState.ACCEPTED
         assert job_application.message == ""
         assert list(job_application.selected_jobs.all()) == []
         assert job_application.resume_link == ""
@@ -4367,7 +4367,7 @@ class HireConfirmationTestCase(TestCase):
         assert job_application.sender_kind == SenderKind.EMPLOYER
         assert job_application.sender_company == self.company
         assert job_application.sender_prescriber_organization is None
-        assert job_application.state == job_application.state.workflow.STATE_ACCEPTED
+        assert job_application.state == JobApplicationState.ACCEPTED
         assert job_application.message == ""
         assert list(job_application.selected_jobs.all()) == []
         assert job_application.resume_link == ""

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -8,8 +8,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertNotContains, assertNumQueries, assertRedirects
 
-from itou.job_applications.enums import SenderKind
-from itou.job_applications.models import JobApplicationWorkflow
+from itou.job_applications.enums import JobApplicationState, SenderKind
 from itou.utils.templatetags.format_filters import format_approval_number
 from tests.approvals.factories import (
     ApprovalFactory,
@@ -37,7 +36,7 @@ class TestApprovalDetailView:
         job_application = JobApplicationFactory(
             approval=approval,
             job_seeker=approval.user,
-            state=JobApplicationWorkflow.STATE_ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             # Make job application.is_sent_by_authorized_prescriber to be true
             sender_kind=SenderKind.PRESCRIBER,
             sender_prescriber_organization=PrescriberOrganizationFactory(authorized=True),
@@ -49,7 +48,7 @@ class TestApprovalDetailView:
         same_siae_job_application = JobApplicationSentByPrescriberOrganizationFactory(
             job_seeker=job_application.job_seeker,
             to_company=job_application.to_company,
-            state=JobApplicationWorkflow.STATE_NEW,
+            state=JobApplicationState.NEW,
         )
         assert not same_siae_job_application.is_sent_by_authorized_prescriber
         # A third job application on another SIAE
@@ -100,7 +99,7 @@ class TestApprovalDetailView:
         Test its content only once.
         """
         job_application = JobApplicationFactory(
-            state=JobApplicationWorkflow.STATE_PROCESSING,
+            state=JobApplicationState.PROCESSING,
             with_approval=True,
             approval__id=1,
             sent_by_authorized_prescriber_organisation=True,
@@ -157,7 +156,7 @@ class TestApprovalDetailView:
             "Date de fin prévisionnelle : 24/04/2025",
         )
 
-        job_application.state = JobApplicationWorkflow.STATE_ACCEPTED
+        job_application.state = JobApplicationState.ACCEPTED
         job_application.save()
         response = client.get(url)
         assertNotContains(

--- a/tests/www/approvals_views/test_pe_approval.py
+++ b/tests/www/approvals_views/test_pe_approval.py
@@ -5,7 +5,6 @@ from django.urls import reverse, reverse_lazy
 from itou.approvals import enums as approvals_enums
 from itou.approvals.models import Approval
 from itou.job_applications import enums as job_applications_enums
-from itou.job_applications.models import JobApplicationWorkflow
 from itou.users.models import User
 from tests.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
@@ -100,7 +99,7 @@ class PoleEmploiApprovalSearchTest(MessagesTestMixin, TestCase):
         """
         self.set_up_pe_approval(with_job_application=True)
         ja = self.job_seeker.job_applications.first()
-        ja.state = JobApplicationWorkflow.STATE_CANCELLED
+        ja.state = job_applications_enums.JobApplicationState.CANCELLED
         ja.save()
 
         self.client.force_login(self.employer)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ne pas donner le nom de l’employeur ayant réalisé l’embauche aux autres employeurs.

## :computer: Captures d'écran <!-- optionnel -->
### Avant
![Screenshot from 2024-04-09 10-03-56](https://github.com/gip-inclusion/les-emplois/assets/2758243/4b7cdeb9-66e9-4eba-8246-7844707f22e0)

### Après
![Screenshot from 2024-04-09 10-03-19](https://github.com/gip-inclusion/les-emplois/assets/2758243/55051dfc-e5bf-469c-9944-12867dad0e32)


## :desert_island: Comment tester

1. Se connecter en tant que EI Garage Martinet
2. Au siège, enregistrer une candidature pour un nouveau candidat
3. Garage Nord, enregistrer une candidature pour le même candidat
4. Embaucher le candidat au garage Nord
5. Accéder à l’historique de candidatures du siège
6. Filtrer par status embaucher ailleurs
7. Accéder à la page de détail de la candidature
8. Dans la section historique, le nom de l’employeur ayant réalisé l’embauche n’est pas affiché
