### PR TITLE
Wording: gestion des orienteurs dans le wizard de refus de candidature

### DIFF
--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -76,7 +76,13 @@
                                         {% for radio in form.refusal_reason %}
                                             <li class="mb-2">
                                                 <div class="form-check">
-                                                    <input id="{{ radio.id_for_label }}" class="form-check-input" name="{{ radio.data.name }}" type="radio" value="{{ radio.data.value }}" {% if radio.data.selected %}checked=""{% endif %} required>
+                                                    <input id="{{ radio.id_for_label }}"
+                                                           class="form-check-input"
+                                                           name="{{ radio.data.name }}"
+                                                           type="radio"
+                                                           value="{{ radio.data.value }}"
+                                                           {% if radio.data.selected %}checked=""{% endif %}
+                                                           {% if form.refusal_reason.field.required %}required{% endif %}>
                                                     <label for="{{ radio.id_for_label }}" class="form-check-label">
                                                         {% if radio.data.value == RefusalReason.PREVENT_OBJECTIVES %}
                                                             {{ radio.choice_label }}

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -27,7 +27,7 @@
                             {% elif wizard.steps.current == "job-seeker-answer" %}
                                 <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Message au candidat
                             {% elif wizard.steps.current == "prescriber-answer" %}
-                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Message au prescripteur
+                                <strong>Étape {{ wizard.steps.step1 }}</strong>/{{ wizard.steps.count }} : Message {{ job_application.is_sent_by_authorized_prescriber|yesno:"au prescripteur,à l’orienteur" }}
                             {% endif %}
                         </p>
                     </div>
@@ -40,7 +40,7 @@
                                 <h2 class="mb-3 mb-md-4">Choix du motif de refus</h2>
                                 <p class="mb-3 mb-md-4">
                                     {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
-                                        Dans le cadre d’un parcours IAE, la transparence sur les motifs de refus est importante pour le candidat comme pour le prescripteur. Nous vous encourageons à répondre à chacune des parties.
+                                        Dans le cadre d’un parcours IAE, la transparence sur les motifs de refus est importante pour le candidat comme pour {{ job_application.is_sent_by_authorized_prescriber|yesno:"le prescripteur,l’orienteur" }}. Nous vous encourageons à répondre à chacune des parties.
                                     {% else %}
                                         Dans le cadre d’un parcours IAE, la transparence sur les motifs de refus est importante pour le candidat.
                                     {% endif %}
@@ -49,7 +49,7 @@
                                 <h2 class="mb-3 mb-md-4">Réponse au candidat</h2>
                                 <p class="mb-3 mb-md-4">
                                     {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
-                                        Une copie de ce message sera adressée au prescripteur.
+                                        Une copie de ce message sera adressée {{ job_application.is_sent_by_authorized_prescriber|yesno:"au prescripteur,à l’orienteur" }}.
                                         <br>
                                     {% endif %}
                                     Merci de bien vouloir adapter ce message en fonction de la situation.
@@ -58,9 +58,11 @@
                                     <strong>Raison du refus :</strong> {{ refusal_reason_label }}
                                 </p>
                             {% elif wizard.steps.current == "prescriber-answer" %}
-                                <h2 class="mb-3 mb-md-4">Réponse au prescripteur</h2>
+                                <h2 class="mb-3 mb-md-4">
+                                    Réponse {{ job_application.is_sent_by_authorized_prescriber|yesno:"au prescripteur,à l’orienteur" }}
+                                </h2>
                                 <p class="mb-3 mb-md-4">
-                                    Vous pouvez partager un message au prescripteur uniquement, comme détailler ou évoquer d’autres motifs de refus.
+                                    Vous pouvez partager un message {{ job_application.is_sent_by_authorized_prescriber|yesno:"au prescripteur,à l’orienteur" }} uniquement, comme détailler ou évoquer d’autres motifs de refus.
                                 </p>
                                 <p class="mb-3 mb-md-4">
                                     <strong>Raison du refus :</strong> {{ refusal_reason_label }}
@@ -88,7 +90,7 @@
                                                         {% elif radio.data.value == RefusalReason.OTHER %}
                                                             {{ radio.choice_label }}
                                                             {% if job_application.sender_kind == SenderKind.PRESCRIBER %}
-                                                                (détails à fournir dans le message au prescripteur)
+                                                                (détails à fournir dans le message {{ job_application.is_sent_by_authorized_prescriber|yesno:"au prescripteur,à l’orienteur" }})
                                                             {% endif %}
                                                         {% else %}
                                                             {{ radio.choice_label }}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -378,7 +378,11 @@ class JobApplicationRefusalReasonForm(forms.Form):
     def __init__(self, job_application, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if job_application.sender_kind == job_applications_enums.SenderKind.PRESCRIBER:
-            self.fields["refusal_reason"].label = "Choisir le motif de refus envoyé au prescripteur"
+            if job_application.is_sent_by_authorized_prescriber:
+                label = "Choisir le motif de refus envoyé au prescripteur"
+            else:
+                label = "Choisir le motif de refus envoyé à l’orienteur"
+            self.fields["refusal_reason"].label = label
         if job_application.to_company.kind == CompanyKind.GEIQ:
             self.fields["refusal_reason"].choices = job_applications_enums.RefusalReason.displayed_choices(
                 extra_exclude_enums=[
@@ -398,10 +402,21 @@ class JobApplicationRefusalJobSeekerAnswerForm(forms.Form):
 
 class JobApplicationRefusalPrescriberAnswerForm(forms.Form):
     prescriber_answer = forms.CharField(
-        label="Commentaire envoyé au prescripteur (n’est pas envoyé au candidat)",
         widget=forms.Textarea(),
         strip=True,
     )
+
+    def __init__(self, job_application, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if job_application.sender_kind == job_applications_enums.SenderKind.PRESCRIBER:
+            if job_application.is_sent_by_authorized_prescriber:
+                self.fields["prescriber_answer"].label = (
+                    "Commentaire envoyé au prescripteur (n’est pas envoyé au candidat)"
+                )
+            else:
+                self.fields["prescriber_answer"].label = (
+                    "Commentaire envoyé à l’orienteur (n’est pas envoyé au candidat)"
+                )
 
 
 class AnswerForm(forms.Form):

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -347,7 +347,7 @@ class JobApplicationRefuseView(LoginRequiredMixin, NamedUrlSessionWizardView):
         }
 
     def get_form_kwargs(self, step=None):
-        if step == self.STEP_REASON:
+        if step in (self.STEP_REASON, self.STEP_PRESCRIBER_ANSWER):
             return {
                 "job_application": self.job_application,
             }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un seul wording "prescripteur" précédemment.

Cf https://itou-inclusion.slack.com/archives/CU8ATF54L/p1713346938777999?thread_ts=1713268571.388719&cid=CU8ATF54L

## :cake: Comment ? <!-- optionnel -->

En fonction du prescripteur on mentionne tantôt "prescripteur" (si habilité), tantôt "orienteur" (non habilité, solo)

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

- Se connecter en tant que GEIC
- Parcourir [les candidatures](https://c1-review-leo-job-application-refusal-orienteurs-fix.cleverapps.io/apply/siae/list?states=new&states=processing&states=prior_to_hire), s'assurer que dans le parcours de refus (3 étapes) :
    - Les mentions "prescripteur" ne concernent que les prescripteur habilités
    - Les mentions "orienteur" sont bien présentes pour les orienteurs et orienteurs solo