### PR TITLE
[GEN-1586] Ajout d'une colonne SIRET à l’extraction CTA 

### DIFF
--- a/itou/scripts/sql/cta_export.sql
+++ b/itou/scripts/sql/cta_export.sql
@@ -8,6 +8,7 @@
 -- * Type de profil utilisateur : employeur, prescripteur habilité, orienteur
 -- * Type d'établissement (EI,EA...PE,CCAS, autre...)
 -- * Nom de l'établissement
+-- * SIRET de l'établissement
 -- * Nom et prénom de chaque membre
 -- * Adresse email de chaque membre
 -- * Le membre est admin de l'établissement (oui/non)
@@ -53,6 +54,7 @@ with company_data as (
         -- company
         company.kind as "Structure - type",
         company.name as "Structure - nom",
+        company.siret as "Structure - SIRET",
         company.address_line_1 as "Structure - adresse ligne 1",
         company.address_line_2 as "Structure - adresse ligne 2",
         company.post_code as "Structure - code postal",
@@ -85,6 +87,7 @@ org_data as (
         -- org
         org.kind as "Structure - type",
         org.name as "Structure - nom",
+        coalesce(org.siret, '') as "Structure - SIRET",
         org.address_line_1 as "Structure - adresse ligne 1",
         org.address_line_2 as "Structure - adresse ligne 2",
         org.post_code as "Structure - code postal",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un export CTA mensuel existe qui est déversé dans Bitwarden. Il faut ajouter le SIRET des structures prescripteurs et employeurs.

https://www.notion.so/plateforme-inclusion/Ajouter-une-colonne-l-extraction-CTA-et-envoyer-le-fichier-chaque-mois-FT-0f7a9457f91d4dd2afb47737cfce3841?pvs=4

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
