### PR TITLE
Arrêter de stocker les adresses des utilisateurs non-candidats [GEN-1553]

### DIFF
--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -77,12 +77,6 @@
                                     {% bootstrap_field form.last_name %}
                                 {% endif %}
                                 {% bootstrap_field form.phone %}
-                                {% bootstrap_field form.address_line_1 %}
-                                {% bootstrap_field form.address_line_2 %}
-                                <div class="row">
-                                    <div class="col-3">{% bootstrap_field form.post_code %}</div>
-                                    <div class="col-9">{% bootstrap_field form.city %}</div>
-                                </div>
 
                                 {% comment "prev_url may be not useful anymore, remove it from the view" %}{% endcomment %}
                                 {% itou_buttons_form primary_label="Enregistrer et quitter" secondary_url=prev_url %}

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.text import slugify
 
-from itou.common_apps.address.forms import JobSeekerAddressForm, OptionalAddressFormMixin
+from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
 from itou.communications import registry as notification_registry
 from itou.communications.models import NotificationRecord, NotificationSettings
@@ -100,18 +100,13 @@ class EditJobSeekerInfoForm(
         return super().save(commit=commit)
 
 
-class EditUserInfoForm(OptionalAddressFormMixin, SSOReadonlyMixin, forms.ModelForm):
+class EditUserInfoForm(SSOReadonlyMixin, forms.ModelForm):
     class Meta:
         model = User
         fields = [
             "first_name",
             "last_name",
             "phone",
-            "address_line_1",
-            "address_line_2",
-            "post_code",
-            "city",
-            "city_slug",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1190,20 +1190,12 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "phone": "0610203050",
-            "address_line_1": "10, rue du Gué",
-            "address_line_2": "Sous l'escalier",
-            "post_code": "35400",
-            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
         assert response.status_code == 302
 
         user = User.objects.get(id=user.id)
         assert user.phone == post_data["phone"]
-        assert user.address_line_1 == post_data["address_line_1"]
-        assert user.address_line_2 == post_data["address_line_2"]
-        assert user.post_code == post_data["post_code"]
-        assert user.city == post_data["city"]
 
     def test_edit_as_prescriber_with_ic(self):
         user = PrescriberFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
@@ -1224,10 +1216,6 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             "first_name": "Bob",
             "last_name": "Saint Clar",
             "phone": "0610203050",
-            "address_line_1": "10, rue du Gué",
-            "address_line_2": "Sous l'escalier",
-            "post_code": "35400",
-            "city": "Saint-Malo",
         }
         response = self.client.post(url, data=post_data)
         assert response.status_code == 302
@@ -1236,10 +1224,6 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         assert user.first_name != "Bob"
         assert user.first_name != "Saint Clair"
         assert user.phone == post_data["phone"]
-        assert user.address_line_1 == post_data["address_line_1"]
-        assert user.address_line_2 == post_data["address_line_2"]
-        assert user.post_code == post_data["post_code"]
-        assert user.city == post_data["city"]
 
 
 class EditJobSeekerInfo(TestCase):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car on ne les utilise pas.

Assez peu de comptes l'ont d'ailleurs remplis.

## :cake: Comment ? <!-- optionnel -->

On supprime les champs du formulaire et une migration permettra de vider les champs dans un second temps.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Se connecter avec un utilisateur non-candidat et aller sur "Modifier mon profil".