### PR TITLE
Retirer session_key des logs Datadog

### DIFF
--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -3,7 +3,7 @@ from django_datadog_logger.formatters import datadog
 
 class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):
     # We don't want those information in our logs
-    LOG_KEYS_TO_REMOVE = ["usr.name", "usr.email"]
+    LOG_KEYS_TO_REMOVE = ["usr.name", "usr.email", "usr.session_key"]
 
     def json_record(self, message, extra, record):
         log_entry_dict = super().json_record(message, extra, record)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Empêcher de prendre le contrôle d’un compte utilisateur à partir des logs ingérés.
