### PR TITLE
Correction de la commande mkchangelog --publish

### DIFF
--- a/scripts/mkchangelog
+++ b/scripts/mkchangelog
@@ -163,6 +163,6 @@ def main(publish):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--publish")
+    parser.add_argument("--publish", action="store_true")
     args = parser.parse_args()
     main(args.publish)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Autrement, `--publish` demande un argument.
