### PR TITLE
Gérer les variables matomo manquantes dans les tests

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -227,11 +227,9 @@
 
                 {% if matomo_user_id %}window._paq.push(['setUserId', '{{ matomo_user_id }}']);{% endif %}
 
-                {% if matomo_custom_url %}
-                    window._paq.push(['setCustomUrl', new URL('{{ matomo_custom_url }}', window.location.origin).href]);
-                {% endif %}
+                window._paq.push(['setCustomUrl', new URL('{{ matomo_custom_url }}', window.location.origin).href]);
 
-                {% if matomo_custom_title %}
+                {% if matomo_custom_title|default:"" %}
                     window._paq.push(['setDocumentTitle', '{{ matomo_custom_title }}']);
                 {% else %}
                     /* defaults to a stripped version (no suffix) of the page title. */

--- a/itou/utils/context_processors.py
+++ b/itou/utils/context_processors.py
@@ -34,6 +34,5 @@ def matomo(request):
     if params:
         url = f"{url}?{urlencode(sorted(params.items()), doseq=True)}"
     context["matomo_custom_url"] = url
-    if request.user:
-        context["matomo_user_id"] = request.user.pk
+    context["matomo_user_id"] = getattr(request.user, "pk", None)
     return context

--- a/itou/www/error.py
+++ b/itou/www/error.py
@@ -1,9 +1,12 @@
+import logging
+
 from csp.context_processors import nonce
 from django.http import HttpResponseServerError
 from django.template import TemplateDoesNotExist, loader
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME, ERROR_PAGE_TEMPLATE
 
+from itou.utils.context_processors import matomo
 from itou.utils.settings_context_processors import expose_settings
 
 
@@ -19,9 +22,10 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
             ERROR_PAGE_TEMPLATE % {"title": "Server Error (500)", "details": ""},
         )
     try:
-        # Those two context processors are needed for layout/base.html
-        context = expose_settings(request) | nonce(request)
+        # Those context processors are needed for layout/base.html
+        context = matomo(request) | expose_settings(request) | nonce(request)
     except Exception:
         # This shouldn't happen, but we really don't want the error page to also crash
+        logging.getLogger("itou.www").exception("Unable to create error page context.")
         context = {}
     return HttpResponseServerError(template.render(context))

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -987,7 +987,7 @@ class AutomaticApprovalAdminViewsTest(TestCase):
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
-    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "matomo_custom_title", "subtitle")
+    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "subtitle")
     def test_manually_add_approval(self):
         # When a Pôle emploi ID has been forgotten and the user has no NIR, an approval must be delivered
         # with a manual verification.

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -124,7 +124,6 @@ class TestTransferUserData:
         response = client.get(reverse("admin:users_user_change", kwargs={"object_id": user.pk}))
         assertContains(response, transfer_url)
 
-    @pytest.mark.ignore_unknown_variable_template_error("matomo_custom_title")
     def test_transfer_without_change_permission(self, client):
         from_user = JobSeekerFactory()
         to_user = JobSeekerFactory()

--- a/tests/utils/__snapshots__/tests.ambr
+++ b/tests/utils/__snapshots__/tests.ambr
@@ -35,9 +35,7 @@
   
                   window._paq.push(['setUserId', '99999']);
   
-                  
-                      window._paq.push(['setCustomUrl', new URL('/doesnotexist?mtm_foo=truc', window.location.origin).href]);
-                  
+                  window._paq.push(['setCustomUrl', new URL('/doesnotexist?mtm_foo=truc', window.location.origin).href]);
   
                   
                       /* defaults to a stripped version (no suffix) of the page title. */
@@ -58,9 +56,7 @@
   
                   window._paq.push(['setUserId', '99999']);
   
-                  
-                      window._paq.push(['setCustomUrl', new URL('company/&lt;int:siae_id&gt;/card?city=paris&amp;mtm_bar=bidule&amp;mtm_foo=truc', window.location.origin).href]);
-                  
+                  window._paq.push(['setCustomUrl', new URL('company/&lt;int:siae_id&gt;/card?city=paris&amp;mtm_bar=bidule&amp;mtm_foo=truc', window.location.origin).href]);
   
                   
                       window._paq.push(['setDocumentTitle', 'Fiche de la structure d&#x27;insertion']);

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1433,7 +1433,7 @@ def test_redact_email_adresse(email, expected):
     assert redact_email_address(email) == expected
 
 
-@pytest.mark.ignore_unknown_variable_template_error("matomo_custom_title", "matomo_event_attrs")
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 def test_matomo_context_processor(client, settings, snapshot):
     """Test on a canically problematic view that we get the right Matomo properties.
 

--- a/tests/www/test_error.py
+++ b/tests/www/test_error.py
@@ -32,6 +32,7 @@ def test_error_handling(client, mocker):
 def test_handler500_view():
     factory = RequestFactory()
     request = factory.get("/")
+    request.user = None
     SessionMiddleware(get_response_for_middlewaremixin).process_request(request)
     CsrfViewMiddleware(get_response_for_middlewaremixin).process_request(request)
     response = server_error(request)


### PR DESCRIPTION
## :thinking: Pourquoi ?

```
Failed: Undefined template variable 'matomo_custom_title' in 'itou/templates/layout/base.html'
```
et ses suites.
