### PR TITLE
Retirer des références restantes à master_clever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: 🔮 CI
 
-on:
-  push:
-    branches-ignore:
-      - master_clever
+on: [push]
 
 jobs:
   build:

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -34,9 +34,8 @@ clever service link-addon c1-prod-database-encrypted --alias "$APP_NAME"
 clever service link-addon c1-redis --alias "$APP_NAME"
 clever service link-addon c1-s3 --alias "$APP_NAME"
 
-# Ensure we've got the last version of master_clever
 git fetch
-clever deploy --alias "$APP_NAME" --branch origin/master_clever --force
+clever deploy --alias "$APP_NAME" --branch origin/master --force
 
 cat << EOF
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

`master_clever` n’existe plus depuis 4068a0c9d820d58b8f972a2003bb4cd4aa066a91.
