### PR TITLE
Ajout du siret à l'export des rejet d'api PE [GEN-1585]

### DIFF
--- a/itou/approvals/management/commands/export_pe_api_rejections.py
+++ b/itou/approvals/management/commands/export_pe_api_rejections.py
@@ -32,8 +32,6 @@ class Command(XlsxExportMixin, BaseCommand):
 
         data = []
         for approval in rejected_approvals:
-            # Use the same logic that Approval.notify_pole_emploi() to get the SIAE using the PASS.
-            company = approval.jobapplication_set.accepted().order_by("-created_at").first().to_company
             data.append(
                 [
                     approval.number,
@@ -44,9 +42,8 @@ class Command(XlsxExportMixin, BaseCommand):
                     approval.user.last_name,
                     approval.user.first_name,
                     approval.user.birthdate.isoformat(),
-                    company.kind,
-                    company.name,
-                    company.department,
+                    approval.origin_siae_kind,
+                    approval.origin_siae_siret,
                 ]
             )
 
@@ -60,8 +57,7 @@ class Command(XlsxExportMixin, BaseCommand):
             "prenom",
             "date_naissance",
             "siae_type",
-            "siae_raison_sociale",
-            "siae_departement",
+            "siae_siret",
         ]
 
         self.export_to_xlsx(filename, headers, data)

--- a/tests/approvals/test_management_commands.py
+++ b/tests/approvals/test_management_commands.py
@@ -24,10 +24,8 @@ class ExportPEApiRejectionsTestCase(TestCase):
             pe_notification_exit_code="FOOBAR",
             user__last_name="Pers,e",
             user__first_name='Jul"ie',
-            with_jobapplication=True,
-            with_jobapplication__to_company__department=42,
-            with_jobapplication__to_company__kind="EI",
-            with_jobapplication__to_company__name="Ma petite entreprise",
+            origin_siae_kind="EI",
+            origin_siae_siret="12345678900000",
         )
         stdout = io.StringIO()
         management.call_command("export_pe_api_rejections", stdout=stdout, stderr=io.StringIO())
@@ -44,8 +42,7 @@ class ExportPEApiRejectionsTestCase(TestCase):
                     "prenom",
                     "date_naissance",
                     "siae_type",
-                    "siae_raison_sociale",
-                    "siae_departement",
+                    "siae_siret",
                 ],
                 [
                     approval.number,
@@ -57,8 +54,7 @@ class ExportPEApiRejectionsTestCase(TestCase):
                     'Jul"ie',
                     str(approval.user.birthdate),
                     "EI",
-                    "Ma petite entreprise",
-                    "42",
+                    "12345678900000",
                 ],
             ]
         finally:


### PR DESCRIPTION
Le siret et le type de l'entreprise à l'origine du pass sont stockés sur le modèle depuis quelques mois, autant les réutiliser !

On attend le GO d'eric pour merger