### PR TITLE
Formatage d'adresse : Gérer le cas où la BAN ne connais pas le code postal de la commune (ie. Saint-Martin)

### DIFF
--- a/itou/asp/fixtures/test_asp_INSEE_communes_factory.json
+++ b/itou/asp/fixtures/test_asp_INSEE_communes_factory.json
@@ -518,5 +518,15 @@
       "start_date": "1900-01-01",
       "end_date": null
     }
+  },
+  {
+    "model": "asp.Commune",
+    "pk": 76197,
+    "fields": {
+      "code": "97801",
+      "name": "SAINT-MARTIN",
+      "start_date": "2007-02-21",
+      "end_date": null
+    }
   }
 ]

--- a/itou/common_apps/address/format.py
+++ b/itou/common_apps/address/format.py
@@ -3,6 +3,7 @@ import re
 from unidecode import unidecode
 
 from itou.asp.models import LaneExtension, LaneType, find_lane_type_aliases
+from itou.cities.models import City
 from itou.utils.apis.exceptions import GeocodingDataError
 from itou.utils.apis.geocoding import get_geocoding_data
 
@@ -124,7 +125,12 @@ def format_address(obj):
 
     # INSEE code: must double check with ASP ref file
     result["insee_code"] = address.get("insee_code")
-    result["post_code"] = address.get("post_code")
     result["city"] = address.get("city")
+
+    postal_code = address.get("post_code")
+    if not postal_code and result["insee_code"]:
+        # Don't try to do smart things when there is multiple post codes, taking the first one should be enough.
+        postal_code = City.objects.get(code_insee=result["insee_code"]).post_codes[0]
+    result["post_code"] = postal_code
 
     return result, None

--- a/tests/asp/__snapshots__/test_sync_communes.ambr
+++ b/tests/asp/__snapshots__/test_sync_communes.ambr
@@ -104,7 +104,8 @@
     '\tREMOVED {"code": "91432", "name": "MORANGIS", "start_date": "1968-01-01", "end_date": "1999-12-31"}',
     '\tREMOVED {"code": "91432", "name": "MORANGIS", "start_date": "2000-01-01", "end_date": null}',
     '\tREMOVED {"code": "97108", "name": "CAPESTERRE-DE-MARIE-GALANT", "start_date": "1900-01-01", "end_date": null}',
-    '> successfully deleted count=52 communes',
+    '\tREMOVED {"code": "97801", "name": "SAINT-MARTIN", "start_date": "2007-02-21", "end_date": null}',
+    '> successfully deleted count=53 communes',
     '> successfully updated count=0 communes',
     '> successfully created count=35 new communes',
   ])

--- a/tests/asp/test_communes.py
+++ b/tests/asp/test_communes.py
@@ -6,9 +6,9 @@ from tests.utils.test import TestCase
 
 class CommunesFixtureTest(TestCase):
     # INSEE commune with a single entry (1 history entry)
-    _CODES_WITHOUT_HISTORY = ["97108", "13200"]
+    _CODES_WITHOUT_HISTORY = ["97108", "13200", "97801"]
     ## Total number of entries in the file
-    _NUMBER_OF_ENTRIES = 52
+    _NUMBER_OF_ENTRIES = 53
     # No commune registered before this date (end_date)
     _PERIOD_MIN_DATE = datetime.date(1900, 1, 1)
 
@@ -43,7 +43,7 @@ class CommunesFixtureTest(TestCase):
     def test_current_entries(self):
         communes = Commune.objects.filter(end_date__isnull=True)
 
-        assert 27 == communes.count()
+        assert 28 == communes.count()
 
         for commune in communes:
             with self.subTest():

--- a/tests/www/autocomplete/tests.py
+++ b/tests/www/autocomplete/tests.py
@@ -505,6 +505,7 @@ class CommunesAutocompleteTest(TestCase):
         assert response.status_code == 200
         assert response.json() == [
             {"code": "64483", "department": "064", "value": "SAINT-JEAN-DE-LUZ (064)"},
+            {"code": "97801", "department": "978", "value": "SAINT-MARTIN (978)"},
             {"code": "62758", "department": "062", "value": "SAINT-MARTIN-BOULOGNE (062)"},
         ]
 
@@ -539,6 +540,7 @@ class Select2CommunesAutocompleteTest(TestCase):
         assert response.json() == {
             "results": [
                 {"id": Commune.objects.by_insee_code("64483").pk, "text": "SAINT-JEAN-DE-LUZ (064)"},
+                {"id": Commune.objects.by_insee_code("97801").pk, "text": "SAINT-MARTIN (978)"},
                 {"id": Commune.objects.by_insee_code("62758").pk, "text": "SAINT-MARTIN-BOULOGNE (062)"},
             ]
         }


### PR DESCRIPTION
## :thinking: Pourquoi ?

La BAN ne semble pas connaître le code postal de Saint-Martin ce qui crée une erreur lors de la géolocalisation de l'adresse dans les fiches salariés : [LES-EMPLOIS-PROD-1R0](https://itou.sentry.io/issues/5102024422/)

## :cake: Comment ? <!-- optionnel -->

Si la BAN ne nous retourne pas de code postal alors nous allons chercher celui présent dans le référentiel INSEE (`cities.City`).

## :desert_island: Comment tester

- Avoir activer la BAN en local
- Embaucher un candidat domicilié à Saint-Martin dans une SIAE
- Créer (sans erreur) la fiche salarié pour ce nouveau salarié
