### PR TITLE
tests: correction de tests pour mieux correspondre à leur utilisation réelle

### DIFF
--- a/tests/www/approvals_views/__snapshots__/test_includes.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_includes.ambr
@@ -27,8 +27,6 @@
       </p>
   
       
-          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
-      
   
       
           
@@ -72,8 +70,6 @@
       </p>
   
       
-          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
-      
   
       
           
@@ -114,8 +110,6 @@
           
       </p>
   
-      
-          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
       
   
       
@@ -158,8 +152,6 @@
       </p>
   
       
-          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
-      
   
       
           
@@ -200,8 +192,6 @@
           
       </p>
   
-      
-          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
       
   
       
@@ -266,8 +256,6 @@
           
       </p>
   
-      
-          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
       
   
       

--- a/tests/www/approvals_views/test_includes.py
+++ b/tests/www/approvals_views/test_includes.py
@@ -4,6 +4,7 @@ import pytest  # noqa
 from django.template import Context, Template
 from freezegun import freeze_time
 
+import itou.job_applications.enums as job_applications_enums
 from tests.approvals.factories import ApprovalFactory
 from tests.eligibility.factories import EligibilityDiagnosisFactory
 from tests.users.factories import EmployerFactory, PrescriberFactory
@@ -19,6 +20,7 @@ class TestStatusInclude:
                 "user": EmployerFactory(),
                 "hiring_pending": False,
                 "job_application": None,
+                "JobApplicationOrigin": job_applications_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -31,6 +33,7 @@ class TestStatusInclude:
                 "user": PrescriberFactory(),
                 "hiring_pending": False,
                 "job_application": None,
+                "JobApplicationOrigin": job_applications_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -43,6 +46,7 @@ class TestStatusInclude:
                 "user": EmployerFactory(),
                 "hiring_pending": False,
                 "job_application": None,
+                "JobApplicationOrigin": job_applications_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -59,6 +63,7 @@ class TestStatusInclude:
                 "user": EmployerFactory(),
                 "hiring_pending": False,
                 "job_application": None,
+                "JobApplicationOrigin": job_applications_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -75,6 +80,7 @@ class TestStatusInclude:
                 "user": PrescriberFactory(),
                 "hiring_pending": False,
                 "job_application": None,
+                "JobApplicationOrigin": job_applications_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -91,6 +97,7 @@ class TestStatusInclude:
                 "user": approval.user,
                 "hiring_pending": False,
                 "job_application": None,
+                "JobApplicationOrigin": job_applications_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)


### PR DESCRIPTION

## :thinking: Pourquoi ?

`JobApplicationOrigin` est normalement fourni par le _context processor_ `itou.utils.context_processors.expose_enums`.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
