### PR TITLE
Mettre à jour le changelog lorsque l’action est lancée à nouveau

### DIFF
--- a/scripts/mkchangelog
+++ b/scripts/mkchangelog
@@ -22,6 +22,19 @@ SKIP = "no-changelog"
 DEPS = "dependencies"
 
 
+def prepare_branch(branch):
+    # The remote branch may not exist, ignore errors.
+    subprocess.run(["git", "fetch", "origin", "master", branch])
+    try:
+        subprocess.run(["git", "switch", branch], check=True)
+        created = False
+    except subprocess.CalledProcessError:
+        subprocess.run(["git", "switch", "--create", branch], check=True)
+        created = True
+    subprocess.run(["git", "reset", "--hard", "origin/master"], check=True)
+    return created
+
+
 def gh(*args, **kwargs):
     env = (
         {
@@ -87,6 +100,9 @@ def main(publish):
             sprint_start = datetime.date.fromisoformat(sprint_start_text)
             sprint_end = sprint_start + datetime.timedelta(days=7)
 
+            branch = f"changelog/{sprint_end}"
+            new_branch = prepare_branch(branch)
+
             if missing := list_missing_pull_requests(sprint_start, sprint_end):
                 missing_pull_requests = "\n- ".join(pr["url"] for pr in missing)
                 sys.exit(f"The following pull requests should have a label:\n- {missing_pull_requests}\n")
@@ -139,26 +155,23 @@ def main(publish):
             pathlib.Path(new_changelog.name).unlink(missing_ok=True)
 
     if publish:
-        branch = f"changelog/{sprint_end}"
+        commit_command_base = [
+            "git",
+            "-c",
+            "user.name=Changelog Bot",
+            "-c",
+            "user.email=noreply@inclusion.beta.gouv.fr",
+            "commit",
+        ]
         sprint_end_inclusive = sprint_end - datetime.timedelta(days=1)
         title = f"changelog: From {sprint_start} to {sprint_end_inclusive}"
-        subprocess.run(["git", "switch", "--create", branch], check=True)
+        subprocess.run([*commit_command_base, "--all", "--message", title], check=True)
         subprocess.run(
-            [
-                "git",
-                "-c",
-                "user.name=Changelog Bot",
-                "-c",
-                "user.email=noreply@inclusion.beta.gouv.fr",
-                "commit",
-                "--all",
-                "--message",
-                title,
-            ],
+            ["git", "push", "--set-upstream", "origin", branch, "--force-with-lease", "--force-if-includes"],
             check=True,
         )
-        subprocess.run(["git", "push", "--set-upstream", "origin", branch], check=True)
-        open_pull_request(branch, title)
+        if new_branch:
+            open_pull_request(branch, title)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter la mise en cohérence des PRs avec le changelog