### PR TITLE
Ajouter une option pour générer la pull request avec mkchangelog

### DIFF
--- a/.github/workflows/mkchangelog.yml
+++ b/.github/workflows/mkchangelog.yml
@@ -14,6 +14,6 @@ jobs:
       with:
         python-version: "3.11"
     - name: 📥 Generate changelog
-      run: scripts/mkchangelog
+      run: scripts/mkchangelog --publish
       env:
         GH_TOKEN: ${{ secrets.ITOU_TECH_GH_TOKEN }}

--- a/scripts/mkchangelog
+++ b/scripts/mkchangelog
@@ -15,6 +15,12 @@ import tempfile
 
 logger = logging.getLogger(__name__)
 
+ADDED = "ajouté"
+CHANGED = "modifié"
+REMOVED = "supprimé"
+SKIP = "no-changelog"
+DEPS = "dependencies"
+
 
 def gh(*args, **kwargs):
     env = (
@@ -52,15 +58,15 @@ def list_pull_requests(start, end, labels):
 
 
 def list_missing_pull_requests(start, end):
-    return list_pull_requests(start, end, "-label:ajouté,modifié,supprimé,dependencies,no-changelog")
+    return list_pull_requests(start, end, f"-label:{ADDED},{CHANGED},{REMOVED},{DEPS},{SKIP}")
 
 
 def list_merged_pull_requests(start, end):
-    return list_pull_requests(start, end, "label:ajouté,modifié,supprimé")
+    return list_pull_requests(start, end, f"label:{ADDED},{CHANGED},{REMOVED}")
 
 
 def open_pull_request(branch, title):
-    gh("pr", "create", "--label", "no-changelog", "--title", title, "--body", "")
+    gh("pr", "create", "--label", SKIP, "--title", title, "--body", "")
 
 
 def main(publish):
@@ -92,14 +98,14 @@ def main(publish):
                 if re.search(r"\!\[[^]]+]", pull_request["body"]):
                     title += " 🖼"
                 labels = [label["name"] for label in pull_request["labels"]]
-                if len({"ajouté", "modifié", "supprimé"}.intersection(set(labels))) != 1:
+                if len({ADDED, CHANGED, REMOVED}.intersection(set(labels))) != 1:
                     label_names = " ".join(labels)
                     raise ValueError(
-                        f"Expected only one of “ajouté”, “modifié” or “supprimé” in labels, got {label_names}."
+                        f"Expected only one of “{ADDED}”, “{CHANGED}” or “{REMOVED}” in labels, got {label_names}."
                     )
-                if "ajouté" in labels:
+                if ADDED in labels:
                     added.append(title)
-                elif "modifié" in labels:
+                elif CHANGED in labels:
                     changed.append(title)
                 else:
                     removed.append(title)

--- a/scripts/mkchangelog
+++ b/scripts/mkchangelog
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 
+import argparse
 import datetime
 import json
 import logging
@@ -62,7 +63,7 @@ def open_pull_request(branch, title):
     gh("pr", "create", "--label", "no-changelog", "--title", title, "--body", "")
 
 
-def main():
+def main(publish):
     changelog_path = pathlib.Path("CHANGELOG.md")
     with (
         open(changelog_path, "r+") as changelog,
@@ -131,6 +132,31 @@ def main():
         finally:
             pathlib.Path(new_changelog.name).unlink(missing_ok=True)
 
+    if publish:
+        branch = f"changelog/{sprint_end}"
+        sprint_end_inclusive = sprint_end - datetime.timedelta(days=1)
+        title = f"changelog: From {sprint_start} to {sprint_end_inclusive}"
+        subprocess.run(["git", "switch", "--create", branch], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Changelog Bot",
+                "-c",
+                "user.email=noreply@inclusion.beta.gouv.fr",
+                "commit",
+                "--all",
+                "--message",
+                title,
+            ],
+            check=True,
+        )
+        subprocess.run(["git", "push", "--set-upstream", "origin", branch], check=True)
+        open_pull_request(branch, title)
+
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--publish")
+    args = parser.parse_args()
+    main(args.publish)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Accidentellement retiré de https://github.com/gip-inclusion/les-emplois/pull/3952. Rajouté sous forme d’une option, pour faciliter le test de la commande en local.
