### PR TITLE
templates: correction d'une typo sur une variable

### DIFF
--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -13,7 +13,7 @@
 
         {% csrf_token %}
 
-        {% if form_address or form_personal_data %}<h2>Candidat</h2>{% endif %}
+        {% if form_user_address or form_personal_data %}<h2>Candidat</h2>{% endif %}
 
         {% if form_personal_data %}
             {% if form_personal_data.nir_error %}{{ form_personal_data.nir_error|safe }}{% endif %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

`form_address` n'a jamais existé et a priori on souhaite en fait vérifier la présence du formulaire `form_user_address` qui sera affiché dans cette section.

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Ajouter l'étiquette « no-changelog » ?
- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
