### PR TITLE
Résolution d'un problème entraînant une erreur 500 en admin

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -398,7 +398,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
     @admin.display(description="adresse en QPV")
     def address_in_qpv(self, obj):
         # DO NOT PUT THIS FIELD IN 'list_display' : dynamically computed, only for detail page
-        if not obj.coords:
+        if not obj.coords or not obj.geocoding_score:
             return "Adresse non-géolocalisée"
         elif obj.geocoding_score < BAN_API_RELIANCE_SCORE:
             return "Adresse imprécise"


### PR DESCRIPTION
## :thinking: Pourquoi ?

La méthode `address_in_qpv` ne teste pas la présence de `geocoding_score` avant de le comparer au seuil d'imprécision.

https://itou.sentry.io/issues/5282930811/?project=6164438

## :cake: Comment ? <!-- optionnel -->

Si `geocoding_score` est `None` ou `0`, on considère que l'adresse est non-géolocalisée.