### PR TITLE
Matomo: correctifs de `buttons_form`

### DIFF
--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -12,7 +12,7 @@
             {% bootstrap_form form alert_error_type="all" %}
 
             {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
-            {% itou_buttons_form primary_label="Mettre en liste d'attente" reset_url=reset_url show_mandatory_fields_mention=False matomo_category="candidature" matomo_action="submit" matomo_event="postpone_application" %}
+            {% itou_buttons_form primary_label="Mettre en liste d'attente" reset_url=reset_url show_mandatory_fields_mention=False matomo_category="candidature" matomo_action="submit" matomo_name="postpone_application" %}
 
         </form>
     </div>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -108,9 +108,9 @@
 
                             {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
                             {% if wizard.steps.prev %}
-                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" secondary_url=wizard.steps.prev matomo_category="candidature" matomo_action="submit" matomo_event="refuse_application_submit" %}
+                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" secondary_url=wizard.steps.prev matomo_category="candidature" matomo_action="submit" matomo_name="refuse_application_submit" %}
                             {% else %}
-                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" matomo_category="candidature" matomo_action="submit" matomo_event="refuse_application_submit" %}
+                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" matomo_category="candidature" matomo_action="submit" matomo_name="refuse_application_submit" %}
                             {% endif %}
                         </form>
                     </div>

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -234,8 +234,8 @@
 
 {% block form_submit_button %}
     {% if request.user.is_employer %}
-        {% itou_buttons_form primary_label="Enregistrer" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_event="candidature_employer" %}
+        {% itou_buttons_form primary_label="Enregistrer" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_employer" %}
     {% else %}
-        {% itou_buttons_form primary_label="Envoyer la candidature" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_event="candidature_"|add:request.user.get_kind_display %}
+        {% itou_buttons_form primary_label="Envoyer la candidature" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_"|add:request.user.get_kind_display %}
     {% endif %}
 {% endblock %}

--- a/itou/templates/companies/edit_job_description.html
+++ b/itou/templates/companies/edit_job_description.html
@@ -54,7 +54,7 @@
                             {% bootstrap_field form.open_positions %}
 
                             {% url "companies_views:job_description_list" as reset_url %}
-                            {% itou_buttons_form primary_label="Suivant" reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_event="edit-infos-fiche-poste" %}
+                            {% itou_buttons_form primary_label="Suivant" reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="edit-infos-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_job_description_details.html
+++ b/itou/templates/companies/edit_job_description_details.html
@@ -86,7 +86,7 @@
 
                             {% url "companies_views:edit_job_description" as secondary_url %}
                             {% url "companies_views:job_description_list" as reset_url %}
-                            {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_event="edit-description-fiche-poste" %}
+                            {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="edit-description-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_job_description_preview.html
+++ b/itou/templates/companies/edit_job_description_preview.html
@@ -53,7 +53,7 @@
                             {% csrf_token %}
                             {% url "companies_views:edit_job_description_details" as secondary_url %}
                             {% url "companies_views:job_description_list" as reset_url %}
-                            {% itou_buttons_form primary_label="Enregistrer" primary_aria_label="Enregistrer" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_event="publier-fiche-poste" %}
+                            {% itou_buttons_form primary_label="Enregistrer" primary_aria_label="Enregistrer" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="publier-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_siae.html
+++ b/itou/templates/companies/edit_siae.html
@@ -72,7 +72,7 @@
                             {% bootstrap_field form.email %}
                             {% bootstrap_field form.website %}
 
-                            {% itou_buttons_form primary_label="Suivant" matomo_category="employeurs" matomo_action="submit" matomo_event="maj-contact-structure" %}
+                            {% itou_buttons_form primary_label="Suivant" matomo_category="employeurs" matomo_action="submit" matomo_name="maj-contact-structure" %}
                         </form>
 
                     </div>

--- a/itou/templates/companies/edit_siae_description.html
+++ b/itou/templates/companies/edit_siae_description.html
@@ -72,7 +72,7 @@
                                 </div>
                             </div>
 
-                            {% itou_buttons_form primary_label="Suivant" secondary_url=prev_url secondary_aria_label="Retourner à l'édition des coordonnées" matomo_category="employeurs" matomo_action="submit" matomo_event="maj-description-structure" %}
+                            {% itou_buttons_form primary_label="Suivant" secondary_url=prev_url secondary_aria_label="Retourner à l'édition des coordonnées" matomo_category="employeurs" matomo_action="submit" matomo_name="maj-description-structure" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -128,7 +128,7 @@
                                 </div>
                             </div>
 
-                            {% itou_buttons_form primary_label="Publier" secondary_url=prev_url secondary_aria_label="Retourner à l'édition de la description" matomo_category="employeurs" matomo_action="submit" matomo_event="publier-infos-structure" %}
+                            {% itou_buttons_form primary_label="Publier" secondary_url=prev_url secondary_aria_label="Retourner à l'édition de la description" matomo_category="employeurs" matomo_action="submit" matomo_name="publier-infos-structure" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -34,6 +34,6 @@
     {% bootstrap_field form.pole_emploi_id %}
     {% bootstrap_field form.lack_of_pole_emploi_id_reason %}
 
-    {% itou_buttons_form primary_label=submit_label reset_url=prev_url matomo_category="salaries" matomo_action="submit" matomo_event="edit_jobseeker_infos_submit" %}
+    {% itou_buttons_form primary_label=submit_label reset_url=prev_url matomo_category="salaries" matomo_action="submit" matomo_name="edit_jobseeker_infos_submit" %}
 
 </form>

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -55,7 +55,7 @@
                             {% url "employee_record_views:list" as reset_url %}
                             {% if wizard.steps.prev %}
                                 {% url 'employee_record_views:add' as secondary_url %}
-                                {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" secondary_url=secondary_url|add:wizard.steps.prev secondary_name="wizard_goto_step" secondary_value=wizard.steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_event="création" %}
+                                {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" secondary_url=secondary_url|add:wizard.steps.prev secondary_name="wizard_goto_step" secondary_value=wizard.steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_name="création" %}
                             {% else %}
                                 {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" %}
                             {% endif %}

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -101,7 +101,7 @@
                         {% if profile.hexa_address_filled %}
                             {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url %}
                         {% else %}
-                            {% itou_buttons_form primary_label="Suivant" primary_deactivated=True secondary_url=secondary_url reset_url=reset_url %}
+                            {% itou_buttons_form primary_label="Suivant" primary_disabled=True secondary_url=secondary_url reset_url=reset_url %}
                         {% endif %}
                     </div>
                 </div>

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -12,7 +12,7 @@
                         <span>Annuler</span>
                     </button>
                 {% else %}
-                    <a href="{% if reset_url %}{{ reset_url }}{% else %}{% url 'dashboard:index' %}{% endif %}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                    <a href="{{ reset_url }}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
                         <i class="ri-close-line ri-lg" aria-hidden="true"></i>
                         <span>Annuler</span>
                     </a>
@@ -22,21 +22,21 @@
                 <div class="form-group col col-lg-auto order-1 order-lg-2">
                     <a href="{{ secondary_url }}"
                        class="btn btn-block btn-outline-primary"
-                       aria-label="{% if secondary_aria_label %}{{ secondary_aria_label }}{% else %}Retourner à l'étape précédente{% endif %}"
+                       aria-label="{{ secondary_aria_label }}"
                        {% if secondary_name and secondary_value %}name="{{ secondary_name }}" value="{{ secondary_value }}"{% endif %}>
                         <span>Retour</span>
                     </a>
                 </div>
             {% endif %}
             <div class="form-group col col-lg-auto order-2 order-lg-3">
-                {% if primary_deactivated %}
+                {% if primary_disabled %}
                     <button type="button" class="btn btn-block btn-primary disabled">
                         <span>{{ primary_label }}</span>
                     </button>
                 {% elif primary_url %}
                     <a href="{{ primary_url }}"
                        class="btn btn-block btn-primary"
-                       aria-label="{% if primary_aria_label %}{{ primary_aria_label }}{% else %}Passer à l'étape suivante{% endif %}"
+                       aria-label="{{ primary_aria_label }}"
                        {% if primary_name and primary_value %}name="{{ primary_name }}" value="{{ primary_value }}"{% endif %}
                        {% if matomo_category and matomo_action and matomo_name %}{% matomo_event matomo_category matomo_action matomo_name %}{% endif %}>
                         <span>{{ primary_label }}</span>
@@ -44,7 +44,7 @@
                 {% else %}
                     <button type="submit"
                             class="btn btn-block btn-primary"
-                            aria-label="{% if primary_aria_label %}{{ primary_aria_label }}{% else %}Passer à l'étape suivante{% endif %}"
+                            aria-label="{{ primary_aria_label }}"
                             {% if primary_name and primary_value %}name="{{ primary_name }}" value="{{ primary_value }}"{% endif %}
                             {% if matomo_category and matomo_action and matomo_name %}{% matomo_event matomo_category matomo_action matomo_name %}{% endif %}>
                         <span>{{ primary_label }}</span>
@@ -69,7 +69,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                    <a href="{% if reset_url %}{{ reset_url }}{% else %}{% url 'dashboard:index' %}{% endif %}" class="btn btn-sm btn-danger">Enregistrer et quitter</a>
+                    <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Enregistrer et quitter</a>
                 </div>
             {% else %}
                 <div class="modal-header">
@@ -82,7 +82,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                    <a href="{% if reset_url %}{{ reset_url }}{% else %}{% url 'dashboard:index' %}{% endif %}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                    <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
                 </div>
             {% endif %}
         </div>

--- a/itou/utils/templatetags/buttons_form.py
+++ b/itou/utils/templatetags/buttons_form.py
@@ -1,11 +1,30 @@
 from django import template
+from django.urls import reverse_lazy
 
 
 register = template.Library()
 
 
 @register.inclusion_tag("./utils/templatetags/buttons_form.html", takes_context=False)
-def itou_buttons_form(**kwargs):
+def itou_buttons_form(
+    *,
+    primary_disabled=False,
+    primary_label="Suivant",
+    primary_url=None,
+    primary_name=None,
+    primary_value=None,
+    primary_aria_label="Passer à l’étape suivante",
+    reset_url=reverse_lazy("dashboard:index"),
+    show_mandatory_fields_mention=True,
+    secondary_url=None,
+    secondary_aria_label="Retourner à l’étape précédente",
+    secondary_name=None,
+    secondary_value=None,
+    matomo_category=None,
+    matomo_action=None,
+    matomo_name=None,
+    modal_content_save_and_quit=False,
+):
     """
     Render buttons on forms.
 
@@ -17,57 +36,39 @@ def itou_buttons_form(**kwargs):
 
         primary_label
             The label for the primary button.
-            Default: "Suivant"
 
         primary_url
             The url for the primary button. If True, display href as a button, instead of a submit button.
-            Optional
-            Default: None
+
+        primary_aria_label
+            The ARIA label for the primary button.
 
         secondary_url
             The url for the secondary button.
-            Optional
-            Default: None
+
+        secondary_aria_label
+            The ARIA label for the secondary button.
 
         reset_url
-            The url for the reset button. If True, display href link, whether reset_submit exists or not.
-            Optional
-            Default: 'dashboard:index'
-
-        reset_submit
-            display a reset button, if True and reset_url is not set.
-            Optional
-            Default: False
+            The url for the reset button.
 
         matomo_category & matomo_action & matomo_name
             If set together, the buttons will send a matomo event on click.
-            Optional
-            Default: None
 
         show_mandatory_fields_mention
-            if True, show the mention "champs obligatoires" on the form.
-            Default: True
+            If True, show the mention "champs obligatoires" on the form.
 
         primary_disabled
-            if True, the primary button is disabled.
-            Optional
-            Default: False
+            If True, the primary button is disabled.
 
         primary_name & primary_value
             If set together, the name and value for the primary button.
-            Optional
-            Default: None
 
         secondary_name & secondary_value
             If set together, the name and value for the secondary button.
-            Optional
-            Default: None
 
         modal_content_save_and_quit
-            if set, force alternate modal content for the save and quit button.
-            Optional
-            Default: None
-
+            If set, force alternate modal content for the save and quit button.
 
     **Usage**::
 
@@ -75,11 +76,28 @@ def itou_buttons_form(**kwargs):
 
     **Example**::
 
-        {% itou_buttons_form reset_submit=True %}
+        {% itou_buttons_form show_mandatory_fields_mention=False %}
     """
-    if kwargs.get("primary_label") is None:
-        kwargs["primary_label"] = "Suivant"
-    if kwargs.get("show_mandatory_fields_mention") is None:
-        kwargs["show_mandatory_fields_mention"] = True
 
-    return {**kwargs}
+    matomo_values = (matomo_category, matomo_action, matomo_name)
+    if any(matomo_values) and not all(matomo_values):
+        raise ValueError("Matomo values are all or nothing")
+
+    return {
+        "show_mandatory_fields_mention": show_mandatory_fields_mention,
+        "primary_aria_label": primary_aria_label,
+        "primary_disabled": primary_disabled,
+        "primary_label": primary_label,
+        "primary_name": primary_name,
+        "primary_value": primary_value,
+        "primary_url": primary_url,
+        "reset_url": reset_url,
+        "secondary_url": secondary_url,
+        "secondary_aria_label": secondary_aria_label,
+        "secondary_name": secondary_name,
+        "secondary_value": secondary_value,
+        "matomo_category": matomo_category,
+        "matomo_action": matomo_action,
+        "matomo_name": matomo_name,
+        "modal_content_save_and_quit": modal_content_save_and_quit,
+    }

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -21,7 +21,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -77,7 +77,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -133,7 +133,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -189,7 +189,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -245,7 +245,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               data-matomo-event="true" data-matomo-category="category" data-matomo-action="action" data-matomo-option="name">
                           <span>Suivant</span>
@@ -355,11 +355,7 @@
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
-                      <button type="submit"
-                              class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
-                              
-                              >
+                      <button type="button" class="btn btn-block btn-primary disabled">
                           <span>Suivant</span>
                       </button>
                   
@@ -413,7 +409,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               name="name" value="1"
                               >
                           <span>Suivant</span>
@@ -469,7 +465,7 @@
                   
                       <a href="/next"
                          class="btn btn-block btn-primary"
-                         aria-label="Passer à l'étape suivante"
+                         aria-label="Passer à l’étape suivante"
                          
                          >
                           <span>Suivant</span>
@@ -590,7 +586,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -645,7 +641,7 @@
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
                       <a href="/do"
                          class="btn btn-block btn-outline-primary"
-                         aria-label="Retourner à l'étape précédente"
+                         aria-label="Retourner à l’étape précédente"
                          name="name" value="1">
                           <span>Retour</span>
                       </a>
@@ -655,7 +651,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -710,7 +706,7 @@
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
                       <a href="/do"
                          class="btn btn-block btn-outline-primary"
-                         aria-label="Retourner à l'étape précédente"
+                         aria-label="Retourner à l’étape précédente"
                          >
                           <span>Retour</span>
                       </a>
@@ -720,7 +716,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>
@@ -776,7 +772,7 @@
                   
                       <button type="submit"
                               class="btn btn-block btn-primary"
-                              aria-label="Passer à l'étape suivante"
+                              aria-label="Passer à l’étape suivante"
                               
                               >
                           <span>Suivant</span>

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -43,14 +43,14 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l'étape précédente" class="btn btn-block btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
+                      <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
                           <span>Retour</span>
                       </a>
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
-                      <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
+                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
                           <span>Confirmer la suppression</span>
                       </button>
                   

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -64,14 +64,14 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l'étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/add/choose-employee" name="wizard_goto_step" value="choose-employee">
+                      <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/add/choose-employee" name="wizard_goto_step" value="choose-employee">
                           <span>Retour</span>
                       </a>
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
-                      <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
+                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" data-matomo-action="submit" data-matomo-category="fiches-salarié" data-matomo-event="true" data-matomo-option="création" type="submit">
                           <span>Confirmer</span>
                       </button>
                   

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -295,14 +295,14 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l'étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/create/[PK of JobApplication]">
+                      <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/create/[PK of JobApplication]">
                           <span>Retour</span>
                       </a>
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
-                      <a aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" href="/employee_record/create_step_3/[PK of JobApplication]">
+                      <a aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" href="/employee_record/create_step_3/[PK of JobApplication]">
                           <span>Suivant</span>
                       </a>
                   

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -123,7 +123,7 @@
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
                   
-                      <button aria-label="Passer à l'étape suivante" class="btn btn-block btn-primary" type="submit">
+                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
                           <span>Inscription</span>
                       </button>
                   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le templatetag acceptait sans broncher la clef `matomo_event` au lieu de celle attendue `matomo_name`

## :cake: Comment ? <!-- optionnel -->

En nommant explicitement toutes les clefs attendues/supportées.
Au passage, la `primary_disabled` était également utilisée à la place de `primary_deactivated` qui était attendue, j'ai tout aligné sur la première.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Aller sur les différents templates pour vérifier l'affichage des boutons avec les bons attributs matomo.
