### PR TITLE
[GEN-1625] Ajout d'un message d'alerte pour inviter à remplir en enquête sur la réattribution des candidatures d’un collaborateur

### DIFF
--- a/itou/templates/prescribers/members.html
+++ b/itou/templates/prescribers/members.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load theme_inclusion %}
 
 {% block title %}Collaborateurs {{ block.super }}{% endblock %}
 
@@ -7,6 +8,31 @@
     <p>
         Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
     </p>
+{% endblock %}
+
+{% block messages %}
+    {# Temporary advertisement alert #}
+    <div class="alert alert-important alert-dismissible fade show" role="status">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+        <div class="row">
+            <div class="d-none d-md-inline col-md-auto">
+                <img src="{% static_theme_images 'ico-bicro-important.svg' %}" alt="" height="80">
+            </div>
+            <div class="col-12 col-md px-md-0">
+                <p class="mb-2">
+                    <strong>Retirer un collaborateur et réattribuer ses candidatures</strong>
+                </p>
+                <p class="mb-0">
+                    Aidez-nous en réalisant un test de 5 minutes : cette nouvelle fonctionnalité vous permettra de réattribuer les candidatures d’un collaborateur lorsque vous le retirez de votre structure.
+                </p>
+            </div>
+            <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                <a class="btn btn-sm btn-primary" href="https://t.maze.co/230815225" target="_blank" role="button">Accéder au test</a>
+            </div>
+        </div>
+    </div>
+
+    {{ block.super }}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/plateforme-inclusion/C1-Test-r-attribution-des-candidatures-6d9b2be7e1424127afd9270f5ab6c1c3

## :computer: Captures d'écran <!-- optionnel -->

<img width="1108" alt="Capture d’écran 2024-04-29 à 17 35 35" src="https://github.com/gip-inclusion/les-emplois/assets/705214/2031ae61-f7ff-4151-b386-14a0328992b6">

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
