### PR TITLE
Acceptation de candidature: ajout de JS manquant pour l'autocomplétion d'adresse

### DIFF
--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -31,4 +31,8 @@
             });
         });
     </script>
+    {% if form_user_address %}
+        {% comment %} Needed for the AddressAutocompleteWidget {% endcomment %}
+        {{ form_user_address.media.js }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le formulaire d'acceptation de candidature utilise également l’autocomplétion d'adresse mais le JS n'y est pas dispo.

Cf https://github.com/gip-inclusion/les-emplois/blob/e722101eb602690f5b4df32a8d906e5b2055311f/itou/templates/apply/submit/hire_confirmation.html#L50-L53

## :cake: Comment ? <!-- optionnel -->

En rajoutant le JS manquant.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Accepter une candidature et voir l'autocomplétion fonctionner.
