### PR TITLE
Simplifier les vérifications de application_geiq_eligibility

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -953,6 +953,9 @@ class ApplicationGEIQEligibilityView(ApplicationBaseView):
             # Do nothing, LoginRequiredMixin will raise in dispatch()
             return
 
+        if self.company.kind != CompanyKind.GEIQ:
+            raise Http404("This form is only for GEIQ")
+
         self.form = GEIQAdministrativeCriteriaForm(
             company=self.company,
             administrative_criteria=(

--- a/itou/www/geiq_eligibility_views/forms.py
+++ b/itou/www/geiq_eligibility_views/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 
-from itou.companies.enums import CompanyKind
 from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
 
 
@@ -29,15 +28,6 @@ class GEIQAdministrativeCriteriaForm(forms.Form):
     pole_emploi_related = forms.CharField(max_length=100, required=False)
 
     def __init__(self, company, administrative_criteria, form_url, accept_no_criteria=True, **kwargs):
-        if not company or company.kind != CompanyKind.GEIQ:
-            raise ValueError("This form is only for GEIQ")
-
-        if administrative_criteria is None:
-            raise ValueError("This form needs a list of criteria, even empty")
-
-        if not form_url:
-            raise ValueError("This form needs a submit URL")
-
         super().__init__(**kwargs)
 
         self.company = company

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3640,7 +3640,6 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         )
         self.assertTemplateNotUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
 
-    @pytest.mark.ignore_template_errors
     def test_sanity_check_geiq_diagnosis_for_non_geiq(self):
         job_seeker = JobSeekerFactory()
         # See comment im previous test:
@@ -3648,13 +3647,13 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         self.client.force_login(self.company.members.first())
         self._setup_session(company_pk=self.company.pk)
 
-        with self.assertRaisesRegex(ValueError, "This form is only for GEIQ"):
-            self.client.get(
-                reverse(
-                    "apply:application_geiq_eligibility",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_pk": job_seeker.pk},
-                )
+        response = self.client.get(
+            reverse(
+                "apply:application_geiq_eligibility",
+                kwargs={"company_pk": self.company.pk, "job_seeker_pk": job_seeker.pk},
             )
+        )
+        assert response.status_code == 404
 
     def test_access_as_authorized_prescriber(self):
         job_seeker = JobSeekerFactory()

--- a/tests/www/geiq_eligibility_views/test_forms.py
+++ b/tests/www/geiq_eligibility_views/test_forms.py
@@ -33,18 +33,6 @@ def criteria_in_radio():
     return GEIQAdministrativeCriteria.objects.filter(slug__in=GEIQAdministrativeCriteriaForm.RADIO_FIELDS)
 
 
-def test_form_init_sanity_check(new_geiq):
-    # Check that we use a correct structure
-    with pytest.raises(ValueError, match="This form is only for GEIQ"):
-        GEIQAdministrativeCriteriaForm(None, None, None)
-
-    with pytest.raises(ValueError, match="This form needs a list of criteria, even empty"):
-        GEIQAdministrativeCriteriaForm(new_geiq, None, None)
-
-    with pytest.raises(ValueError, match="This form needs a submit URL"):
-        GEIQAdministrativeCriteriaForm(new_geiq, (), None)
-
-
 def test_init_geiq_administrative_criteria_form(new_geiq, administrative_criteria_for_checkboxes):
     # Mainly checks addition of htmx attributes
     for criterion in administrative_criteria_for_checkboxes:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le formulaire vérifiait ses arguments, mais deux des trois cas vérifiés étaient impossibles.

Pour le dernier, la vérification a été déplacée dans la vue, pour un peu mieux indiquer le problème (qui ne devrait jamais se produire) aux utilisateurs.
