### PR TITLE
Notifier #mep-c1 lors d’une mise en prod [GEN-1528]

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -1,0 +1,22 @@
+name: 📢 Notify Slack of changed PR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify:
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
+    if: >
+      github.event.pull_request.merged == true
+      && !contains(github.event.pull_request.labels.*.name, 'no-changelog')
+      && !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    steps:
+      - name: "📢 Notify the #mep-c1 channel"
+        run: >
+          curl
+          --request POST
+          --header 'Content-type: application/json'
+          --data '{"text":"<${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"}'
+          '${{ secrets.SLACK_MEP_C1_WEBHOOK_URL }}'


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de le faire à la main.
