### PR TITLE
[GEN-132] Disparition automatique des toasts après 6 secondes

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -216,6 +216,10 @@
                     $(this).toast("show");
                 });
             });
+
+            document.querySelectorAll(".toast-container .toast").forEach(
+                toastEl => bootstrap.Toast.getOrCreateInstance(toastEl).show()
+            );
         </script>
 
         {% if MATOMO_BASE_URL %}

--- a/itou/templates/utils/toasts.html
+++ b/itou/templates/utils/toasts.html
@@ -1,7 +1,7 @@
 {% load theme_inclusion %}
 {% for message in messages %}
     {% if "toast" in message.tags %}
-        <div class="toast {{ message|itou_toast_classes }} show" role="status" aria-live="assertive" aria-atomic="true">
+        <div class="toast {{ message|itou_toast_classes }}" role="status" aria-live="assertive" aria-atomic="true" data-delay="6000">
             <div class="toast-header">
                 {% if message.level_tag == "warning" %}
                     <i class="ri-error-warning-line ri-lg me-1" aria-hidden="true"></i>


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/plateforme-inclusion/Disparition-automatique-des-toasts-apr-s-un-certain-d-lais-e327e924783348b0a7d26a088fce6dd6?pvs=4

## :cake: Comment ? <!-- optionnel -->

- Suppression de l'affichage sticky par défaut
- Initialisation des toasts + affichage au chargement de la page

## :computer: Captures d'écran <!-- optionnel -->

https://github.com/gip-inclusion/les-emplois/assets/705214/1eaaa705-d25b-4ec7-9257-a26cf816c648
