### PR TITLE
Carte candidature : Afficher à nouveau le nom de l’émetteur [GEN-1565]

### DIFF
--- a/itou/templates/apply/list_for_prescriber.html
+++ b/itou/templates/apply/list_for_prescriber.html
@@ -45,7 +45,7 @@
                     </aside>
                 </div>
                 <div class="col-12 col-md-8">
-                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request only %}
+                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request SenderKind=SenderKind only %}
                 </div>
             </div>
         </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -51,7 +51,7 @@
                     </aside>
                 </div>
                 <div class="col-12 col-md-8">
-                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request pending_states_job_applications_count=pending_states_job_applications_count only %}
+                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request pending_states_job_applications_count=pending_states_job_applications_count SenderKind=SenderKind only %}
                 </div>
             </div>
         </div>

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -1359,6 +1359,15 @@
       <p class="fs-sm mb-0 flex-grow-1">
           Émise le 30 mars 2023 par
           
+              <span class="text-nowrap">
+                  
+                      <strong>Max THROUGHPUT</strong>
+                  
+                  
+                      <i aria-hidden="true" class="ri-home-smile-2-line me-1"></i>Orienteur
+                  
+              </span>
+          
           
       </p>
       <div><span class="badge rounded-pill text-wrap badge-sm mb-1 bg-info" id="state_11111111-1111-1111-1111-111111111111">Nouvelle candidature</span></div>
@@ -1456,6 +1465,15 @@
       <p class="fs-sm mb-0 flex-grow-1">
           Émise le 18 mars 2023 par
           
+              <span class="text-nowrap">
+                  
+                      <strong>Max THROUGHPUT</strong>
+                  
+                  
+                      <i aria-hidden="true" class="ri-home-smile-2-line me-1"></i>Orienteur
+                  
+              </span>
+          
           
       </p>
       <div><span class="badge rounded-pill text-wrap badge-sm mb-1 bg-info" id="state_22222222-2222-2222-2222-222222222222">Nouvelle candidature</span></div>
@@ -1527,6 +1545,15 @@
   <div class="d-flex flex-column flex-lg-row gap-1 gap-lg-3 mb-3">
       <p class="fs-sm mb-0 flex-grow-1">
           Émise le 16 février 2023 par
+          
+              <span class="text-nowrap">
+                  
+                      <strong>Max THROUGHPUT</strong>
+                  
+                  
+                      <i aria-hidden="true" class="ri-home-smile-2-line me-1"></i>Orienteur
+                  
+              </span>
           
           
       </p>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il ne s’affichait plus, à cause d’un bug.

## :desert_island: Comment tester

- Accéder à la liste des candidatures pour un candidat, un employeur et un prescripteur. Tous doivent afficher qui à fait la candidature (par XXX).
