### PR TITLE
Admin : Éviter les doublons lorsqu’on liste les PASS IAE d’une entreprise

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -230,8 +230,10 @@ class ApprovalQuerySet(CommonApprovalQuerySet):
         )
 
     def is_assigned_to(self, company_id):
+        from itou.job_applications.models import JobApplication
+
         return (
-            self.filter(user__job_applications__to_company=company_id)
+            self.filter(pk__in=JobApplication.objects.filter(to_company=company_id).values_list("approval"))
             .with_assigned_company()
             .filter(assigned_company=company_id)
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si un candidat avait émit plusieurs candidatures vers une entreprise, son PASS était listé une fois par candidature.

## :cake: Comment ? <!-- optionnel -->

`Exists`

## :desert_island: Comment tester

Comparer `/admin/approvals/approval/?assigned_company=11919&o=2.-6` entre la prod et cette branche.
