### PR TITLE
[GEN-1567] Privilégier les administrateurs de l’organisation lors des notifications de relance des demandes de Prolongation

### DIFF
--- a/itou/approvals/notifications.py
+++ b/itou/approvals/notifications.py
@@ -49,8 +49,9 @@ class ProlongationRequestCreatedReminder(BaseNotification):
             PrescriberMembership.objects.active()
             .filter(organization=self.prolongation_request.prescriber_organization)
             .exclude(user=self.prolongation_request.validated_by)
-            # Limit to the last 10 active colleagues, it should cover the ones dedicated to the IAE and some more.
-            .order_by(F("user__last_login").desc(nulls_last=True), "-joined_at", "-pk")[:10]
+            # Limit to the last 10 active colleagues, admins take precedence over regular members.
+            # It should cover the ones dedicated to the IAE and some more.
+            .order_by("-is_admin", F("user__last_login").desc(nulls_last=True), "-joined_at", "-pk")[:10]
             .values_list("user__email", flat=True)
         )
         context = {


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://itou-inclusion.slack.com/archives/C01AQKD7MAN/p1713261492340899

https://www.notion.so/plateforme-inclusion/Notifications-de-relance-des-demandes-de-Prolongation-Privil-gier-les-administrateurs-de-l-organis-c6caa619c19448409a065ef57a116cf2?pvs=4

## :cake: Comment ? <!-- optionnel -->

Priorisation des administrateurs

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
