### PR TITLE
Configurer `ruff` pour qu'il corrige les erreurs automatiquement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         language: system
       - id: ruff
         name: Ruff
-        entry: ruff
+        entry: ruff check --fix
         types: [python]
         language: system
       - id: djlint


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lorsque `pre-commit` se lance à chaque commit, s'il y a une erreur dans un fichier python `ruff` la signale mais ne la corrige pas même s'il peut.

## :cake: Comment ? <!-- optionnel -->

On modifie la configuration `pre-commit` pour laisser `ruff` corriger automatiquement s'il peut.


## :desert_island: Comment tester

Lancer `pre-commit install`, rajouter par exemples des lignes vides à la suite des imports d'un fichier et essayer de créer un commit avec ces modifications. `ruff` devrait automatiquement enlever les lignes inutiles.
