### PR TITLE
[DataInclusion] Ne pas appeler l'API quand l'URL n'est pas définie

### DIFF
--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -51,7 +51,7 @@ def get_data_inclusion_services(code_insee):
     """Returns 3 random DI services, in a 'stable' way: for a given city and day so that an user
     who refreshes the page or shares the URL would not get different services in the same day.
     """
-    if not code_insee:
+    if not settings.API_DATA_INCLUSION_BASE_URL or not code_insee:
         return []
     cache_key = f"{DATA_INCLUSION_API_CACHE_PREFIX}:{code_insee}:{timezone.localdate()}"
     cache = caches["failsafe"]


### PR DESCRIPTION
## :thinking: Pourquoi ?

En local, j'ai eu une TypeError car la variable d'environnement n'était pas définie.
Je propose de récupérer les services DI uniquement quand la variable est définie.

## :cake: Comment ?

Ajout d'une condition