### PR TITLE
Recherche employeur : amélioration de l’affichage lorsque le formulaire de recherche est invalide

### DIFF
--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -42,6 +42,19 @@ class EmployerSearchBaseView(FormView):
         # to be able to share the search results URL.
         return self.post(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        context = {
+            "back_url": reverse("search:employers_home"),
+            "filters_query_string": "",
+            "job_descriptions_count": 0,
+            "siaes_count": 0,
+            "results_page": [],
+            # Keep title as “Recherche employeurs solidaires” for matomo stats.
+            "matomo_custom_title": "Recherche d'employeurs solidaires",
+        }
+        context.update(kwargs)
+        return super().get_context_data(**context)
+
     def get_template_names(self):
         return [
             "search/includes/siaes_search_results.html" if self.request.htmx else "search/siaes_search_results.html"
@@ -139,19 +152,8 @@ class EmployerSearchBaseView(FormView):
             "results_page": results_and_counts.results_page,
             "siaes_count": results_and_counts.siaes_count,
             "job_descriptions_count": results_and_counts.job_descriptions_count,
-            # Keep title as “Recherche employeurs solidaires” for matomo stats.
-            "matomo_custom_title": "Recherche d'employeurs solidaires",
-            "back_url": reverse("search:employers_home"),
         }
-        return render(self.request, self.get_template_names(), context)
-
-    def form_invalid(self, form):
-        context = {
-            "form": form,
-            # Keep title as “Recherche employeurs solidaires” for matomo stats.
-            "matomo_custom_title": "Recherche d'employeurs solidaires",
-        }
-        return render(self.request, self.get_template_names(), context)
+        return render(self.request, self.get_template_names(), self.get_context_data(**context))
 
 
 class EmployerSearchView(EmployerSearchBaseView):

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -27,7 +27,6 @@ class SearchCompanyTest(TestCase):
     URL = reverse_lazy("search:employers_results")
     URL_JOBS = reverse_lazy("search:job_descriptions_results")
 
-    @pytest.mark.ignore_template_errors
     def test_not_existing(self):
         response = self.client.get(self.URL, {"city": "foo-44"})
         self.assertContains(response, "Aucun résultat avec les filtres actuels.")
@@ -426,7 +425,6 @@ class JobDescriptionSearchViewTest(TestCase):
     URL = reverse_lazy("search:job_descriptions_results")
     URL_EMPLOYERS = reverse_lazy("search:employers_results")
 
-    @pytest.mark.ignore_template_errors
     def test_not_existing(self):
         response = self.client.get(self.URL, {"city": "foo-44"})
         self.assertContains(response, "Aucun résultat avec les filtres actuels.")
@@ -824,7 +822,6 @@ class JobDescriptionSearchViewTest(TestCase):
         self.assertNotContains(response, job2_name, html=True)
         self.assertNotContains(response, job3_name, html=True)
 
-    @pytest.mark.ignore_template_errors
     def test_domains(self):
         create_test_romes_and_appellations(("N1101", "M1805"))
         city = create_city_saint_andre()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Plusieurs petits problèmes d’affichage, dont les compteurs qui n’étaient pas initialisés (badges vides sur les onglets), bouton retour manquant.

Les problèmes ont été révélés en enlevant le marqueur `ignore_template_errors`.

## :cake: Comment ? <!-- optionnel -->

Afin de mutualiser la construction du contexte entre `form_valid()` et `form_invalid()`, définition d’un `get_context_data()`.

## :computer: Captures d'écran <!-- optionnel -->

### Avant
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/c690d77a-27c0-4052-bae1-1d3ad23a4589)

### Après
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/e8a5375a-ddfc-44a3-8e5c-ca668b708a10)

## :desert_island: Comment tester

1. Visiter la page `/search/employers/results?city=foo-44`
