### PR TITLE
github: Also (re)run `require-labels` on labels changes

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -2,7 +2,9 @@ name: Label Checks
 
 # Add merge_group and make the check required when
 # https://github.com/mheap/github-action-required-labels/issues/66 is solved.
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   require-label:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour que l'action `require-labels` se relance lors d'un changement de label, par exemple si on reprend une veille PR et qu'on a déjà _push_ ;).

## :computer: Captures d'écran <!-- optionnel -->

Sans label : https://github.com/gip-inclusion/les-emplois/actions/runs/8921667281/job/24502236608?pr=4018
Ajout de "no-changelog" : https://github.com/gip-inclusion/les-emplois/actions/runs/8921674884/job/24502262012?pr=4018

## :desert_island: Comment tester

Ajouter et enlever les labels sur cette PR.