### PR TITLE
Template: suppression de code inaccessible

### DIFF
--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -42,35 +42,6 @@
                             {% itou_buttons_form primary_label="Envoyer" reset_url=back_url %}
                         </form>
                     </div>
-
-                    {% if pending_invitations %}
-                        <div class="c-box mt-3 mt-md-5">
-                            <h3 class="h4">Invitations en attente</h3>
-                            <div class="table-responsive-lg mt-3">
-                                <table class="table">
-                                    <caption class="visually-hidden">Liste des invitations en attente</caption>
-                                    <thead>
-                                        <tr>
-                                            <th scope="col">Prénom</th>
-                                            <th scope="col">Nom</th>
-                                            <th scope="col">Adresse e-mail</th>
-                                            <th scope="col">Envoyée le</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for invitation in pending_invitations %}
-                                            <tr>
-                                                <td>{{ invitation.first_name|title }}</td>
-                                                <td>{{ invitation.last_name|upper }}</td>
-                                                <td>{{ invitation.email }}</td>
-                                                <td>{{ invitation.sent_at|date }}</td>
-                                            </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    {% endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ajouté en juin 2020 (32a038923d47a4eb2): on voyait alors la liste des invitations en attente sur l'écran de création d'une invitation.
Mais dès juillet 2020 (4862b8136b29afef4) ce n'est plus le cas et la liste des invitations en attente a été ajouté à l'écran de la liste des membres.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

`itou/templates/invitations_views/create.html` n'est utilisé que dans 3 vues et aucune ne rajoute la clef `pending_invitations` dans son contexte.
