### PR TITLE
Partenariat AFPA : Inviter à contacter l’Afpa dans les mails envoyés aux candidats pour les refus de candidatures et de demande de prolongation dans les Hauts-de-France et en Nouvelle Aquitaine [GEN-225]

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -5,6 +5,7 @@ from itou.common_apps.notifications.base_class import BaseNotification
 from itou.communications import NotificationCategory, registry as notifications_registry
 from itou.communications.dispatch import EmailNotification, EmployerNotification, JobSeekerNotification
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
+from itou.job_applications.utils import show_afpa_ad
 from itou.prescribers.models import PrescriberMembership
 from itou.utils.emails import get_email_message
 from itou.utils.urls import get_absolute_url
@@ -93,8 +94,12 @@ class ProlongationRequestDeniedJobSeeker(BaseNotification):
 
     @property
     def email(self):
-        to = [self.prolongation_request.approval.user.email]
-        context = {"prolongation_request": self.prolongation_request}
+        user = self.prolongation_request.approval.user
+        to = [user.email]
+        context = {
+            "prolongation_request": self.prolongation_request,
+            "show_afpa_ad": show_afpa_ad(user),
+        }
         subject = "approvals/email/prolongation_request/denied/jobseeker_subject.txt"
         body = "approvals/email/prolongation_request/denied/jobseeker_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/job_applications/notifications.py
+++ b/itou/job_applications/notifications.py
@@ -7,6 +7,7 @@ from itou.communications.dispatch import (
     PrescriberNotification,
     PrescriberOrEmployerNotification,
 )
+from itou.job_applications.utils import show_afpa_ad
 from itou.utils.emails import get_email_message
 
 
@@ -98,6 +99,11 @@ class JobApplicationRefusedForJobSeekerNotification(JobSeekerNotification, Email
     category = NotificationCategory.JOB_APPLICATION
     subject_template = "apply/email/refuse_subject.txt"
     body_template = "apply/email/refuse_body_for_job_seeker.txt"
+
+    def get_context(self):
+        context = super().get_context()
+        context["show_afpa_ad"] = show_afpa_ad(self.user)
+        return context
 
 
 @notifications_registry.register

--- a/itou/job_applications/utils.py
+++ b/itou/job_applications/utils.py
@@ -1,0 +1,23 @@
+def show_afpa_ad(user):
+    postcode = user.jobseeker_profile.hexa_post_code or user.post_code
+    return postcode[:2] in [
+        # Hauts-de-france
+        "02",
+        "59",
+        "60",
+        "62",
+        "80",
+        # Nouvelle aquitaine
+        "16",
+        "17",
+        "19",
+        "23",
+        "24",
+        "33",
+        "40",
+        "47",
+        "64",
+        "79",
+        "86",
+        "87",
+    ]

--- a/itou/templates/apply/email/refuse_body_for_job_seeker.txt
+++ b/itou/templates/apply/email/refuse_body_for_job_seeker.txt
@@ -14,5 +14,10 @@ Nous vous souhaitons bon courage dans votre recherche et sommes persuadés que v
 
 {{ job_application.answer }}
 {% endif %}
+{% if show_afpa_ad %}
+
+L’Afpa, 1er acteur de la formation professionnelle en France peut vous accompagner et vous proposer des solutions pour accéder à la formation afin de vous aider dans votre parcours vers l’emploi.
+Si vous souhaitez être contacté, suivez ce lien https://cloud.info.afpa.fr/partenariat-afpa-plateforme-de-l-inclusion
+{% endif %}
 
 {% endblock body %}

--- a/itou/templates/approvals/email/prolongation_request/denied/jobseeker_body.txt
+++ b/itou/templates/approvals/email/prolongation_request/denied/jobseeker_body.txt
@@ -22,6 +22,11 @@ Actions envisagées par le prescripteur :
 - Précisions : {{ prolongation_request.deny_information.proposed_actions_explanation }}
 {% endif %}
 {% endif %}
+{% if show_afpa_ad %}
+
+L’Afpa, 1er acteur de la formation professionnelle en France peut vous accompagner et vous proposer des solutions pour accéder à la formation afin de vous aider dans votre parcours vers l’emploi.
+Si vous souhaitez être contacté, suivez ce lien https://cloud.info.afpa.fr/partenariat-afpa-plateforme-de-l-inclusion
+{% endif %}
 
 Vous pouvez consulter la date de fin prévisionnelle de votre PASS IAE dans votre espace candidat sur les emplois de l’inclusion.
 {% endblock body %}

--- a/tests/approvals/test_prolongation_requests.py
+++ b/tests/approvals/test_prolongation_requests.py
@@ -61,8 +61,9 @@ def test_grant():
 
 
 @freeze_time()
-def test_deny():
-    prolongation_request = ProlongationRequestFactory()
+@pytest.mark.parametrize("postcode,contained", [("59284", True), ("75001", False)])
+def test_deny(postcode, contained):
+    prolongation_request = ProlongationRequestFactory(approval__user__jobseeker_profile__hexa_post_code=postcode)
     deny_information = ProlongationRequestDenyInformationFactory.build(request=None)
 
     prolongation_request.deny(prolongation_request.validated_by, deny_information)
@@ -84,6 +85,12 @@ def test_deny():
         [prolongation_request.declared_by.email],
         [prolongation_request.approval.user.email],
     ]
+    jobseeker_email = mail.outbox[1]
+    afpa = "Afpa"
+    if contained:
+        assert afpa in jobseeker_email.body
+    else:
+        assert afpa not in jobseeker_email.body
 
 
 @pytest.mark.parametrize(

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -701,6 +701,8 @@ class JobApplicationQuerySetTest(TestCase):
 
 
 class JobApplicationNotificationsTest(TestCase):
+    AFPA = "Afpa"
+
     @classmethod
     def setUpTestData(cls):
         # Set up data for the whole TestCase.
@@ -891,6 +893,7 @@ class JobApplicationNotificationsTest(TestCase):
         assert job_application.to_company.display_name in email.body
         assert job_application.answer in email.body
         assert job_application.answer_to_prescriber in email.body
+        assert self.AFPA not in email.body
 
         # When sent by jobseeker.
         job_application = JobApplicationSentByJobSeekerFactory(
@@ -906,6 +909,7 @@ class JobApplicationNotificationsTest(TestCase):
         assert job_application.to_company.display_name in email.body
         assert job_application.answer in email.body
         assert job_application.answer_to_prescriber not in email.body
+        assert self.AFPA not in email.body
 
     def test_refuse_without_sender(self):
         # When sent by authorized prescriber.
@@ -921,6 +925,20 @@ class JobApplicationNotificationsTest(TestCase):
         job_application.refuse()
         [email] = mail.outbox
         assert email.to == [job_application.job_seeker.email]
+        assert self.AFPA not in email.body
+
+    def test_refuse_afpa_message(self):
+        job_application = JobApplicationSentByJobSeekerFactory(
+            job_seeker__jobseeker_profile__hexa_post_code="59284",
+            refusal_reason=RefusalReason.DID_NOT_COME,
+            answer_to_prescriber="Le candidat n'est pas venu.",
+        )
+        email = job_application.notifications_refuse_for_job_seeker.build()
+        assert [job_application.job_seeker.email] == email.to
+        assert job_application.to_company.display_name in email.body
+        assert job_application.answer in email.body
+        assert job_application.answer_to_prescriber not in email.body
+        assert self.AFPA in email.body
 
     def test_notifications_deliver_approval(self):
         job_seeker = JobSeekerFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Encourager les candidats à se former avec l’Afpa.
