### PR TITLE
Contrôle a posteriori : donner l'accès aux pièces justificatives des contrôles précédents aux employeurs

### DIFF
--- a/itou/templates/siae_evaluations/evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/evaluated_job_application.html
@@ -34,6 +34,20 @@
                         </div>
                         <hr class="m-0">
                         <div class="c-box--results__body">
+                            {% if evaluated_job_application.evaluated_siae.reviewed_at %}
+                                {% if not evaluated_job_application.hide_state_from_siae %}
+                                    {% with jobapp_state=evaluated_job_application.compute_state %}
+                                        {% if jobapp_state == 'REFUSED' or jobapp_state == 'REFUSED_2' %}
+                                            <p>
+                                                <b>Commentaire de la DDETS</b>
+                                            </p>
+                                            <div class="card">
+                                                <div class="card-body">{{ evaluated_job_application.labor_inspector_explanation|linebreaks }}</div>
+                                            </div>
+                                        {% endif %}
+                                    {% endwith %}
+                                {% endif %}
+                            {% endif %}
                             <div class="c-info c-info--secondary mt-3">
                                 <button class="c-info__summary"
                                         data-bs-toggle="collapse"

--- a/itou/templates/siae_evaluations/evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/evaluated_job_application.html
@@ -27,7 +27,7 @@
                     <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                         <div class="c-box--results__header">
                             {% if request.user.is_employer %}
-                                {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=evaluated_job_application.job_application.job_seeker approval=evaluated_job_application.job_application.approval state=evaluated_job_application.compute_state reviewed_at=evaluated_job_application.evaluated_siae.reviewed_at %}
+                                {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with evaluated_job_application=evaluated_job_application %}
                             {% else %}
                                 {% include "siae_evaluations/includes/job_seeker_infos_for_institution.html" with job_seeker=evaluated_job_application.job_application.job_seeker approval=evaluated_job_application.job_application.approval state=evaluated_job_application.compute_state %}
                             {% endif %}

--- a/itou/templates/siae_evaluations/evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/evaluated_job_application.html
@@ -26,7 +26,11 @@
                 <div class="col-12">
                     <div class="c-box c-box--results has-links-inside my-3 my-md-4">
                         <div class="c-box--results__header">
-                            {% include "siae_evaluations/includes/job_seeker_infos_for_institution.html" with job_seeker=evaluated_job_application.job_application.job_seeker approval=evaluated_job_application.job_application.approval state=evaluated_job_application.compute_state %}
+                            {% if request.user.is_employer %}
+                                {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=evaluated_job_application.job_application.job_seeker approval=evaluated_job_application.job_application.approval state=evaluated_job_application.compute_state reviewed_at=evaluated_job_application.evaluated_siae.reviewed_at %}
+                            {% else %}
+                                {% include "siae_evaluations/includes/job_seeker_infos_for_institution.html" with job_seeker=evaluated_job_application.job_application.job_seeker approval=evaluated_job_application.job_application.approval state=evaluated_job_application.compute_state %}
+                            {% endif %}
                         </div>
                         <hr class="m-0">
                         <div class="c-box--results__body">

--- a/itou/templates/siae_evaluations/evaluated_siae_detail.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_detail.html
@@ -100,7 +100,7 @@
                                     <hr class="m-0">
                                     <div class="c-box--results__footer">
                                         <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-                                            <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">
+                                            <a href="{% url 'siae_evaluations_views:evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">
                                                 Contrôler cette auto-prescription
                                             </a>
                                         </div>
@@ -109,7 +109,7 @@
                                     <hr class="m-0">
                                     <div class="c-box--results__footer">
                                         <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-                                            <a href="{% url 'siae_evaluations_views:institution_evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">
+                                            <a href="{% url 'siae_evaluations_views:evaluated_job_application' evaluated_job_application.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">
                                                 Revoir ses justificatifs
                                             </a>
                                         </div>

--- a/itou/templates/siae_evaluations/evaluated_siae_sanction.html
+++ b/itou/templates/siae_evaluations/evaluated_siae_sanction.html
@@ -30,7 +30,7 @@
                                 <b>Commentaire de votre DDETS</b>
                             </p>
                             <div class="card">
-                                <div class="card-body">{{ evaluated_siae.notification_text }}</div>
+                                <div class="card-body">{{ evaluated_siae.notification_text|linebreaks }}</div>
                             </div>
                         </div>
                         <div class="card-body">
@@ -39,7 +39,7 @@
                             {% if sanctions.training_session %}
                                 <h3 class="mt-5">Participation à une session de présentation de l’auto-prescription</h3>
                                 <div class="card">
-                                    <div class="card-body">{{ sanctions.training_session }}</div>
+                                    <div class="card-body">{{ sanctions.training_session|linebreaks }}</div>
                                 </div>
                             {% endif %}
 

--- a/itou/templates/siae_evaluations/includes/evaluation_data.html
+++ b/itou/templates/siae_evaluations/includes/evaluation_data.html
@@ -15,7 +15,7 @@
                     </li>
                 {% endif %}
             </ul>
-            <a target="_blank" href="{% url 'siae_evaluations_views:institution_evaluated_siae_detail' evaluated_siae_pk=evaluated_siae.pk %}">Revoir
+            <a target="_blank" href="{% url 'siae_evaluations_views:evaluated_siae_detail' evaluated_siae_pk=evaluated_siae.pk %}">Revoir
                 {% if job_apps_count == 1 %}
                     l’auto-prescription
                 {% else %}

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
@@ -11,6 +11,12 @@
     <div>
         {% if state == "REFUSED_2" %}
             <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
+        {% elif final_reviewed_at %}
+            {% if state == "ACCEPTED" or state == "SUBMITTED" %}
+                <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
+            {% else %}
+                <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
+            {% endif %}
         {% elif reviewed_at %}
             {% if state == "ACCEPTED" %}
                 <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
@@ -4,43 +4,46 @@
     <div class="c-box--results__summary flex-grow-1">
         <i class="ri-pass-valid-line" aria-hidden="true"></i>
         <div>
-            <h3>PASS IAE {{ approval.number|format_approval_number }} délivré le {{ approval.start_at|date:"d E Y" }}</h3>
-            <span>{{ job_seeker.get_full_name }}</span>
+            <h3>
+                PASS IAE {{ evaluated_job_application.job_application.approval.number|format_approval_number }} délivré le {{ evaluated_job_application.job_application.approval.start_at|date:"d E Y" }}
+            </h3>
+            <span>{{ evaluated_job_application.job_application.job_seeker.get_full_name }}</span>
         </div>
     </div>
     <div>
-        {% if state == "REFUSED_2" %}
-            <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
-        {% elif final_reviewed_at %}
-            {% if state == "ACCEPTED" or state == "SUBMITTED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
+        {% with state=evaluated_job_application.compute_state_for_siae %}
+            {% if evaluated_job_application.evaluated_siae.evaluation_campaign.ended_at %}
+                {% if state == "ACCEPTED" or state == "SUBMITTED" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
+                {% else %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
+                {% endif %}
+            {% elif evaluated_job_application.evaluated_siae.reviewed_at %}
+                {% if state == "ACCEPTED" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
+                {% elif state == "UPLOADED" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Justificatifs téléversés</span>
+                {% elif state == "SUBMITTED" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-success-lighter text-success">Transmis</span>
+                {% elif state == "REFUSED" or state == "REFUSED_2" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
+                {% elif state == "PROCESSING" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">À traiter</span>
+                {% elif state == "PENDING" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Nouveaux justificatifs à traiter</span>
+                {% endif %}
             {% else %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
+                {% if state == "PENDING" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">À traiter</span>
+                {% elif state == "PROCESSING" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-info text-white">En cours</span>
+                {% elif state == "UPLOADED" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Justificatifs téléversés</span>
+                {% elif state == "SUBMITTED" or state == "REFUSED" or state == "ACCEPTED" %}
+                    <span class="badge badge-sm rounded-pill text-nowrap bg-success-lighter text-success">Transmis</span>
+                {% endif %}
+                {# We should never have a REFUSED_2 here because it only exist in phase 3 which happens when we add a reviewed_at on the valuated_siae #}
             {% endif %}
-        {% elif reviewed_at %}
-            {% if state == "ACCEPTED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
-            {% elif state == "UPLOADED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Justificatifs téléversés</span>
-            {% elif state == "SUBMITTED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-success-lighter text-success">Transmis</span>
-            {% elif state == "REFUSED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
-            {% elif state == "PROCESSING" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">À traiter</span>
-            {% else %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Nouveaux justificatifs à traiter</span>
-            {% endif %}
-        {% else %}
-            {% if state == "PENDING" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">À traiter</span>
-            {% elif state == "PROCESSING" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-info text-white">En cours</span>
-            {% elif state == "UPLOADED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Justificatifs téléversés</span>
-            {% elif state == "SUBMITTED" or state == "REFUSED" or state == "ACCEPTED" %}
-                <span class="badge badge-sm rounded-pill text-nowrap bg-success-lighter text-success">Transmis</span>
-            {% endif %}
-        {% endif %}
+        {% endwith %}
     </div>
 </div>

--- a/itou/templates/siae_evaluations/includes/list_item.html
+++ b/itou/templates/siae_evaluations/includes/list_item.html
@@ -3,7 +3,7 @@
 {# navigation : anchor to scroll to a specific card when returning to this page #}
 <div class="c-box c-box--results has-links-inside my-3 my-md-4" id="{{ item.pk }}">
     <div class="c-box--results__header">
-        {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=item.job_application.job_seeker approval=item.job_application.approval state=item.compute_state_for_siae reviewed_at=item.evaluated_siae.reviewed_at %}
+        {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with evaluated_job_application=item %}
     </div>
     <hr class="m-0">
     {% if item.evaluated_siae.reviewed_at or item.evaluated_administrative_criteria.all %}

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_list.html
@@ -48,7 +48,7 @@
                                     {% if evaluated_siae.state == "REFUSED" and evaluated_siae.notified_at %}
                                         <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "siae_evaluations_views:institution_evaluated_siae_sanction" evaluated_siae.pk %}">Voir la notification de sanction</a>
                                     {% endif %}
-                                    <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_detail' evaluated_siae.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">
+                                    <a href="{% url 'siae_evaluations_views:evaluated_siae_detail' evaluated_siae.pk %}" class="btn btn-outline-primary btn-block w-100 w-md-auto">
                                         {% if evaluated_siae.evaluation_is_final %}
                                             Voir le résultat
                                         {% else %}

--- a/itou/templates/siae_evaluations/siae_select_criteria.html
+++ b/itou/templates/siae_evaluations/siae_select_criteria.html
@@ -3,7 +3,9 @@
 {% load django_bootstrap5 %}
 {% load static %}
 
-{% block title %}Auto-prescriptions à justifier pour {{ job_seeker.get_full_name }}{% endblock %}
+{% block title %}
+    Auto-prescriptions à justifier pour {{ evaluated_job_application.job_application.job_seeker.get_full_name }}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
@@ -12,7 +14,7 @@
                 <div class="col-12 col-md-8">
                     <div class="card">
                         <div class="card-header">
-                            {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=job_seeker approval=approval state=state %}
+                            {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with evaluated_job_application=evaluated_job_application %}
                         </div>
                         <div class="card-body">
                             <div class="row mt-3">

--- a/itou/templates/siae_evaluations/siae_upload_doc.html
+++ b/itou/templates/siae_evaluations/siae_upload_doc.html
@@ -12,7 +12,7 @@
                 <div class="col-12 col-md-8">
                     <div class="card">
                         <div class="card-header">
-                            {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with job_seeker=evaluated_administrative_criteria.evaluated_job_application.job_application.job_seeker approval=evaluated_administrative_criteria.evaluated_job_application.job_application.approval state=evaluated_administrative_criteria.evaluated_job_application.compute_state reviewed_at=evaluated_administrative_criteria.evaluated_job_application.evaluated_siae.reviewed_at %}
+                            {% include "siae_evaluations/includes/job_seeker_infos_for_siae.html" with evaluated_job_application=evaluated_administrative_criteria.evaluated_job_application %}
                         </div>
                         <div class="card-body">
                             <div class="row mt-3">

--- a/itou/www/siae_evaluations_views/urls.py
+++ b/itou/www/siae_evaluations_views/urls.py
@@ -19,9 +19,9 @@ urlpatterns = [
         name="institution_evaluated_siae_list",
     ),
     path(
-        "institution_evaluated_siae_detail/<int:evaluated_siae_pk>/",
-        views.institution_evaluated_siae_detail,
-        name="institution_evaluated_siae_detail",
+        "evaluated_siae_detail/<int:evaluated_siae_pk>/",
+        views.evaluated_siae_detail,
+        name="evaluated_siae_detail",
     ),
     path(
         "institution_evaluated_siae_notify/<int:evaluated_siae_pk>/",
@@ -52,9 +52,9 @@ urlpatterns = [
         name="siae_sanction",
     ),
     path(
-        "institution_evaluated_job_application/<int:evaluated_job_application_pk>/",
-        views.institution_evaluated_job_application,
-        name="institution_evaluated_job_application",
+        "evaluated_job_application/<int:evaluated_job_application_pk>/",
+        views.evaluated_job_application,
+        name="evaluated_job_application",
     ),
     path(
         "institution_evaluated_administrative_criteria/<int:evaluated_administrative_criteria_pk>/<slug:action>",

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -639,9 +639,7 @@ def siae_select_criteria(
     back_url = get_safe_url(request, "back_url", fallback_url=url)
 
     context = {
-        "job_seeker": evaluated_job_application.job_application.job_seeker,
-        "approval": evaluated_job_application.job_application.approval,
-        "state": evaluated_job_application.compute_state(),
+        "evaluated_job_application": evaluated_job_application,
         "form_administrative_criteria": form_administrative_criteria,
         "level_1_fields": level_1_fields,
         "level_2_fields": level_2_fields,

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -245,7 +245,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             )
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         self.assertContains(
@@ -295,7 +295,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             count=1,
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         self.assertContains(
@@ -342,7 +342,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             count=1,
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         self.assertContains(
@@ -388,7 +388,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             count=1,
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         self.assertContains(
@@ -428,7 +428,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         self.assertContains(
@@ -500,7 +500,7 @@ class InstitutionEvaluatedSiaeListViewTest(TestCase):
         self.assertContains(
             response,
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
@@ -678,7 +678,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         # institution without evaluation_campaign
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": 99999},
             )
         )
@@ -688,7 +688,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluation_campaign = EvaluationCampaignFactory(institution=self.institution)
         evaluated_siae = create_evaluated_siae_consistent_datas(evaluation_campaign)
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
 
@@ -717,12 +717,12 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": job_app.pk},
         )
         self.assertContains(
@@ -766,7 +766,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -802,7 +802,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -848,7 +848,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -887,7 +887,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -922,7 +922,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -947,7 +947,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -962,11 +962,11 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
 
         evaluated_job_application_url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         validation_url = reverse(
@@ -1269,11 +1269,11 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluation_campaign.freeze(timezone.now())
 
         evaluated_job_application_url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
         validation_url = reverse(
@@ -1396,7 +1396,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1419,7 +1419,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1446,7 +1446,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1476,7 +1476,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1510,7 +1510,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1540,7 +1540,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1570,7 +1570,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1589,12 +1589,12 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         )
         evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
         evaluated_job_application_url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
@@ -1622,7 +1622,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluated_siae = create_evaluated_siae_consistent_datas(evaluation_campaign)
 
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
 
@@ -1677,7 +1677,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         evaluation_campaign.freeze(timezone.now())
 
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
 
@@ -1735,7 +1735,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_job_application.evaluated_siae_id},
             )
         )
@@ -1751,7 +1751,7 @@ class InstitutionEvaluatedSiaeDetailViewTest(TestCase):
         EvaluatedJobApplicationFactory.create_batch(10, evaluated_siae=evaluated_siae)
 
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": evaluated_siae.pk},
         )
 
@@ -1931,7 +1931,7 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
         self.assertContains(
             response,
             f"""
-            <a target="_blank" href="/siae_evaluation/institution_evaluated_siae_detail/{evaluated_siae.pk}/">
+            <a target="_blank" href="/siae_evaluation/evaluated_siae_detail/{evaluated_siae.pk}/">
              Revoir les 5 auto-prescriptions
              <i class="ri-external-link-line">
              </i>
@@ -2096,7 +2096,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep1Test(InstitutionEvaluatedSiaeNotify
         self.assertContains(
             response,
             f"""
-            <a target="_blank" href="/siae_evaluation/institution_evaluated_siae_detail/{evaluated_siae.pk}/">
+            <a target="_blank" href="/siae_evaluation/evaluated_siae_detail/{evaluated_siae.pk}/">
              Revoir l’auto-prescription
              <i class="ri-external-link-line">
              </i>
@@ -3320,7 +3320,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         # institution without evaluation_campaign
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": 1},
             )
         )
@@ -3332,7 +3332,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
             )
         )
@@ -3343,7 +3343,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluation_campaign.save(update_fields=["evaluations_asked_at"])
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
             )
         )
@@ -3360,7 +3360,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": job_app.pk},
             )
         )
@@ -3394,7 +3394,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.post(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": job_app.pk},
             ),
             data={"labor_inspector_explanation": "Test"},
@@ -3412,7 +3412,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": job_app.pk},
             )
         )
@@ -3427,7 +3427,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
             )
         )
@@ -3437,7 +3437,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         assert (
             response.context["back_url"]
             == reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
             + f"#{evaluated_job_application.pk}"
@@ -3459,7 +3459,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
             )
         )
@@ -3482,7 +3482,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
             )
         )
@@ -3500,7 +3500,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": past_job_application.pk},
             )
         )
@@ -3536,7 +3536,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.post(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": past_job_application.pk},
             ),
             data={"labor_inspector_explanation": "Invalide !"},
@@ -3554,7 +3554,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         accepte_url = self.accept_url(evaluated_administrative_criteria)
         reinit_url = self.reinit_url(evaluated_administrative_criteria)
         url_view = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_administrative_criteria.evaluated_job_application.pk},
         )
 
@@ -3639,7 +3639,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
 
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
         )
 
@@ -3652,7 +3652,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         assert (
             response.url
             == reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
             + f"#{evaluated_job_application.pk}"
@@ -3673,7 +3673,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         job_app = evaluated_siae.evaluated_job_applications.get()
         response = self.client.post(
             reverse(
-                "siae_evaluations_views:institution_evaluated_job_application",
+                "siae_evaluations_views:evaluated_job_application",
                 kwargs={"evaluated_job_application_pk": job_app.pk},
             ),
             data={"labor_inspector_explanation": "updated"},
@@ -3697,7 +3697,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         )
 
         url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_administrative_criteria.evaluated_job_application.pk},
         )
         with self.assertNumQueries(
@@ -3722,7 +3722,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
         evaluated_administrative_criteria.save(update_fields=["submitted_at", "proof"])
 
         url_view = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_administrative_criteria.evaluated_job_application.pk},
         )
 
@@ -3814,7 +3814,7 @@ class InstitutionEvaluatedAdministrativeCriteriaViewTest(TestCase):
         # fixme vincentporte : use EvaluatedAdministrativeCriteria instead
         evaluated_administrative_criteria = get_evaluated_administrative_criteria(self.institution)
         redirect_url = reverse(
-            "siae_evaluations_views:institution_evaluated_job_application",
+            "siae_evaluations_views:evaluated_job_application",
             kwargs={"evaluated_job_application_pk": evaluated_administrative_criteria.evaluated_job_application.pk},
         )
 
@@ -3954,7 +3954,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(MessagesTestMixin, TestCase):
             kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
         )
         redirect_url = reverse(
-            "siae_evaluations_views:institution_evaluated_siae_detail",
+            "siae_evaluations_views:evaluated_siae_detail",
             kwargs={"evaluated_siae_pk": self.evaluated_siae.pk},
         )
 
@@ -4039,7 +4039,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(MessagesTestMixin, TestCase):
         self.assertRedirects(
             response,
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
@@ -4069,7 +4069,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(MessagesTestMixin, TestCase):
         self.assertRedirects(
             response,
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
@@ -4098,7 +4098,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(MessagesTestMixin, TestCase):
         self.assertRedirects(
             response,
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )
@@ -4128,7 +4128,7 @@ class InstitutionEvaluatedSiaeValidationViewTest(MessagesTestMixin, TestCase):
         self.assertRedirects(
             response,
             reverse(
-                "siae_evaluations_views:institution_evaluated_siae_detail",
+                "siae_evaluations_views:evaluated_siae_detail",
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             ),
         )

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -34,6 +34,7 @@ from tests.siae_evaluations.factories import (
 )
 from tests.users.factories import JobSeekerFactory
 from tests.utils.test import BASE_NUM_QUERIES, TestCase, parse_response_to_soup
+from tests.www.siae_evaluations_views.test_siaes_views import SiaeEvaluatedJobApplicationViewTest
 
 
 # fixme vincentporte : convert this method into factory
@@ -3276,7 +3277,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
     btn_modifier_html = """
     <button class="btn btn-sm btn-primary" aria-label="Modifier l'état de ce justificatif">Modifier</button>
     """
-    save_text = "Enregistrer le commentaire"
+    save_text = "Enregistrer le commentaire et retourner à la liste des auto-prescriptions"
 
     def setUp(self):
         super().setUp()
@@ -3443,6 +3444,7 @@ class InstitutionEvaluatedJobApplicationViewTest(TestCase):
             + f"#{evaluated_job_application.pk}"
         )
         self.assertContains(response, self.save_text, count=1)
+        self.assertNotContains(response, SiaeEvaluatedJobApplicationViewTest.refusal_comment_txt)
 
     def test_get_before_new_criteria_submitted(self):
         now = timezone.now()

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -617,8 +617,6 @@ class SiaeSelectCriteriaViewTest(TestCase):
 
         assert response.status_code == 200
 
-        assert evaluated_job_application.job_application.job_seeker == response.context["job_seeker"]
-        assert evaluated_job_application.job_application.approval == response.context["approval"]
         assert (
             reverse(
                 "siae_evaluations_views:siae_job_applications_list",
@@ -627,7 +625,6 @@ class SiaeSelectCriteriaViewTest(TestCase):
             + f"#{evaluated_job_application.pk}"
             == response.context["back_url"]
         )
-        assert evaluated_job_application.compute_state() == response.context["state"]
         assert evaluated_siae.siae.kind == response.context["kind"]
 
     @pytest.mark.ignore_unknown_variable_template_error("reviewed_at")

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -1142,3 +1142,53 @@ class SiaeCalendarViewTest(TestCase):
         evaluated_siae.evaluation_campaign.calendar.delete()
         response = self.client.get(reverse("dashboard:index"))
         self.assertNotContains(response, calendar_url)
+
+
+class SiaeEvaluatedSiaeDetailViewTest(TestCase):
+    def test_access(self):
+        membership = CompanyMembershipFactory()
+        user = membership.user
+        siae = membership.company
+
+        self.client.force_login(user)
+
+        evaluated_job_application = create_evaluated_siae_with_consistent_datas(siae, user)
+        evaluated_siae = evaluated_job_application.evaluated_siae
+        url = reverse(
+            "siae_evaluations_views:evaluated_siae_detail",
+            kwargs={"evaluated_siae_pk": evaluated_siae.pk},
+        )
+
+        response = self.client.get(url)
+        assert response.status_code == 404
+
+        evaluation_campaign = evaluated_siae.evaluation_campaign
+        evaluation_campaign.ended_at = timezone.now()
+        evaluation_campaign.save(update_fields=["ended_at"])
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+
+class SiaeEvaluatedJobApplicationViewTest(TestCase):
+    def test_access(self):
+        membership = CompanyMembershipFactory()
+        user = membership.user
+        siae = membership.company
+
+        self.client.force_login(user)
+
+        evaluated_job_application = create_evaluated_siae_with_consistent_datas(siae, user)
+        evaluated_siae = evaluated_job_application.evaluated_siae
+        evaluated_job_application = evaluated_siae.evaluated_job_applications.first()
+        url = reverse(
+            "siae_evaluations_views:evaluated_job_application",
+            kwargs={"evaluated_job_application_pk": evaluated_job_application.pk},
+        )
+        response = self.client.get(url)
+        assert response.status_code == 404
+
+        evaluation_campaign = evaluated_siae.evaluation_campaign
+        evaluation_campaign.ended_at = timezone.now()
+        evaluation_campaign.save(update_fields=["ended_at"])
+        response = self.client.get(url)
+        assert response.status_code == 200

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -77,7 +77,9 @@ class EvaluatedSiaeSanctionViewTest(TestCase):
                 <b>Commentaire de votre DDETS</b>
             </p>
             <div class="card">
-                <div class="card-body">A envoyé une photo de son chat. Séparé de son chat pendant une journée.</div>
+                <div class="card-body">
+                    <p>A envoyé une photo de son chat. Séparé de son chat pendant une journée.</p>
+                </div>
             </div>
             """,
             html=True,
@@ -185,7 +187,7 @@ class EvaluatedSiaeSanctionViewTest(TestCase):
              </h3>
              <div class="card">
               <div class="card-body">
-               RDV le 18 avril à 14h dans les locaux de Pôle Emploi.
+               <p>RDV le 18 avril à 14h dans les locaux de Pôle Emploi.</p>
               </div>
              </div>
             </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Certaines pages n'étaient accessibles que pour les institutions mais le lien était présent dans la page des employeur
et le commentaire des la DDETS manquait

## :desert_island: Comment tester

Détourner http://127.0.0.1:8000/admin/users/user/511

- Contrôle à posteriori
- Historique
- Campagne de contrôle a posteriori du 01/01/2022 au 31/12/2022 
- Revoir les 2 auto-prescriptions
  - -> Plus de 404 :+1: 
- Revoir ses justificatifs 
  - -> Présence du commentaire de la DDETS
