### PR TITLE
Amélioration du marker `ignore_unknown_variable_template_error` pour autoriser une liste de noms spécifiques

### DIFF
--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -987,7 +987,7 @@ class AutomaticApprovalAdminViewsTest(TestCase):
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class CustomApprovalAdminViewsTest(MessagesTestMixin, TestCase):
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "matomo_custom_title", "subtitle")
     def test_manually_add_approval(self):
         # When a Pôle emploi ID has been forgotten and the user has no NIR, an approval must be delivered
         # with a manual verification.

--- a/tests/openid_connect/inclusion_connect/tests.py
+++ b/tests/openid_connect/inclusion_connect/tests.py
@@ -782,7 +782,7 @@ class InclusionConnectLogoutTest(InclusionConnectBaseTestCase):
 
 
 class InclusionConnectmapChannelTest(MessagesTestMixin, InclusionConnectBaseTestCase):
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
     @respx.mock
     def test_happy_path(self):
         job_application = JobApplicationSentByPrescriberPoleEmploiFactory(
@@ -815,7 +815,7 @@ class InclusionConnectmapChannelTest(MessagesTestMixin, InclusionConnectBaseTest
         response = self.client.get(response.url)
         assert response.status_code == 200
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
     @respx.mock
     def test_create_user(self):
         # Application sent by a colleague from the same agency but not by the prescriber himself.

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -124,6 +124,7 @@ class TestTransferUserData:
         response = client.get(reverse("admin:users_user_change", kwargs={"object_id": user.pk}))
         assertContains(response, transfer_url)
 
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_custom_title")
     def test_transfer_without_change_permission(self, client):
         from_user = JobSeekerFactory()
         to_user = JobSeekerFactory()
@@ -141,7 +142,7 @@ class TestTransferUserData:
         response = client.get(transfer_url_2)
         assert response.status_code == 403
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "subtitle")
     def test_transfer_no_data_to_transfer(self, admin_client):
         user = JobSeekerFactory()
         transfer_url = reverse("admin:transfer_user_data", kwargs={"from_user_pk": user.pk})
@@ -149,7 +150,7 @@ class TestTransferUserData:
         assertContains(response, self.IMPOSSIBLE_TRANSFER_TEXT)
         assertNotContains(response, self.CHOOSE_TARGET_TEXT, html=True)
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "subtitle")
     @freeze_time("2023-08-31 12:34:56")
     def test_transfer_data(self, admin_client, snapshot):
         job_application = JobApplicationFactory(with_approval=True)

--- a/tests/utils/test_redirect_legacy_views.py
+++ b/tests/utils/test_redirect_legacy_views.py
@@ -5,7 +5,7 @@ from pytest_django.asserts import assertRedirects
 from tests.companies.factories import CompanyFactory
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 def test_redirect_siae_views(client):
     company = CompanyFactory()
 

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1433,7 +1433,7 @@ def test_redact_email_adresse(email, expected):
     assert redact_email_address(email) == expected
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("matomo_custom_title", "matomo_event_attrs")
 def test_matomo_context_processor(client, settings, snapshot):
     """Test on a canically problematic view that we get the right Matomo properties.
 

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -69,7 +69,7 @@ REFUSED_JOB_APPLICATION_PRESCRIBER_SECTION_BODY = (
 )
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("has_form_error", "with_matomo_event")
 @pytest.mark.usefixtures("unittest_compatibility")
 class ProcessViewsTest(MessagesTestMixin, TestCase):
     DIAGORIENTE_INVITE_TITLE = "Ce candidat n’a pas de CV ?"
@@ -2672,7 +2672,7 @@ def test_refuse_jobapplication_geiq_reasons(client, reason):
     }
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("expired_eligibility_diagnosis", "with_matomo_event")
 def test_details_for_prescriber_not_can_have_prior_actions(client):
     kind = random.choice(list(set(CompanyKind) - {CompanyKind.GEIQ}))
     job_application = JobApplicationFactory(
@@ -2687,7 +2687,7 @@ def test_details_for_prescriber_not_can_have_prior_actions(client):
     assertNotContains(response, PRIOR_ACTION_SECTION_TITLE)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
 def test_details_for_prescriber_geiq_without_prior_actions(client):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
@@ -2705,7 +2705,7 @@ def test_details_for_prescriber_geiq_without_prior_actions(client):
     assertNotContains(response, PRIOR_ACTION_SECTION_TITLE)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("with_matomo_event", "with_oob_state_update")
 def test_details_for_prescriber_geiq_with_prior_actions(client):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
@@ -2730,7 +2730,7 @@ def test_details_for_prescriber_geiq_with_prior_actions(client):
     assertNotContains(response, delete_button)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("with_matomo_event", "with_oob_state_update")
 def test_details_for_jobseeker_geiq_with_prior_actions(client):
     job_application = JobApplicationFactory(
         sent_by_authorized_prescriber_organisation=True,
@@ -2756,7 +2756,7 @@ def test_details_for_jobseeker_geiq_with_prior_actions(client):
     assertNotContains(response, delete_button)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
 def test_details_sender_email_display_for_job_seeker(client):
     SENDER_EMAIL_HIDDEN = "<small>Adresse e-mail</small><strong>Non communiquée</strong>"
 
@@ -2795,7 +2795,7 @@ def test_details_sender_email_display_for_job_seeker(client):
     assertNotContains(response, SENDER_EMAIL_HIDDEN, html=True)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("final_hr")
 def test_accept_button(client):
     job_application = JobApplicationFactory(
         state=job_applications_enums.JobApplicationState.PROCESSING,
@@ -2839,7 +2839,7 @@ def test_add_prior_action_new(client):
     assert not job_application.prior_actions.exists()
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("final_hr")
 @freeze_time("2023-12-12 13:37:00", tz_offset=-1)
 def test_add_prior_action_processing(client, snapshot):
     job_application = JobApplicationFactory(
@@ -2961,7 +2961,7 @@ def test_delete_prior_action_accepted(client):
     prior_action.refresh_from_db()
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("final_hr", "with_oob_state_update")
 @pytest.mark.parametrize("with_geiq_diagnosis", [True, False])
 @freeze_time("2023-12-12 13:37:00", tz_offset=-1)
 def test_delete_prior_action(client, snapshot, with_geiq_diagnosis):
@@ -3035,7 +3035,7 @@ def test_delete_prior_action(client, snapshot, with_geiq_diagnosis):
     assertSoupEqual(parse_response_to_soup(response, selector="#main"), simulated_page)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("final_hr")
 def test_htmx_add_prior_action_and_cancel(client):
     job_application = JobApplicationFactory(
         to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.PROCESSING
@@ -3066,7 +3066,7 @@ def test_htmx_add_prior_action_and_cancel(client):
     assertSoupEqual(parse_response_to_soup(response, selector="#main"), simulated_page)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("add_prior_action_form", "final_hr", "with_oob_state_update")
 def test_htmx_modify_prior_action_and_cancel(client):
     job_application = JobApplicationFactory(
         to_company__kind=CompanyKind.GEIQ, state=job_applications_enums.JobApplicationState.PROCESSING
@@ -3096,7 +3096,7 @@ def test_htmx_modify_prior_action_and_cancel(client):
     assertSoupEqual(parse_response_to_soup(response, selector="#main"), simulated_page)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("final_hr", "with_oob_state_update")
 @pytest.mark.parametrize("with_geiq_diagnosis", [True, False])
 def test_details_for_company_with_prior_action(client, with_geiq_diagnosis):
     job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ)
@@ -3212,7 +3212,7 @@ def test_details_for_company_with_prior_action(client, with_geiq_diagnosis):
     assertSoupEqual(parse_response_to_soup(response, selector="#main"), simulated_page)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
 def test_precriber_details_with_older_valid_approval(client, faker):
     # Ensure that the approval details are displayed for a prescriber
     # when the job seeker has a valid approval created on an older approval

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4199,7 +4199,6 @@ class GEIQEligibilityForHireTestCase(TestCase):
         response = self.client.get(self._reverse("apply:geiq_eligibility_for_hire"))
         assert response.status_code == 404
 
-    @pytest.mark.ignore_unknown_variable_template_error
     def test_job_seeker_with_valid_diagnosis(self):
         diagnosis = GEIQEligibilityDiagnosisFactory(job_seeker=self.job_seeker, with_geiq=True)
         diagnosis.administrative_criteria.add(GEIQAdministrativeCriteria.objects.get(pk=19))
@@ -4249,7 +4248,6 @@ class GEIQEligibilityForHireTestCase(TestCase):
         assert GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(self.job_seeker, self.company).exists()
 
 
-@pytest.mark.ignore_unknown_variable_template_error
 class HireConfirmationTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -4410,7 +4408,6 @@ class NewHireProcessInfoTestCase(TestCase):
         self.assertNotContains(response, self.GEIQ_APPLY_PROCESS_INFO)
         self.assertNotContains(response, self.GEIQ_DIRECT_HIRE_PROCESS_INFO)
 
-    @pytest.mark.ignore_unknown_variable_template_error
     def test_as_prescriber(self):
         self.client.force_login(PrescriberFactory())
         response = self.client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": self.company.pk}))
@@ -4420,7 +4417,6 @@ class NewHireProcessInfoTestCase(TestCase):
         self.assertNotContains(response, self.GEIQ_APPLY_PROCESS_INFO)
         self.assertNotContains(response, self.GEIQ_DIRECT_HIRE_PROCESS_INFO)
 
-    @pytest.mark.ignore_unknown_variable_template_error
     def test_as_employer(self):
         self.client.force_login(self.company.members.first())
         response = self.client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": self.company.pk}))

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -688,7 +688,9 @@ class ApplyAsJobSeekerTest(TestCase):
         self.assertContains(response, expected_html, html=True)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error(
+    "confirmation_needed", "job_seeker", "readonly_form", "update_job_seeker"
+)
 @pytest.mark.usefixtures("unittest_compatibility")
 class ApplyAsAuthorizedPrescriberTest(TestCase):
     def setUp(self):
@@ -1316,7 +1318,9 @@ class ApplyAsPrescriberTest(MessagesTestMixin, TestCase):
             response, expected_url=reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
         )
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error(
+        "confirmation_needed", "job_seeker", "readonly_form", "update_job_seeker"
+    )
     @override_settings(API_BAN_BASE_URL="http://ban-api")
     @mock.patch(
         "itou.utils.apis.geocoding.get_geocoding_data",
@@ -1608,7 +1612,7 @@ class ApplyAsPrescriberTest(MessagesTestMixin, TestCase):
         )
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("job_seeker")
 class ApplyAsPrescriberNirExceptionsTest(TestCase):
     """
     The following normal use cases are tested in tests above:
@@ -1799,7 +1803,9 @@ class ApplyAsCompanyTest(TestCase):
             status_code=403,
         )
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error(
+        "confirmation_needed", "job_seeker", "readonly_form", "update_job_seeker"
+    )
     @override_settings(API_BAN_BASE_URL="http://ban-api")
     @mock.patch(
         "itou.utils.apis.geocoding.get_geocoding_data",
@@ -2063,7 +2069,7 @@ class ApplyAsCompanyTest(TestCase):
         response = self.client.get(next_url)
         assert response.status_code == 200
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("job_seeker")
     def test_cannot_create_job_seeker_with_pole_emploi_email(self):
         # It's unlikely to happen
         membership = CompanyMembershipFactory()
@@ -2133,7 +2139,9 @@ class DirectHireFullProcessTest(TestCase):
             status_code=403,
         )
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error(
+        "confirmation_needed", "is_subject_to_eligibility_rules", "job_seeker", "readonly_form", "update_job_seeker"
+    )
     @override_settings(API_BAN_BASE_URL="http://ban-api")
     @mock.patch(
         "itou.utils.apis.geocoding.get_geocoding_data",
@@ -3431,7 +3439,9 @@ class UpdateJobSeekerStep3ViewTestCase(TestCase):
         )
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error(
+    "confirmation_needed", "job_seeker", "readonly_form", "update_job_seeker"
+)
 def test_detect_existing_job_seeker(client):
     company = CompanyWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
 
@@ -3886,7 +3896,9 @@ class CheckPreviousApplicationsViewTestCase(TestCase):
         self.assertContains(response, self.check_prev_applications_url)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error(
+    "confirmation_needed", "job_seeker", "readonly_form", "update_job_seeker"
+)
 class FindJobSeekerForHireViewTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -4087,7 +4099,7 @@ class CheckJobSeekerInformationsForHireTestCase(TestCase):
         self.assertContains(response, reverse("dashboard:index"))
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("is_subject_to_eligibility_rules")
 class CheckPreviousApplicationsForHireViewTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
@@ -4137,7 +4149,7 @@ class CheckPreviousApplicationsForHireViewTestCase(TestCase):
         self.assertRedirects(response, self._reverse("apply:geiq_eligibility_for_hire"))
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("is_subject_to_eligibility_rules")
 class EligibilityForHireTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -116,7 +116,7 @@ def test_job_application_job_seeker_in_list():
 # QPV / ZRR eligibility details
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("request")
 def test_known_criteria_template_with_no_criterion():
     tmpl = load_template("apply/includes/known_criteria.html")
     rendered = tmpl.render(Context({"job_seeker": JobSeekerWithAddressFactory()}))
@@ -126,7 +126,7 @@ def test_known_criteria_template_with_no_criterion():
     assert "est partiellement classée en ZRR" not in rendered
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("request")
 def test_known_criteria_template_with_qpv_criterion():
     tmpl = load_template("apply/includes/known_criteria.html")
     job_seeker = JobSeekerWithAddressFactory(with_address_in_qpv=True)
@@ -138,7 +138,7 @@ def test_known_criteria_template_with_qpv_criterion():
     assert escape(job_seeker.address_on_one_line) in rendered
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("request")
 def test_known_criteria_template_with_zrr_criterion():
     tmpl = load_template("apply/includes/known_criteria.html")
     job_seeker = JobSeekerWithAddressFactory(with_city_in_zrr=True)
@@ -150,7 +150,7 @@ def test_known_criteria_template_with_zrr_criterion():
     assert escape(job_seeker.city) in rendered
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("request")
 def test_known_criteria_template_with_partial_zrr_criterion():
     tmpl = load_template("apply/includes/known_criteria.html")
     job_seeker = JobSeekerWithAddressFactory(with_city_partially_in_zrr=True)

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -100,7 +100,7 @@ class TestApprovalDetailView:
         assertContains(response, "Informations du salarié")
         assertContains(response, "Candidatures de ce salarié")
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
     @freeze_time("2023-04-26")
     def test_approval_status_includes(self, client, snapshot):
         """

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -303,7 +303,7 @@ class TestApprovalsListView:
         response = client.get(url)
         assertContains(response, "0 résultat")
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("boost", "boost_target", "boost_indicator")
     def test_approval_expiry_filter_default(self, client):
         company = CompanyFactory(with_membership=True)
         # Make sure we have access to page 2

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -21,7 +21,7 @@ from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
 from tests.utils.test import parse_response_to_soup
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("job_application", "hiring_pending")
 @pytest.mark.usefixtures("unittest_compatibility")
 @freeze_time("2023-08-23")
 class ApprovalProlongationTest(TestCase):

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -95,7 +95,7 @@ def test_list_view_only_pending_filter(client):
     assert list(response.context["pager"].object_list) == [pending_prolongation_request]
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application")
 def test_show_view_access(client):
     prolongation_request, other_prolongation_request = approvals_factories.ProlongationRequestFactory.create_batch(2)
 
@@ -123,7 +123,7 @@ def test_show_view_access(client):
     assert response.status_code == 404
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application", "matomo_event_attrs")
 def test_show_view(snapshot, client):
     prolongation_request = approvals_factories.ProlongationRequestFactory(for_snapshot=True)
     client.force_login(prolongation_request.validated_by)

--- a/tests/www/approvals_views/test_suspend.py
+++ b/tests/www/approvals_views/test_suspend.py
@@ -20,7 +20,7 @@ from tests.utils.test import TestCase, parse_response_to_soup
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class ApprovalSuspendViewTest(TestCase):
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application")
     def test_suspend_approval(self):
         """
         Test the creation of a suspension.

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -600,7 +600,7 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
         self.assertContains(response, reverse("companies_views:job_description_list"))
         self.assertNotContains(response, self.apply_start_url(self.company))
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_prescriber_card_actions(self):
         # Checks if non-employers can apply to opened job descriptions
         self.client.force_login(PrescriberOrganizationWithMembershipFactory().members.first())
@@ -624,7 +624,7 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
             self.update_job_description_url(self.job_description),
         )
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_job_seeker_card_actions(self):
         self.client.force_login(JobSeekerFactory())
 
@@ -642,7 +642,7 @@ class JobDescriptionCardTest(JobDescriptionAbstractTest):
         self.assertContains(response, self.apply_start_url(self.company))
         self.assertNotContains(response, self.update_job_description_url(self.job_description))
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_anonymous_card_actions(self):
         response = self.client.get(self.url)
 

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -32,7 +32,7 @@ from tests.users.factories import EmployerFactory, JobSeekerFactory
 from tests.utils.test import BASE_NUM_QUERIES, TestCase, assert_previous_step, parse_response_to_soup
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 @pytest.mark.usefixtures("unittest_compatibility")
 class CardViewTest(TestCase):
     OTHER_TAB_ID = "autres-metiers"
@@ -242,7 +242,7 @@ class CardViewTest(TestCase):
         self.assertContains(response, company_card_url_other_formatting)
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 @pytest.mark.usefixtures("unittest_compatibility")
 class JobDescriptionCardViewTest(TestCase):
     @classmethod

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -696,7 +696,7 @@ class DashboardViewTest(TestCase):
         response = self.client.get(reverse("dashboard:index"))
         self.assertContains(response, self.SUSPEND_TEXT)
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application")
     @freeze_time("2022-09-15")
     def test_dashboard_access_by_a_jobseeker(self):
         approval = ApprovalFactory(start_at=datetime(2022, 6, 21), end_at=datetime(2022, 12, 6))
@@ -1815,7 +1815,7 @@ class EditUserEmailFormTest(TestCase):
 
 
 class SwitchCompanyTest(TestCase):
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_switch_company(self):
         company = CompanyFactory(with_membership=True)
         user = company.members.first()
@@ -2379,7 +2379,7 @@ TOKEN_MENU_STR = "Accès aux APIs"
 API_TOKEN_URL = reverse_lazy("dashboard:api_token")
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 def test_api_token_view_for_company_admin(client):
     employer = CompanyMembershipFactory().user
     client.force_login(employer)

--- a/tests/www/invitations_views/test_company_send.py
+++ b/tests/www/invitations_views/test_company_send.py
@@ -33,7 +33,7 @@ class TestSendSingleCompanyInvitation(TestCase):
             "form-0-email": self.guest_data["email"],
         }
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_send_one_invitation(self):
         self.client.force_login(self.sender)
         response = self.client.get(INVITATION_URL)
@@ -58,7 +58,7 @@ class TestSendSingleCompanyInvitation(TestCase):
         outbox_emails = [receiver for message in mail.outbox for receiver in message.to]
         assert self.post_data["form-0-email"] in outbox_emails
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_send_invitation_user_already_exists(self):
         guest = EmployerFactory(
             first_name=self.guest_data["first_name"],
@@ -99,7 +99,7 @@ class TestSendSingleCompanyInvitation(TestCase):
                     assert key == "email"
                     assert error_dict["email"][0] == "Cet utilisateur n'est pas un employeur."
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_two_employers_invite_the_same_guest(self):
         # company 1 invites guest.
         self.client.force_login(self.sender)
@@ -187,7 +187,7 @@ class TestSendInvitationToSpecialGuest(TestCase):
             "form-MAX_NUM_FORMS": "",
         }
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_invite_existing_user_with_existing_inactive_company(self):
         """
         An inactive SIAIE user (i.e. attached to a single inactive company)
@@ -206,7 +206,7 @@ class TestSendInvitationToSpecialGuest(TestCase):
         assert response.status_code == 200
         assert EmployerInvitation.objects.count() == 1
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
     def test_invite_former_employer(self):
         """
         Admins can "deactivate" members of the organization (making the membership inactive).

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -584,7 +584,6 @@ class JobDescriptionSearchViewTest(TestCase):
         response = self.client.get(self.URL, {"city": city.slug, "kinds": [CompanyKind.EI]})
         self.assertContains(response, "Aucun résultat")
 
-    @pytest.mark.ignore_unknown_variable_template_error
     def test_distance(self):
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         # 3 companies in two departments to test distance and department filtering

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -3543,7 +3543,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         )
         assert response.status_code == 404
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")
     def test_criterion_validation(self):
         self.client.force_login(self.user)
 
@@ -3712,7 +3712,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
             response = self.client.get(url)
         assert response.status_code == 200
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")
     def test_job_application_state_labels(self):
         self.client.force_login(self.user)
         # fixme vincentporte : use EvaluatedAdministrativeCriteria instead

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -601,7 +601,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
 
         assert response.status_code == 404
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")
     def test_access(self):
         self.client.force_login(self.user)
 
@@ -630,7 +630,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
         assert evaluated_job_application.compute_state() == response.context["state"]
         assert evaluated_siae.siae.kind == response.context["kind"]
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")
     def test_context_fields_list(self):
         self.client.force_login(self.user)
 
@@ -655,7 +655,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
             assert level_1 is bool(response.context["level_1_fields"])
             assert level_2 is bool(response.context["level_2_fields"])
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")
     def test_post(self):
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
@@ -701,7 +701,7 @@ class SiaeSelectCriteriaViewTest(TestCase):
         assert response.status_code == 403
         assert evaluated_job_application.evaluated_administrative_criteria.count() == 0
 
-    @pytest.mark.ignore_unknown_variable_template_error
+    @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")
     def test_initial_data_form(self):
         # no preselected criteria
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -19,7 +19,6 @@ from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
 from tests.utils.test import TestCase, parse_response_to_soup, reload_module
 
 
-@pytest.mark.ignore_unknown_variable_template_error
 @pytest.mark.usefixtures("unittest_compatibility")
 class JobSeekerSignupTest(TestCase):
     def setUp(self):

--- a/tests/www/test_error.py
+++ b/tests/www/test_error.py
@@ -15,7 +15,7 @@ class FailingForm:
         raise Exception("Something bad")
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("messages", "request")
 def test_error_handling(client, mocker):
     mocker.patch("itou.www.search.views.SiaeSearchForm", FailingForm)
 
@@ -28,7 +28,7 @@ def test_error_handling(client, mocker):
         client.get(reverse("search:employers_home"))
 
 
-@pytest.mark.ignore_unknown_variable_template_error
+@pytest.mark.ignore_unknown_variable_template_error("messages", "request")
 def test_handler500_view():
     factory = RequestFactory()
     request = factory.get("/")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela permet d'être moins permissif (seules ces erreurs sont tolérées) et également de facilement retrouver tous les tests corrigés lorsqu'on modifie la disponibilité d'une variable.

Et si j'ai le courage de sortir ça dans une lib ou d'intégrer cela à pytest-django, cela sera plus propre.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

