### PR TITLE
Analytics: Ajouter le type d’utilisateur et le type d’organisation à Matomo [GEN-249]

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -228,6 +228,8 @@
                 /* beautify ignore:start */
                 window._paq = window._paq || [];
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                window._paq.push(['setCustomDimension', 1, "{{ request.user.kind|default:'anonymous' }}"]);
+                window._paq.push(['setCustomDimension', 3, "{{ request.current_organization.kind|default:'' }}"]);
 
                 {% if matomo_user_id %}window._paq.push(['setUserId', '{{ matomo_user_id }}']);{% endif %}
 

--- a/tests/utils/__snapshots__/tests.ambr
+++ b/tests/utils/__snapshots__/tests.ambr
@@ -32,6 +32,8 @@
                   /* beautify ignore:start */
                   window._paq = window._paq || [];
                   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                  window._paq.push(['setCustomDimension', 1, "employer"]);
+                  window._paq.push(['setCustomDimension', 3, "EI"]);
   
                   window._paq.push(['setUserId', '99999']);
   
@@ -53,6 +55,8 @@
                   /* beautify ignore:start */
                   window._paq = window._paq || [];
                   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                  window._paq.push(['setCustomDimension', 1, "employer"]);
+                  window._paq.push(['setCustomDimension', 3, "EI"]);
   
                   window._paq.push(['setUserId', '99999']);
   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Segmenter les utilisateurs par type dans Matomo.

## :cake: Comment ? <!-- optionnel -->

Utilisation de custom dimensions.
https://matomo.inclusion.beta.gouv.fr/index.php?module=CustomDimensions&action=manage&idSite=117&period=day&date=yesterday#/list
https://matomo.org/guide/reporting-tools/custom-dimensions/

## :desert_island: Comment tester

https://matomo.inclusion.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=220&period=day&date=yesterday#?idSite=220&period=day&date=yesterday&segment=dimension1%3D%3Demployer;dimension3%3D%3DEI&category=General_Actions&subcategory=Events_Events

1. Naviguer sur la review app ou sur la PR, en s’assurant que les Matomo est bien configuré
2. S’assurer de déclencher des évènements (par exemple, démarrer une candidature)
3. Sur Matomo, [créer un segment](https://matomo.org/guide/reporting-tools/segmentation/) pour analyser les actions.
