### PR TITLE
Retirer les arguments par défaut de FullNameFormMixin

### DIFF
--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -61,15 +61,11 @@ class FullnameFormMixin(forms.Form):
     first_name = forms.CharField(
         label="Prénom",
         max_length=User._meta.get_field("first_name").max_length,
-        required=True,
-        strip=True,
     )
 
     last_name = forms.CharField(
         label="Nom",
         max_length=User._meta.get_field("last_name").max_length,
-        required=True,
-        strip=True,
     )
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

C’est le comportement par défaut.

## :desert_island: Comment tester

- Vérifier les champs prénom et nom dans le parcours d’inscription à la plateforme.
