### PR TITLE
[GEN-191] Affichage des boutons enregistrer en haut des formulaires d'admin

### DIFF
--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -112,6 +112,9 @@ class InconsistencyCheckMixin:
 
 
 class ItouModelAdmin(ModelAdmin):
+    # Add save buttons on top of each change forms by default
+    save_on_top = True
+
     def _get_queryset_with_relations(self, request):
         select_related_fields, prefetch_related_fields = set(), set()
         for field in self.model._meta.get_fields():


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le formulaire d'édition peut être très long en admin et la plupart des actions se font en partie haute.
Évite de scroll tout en bas du form.

https://www.notion.so/plateforme-inclusion/Ajout-d-un-bouton-enregistrer-dans-l-admin-1385ab2419b0439c92ef1d42cc7a1fe3?pvs=4

## :cake: Comment ? <!-- optionnel -->

Django prévoit le coup avec [ModelAdmin.save_on_top](https://docs.djangoproject.com/en/5.0/ref/contrib/admin/#django.contrib.admin.ModelAdmin.save_on_top) mais ne fournit pas de settings pour le configurer par défaut.

→ ~Monkey patch de ModelAdmin au démarrage de l'app (la surchage du template [ne s'y prête pas bien](https://github.com/django/django/blob/53719d6b5b745dd99b1ab9315afb242f706ebbf1/django/contrib/admin/templates/admin/change_form.html#L40)).~

→ Ajout de l'option à `ItouModelAdmin`

## :computer: Captures d'écran <!-- optionnel -->

#### Avant

<img width="1132" alt="Capture d’écran 2024-04-22 à 15 10 44" src="https://github.com/gip-inclusion/les-emplois/assets/705214/0c4e7f01-71ec-496b-ae00-ccdf7e5c3067">

#### Après

<img width="1121" alt="Capture d’écran 2024-04-22 à 15 11 06" src="https://github.com/gip-inclusion/les-emplois/assets/705214/77c6bd20-d329-48de-acfd-d5b35080064a">

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
