### PR TITLE
E-mails : Indiquer le type d’organisation prescriptrice dans les demandes d’habilitation [GEN-279]

### DIFF
--- a/itou/templates/prescribers/email/must_validate_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/must_validate_prescriber_organization_email_body.txt
@@ -8,6 +8,7 @@ Une nouvelle organisation de prescripteur a été créée. L'habilitation de cet
 
 - Nom : {{ organization.display_name }}
 - ID : {{ organization.id }}
+- Type sélectionné par l’utilisateur : {{ organization.get_kind_display }}
 
 {{ itou_protocol }}://{{ itou_fqdn }}{% url 'admin:prescribers_prescriberorganization_change' organization.id %}
 

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -295,9 +295,11 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         assert membership.is_admin
 
         # Check email has been sent to support (validation/refusal of authorisation needed).
-        assert len(mail.outbox) == 1
-        subject = mail.outbox[0].subject
-        assert "Vérification de l'habilitation d'une nouvelle organisation" in subject
+        [email] = mail.outbox
+        assert "Vérification de l'habilitation d'une nouvelle organisation" in email.subject
+        body_lines = email.body.splitlines()
+        assert "- Nom : CENTRE COMMUNAL D'ACTION SOCIALE" in body_lines
+        assert f"- ID : {org.pk}" in body_lines
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -300,6 +300,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         body_lines = email.body.splitlines()
         assert "- Nom : CENTRE COMMUNAL D'ACTION SOCIALE" in body_lines
         assert f"- ID : {org.pk}" in body_lines
+        assert "- Type sélectionné par l’utilisateur : Cap emploi" in body_lines
 
     @respx.mock
     @mock.patch("itou.utils.apis.geocoding.call_ban_geocoding_api", return_value=BAN_GEOCODING_API_RESULT_MOCK)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter la vie du support

## :desert_island: Comment tester

1. Démarrer un serveur de dev inclusion-connect
2. Appliquer le patch suivant :
   ```diff
   diff --git a/itou/utils/apis/api_entreprise.py b/itou/utils/apis/api_entreprise.py
   index 30b2ed7a4..24c54893a 100644
   --- a/itou/utils/apis/api_entreprise.py
   +++ b/itou/utils/apis/api_entreprise.py
   @@ -45,6 +45,17 @@ def etablissement_get_or_error(siret):
        Return a tuple (etablissement, error) where error is None on success.
        https://www.sirene.fr/static-resources/htm/siret_unitaire_variables_reponse.html
        """
   +    etablissement = Etablissement(
   +        name="Cap emploi",
   +        address_line_1="12 rue chez moi",
   +        address_line_2="",
   +        post_code="68000",
   +        city="Colmar",
   +        department="68",
   +        is_closed=False,
   +        is_head_office=True,
   +    )
   +    return etablissement, None

        access_token = get_access_token()
        if not access_token:
   ```
3. S’inscrire en tant que prescripteur
4. SIRET organisation : 39782034941111, code postal : 68000 (détails : http://localhost:8000/admin/prescribers/prescriberorganization/38/change/)
4. Choisir le type “Cap emploi”
5. S’inscrire sur inclusion-connect
6. Au retour sur les emplois, regarder la console du `runserver` des emplois
7. La mention - Type sélectionné par l’utilisateur : Cap emploi doit être présente dans le mail envoyé au support (`To: assistance@inclusion.beta.gouv.fr`)
