### PR TITLE
Remplacer EligibilityDiagnosis.for_job_seeker{,_for_siae}

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -203,8 +203,7 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
     geiq_eligibility_diagnosis = (
         job_application.to_company.kind == CompanyKind.GEIQ
         and GEIQEligibilityDiagnosis.objects.valid()
-        .filter(author_prescriber_organization__isnull=False)
-        .for_job_seeker(job_application.job_seeker)
+        .filter(job_seeker=job_application.job_seeker, author_prescriber_organization__isnull=False)
         .select_related("author", "author_geiq", "author_prescriber_organization")
         .first()
     )

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2816,7 +2816,7 @@ class ApplicationViewTest(TestCase):
             fetch_redirect_response=False,
         )
         assert [eligibility_diagnosis] == list(
-            EligibilityDiagnosis.objects.for_job_seeker(eligibility_diagnosis.job_seeker)
+            EligibilityDiagnosis.objects.for_job_seeker_and_siae(job_seeker=eligibility_diagnosis.job_seeker)
         )
 
         # If "shrouded" is NOT present then we update the eligibility diagnosis
@@ -2836,7 +2836,9 @@ class ApplicationViewTest(TestCase):
             fetch_redirect_response=False,
         )
         new_eligibility_diagnosis = (
-            EligibilityDiagnosis.objects.for_job_seeker(eligibility_diagnosis.job_seeker).order_by().last()
+            EligibilityDiagnosis.objects.for_job_seeker_and_siae(job_seeker=eligibility_diagnosis.job_seeker)
+            .order_by()
+            .last()
         )
         assert new_eligibility_diagnosis != eligibility_diagnosis
         assert new_eligibility_diagnosis.author == prescriber


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le seul endroit où `for_job_seeker` est utilisé peut être simplifié en utilisant directement `for_job_seeker_and_siae` avec `siae=None`.

Comme `for_job_seeker` n’est plus utilisé en dehors des tests, la méthode a été supprimée.
