### PR TITLE
API : Indiquer de filtrer par SIRET sur l’API `employee-records` et non `candidats_list`

### DIFF
--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -21,16 +21,16 @@
                                     <ul>
                                         <li>
                                             Fiches salarié (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/employee-records" target="_blank">voir la documentation</a>) : cette API est disponible par défaut pour toutes vos structures.
-                                        </li>
-                                        <li>
-                                            Candidats  (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/candidats" target="_blank">voir la documentation</a>) : cette API est disponible par défaut sur une seule structure mais vous pouvez utiliser
-                                            des paramètres pour accéder aux candidats de toutes vos structures.
                                             <div class="alert alert-warning">
                                                 <p class="mb-0">
 
                                                     Important : Votre éditeur de logiciel doit filtrer les données par “SIRET” afin qu’elles soient rattachées dans les bonnes structures.
                                                 </p>
                                             </div>
+                                        </li>
+                                        <li>
+                                            Candidats  (<a href="https://emplois.inclusion.beta.gouv.fr/api/v1/redoc/#tag/candidats" target="_blank">voir la documentation</a>) : cette API est disponible par défaut sur une seule structure mais vous pouvez utiliser
+                                            des paramètres pour accéder aux candidats de toutes vos structures.
                                         </li>
                                     </ul>
                                     <p>Listes de vos structures :</p>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter les confusions.

## :computer: Captures d'écran <!-- optionnel -->

## :desert_island: Comment tester

1. Se connecter en tant que l’EI
2. Depuis le dropdown du « Mon espace », aller sur « Accès aux API »
3. Voir le message d’avertissement à destination des utilisateurs de l’API `employee-records`
