### PR TITLE
Désactiver GPS en démo

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -657,4 +657,4 @@ DORA_BASE_URL = os.getenv("DORA_BASE_URL", "https://dora.inclusion.beta.gouv.fr"
 # GPS
 # ------------------------------------------------------------------------------
 # Until GPS goes live for everyone, keep the feature hidden in production.
-GPS_ENABLED = ITOU_ENVIRONMENT != "PROD"
+GPS_ENABLED = ITOU_ENVIRONMENT not in ("DEMO", "PROD")


### PR DESCRIPTION
## :thinking: Pourquoi ?

En attendant que l'outil devienne public, ne l'affichons pas en démo.
