### PR TITLE
Recherche prescripteur : amélioration de la page lorsque le formulaire est invalide

### DIFF
--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -2,9 +2,13 @@
 {% load str_filters %}
 
 {% block title %}
-    {% with request.GET.city_name as city and request.GET.distance as distance %}
-        Prescripteurs à {{ distance }} km du centre de {{ city }}
-    {% endwith %}
+    {% if "city_name" in request.GET and "distance" in request.GET %}
+        {% with request.GET.city_name as city and request.GET.distance as distance %}
+            Prescripteurs à {{ distance }} km du centre de {{ city }}
+        {% endwith %}
+    {% else %}
+        Rechercher des prescripteurs habilités
+    {% endif %}
     {{ block.super }}
 {% endblock %}
 

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -292,7 +292,7 @@ def search_prescribers_results(request, template_name="search/prescribers_search
     city = None
     distance = None
     form = PrescriberSearchForm(data=request.GET or None, initial={"distance": PrescriberSearchForm.DISTANCE_DEFAULT})
-    prescriber_orgs_page = None
+    prescriber_orgs = []
 
     if form.is_valid():
         city = form.cleaned_data["city"]
@@ -304,7 +304,7 @@ def search_prescribers_results(request, template_name="search/prescribers_search
             .annotate(distance=Distance("coords", city.coords))
             .order_by("distance")
         )
-        prescriber_orgs_page = pager(prescriber_orgs, request.GET.get("page"), items_per_page=10)
+    prescriber_orgs_page = pager(prescriber_orgs, request.GET.get("page"), items_per_page=10)
 
     context = {
         "city": city,

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -1,4 +1,3 @@
-import pytest
 from django.contrib.gis.geos import Point
 from django.template.defaultfilters import capfirst, urlencode as urlencode_filter
 from django.templatetags.static import static
@@ -400,7 +399,11 @@ class SearchPrescriberTest(TestCase):
         response = self.client.get(url)
         self.assertContains(response, "Rechercher des prescripteurs habilités")
 
-    @pytest.mark.ignore_template_errors
+    def test_invalid(self):
+        response = self.client.get(reverse("search:prescribers_results"), {"city": "foo-44"})
+        self.assertContains(response, "Rechercher des prescripteurs habilités")
+        self.assertContains(response, "Sélectionnez un choix valide. Ce choix ne fait pas partie de ceux disponibles.")
+
     def test_results(self):
         url = reverse("search:prescribers_results")
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Enlever des accès à des variables non définies dans le contexte, s’assurer que la page s’affiche comme prévu.
