### PR TITLE
Github actions: simplification du message de la recette jetable

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -84,11 +84,6 @@ jobs:
       with:
         message: |-
           🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](https://${{ env.DEPLOY_URL }})
-
-          ---
-          Préciser comment accéder à la fonctionnalité pour le métier :
-
-            1. …
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   redeploy:

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -80,7 +80,7 @@ jobs:
         $CLEVER_CLI deploy --branch $BRANCH --force
 
     - name: 🍻 Add link to pull request
-      uses: thollander/actions-comment-pull-request@main
+      uses: thollander/actions-comment-pull-request@v2.5.0
       with:
         message: |-
           🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](https://${{ env.DEPLOY_URL }})


### PR DESCRIPTION
## :thinking: Pourquoi ?

Personne ne remplissait les étapes dans le message de la recette et maintenant on a la section ":desert_island: Comment tester" pour le faire.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Rajouter le tag (ce que je vais faire) et regarder le message posté automatiquement.
