### PR TITLE
UX/UI : Ajouter une balise `<noscript>` sur le site

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -39,6 +39,15 @@
         {% block extra_head %}{% endblock %}
     </head>
     <body class="{% block body_class %}{% endblock %}">
+        <noscript>
+            <div class="alert alert-info">
+                <p class="mb-0">
+                    Pour bénéficier de toutes les fonctionnalités de ce site, l’activation de JavaScript est nécessaire.
+                    Voici les <a href="https://www.enablejavascript.io/" target="_blank" rel="noopener">
+                    instructions pour activer JavaScript dans votre navigateur Web</a>.
+                </p>
+            </div>
+        </noscript>
         <nav role="navigation" aria-label="Accès rapide" tabindex="0" class="visually-hidden">
             <ul>
                 <li>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -205,11 +205,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.6.1.zip",
-            "sha256": "89606203853bb1f6b2d536f2c9804686618e4bfc564d3d76ff9b3811f0a7d8b6",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.6.2.zip",
+            "sha256": "cd7b3bb1d9d2d517be5a40b386ea1a05c96be2e5558de716e7629289b7a8c443",
         },
         "extract": {
-            "origin": "itou-theme-1.6.1/dist",
+            "origin": "itou-theme-1.6.2/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Indiquer aux utilisateurs comment activer JavaScript, afin qu’ils puissent utiliser toutes les fonctionnalités du site (dont des fonctionnalités essentielles, comme la recherche d’employeur).

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/ce8758e8-a433-4ddb-8876-996a97c0b07d)



## :desert_island: Comment tester

Désactiver JavaScript, le bandeau doit apparaître en haut des pages, comme sur la capture d’écran ci-dessus.
