### PR TITLE
[GEN-233] Masquage de l’adresse email du prescripteur ou de l'employeur dans la page candidature pour le candidat

### DIFF
--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -12,17 +12,21 @@
     </li>
     <li>
         <small>Adresse e-mail</small>
-        <strong>{{ job_application.sender.email }}</strong>
-        <button class="btn-link"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-                data-bs-trigger="manual"
-                data-bs-title="Copié!"
-                data-it-clipboard-button="copy"
-                data-it-copy-to-clipboard="{{ job_application.sender.email }}"
-                {% matomo_event "candidature" "clic" "copied_sender_email" %}>
-            <i class="ri-file-copy-line"></i>
-        </button>
+        {% if request.user.is_job_seeker and job_application.sender_kind != SenderKind.JOB_SEEKER %}
+            <strong>Non communiquée</strong>
+        {% else %}
+            <strong>{{ job_application.sender.email }}</strong>
+            <button class="btn-link"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    data-bs-trigger="manual"
+                    data-bs-title="Copié!"
+                    data-it-clipboard-button="copy"
+                    data-it-copy-to-clipboard="{{ job_application.sender.email }}"
+                    {% matomo_event "candidature" "clic" "copied_sender_email" %}>
+                <i class="ri-file-copy-line"></i>
+            </button>
+        {% endif %}
     </li>
 
     {% if job_application.sender_prescriber_organization %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Depuis la dernière mise à jour l’adresse email du prescripteur est visible dans le détail de candidatures coté candidat

## :cake: Comment ? <!-- optionnel -->

Lorsque l'utilisateur connecté est un candidat, on cache dorénavant l'adresse e-mail de l'émetteur si ce dernier n'est pas de type candidat.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
