### PR TITLE
Profil utilisateur : Demander le prénom avant le nom, pour être cohérent avec le parcours d’inscription

### DIFF
--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -55,8 +55,8 @@
                             <div class="text-end small font-italic mb-0">{% include "signup/includes/no_email_link.html" %}</div>
 
                             {% bootstrap_field form.title wrapper_class="form-group mt-1" %}
-                            {% bootstrap_field form.last_name %}
                             {% bootstrap_field form.first_name %}
+                            {% bootstrap_field form.last_name %}
                             {% bootstrap_field form.password1 %}
                             {% bootstrap_field form.password2 %}
 

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -58,8 +58,8 @@
     <option value="MME">Madame</option>
   
   </select></div>
-                              <div class="form-group form-group-required"><label class="form-label" for="id_last_name">Nom</label><input class="form-control" id="id_last_name" maxlength="150" name="last_name" placeholder="Durand" required="" type="text"/></div>
                               <div class="form-group form-group-required"><label class="form-label" for="id_first_name">Prénom</label><input class="form-control" id="id_first_name" maxlength="150" name="first_name" placeholder="Dominique" required="" type="text"/></div>
+                              <div class="form-group form-group-required"><label class="form-label" for="id_last_name">Nom</label><input class="form-control" id="id_last_name" maxlength="150" name="last_name" placeholder="Durand" required="" type="text"/></div>
                               <div class="form-group form-group-required"><label class="form-label" for="id_password1">Mot de passe</label><div class="input-group">
       <input aria-describedby="id_password1_helptext" autocomplete="new-password" class="form-control" id="id_password1" name="password1" placeholder="**********" required="" type="password"/>
   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter les erreurs de saisie, et être cohérent avec le reste du site.

## :desert_island: Comment tester

- Se connecter en tant que candidat
- Depuis le tableau de bord, accéder au profil du candidat
- Vérifier que le prénom est bien demandé avant le nom
