### PR TITLE
Statistiques : La Direction Territoriale Alpes de Haute Provence et Hautes Alpes supervise 2 départements (04, 05)

### DIFF
--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -104,6 +104,7 @@ DRPE_SAFIR_CODES = [
 # By default (`None`) a DTPE oversees its own department unless a list of several departments is specified below.
 DTPE_SAFIR_CODE_TO_DEPARTMENTS = {
     # Note that the first two digits of the SAFIR code usually indicate the department.
+    "04016": ["04", "05"],
     "10038": None,
     "11030": ["09", "11"],
     "13010": None,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement seul le 05 (département renseigné sur l'organisation) est accessible à cette DT.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/35a66366-6c59-4508-8c0d-6c136fa92b1e)

## :desert_island: Comment tester

- Avoir configuré les variables `METABASE_SITE_URL` et `METABASE_SECRET_KEY`.
- Se connecter avec un compte rattaché à une organisation prescriptrice `France Travail` ayant le code SAFIR `04016`.
- Accéder au tableau de bord metabase via l'onglet "Statistique".