### PR TITLE
Recherche employeur : Afficher le bouton “Postuler” sur la carte entreprise [GEN-238]

### DIFF
--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -49,6 +49,23 @@
             </div>
         </div>
     </div>
+    {% if siae.active_job_descriptions %}
+        <div class="d-none matomo-PostulerEmployeurAvecMetier">
+            <hr class="m-0">
+            <div class="c-box--results__body">
+                <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
+                    <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
+                    <a class="btn btn-ico btn-primary"
+                       href="{% url 'apply:start' company_pk=siae.pk %}"
+                       {% matomo_event "candidature" "clic" "start_application" %}
+                       aria-label="Postuler auprès de l'employeur solidaire {{ siae.display_name }}">
+                        <i class="ri ri-draft-line" aria-hidden="true"></i>
+                        <span>Postuler</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    {% endif %}
     <hr class="m-0">
 
     {% if not siae.has_active_members %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -94,4 +94,33 @@
             $("#search-form").submit();
         });
     </script>
+    {# A / B testing: apply to company with job descriptions #}
+    <script nonce="{{ CSP_NONCE }}">
+        var _paq = _paq || [];
+        _paq.push(['AbTesting::create', {
+            name: 'PostulerEmployeurAvecMetier',
+            percentage: 100,
+            includedTargets: [{
+                "attribute": "path",
+                "inverted": "0",
+                "type": "starts_with",
+                "value": "\/search\/employers\/results"
+            }],
+            excludedTargets: [],
+            variations: [{
+                name: 'original',
+                activate: function() {}
+            }, {
+                name: 'apply-employer',
+                percentage: 50,
+                activate: function() {
+                    document.getElementsByClassName("matomo-PostulerEmployeurAvecMetier")
+                        .forEach((elt) => {
+                            elt.classList.remove("d-none")
+                        });
+                }
+            }],
+            trigger: () => document.getElementsByClassName("matomo-PostulerEmployeurAvecMetier").length,
+        }]);
+    </script>
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter la candidature.

## :cake: Comment ? <!-- optionnel -->

Vérification de la pertinence de l’expérimentation via une campagne A/B testing Matomo.
https://matomo.inclusion.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=117&period=day&date=yesterday#?period=day&date=yesterday&category=AbTesting_Experiments&subcategory=AbTesting_ManageExperiments&idExperiment=6

## :computer: Captures d'écran <!-- optionnel -->
### Avant
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/375c9453-c6a1-4d48-be12-d69b76d4a9c2)

### Après
![2024-04-09_11-44](https://github.com/gip-inclusion/les-emplois/assets/2758243/c6bf7e8f-f3e3-472e-b223-38bdbd0fed72)

## :desert_island: Comment tester

1. Rechercher un employeur
2. Si matomo est configuré, une fois sur deux le bouton sera visible. Autrement, retirer la classe `d-none` de l’élément dans le template.
