### PR TITLE
settings: add http.status_code key to request logs

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -301,6 +301,8 @@ LOGGING = {
     },
 }
 
+DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE = r"django_datadog_logger\.middleware\.request_log"
+
 AUTH_USER_MODEL = "users.User"
 
 AUTHENTICATION_BACKENDS = (


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour avoir le code HTTP dans les logs.

## :cake: Comment ? <!-- optionnel -->

Le setting `DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE` permet d'inclure les `extra` fourni au logger dans le log JSON.
Dans notre cas, la clef `http.status_code`.

## :rotating_light: À vérifier

- [x] Ajouter l'étiquette « no-changelog » ?
- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Lancer en dev, enlever le code supprimant le formatter JSON dans config/settings/dev.py et tester une requête.
