### PR TITLE
Contrôle a posteriori : Modification du champ preuve dans l'admin en RO

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -287,6 +287,7 @@ class EvaluatedAdministrativeCriteriaAdmin(ItouModelAdmin):
         "proof_link",
         "submitted_at",
         "review_state",
+        "proof",
     )
 
     @admin.display(description="lien du fichier bilan")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Impossible de charger les pages de l'admin  sans cela : https://emplois.inclusion.beta.gouv.fr/admin/siae_evaluations/evaluatedadministrativecriteria/