### PR TITLE
Retirer JobSeekerProfile.previous_employer_kind de la base de données

### DIFF
--- a/itou/users/migrations/0003_remove_jobseekerprofile_previous_employer_kind_from_db.py
+++ b/itou/users/migrations/0003_remove_jobseekerprofile_previous_employer_kind_from_db.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0002_remove_jobseekerprofile_previous_employer_kind"),
+    ]
+
+    operations = [
+        migrations.RunSQL("ALTER TABLE users_jobseekerprofile DROP COLUMN previous_employer_kind"),
+    ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Non utilisée.
