### PR TITLE
Pack de motifs de refus

### DIFF
--- a/itou/job_applications/enums.py
+++ b/itou/job_applications/enums.py
@@ -45,7 +45,7 @@ class RefusalReason(models.TextChoices):
     )
     NO_POSITION = "no_position", "Pas de recrutement en cours"
     DUPLICATE = "duplicate", "Candidature en doublon"
-    OTHER = "other", "Autre (détails dans le message ci-dessous)"
+    OTHER = "other", "Autre"
 
     # Hidden reasons kept for history.
     APPROVAL_EXPIRATION_TOO_CLOSE = (

--- a/itou/job_applications/migrations/0001_initial.py
+++ b/itou/job_applications/migrations/0001_initial.py
@@ -129,7 +129,7 @@ class Migration(migrations.Migration):
                             ),
                             ("no_position", "Pas de recrutement en cours"),
                             ("duplicate", "Candidature en doublon"),
-                            ("other", "Autre (détails dans le message ci-dessous)"),
+                            ("other", "Autre"),
                             ("approval_expiration_too_close", "La date de fin du PASS IAE / agrément est trop proche"),
                             ("unavailable", "Candidat indisponible ou non intéressé par le poste"),
                             (

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -79,6 +79,12 @@ class JobApplicationWorkflow(xwf_models.Workflow):
         JobApplicationState.CANCELLED,
     ]
     CAN_BE_TRANSFERRED_STATES = CAN_BE_ACCEPTED_STATES
+    CAN_BE_REFUSED_STATES = [
+        JobApplicationState.NEW,
+        JobApplicationState.PROCESSING,
+        JobApplicationState.PRIOR_TO_HIRE,
+        JobApplicationState.POSTPONED,
+    ]
     CAN_ADD_PRIOR_ACTION_STATES = [
         JobApplicationState.PROCESSING,
         JobApplicationState.POSTPONED,
@@ -97,16 +103,7 @@ class JobApplicationWorkflow(xwf_models.Workflow):
         (TRANSITION_ACCEPT, CAN_BE_ACCEPTED_STATES, JobApplicationState.ACCEPTED),
         (TRANSITION_MOVE_TO_PRIOR_TO_HIRE, CAN_ADD_PRIOR_ACTION_STATES, JobApplicationState.PRIOR_TO_HIRE),
         (TRANSITION_CANCEL_PRIOR_TO_HIRE, [JobApplicationState.PRIOR_TO_HIRE], JobApplicationState.PROCESSING),
-        (
-            TRANSITION_REFUSE,
-            [
-                JobApplicationState.NEW,
-                JobApplicationState.PROCESSING,
-                JobApplicationState.PRIOR_TO_HIRE,
-                JobApplicationState.POSTPONED,
-            ],
-            JobApplicationState.REFUSED,
-        ),
+        (TRANSITION_REFUSE, CAN_BE_REFUSED_STATES, JobApplicationState.REFUSED),
         (TRANSITION_CANCEL, JobApplicationState.ACCEPTED, JobApplicationState.CANCELLED),
         (
             TRANSITION_RENDER_OBSOLETE,

--- a/itou/templates/apply/includes/buttons/refuse.html
+++ b/itou/templates/apply/includes/buttons/refuse.html
@@ -1,5 +1,5 @@
 {% load matomo %}
-<a href="{% url 'apply:refuse' job_application_id=job_application.id %}" class="btn btn-lg btn-outline-white btn-block btn-ico" {% matomo_event "candidature" "clic" "refuse_application" %}>
+<a href="{% url 'apply:refuse' job_application_id=job_application.id step='reason' %}" class="btn btn-lg btn-outline-white btn-block btn-ico" {% matomo_event "candidature" "clic" "refuse_application" %}>
     <i class="ri-close-line font-weight-medium" aria-hidden="true"></i>
     <span>Décliner</span>
 </a>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -1,72 +1,142 @@
 {% extends "apply/process_base.html" %}
 {% load django_bootstrap5 %}
+{% load theme_inclusion %}
 {% load buttons_form %}
 
-{% block content_extend %}
-    <div class="c-form">
-        <h2>Renseigner le motif de refus de candidature.</h2>
-        <form method="post" class="js-prevent-multiple-submit">
+{% block content_title %}
+    <div class="d-md-flex align-items-center mb-3">
+        <h1 class="mb-1 mb-md-0 me-3">
+            Refuser la candidature de <span class="text-muted">{{ job_application.job_seeker.get_full_name }}</span>
+        </h1>
+    </div>
+{% endblock %}
 
-            {% csrf_token %}
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="row">
+                <div class="col-12 col-lg-8">
+                    <div class="c-stepper mb-3 mb-lg-5">
+                        <div class="progress progress--emploi">
+                            <div class="progress-bar progress-bar-{{ wizard|stepper_progress }}" role="progressbar" aria-valuenow="{{ wizard|stepper_progress }}" aria-valuemin="0" aria-valuemax="100">
+                            </div>
+                        </div>
+                        <p>
+                            {% if wizard.steps.current == "reason" %}
+                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Choix du motif de refus
+                            {% elif wizard.steps.current == "job-seeker-answer" %}
+                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Message au candidat
+                            {% elif wizard.steps.current == "prescriber-answer" %}
+                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Message au prescripteur
+                            {% endif %}
+                        </p>
+                    </div>
+                    <div class="c-form mb-3 mb-lg-5">
+                        <form method="post" class="js-prevent-multiple-submit">
+                            {% csrf_token %}
+                            {{ wizard.management_form }}
 
-            {% bootstrap_form_errors form type="all" %}
+                            {% if wizard.steps.current == "reason" %}
+                                <h2 class="mb-3 mb-md-4">Choix du motif de refus</h2>
+                                <p class="mb-3 mb-md-4">
+                                    {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
+                                        Dans le cadre d’un parcours IAE, la transparence sur les motifs de refus est importante pour le candidat comme pour le prescripteur. Nous vous encourageons à répondre à chacune des parties.
+                                    {% else %}
+                                        Dans le cadre d’un parcours IAE, la transparence sur les motifs de refus est importante pour le candidat.
+                                    {% endif %}
+                                </p>
+                            {% elif wizard.steps.current == "job-seeker-answer" %}
+                                <h2 class="mb-3 mb-md-4">Réponse au candidat</h2>
+                                <p class="mb-3 mb-md-4">
+                                    {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
+                                        Une copie de ce message sera adressée au prescripteur.
+                                        <br>
+                                    {% endif %}
+                                    Merci de bien vouloir adapter ce message en fonction de la situation.
+                                </p>
+                                <p class="mb-3 mb-md-4">
+                                    <strong>Raison du refus :</strong> {{ refusal_reason_label }}
+                                </p>
+                            {% elif wizard.steps.current == "prescriber-answer" %}
+                                <h2 class="mb-3 mb-md-4">Réponse au prescripteur</h2>
+                                <p class="mb-3 mb-md-4">
+                                    Vous pouvez partager un message au prescripteur uniquement, comme détailler ou évoquer d’autres motifs de refus.
+                                </p>
+                                <p class="mb-3 mb-md-4">
+                                    <strong>Raison du refus :</strong> {{ refusal_reason_label }}
+                                </p>
+                            {% endif %}
 
-            {# TODO: Fix incorrect rendering of form with radio buttons #}
-            {# https://github.com/zostera/django-django_bootstrap5/issues/126 #}
-            <div class="form-group{% if form.refusal_reason.field.required %} form-group-required{% endif %} js-refusal-reasons">
-                {{ form.refusal_reason.label_tag }}
-                <ul class="list-unstyled">
-                    {% for radio in form.refusal_reason %}
-                        <li>
-                            <label for="{{ radio.id_for_label }}">
-                                {{ radio.tag }}
-                                {% if radio.data.value == RefusalReason.PREVENT_OBJECTIVES %}
-                                    {{ radio.choice_label }}&nbsp;<i class="ri-information-line ri-xl text-button ms-1"
-   data-bs-toggle="tooltip"
-   data-bs-placement="top"
-   title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
-                                {% elif radio.data.value == RefusalReason.NO_POSITION %}
-                                    {{ radio.choice_label }}&nbsp;<i class="ri-information-line ri-xl text-button ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
+                            {% if wizard.steps.current == "reason" %}
+                                <fieldset class="js-refusal-reasons form-group{% if form.refusal_reason.field.required %} form-group-required{% endif %}">
+                                    {{ form.refusal_reason.label_tag }}
+                                    <ul class="list-unstyled">
+                                        {% for radio in form.refusal_reason %}
+                                            <li class="mb-2">
+                                                <div class="form-check">
+                                                    <input id="{{ radio.id_for_label }}" class="form-check-input" name="{{ radio.data.name }}" type="radio" value="{{ radio.data.value }}" {% if radio.data.selected %}checked=""{% endif %} required>
+                                                    <label for="{{ radio.id_for_label }}" class="form-check-label">
+                                                        {% if radio.data.value == RefusalReason.PREVENT_OBJECTIVES %}
+                                                            {{ radio.choice_label }}
+                                                            <i class="ri-information-line ri-lg text-info ms-1"
+                                                               data-bs-toggle="tooltip"
+                                                               data-bs-placement="top"
+                                                               title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
+                                                        {% elif radio.data.value == RefusalReason.NO_POSITION %}
+                                                            {{ radio.choice_label }}
+                                                            <i class="ri-information-line ri-lg text-info ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
+                                                        {% elif radio.data.value == RefusalReason.OTHER %}
+                                                            {{ radio.choice_label }}
+                                                            {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
+                                                                (détails à fournir dans le message au prescripteur)
+                                                            {% endif %}
+                                                        {% else %}
+                                                            {{ radio.choice_label }}
+                                                        {% endif %}
+                                                    </label>
+                                                </div>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                    <div class="c-info refusal-reason-no-position-info mt-2 d-none">
+                                        <span class="c-info__summary">En choisissant ce motif, les fiches de postes associées seront dépubliées.</span>
+                                    </div>
+                                </fieldset>
+                            {% else %}
+                                {% bootstrap_form wizard.form alert_error_type="non_fields" %}
+                            {% endif %}
 
-                                {% else %}
-                                    {{ radio.choice_label }}
-                                {% endif %}
-                            </label>
-                        </li>
-                    {% endfor %}
-                </ul>
-                <div class="c-info refusal-reason-no-position-info d-none">
-                    <span class="c-info__summary">En choisissant ce motif, les fiches de postes associées seront dépubliées.</span>
+                            {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
+                            {% if wizard.steps.prev %}
+                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" secondary_url=wizard.steps.prev matomo_category="candidature" matomo_action="submit" matomo_event="refuse_application_submit" %}
+                            {% else %}
+                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" matomo_category="candidature" matomo_action="submit" matomo_event="refuse_application_submit" %}
+                            {% endif %}
+                        </form>
+                    </div>
                 </div>
             </div>
-
-            {% if form.answer_to_prescriber %}
-                {% bootstrap_field form.answer_to_prescriber %}
-            {% endif %}
-
-            <hr>
-            <h2>Répondre au candidat</h2>
-
-            {% bootstrap_field form.answer %}
-
-            {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
-            {% itou_buttons_form primary_label="Confirmer le refus" reset_url=reset_url matomo_category="candidature" matomo_action="submit" matomo_event="refuse_application_submit" %}
-
-        </form>
-    </div>
+        </div>
+    </section>
 {% endblock %}
 
 {% block script %}
     {{ block.super }}
-    <script nonce="{{ CSP_NONCE }}">
-        $(document).ready(function() {
-            $('input[name="refusal_reason"]').change(function() {
-                if (this.value === 'no_position') {
+    {% if wizard.steps.current == "reason" %}
+        <script nonce="{{ CSP_NONCE }}">
+            function manageWarningSection(value) {
+                if (value === 'no_position') {
                     $('.refusal-reason-no-position-info').removeClass('d-none');
                 } else {
                     $('.refusal-reason-no-position-info').addClass('d-none');
                 }
+            }
+            $(document).ready(function() {
+                manageWarningSection($('input[name="reason-refusal_reason"]:checked').val());
+                $('input[name="reason-refusal_reason"]').change(function() {
+                    manageWarningSection(this.value);
+                });
             });
-        });
-    </script>
+        </script>
+    {% endif %}
 {% endblock %}

--- a/itou/templates/apply/refusal_messages/did_not_come.txt
+++ b/itou/templates/apply/refusal_messages/did_not_come.txt
@@ -1,0 +1,7 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention et souhaitions vous retenir sur le poste. Malheureusement, nous avons tenté de vous joindre à plusieurs reprises sans succès par mail et par téléphone. Je vous invite à nous recontacter ou à renvoyer votre candidature avec vos coordonnées actualisées au cas où nous n’ayons pas clôturé notre recrutement.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/did_not_come_to_interview.txt
+++ b/itou/templates/apply/refusal_messages/did_not_come_to_interview.txt
@@ -1,0 +1,15 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention mais nous sommes au regret de vous informer que celle-ci n'a pas été retenue.
+
+Comme convenu communément, vous étiez donc invité à vous rendre à votre entretien d’embauche dans nos locaux.
+
+Malheureusement, vous n’êtes pas venu à ce RDV sans avertir de votre indisponibilité.
+
+C’est pourquoi nous considérons que vous n’êtes pas disponible pour cet emploi.
+
+Nous vous souhaitons une pleine réussite dans vos recherches futures.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/duplicate.txt
+++ b/itou/templates/apply/refusal_messages/duplicate.txt
@@ -1,0 +1,11 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention.
+
+Nous avons déjà reçu votre candidature précédemment.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, et reviendrons vers vous prochainement si le besoin se confirme dans notre entreprise.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/hired_elsewhere.txt
+++ b/itou/templates/apply/refusal_messages/hired_elsewhere.txt
@@ -1,0 +1,9 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention mais nous sommes au regret de vous informer que celle-ci n'a pas été retenue.
+
+Malheureusement, vous nous indiquez être en poste et ne pas être disponible actuellement.
+
+Nous sommes très sensibles à l'intérêt que vous avez porté à notre entreprise lors de votre dépôt de candidature et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Nous vous souhaitons une pleine réussite dans votre emploi.

--- a/itou/templates/apply/refusal_messages/incompatible.txt
+++ b/itou/templates/apply/refusal_messages/incompatible.txt
@@ -1,0 +1,15 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention.
+
+Malheureusement, un des freins à l'emploi que vous mentionnez est incompatible avec le poste sur lequel vous avez postulé dans notre établissement.
+
+Soyez assuré que cette décision ne met pas en cause vos qualités personnelles.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat
+
+Pour information, voici un moteur de recherche susceptible de vous intéresser : https://dora.fabrique.social.gouv.fr/

--- a/itou/templates/apply/refusal_messages/lacking_skills.txt
+++ b/itou/templates/apply/refusal_messages/lacking_skills.txt
@@ -1,0 +1,13 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention.
+
+Malheureusement, vous n’avez pas les compétences requises pour le poste sur lequel vous avez postulé dans notre établissement.
+
+Soyez assuré que cette décision ne met pas en cause vos qualités personnelles.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/no_position.txt
+++ b/itou/templates/apply/refusal_messages/no_position.txt
@@ -1,0 +1,11 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention.
+
+Malheureusement, nous n’avons pas de recrutement en cours actuellement.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/non_eligible.txt
+++ b/itou/templates/apply/refusal_messages/non_eligible.txt
@@ -1,0 +1,18 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention mais nous sommes au regret de vous informer que celle-ci n'a pas été retenue.
+{% if job_application.to_company.is_subject_to_eligibility_rules %}
+Malheureusement, sauf erreur de notre part, vous n’êtes pas éligible à l’IAE.
+
+Le diagnostic d’éligibilité IAE a une durée de validité de 6 mois. Nous vous invitons à vous rapprocher d’un prescripteur habilité avec qui vous pourrez renvoyer une nouvelle candidature avec un nouveau diagnostic d’éligibilité IAE pour 6 mois. Voici la liste des des prescripteurs habilités :
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733442624657
+{% else %}
+Malheureusement, sauf erreur de notre part, vous n’êtes pas éligible au dispositif.
+
+Nous vous invitons à vous rapprocher d’un prescripteur habilité afin qu’il puisse vous accompagner dans vos démarches.
+{% endif %}
+Vous pouvez chercher directement un prescripteur habilité de votre territoire : https://emplois.inclusion.beta.gouv.fr/search/prescribers
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise et vous invitons à nous recontacter lorsque vous serez éligible.
+
+Nous vous souhaitons une pleine réussite dans vos démarches de recherche d’emploi.

--- a/itou/templates/apply/refusal_messages/not_interested.txt
+++ b/itou/templates/apply/refusal_messages/not_interested.txt
@@ -1,0 +1,13 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention mais nous sommes au regret de vous informer que celle-ci n'a pas été retenue.
+
+Malheureusement, après avoir pris contact avec vous, vous nous indiquez ne plus être intéressé par le poste.
+
+Nous sommes très sensibles à l'intérêt que vous avez porté à notre entreprise lors de votre dépôt de candidature.
+
+Nous vous souhaitons une pleine réussite dans votre recherche d’emploi.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/not_mobile.txt
+++ b/itou/templates/apply/refusal_messages/not_mobile.txt
@@ -1,0 +1,13 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention.
+
+Malheureusement, votre mobilité n’est pas opérationnelle à ce jour et elle est indispensable sur le poste sur lequel vous avez postulé dans notre établissement.
+
+Soyez assuré que cette décision ne met pas en cause vos qualités personnelles.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Pour information, voici un moteur de recherche susceptible de vous intéresser dans votre besoin d’aide à la mobilité : https://dora.inclusion.beta.gouv.fr/recherche?cats=mobilite (Renseigner votre adresse dans le moteur de recherche pour trouver les services près de chez vous).
+
+Un tutoriel est disponible si besoin : https://aide.dora.inclusion.beta.gouv.fr/fr/article/effectuer-une-recherche-par-lieu-ville-1wyr8yd/

--- a/itou/templates/apply/refusal_messages/prevent_objectives.txt
+++ b/itou/templates/apply/refusal_messages/prevent_objectives.txt
@@ -1,0 +1,13 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention.
+
+Malheureusement, cette embauche est incompatible avec le poste sur lequel vous avez postulé dans notre établissement.
+
+Soyez assuré que cette décision ne met pas en cause vos qualités personnelles.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Pour information, voici le mode d’emploi pour envoyer d’autres candidatures à des employeurs :
+
+https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/16920193628177--Postuler-en-tant-que-candidat

--- a/itou/templates/apply/refusal_messages/training.txt
+++ b/itou/templates/apply/refusal_messages/training.txt
@@ -1,0 +1,9 @@
+Bonjour,
+
+Nous avons étudié votre candidature avec la plus grande attention mais nous sommes au regret de vous informer que celle-ci n'a pas été retenue.
+
+Malheureusement, vous nous indiquez ne pas être disponible actuellement car en formation professionnelle.
+
+Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise et conservons vos coordonnées afin de vous recontacter au besoin.
+
+Nous vous souhaitons une pleine réussite dans votre formation.

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -368,37 +368,17 @@ class SubmitJobApplicationForm(forms.Form):
         message.help_text = help_text
 
 
-class RefusalForm(forms.Form):
-    ANSWER_INITIAL = (
-        "Nous avons étudié votre candidature avec la plus grande attention mais "
-        "nous sommes au regret de vous informer que celle-ci n'a pas été retenue.\n\n"
-        "Soyez assuré que cette décision ne met pas en cause vos qualités personnelles. "
-        "Nous sommes très sensibles à l'intérêt que vous portez à notre entreprise, "
-        "et conservons vos coordonnées afin de vous recontacter au besoin.\n\n"
-        "Nous vous souhaitons une pleine réussite dans vos recherches futures."
-    )
-
+class JobApplicationRefusalReasonForm(forms.Form):
     refusal_reason = forms.ChoiceField(
-        label="Sélectionner un motif de refus (n'est pas envoyé au candidat)",
+        label="Choisir le motif de refus",
         widget=forms.RadioSelect,
         choices=job_applications_enums.RefusalReason.displayed_choices(),
-    )
-    answer = forms.CharField(
-        label="Message à envoyer au candidat (une copie sera envoyée au prescripteur)",
-        widget=forms.Textarea(),
-        strip=True,
-        initial=ANSWER_INITIAL,
-        help_text="Vous pouvez modifier le texte proposé ou l'utiliser tel quel.",
-    )
-    answer_to_prescriber = forms.CharField(
-        label="Commentaire privé à destination du prescripteur (n'est pas envoyé au candidat)",
-        widget=forms.Textarea(attrs={"placeholder": ""}),
-        strip=True,
-        required=False,
     )
 
     def __init__(self, job_application, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if job_application.sender_kind == job_applications_enums.SenderKind.PRESCRIBER:
+            self.fields["refusal_reason"].label = "Choisir le motif de refus envoyé au prescripteur"
         if job_application.to_company.kind == CompanyKind.GEIQ:
             self.fields["refusal_reason"].choices = job_applications_enums.RefusalReason.displayed_choices(
                 extra_exclude_enums=[
@@ -407,9 +387,21 @@ class RefusalForm(forms.Form):
                 ]
             )
 
-        if job_application.sender_kind != job_applications_enums.SenderKind.PRESCRIBER:
-            self.fields.pop("answer_to_prescriber")
-            self.fields["answer"].label = "Message à envoyer au candidat"
+
+class JobApplicationRefusalJobSeekerAnswerForm(forms.Form):
+    job_seeker_answer = forms.CharField(
+        label="Commentaire envoyé au candidat",
+        widget=forms.Textarea(),
+        strip=True,
+    )
+
+
+class JobApplicationRefusalPrescriberAnswerForm(forms.Form):
+    prescriber_answer = forms.CharField(
+        label="Commentaire envoyé au prescripteur (n’est pas envoyé au candidat)",
+        widget=forms.Textarea(),
+        strip=True,
+    )
 
 
 class AnswerForm(forms.Form):

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -245,7 +245,16 @@ urlpatterns = [
         process_views.geiq_eligibility_criteria,
         name="geiq_eligibility_criteria",
     ),
-    path("<uuid:job_application_id>/siae/refuse", process_views.refuse, name="refuse"),
+    path(
+        "<uuid:job_application_id>/siae/refuse",
+        process_views.JobApplicationRefuseView.as_view(url_name="refuse"),
+        name="refuse",
+    ),
+    path(
+        "<uuid:job_application_id>/siae/refuse/<slug:step>",
+        process_views.JobApplicationRefuseView.as_view(url_name="refuse"),
+        name="refuse",
+    ),
     path("<uuid:job_application_id>/siae/postpone", process_views.postpone, name="postpone"),
     path("<uuid:job_application_id>/siae/accept", process_views.accept, name="accept"),
     path("<uuid:job_application_id>/siae/cancel", process_views.cancel, name="cancel"),

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -12,16 +13,24 @@ from django.utils.http import urlencode
 from django.views.decorators.http import require_POST
 from django.views.generic.base import TemplateView
 from django_xworkflows import models as xwf_models
+from formtools.wizard.views import NamedUrlSessionWizardView
 
 from itou.companies.enums import CompanyKind, ContractType
 from itou.companies.models import Company
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
-from itou.job_applications.enums import JobApplicationState
+from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow, PriorAction
 from itou.utils.perms.prescriber import get_all_available_job_applications_as_prescriber
 from itou.utils.urls import get_safe_url
-from itou.www.apply.forms import AcceptForm, AnswerForm, PriorActionForm, RefusalForm
+from itou.www.apply.forms import (
+    AcceptForm,
+    AnswerForm,
+    JobApplicationRefusalJobSeekerAnswerForm,
+    JobApplicationRefusalPrescriberAnswerForm,
+    JobApplicationRefusalReasonForm,
+    PriorActionForm,
+)
 from itou.www.apply.views import common as common_views, constants as apply_view_constants
 
 
@@ -239,37 +248,128 @@ def process(request, job_application_id):
     return HttpResponseRedirect(next_url)
 
 
-@login_required
-def refuse(request, job_application_id, template_name="apply/process_refuse.html"):
-    queryset = JobApplication.objects.is_active_company_member(request.user).select_related("job_seeker")
-    job_application = get_object_or_404(queryset, id=job_application_id)
+def _show_prescriber_answer_form(wizard):
+    return wizard.job_application.sender_kind == job_applications_enums.SenderKind.PRESCRIBER
 
-    form = RefusalForm(job_application=job_application, data=request.POST or None)
 
-    if request.method == "POST" and form.is_valid():
+class JobApplicationRefuseView(LoginRequiredMixin, NamedUrlSessionWizardView):
+    STEP_REASON = "reason"
+    STEP_JOB_SEEKER_ANSWER = "job-seeker-answer"
+    STEP_PRESCRIBER_ANSWER = "prescriber-answer"
+
+    template_name = "apply/process_refuse.html"
+    form_list = [
+        (STEP_REASON, JobApplicationRefusalReasonForm),
+        (STEP_JOB_SEEKER_ANSWER, JobApplicationRefusalJobSeekerAnswerForm),
+        (STEP_PRESCRIBER_ANSWER, JobApplicationRefusalPrescriberAnswerForm),
+    ]
+    condition_dict = {
+        STEP_PRESCRIBER_ANSWER: _show_prescriber_answer_form,
+    }
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+
+        if request.user.is_authenticated:
+            self.job_application = get_object_or_404(
+                JobApplication.objects.is_active_company_member(request.user).select_related("job_seeker"),
+                pk=kwargs["job_application_id"],
+            )
+
+    def check_wizard_state(self, *args, **kwargs):
+        # Redirect to job application details if the state is not refusable
+        if self.job_application.state not in JobApplicationWorkflow.CAN_BE_REFUSED_STATES:
+            message = "Action déjà effectuée." if self.job_application.state.is_refused else "Action impossible."
+            messages.error(self.request, message, extra_tags="toast")
+            return HttpResponseRedirect(
+                reverse("apply:details_for_company", kwargs={"job_application_id": self.job_application.pk})
+            )
+
+        # Redirect to first step if form data is not retrieved in session (eg. direct url access)
+        if kwargs.get("step") in [
+            self.STEP_JOB_SEEKER_ANSWER,
+            self.STEP_PRESCRIBER_ANSWER,
+        ] and not self.get_cleaned_data_for_step(self.STEP_REASON):
+            return HttpResponseRedirect(self.get_step_url(self.STEP_REASON))
+
+    def get(self, *args, **kwargs):
+        if check_response := self.check_wizard_state(*args, **kwargs):
+            return check_response
+        return super().get(*args, **kwargs)
+
+    def post(self, *args, **kwargs):
+        if check_response := self.check_wizard_state(*args, **kwargs):
+            return check_response
+        return super().post(*args, **kwargs)
+
+    def done(self, form_list, *args, **kwargs):
         try:
             # After each successful transition, a save() is performed by django-xworkflows.
-            job_application.refusal_reason = form.cleaned_data["refusal_reason"]
-            job_application.answer = form.cleaned_data["answer"]
-            job_application.answer_to_prescriber = form.cleaned_data.get("answer_to_prescriber", "")
-            job_application.refuse(user=request.user)
+            cleaned_data = self.get_all_cleaned_data()
+            self.job_application.refusal_reason = cleaned_data["refusal_reason"]
+            self.job_application.answer = cleaned_data["job_seeker_answer"]
+            self.job_application.answer_to_prescriber = cleaned_data.get("prescriber_answer", "")
+            self.job_application.refuse(user=self.request.user)
             messages.success(
-                request,
-                f"La candidature de {job_application.job_seeker.get_full_name()} a bien été déclinée.",
+                self.request,
+                f"La candidature de {self.job_application.job_seeker.get_full_name()} a bien été déclinée.",
                 extra_tags="toast",
             )
         except xwf_models.InvalidTransitionError:
-            messages.error(request, "Action déjà effectuée.", extra_tags="toast")
+            messages.error(self.request, "Action déjà effectuée.", extra_tags="toast")
 
-        next_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id})
+        next_url = reverse("apply:details_for_company", kwargs={"job_application_id": self.job_application.pk})
         return HttpResponseRedirect(next_url)
-    context = {
-        "form": form,
-        "job_application": job_application,
-        "can_view_personal_information": True,  # SIAE members have access to personal info
-        "matomo_custom_title": "Candidature refusée",
-    }
-    return render(request, template_name, context)
+
+    def get_prefix(self, request, *args, **kwargs):
+        """
+        Ensure that each refuse session is bound to a job application.
+        Avoid session conflicts when using multiple tabs.
+        """
+        return f"job_application_{self.job_application.pk}_refuse"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        if self.steps.current != self.STEP_REASON:
+            context.update(
+                refusal_reason_label=(
+                    job_applications_enums.RefusalReason(
+                        self.get_cleaned_data_for_step(self.STEP_REASON)["refusal_reason"]
+                    ).label
+                )
+            )
+        return context | {
+            "job_application": self.job_application,
+            "can_view_personal_information": True,  # SIAE members have access to personal info
+            "matomo_custom_title": "Candidature refusée",
+            "primary_button_label": "Suivant" if context["wizard"]["steps"].next else "Confirmer le refus",
+            "secondary_button_label": "Précédent" if context["wizard"]["steps"].prev else "Annuler",
+        }
+
+    def get_form_kwargs(self, step=None):
+        if step == self.STEP_REASON:
+            return {
+                "job_application": self.job_application,
+            }
+        return {}
+
+    def get_form_initial(self, step):
+        initial_data = self.initial_dict.get(step, {})
+        if step == self.STEP_JOB_SEEKER_ANSWER:
+            refusal_reason = self.get_cleaned_data_for_step(self.STEP_REASON).get("refusal_reason")
+            if refusal_reason:
+                initial_data["job_seeker_answer"] = loader.render_to_string(
+                    f"apply/refusal_messages/{refusal_reason}.txt",
+                    context={
+                        "job_application": self.job_application,
+                    },
+                    request=self.request,
+                )
+
+        return initial_data
+
+    def get_step_url(self, step):
+        return reverse(f"apply:{self.url_name}", kwargs={"job_application_id": self.job_application.pk, "step": step})
 
 
 @login_required
@@ -418,9 +518,9 @@ def archive(request, job_application_id):
     job_application = get_object_or_404(queryset, id=job_application_id)
 
     cancelled_states = [
-        JobApplicationState.REFUSED,
-        JobApplicationState.CANCELLED,
-        JobApplicationState.OBSOLETE,
+        job_applications_enums.JobApplicationState.REFUSED,
+        job_applications_enums.JobApplicationState.CANCELLED,
+        job_applications_enums.JobApplicationState.OBSOLETE,
     ]
 
     qs = urlencode({"states": cancelled_states}, doseq=True)

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -11,12 +11,7 @@ from itou.job_applications.enums import JobApplicationState, QualificationLevel,
 from itou.www.apply import forms as apply_forms
 from tests.cities.factories import create_test_cities
 from tests.companies.factories import JobDescriptionFactory
-from tests.job_applications.factories import (
-    JobApplicationFactory,
-    JobApplicationSentByCompanyFactory,
-    JobApplicationSentByJobSeekerFactory,
-    JobApplicationSentByPrescriberFactory,
-)
+from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import JobSeekerFactory, JobSeekerProfileFactory, PrescriberFactory
 from tests.utils.test import TestCase
@@ -72,22 +67,6 @@ class CheckJobSeekerNirFormTest(TestCase):
             "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
             "n'est pas associé à un compte candidat."
         ) == form.errors["__all__"][0]
-
-
-class RefusalFormTest(TestCase):
-    def test_job_application_sent_by_prescriber(self):
-        job_application = JobApplicationSentByPrescriberFactory()
-        form = apply_forms.RefusalForm(job_application=job_application)
-        assert "answer_to_prescriber" in form.fields.keys()
-
-    def test_job_application_not_sent_by_prescriber(self):
-        job_application = JobApplicationSentByJobSeekerFactory()
-        form = apply_forms.RefusalForm(job_application=job_application)
-        assert "answer_to_prescriber" not in form.fields.keys()
-
-        job_application = JobApplicationSentByCompanyFactory()
-        form = apply_forms.RefusalForm(job_application=job_application)
-        assert "answer_to_prescriber" not in form.fields.keys()
 
 
 class TestAcceptForm:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Meilleure gestion du wizard dans les cas d'usage suivants :
- Ouverture de plusieurs formulaires de refus en simultané sur une même session
- Accès à un step avancé directement par l'URL sans avoir les données précédentes en session

## :cake: Comment ? <!-- optionnel -->

- Ajout de la méthode `get_prefix` pour namespace le storage à une candidature spécifique
- Ajout de vérifications au get/post du wizard pour s'assurer que l'état est conforme par rapport au step courant (commit à part, à squash)
## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
