### PR TITLE
Pilotage : Ouverture d'une nouvelle version des stats ETP employeur à une liste blanche (Groupe SOS)

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -9,19 +9,18 @@
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'stats:stats_siae_aci' %}" class="btn-link btn-ico">
                             <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
-                            <span>Voir le suivi du cofinancement de mon ACI</span>
+                            <span>Suivre le cofinancement de mon ACI</span>
                         </a>
                     </li>
                 {% endif %}
                 {% if can_view_stats_siae_etp %}
-                    <!-- Stats temporarily suspended until we stabilize them
-                        <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_siae_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
-                                <span>Voir les données de ma structure (extranet ASP)</span>
-                            </a>
-                        </li>
-                    -->
+                    <li class="d-flex justify-content-between align-items-center mb-3">
+                        <a href="{% url 'stats:stats_siae_etp' %}" class="btn-link btn-ico">
+                            <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
+                            <span>Suivre les effectifs annuels et mensuels en ETP</span>
+                        </a>
+                        {% include "dashboard/includes/stats_new_badge.html" %}
+                    </li>
                 {% endif %}
                 {% if can_view_stats_siae %}
                     <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 ASP_SIAE_FILTER_KEY_FLAVOR1 = "identifiant_de_la_structure"
 ASP_SIAE_FILTER_KEY_FLAVOR2 = "id_asp_de_la_siae"
+ASP_SIAE_FILTER_KEY_FLAVOR3 = "id_asp_siae"
 C1_SIAE_FILTER_KEY = "identifiant_de_la_structure_(c1)"
 IAE_NETWORK_FILTER_KEY = "id_r%C3%A9seau"
 DEPARTMENT_FILTER_KEY = "d%C3%A9partement"
@@ -29,7 +30,7 @@ METABASE_DASHBOARDS = {
         "dashboard_id": 327,
     },
     "stats_siae_etp": {
-        "dashboard_id": 128,
+        "dashboard_id": 440,
     },
     "stats_siae_hiring": {
         "dashboard_id": 185,

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -54,7 +54,11 @@ def can_view_stats_siae_etp(request):
     """
     Non official stats with very specific access rights.
     """
-    return can_view_stats_siae(request) and request.user.pk in settings.STATS_SIAE_USER_PK_WHITELIST
+    return (
+        can_view_stats_siae(request)
+        and request.is_current_organization_admin
+        and request.user.pk in settings.STATS_SIAE_USER_PK_WHITELIST
+    )
 
 
 def can_view_stats_siae_hiring_report(request):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -217,14 +217,19 @@ def stats_siae_etp(request):
     if not utils.can_view_stats_siae_etp(request):
         raise PermissionDenied
     context = {
-        "page_title": "Données de ma structure (extranet ASP)",
+        "page_title": "Suivi des effectifs annuels et mensuels en ETP",
         "department": current_org.department,
         "matomo_custom_url_suffix": format_region_and_department_for_matomo(current_org.department),
     }
     return render_stats(
         request=request,
         context=context,
-        params={mb.ASP_SIAE_FILTER_KEY_FLAVOR1: current_org.convention.asp_id},
+        params={
+            mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [
+                str(membership.company.convention.asp_id)
+                for membership in request.user.active_or_in_grace_period_company_memberships()
+            ]
+        },
     )
 
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -228,6 +228,7 @@ def stats_siae_etp(request):
             mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [
                 str(membership.company.convention.asp_id)
                 for membership in request.user.active_or_in_grace_period_company_memberships()
+                if membership.is_admin
             ]
         },
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les stats ETP employeur (TB 128) étaient désactivées depuis un moment. Cette PR introduit enfin une nouvelle version (TB 440) prête à être testée par une liste blanche d'employeurs (Groupe SOS, 60 SIAE environ).

## Notes

- Voir et valider aussi https://github.com/gip-inclusion/itou-secrets/pull/77 qui accompagne cette PR.

## :computer: Captures d'écran

<img width="996" alt="image" src="https://github.com/gip-inclusion/les-emplois/assets/10533583/67a033e4-48ae-4db9-aca4-da247f12db8d">


<img width="882" alt="image" src="https://github.com/gip-inclusion/les-emplois/assets/10533583/9b92d0d1-fac6-4354-85d4-bcce46e2438c">
