### PR TITLE
Suppression de la synchro automatique des notifications

### DIFF
--- a/itou/communications/apps.py
+++ b/itou/communications/apps.py
@@ -11,9 +11,6 @@ class CommunicationsConfig(AppConfig):
     def ready(self):
         self.module.autodiscover()
         post_migrate.connect(post_communications_migrate_handler, sender=self)
-        if settings.DEBUG:
-            # Sync on every reload during development
-            sync_notifications(self.get_model("NotificationRecord"))
 
 
 def post_communications_migrate_handler(sender, app_config, **kwargs):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour faciliter le développement, une synchro automatique des notifications était mise en place au `ready()` lorsque `settings.DEBUG is True`.

Depuis Django 5, le warning suivant est affiché au démarrage :

> RuntimeWarning: Accessing the database during app initialization is discouraged. To fix this warning, avoid executing queries in AppConfig.ready() or when your app modules are imported.

## :cake: Comment ? <!-- optionnel -->

Décision prise de retirer la synchro automatique. Il faudra faire un migrate pour synchroniser les notifications.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
