### PR TITLE
Passer à `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: local
     hooks:
-      - id: black
-        name: Black
-        entry: black
+      - id: ruff-format
+        name: Ruff format
+        entry: ruff format
         types: [python]
         language: system
-      - id: ruff
-        name: Ruff
+      - id: ruff-check
+        name: Ruff check
         entry: ruff check --fix
         types: [python]
         language: system

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,7 +9,6 @@
 		"ms-vsliveshare.vsliveshare",
 		"ms-python.vscode-pylance",
 		"ms-python.python",
-		"ms-python.black-formatter",
 		"monosans.djlint",
 		"editorconfig.editorconfig",
 		"charliermarsh.ruff"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,7 @@
     "files.trimTrailingWhitespace": true,
     "html.format.enable": true,
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.defaultFormatter": "charliermarsh.ruff",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.organizeImports": "explicit"

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 	find . -type d -name "__pycache__" -depth -exec rm -rf '{}' \;
 
 quality: $(VENV_REQUIREMENT)
-	black --check $(LINTER_CHECKED_DIRS)
+	ruff format --check $(LINTER_CHECKED_DIRS)
 	ruff check $(LINTER_CHECKED_DIRS)
 	djlint --lint --check itou
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
@@ -50,7 +50,7 @@ quality: $(VENV_REQUIREMENT)
 	python manage.py collectstatic --no-input
 
 fast_fix: $(VENV_REQUIREMENT)
-	black $(LINTER_CHECKED_DIRS)
+	ruff format $(LINTER_CHECKED_DIRS)
 	ruff check --fix $(LINTER_CHECKED_DIRS)
 	find * -type f -name '*.sh' -exec shellcheck --external-sources --format=diff {} + | git apply --allow-empty
 

--- a/docs/coding-style.md
+++ b/docs/coding-style.md
@@ -1,6 +1,6 @@
 # Style de programmation (coding style)
 
-La majeure partie est assurée par les outils automatiques (ruff, black, …), qui
+La majeure partie est assurée par les outils automatiques (ruff, …), qui
 sauront porter les non-conformités à votre attention. Il reste quelques
 conventions listées dans ce document.
 

--- a/itou/analytics/migrations/0001_initial.py
+++ b/itou/analytics/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/itou/antivirus/migrations/0001_initial.py
+++ b/itou/antivirus/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/api/migrations/0001_initial.py
+++ b/itou/api/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -45,9 +45,7 @@ class Command(BaseCommand):
             | Q(user__birthdate=None)
             | Q(user__first_name="")
             | Q(user__last_name="")
-        ).update(
-            pe_notification_status=api_enums.PEApiNotificationStatus.READY
-        )
+        ).update(pe_notification_status=api_enums.PEApiNotificationStatus.READY)
         approvals_models.CancelledApproval.objects.filter(
             pe_notification_status=api_enums.PEApiNotificationStatus.PENDING,
             start_at__lte=today,

--- a/itou/approvals/migrations/0001_initial.py
+++ b/itou/approvals/migrations/0001_initial.py
@@ -17,7 +17,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/approvals/migrations/0003_alter_approval_updated_at.py
+++ b/itou/approvals/migrations/0003_alter_approval_updated_at.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("approvals", "0002_fill_approval_updated_at"),
     ]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -126,7 +126,8 @@ class CommonApprovalMixin(models.Model):
         A.k.a an Approval, a Suspension or a Prolongation
         """
         return max(
-            obj.end_at - timezone.localdate()
+            obj.end_at
+            - timezone.localdate()
             # end_at is inclusive.
             + datetime.timedelta(days=1),
             datetime.timedelta(0),

--- a/itou/cities/migrations/0001_initial.py
+++ b/itou/cities/migrations/0001_initial.py
@@ -14,7 +14,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/itou/companies/management/commands/update_companies_job_app_score.py
+++ b/itou/companies/management/commands/update_companies_job_app_score.py
@@ -17,6 +17,7 @@ class Command(BaseCommand):
             .exclude(
                 Q(job_app_score=F("computed_job_app_score"))
                 | Q(job_app_score__isnull=True) & Q(computed_job_app_score__isnull=True)
-            ).update(job_app_score=F("computed_job_app_score"))
+            )
+            .update(job_app_score=F("computed_job_app_score"))
         )
         self.stdout.write(f"Updated {nb_updated} companies in {time.perf_counter() - start:.3f} seconds")

--- a/itou/companies/migrations/0001_initial.py
+++ b/itou/companies/migrations/0001_initial.py
@@ -14,7 +14,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/eligibility/migrations/0001_initial.py
+++ b/itou/eligibility/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/employee_record/migrations/0001_initial.py
+++ b/itou/employee_record/migrations/0001_initial.py
@@ -9,7 +9,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/external_data/migrations/0001_initial.py
+++ b/itou/external_data/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/geo/migrations/0001_initial.py
+++ b/itou/geo/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/itou/gps/migrations/0001_initial.py
+++ b/itou/gps/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/gps/models.py
+++ b/itou/gps/models.py
@@ -5,7 +5,6 @@ from itou.users.models import User
 
 
 class FollowUpGroup(models.Model):
-
     created_at = models.DateTimeField(verbose_name="date de création", default=timezone.now)
 
     updated_at = models.DateTimeField(verbose_name="date de modification", auto_now=True)
@@ -35,7 +34,6 @@ class FollowUpGroup(models.Model):
 
 
 class FollowUpGroupMembership(models.Model):
-
     is_referent = models.BooleanField(default=False, verbose_name="référent")
 
     # Is this user still an active member of the group?

--- a/itou/institutions/migrations/0001_initial.py
+++ b/itou/institutions/migrations/0001_initial.py
@@ -12,7 +12,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/invitations/migrations/0001_initial.py
+++ b/itou/invitations/migrations/0001_initial.py
@@ -10,7 +10,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/job_applications/migrations/0001_initial.py
+++ b/itou/job_applications/migrations/0001_initial.py
@@ -13,7 +13,6 @@ import itou.utils.models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/job_applications/migrations/0002_jobapplication_refusal_reason_shared_with_job_seeker.py
+++ b/itou/job_applications/migrations/0002_jobapplication_refusal_reason_shared_with_job_seeker.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("job_applications", "0001_initial"),
     ]

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -405,7 +405,8 @@ class JobApplicationQuerySet(models.QuerySet):
             EmployeeRecord.objects.for_asp_company(siae)
             # We need to exclude NEW employee records otherwise we are shooting ourselves in the foot by excluding
             # job applications selected in `._eligible_job_applications_with_employee_record()`
-            .exclude(status__in=[employeerecord_enums.Status.NEW]).values("approval_number")
+            .exclude(status__in=[employeerecord_enums.Status.NEW])
+            .values("approval_number")
         )
 
         # TIP: you can't filter on a UNION of querysets,

--- a/itou/jobs/migrations/0001_initial.py
+++ b/itou/jobs/migrations/0001_initial.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/itou/openid_connect/france_connect/migrations/0001_initial.py
+++ b/itou/openid_connect/france_connect/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/itou/openid_connect/inclusion_connect/migrations/0001_initial.py
+++ b/itou/openid_connect/inclusion_connect/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/itou/prescribers/migrations/0001_initial.py
+++ b/itou/prescribers/migrations/0001_initial.py
@@ -13,7 +13,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/siae_evaluations/migrations/0001_initial.py
+++ b/itou/siae_evaluations/migrations/0001_initial.py
@@ -11,7 +11,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/users/migrations/0001_initial.py
+++ b/itou/users/migrations/0001_initial.py
@@ -20,7 +20,6 @@ import itou.utils.validators
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/itou/users/migrations/0002_remove_jobseekerprofile_previous_employer_kind.py
+++ b/itou/users/migrations/0002_remove_jobseekerprofile_previous_employer_kind.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("users", "0001_initial"),
     ]

--- a/itou/users/migrations/0003_remove_jobseekerprofile_previous_employer_kind_from_db.py
+++ b/itou/users/migrations/0003_remove_jobseekerprofile_previous_employer_kind_from_db.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("users", "0002_remove_jobseekerprofile_previous_employer_kind"),
     ]

--- a/itou/users/migrations/0005_clean_pe_connect_users_from_allauth.py
+++ b/itou/users/migrations/0005_clean_pe_connect_users_from_allauth.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("users", "0004_remove_non_job_seeker_address"),
     ]

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -46,7 +46,6 @@ class ApprovalAlreadyExistsError(Exception):
 
 
 class ItouUserManager(UserManager):
-
     def autocomplete(self, search_string, limit=10, kind=UserKind.JOB_SEEKER, current_user=None):
         """
         A `search_string` equals to `foo bar` will match all results beginning with `foo` and `bar`.

--- a/itou/utils/apis/esd.py
+++ b/itou/utils/apis/esd.py
@@ -1,6 +1,6 @@
 """
-    Pôle emploi's Emploi Store Dev aka ESD.
-    https://www.emploi-store-dev.fr/portail-developpeur/catalogueapi
+Pôle emploi's Emploi Store Dev aka ESD.
+https://www.emploi-store-dev.fr/portail-developpeur/catalogueapi
 """
 
 import collections

--- a/itou/utils/faker_providers.py
+++ b/itou/utils/faker_providers.py
@@ -5,7 +5,6 @@ from faker.providers import BaseProvider
 
 
 class ItouProvider(BaseProvider):
-
     def asp_batch_filename(self) -> str:
         return f"RIAE_FS_{random.randint(0, 99999999999999)}.json"
 

--- a/itou/utils/tokens.py
+++ b/itou/utils/tokens.py
@@ -59,9 +59,7 @@ class CompanySignupTokenGenerator:
         timestamp_b36 = int_to_base36(timestamp)
         hash_string = salted_hmac(
             self.key_salt, self._make_hash_value(company, timestamp), secret=self.secret
-        ).hexdigest()[
-            ::2
-        ]  # Limit to 20 characters to shorten the URL.
+        ).hexdigest()[::2]  # Limit to 20 characters to shorten the URL.
         return f"{timestamp_b36}-{hash_string}"
 
     def _make_hash_value(self, company, timestamp):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -414,13 +414,13 @@ class JobApplicationRefusalPrescriberAnswerForm(forms.Form):
         super().__init__(*args, **kwargs)
         if job_application.sender_kind == job_applications_enums.SenderKind.PRESCRIBER:
             if job_application.is_sent_by_authorized_prescriber:
-                self.fields["prescriber_answer"].label = (
-                    "Commentaire envoyé au prescripteur (n’est pas communiqué au candidat)"
-                )
+                self.fields[
+                    "prescriber_answer"
+                ].label = "Commentaire envoyé au prescripteur (n’est pas communiqué au candidat)"
             else:
-                self.fields["prescriber_answer"].label = (
-                    "Commentaire envoyé à l’orienteur (n’est pas communiqué au candidat)"
-                )
+                self.fields[
+                    "prescriber_answer"
+                ].label = "Commentaire envoyé à l’orienteur (n’est pas communiqué au candidat)"
 
 
 class AnswerForm(forms.Form):

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -388,9 +388,9 @@ class ProlongationRequestDenyInformationReasonForm(forms.ModelForm):
     def __init__(self, *args, employee, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["reason"].label = (
-            f"Pour quel motif refusez-vous la prolongation du parcours IAE de {employee.get_full_name()} ?"
-        )
+        self.fields[
+            "reason"
+        ].label = f"Pour quel motif refusez-vous la prolongation du parcours IAE de {employee.get_full_name()} ?"
 
 
 class ProlongationRequestDenyInformationReasonExplanationForm(forms.ModelForm):

--- a/itou/www/companies_views/forms.py
+++ b/itou/www/companies_views/forms.py
@@ -155,12 +155,12 @@ class EditSiaeDescriptionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["description"].widget.attrs[
-            "placeholder"
-        ] = "Présentez votre entreprise, votre secteur d’activité, domaines d’intervention, etc."
-        self.fields["provided_support"].widget.attrs[
-            "placeholder"
-        ] = "Indiquez les modalités d’accompagnement, par qui, comment, à quelle fréquence, etc."
+        self.fields["description"].widget.attrs["placeholder"] = (
+            "Présentez votre entreprise, votre secteur d’activité, domaines d’intervention, etc."
+        )
+        self.fields["provided_support"].widget.attrs["placeholder"] = (
+            "Indiquez les modalités d’accompagnement, par qui, comment, à quelle fréquence, etc."
+        )
 
 
 class BlockJobApplicationsForm(forms.ModelForm):

--- a/itou/www/gps/views.py
+++ b/itou/www/gps/views.py
@@ -13,7 +13,6 @@ from itou.www.gps.forms import GpsUserSearchForm
 @settings_protected_view("GPS_ENABLED")
 @user_passes_test(lambda u: not u.is_job_seeker, login_url=reverse_lazy("dashboard:index"), redirect_field_name=None)
 def my_groups(request, template_name="gps/my_groups.html"):
-
     current_user = request.user
 
     memberships = (
@@ -40,7 +39,6 @@ def my_groups(request, template_name="gps/my_groups.html"):
 @settings_protected_view("GPS_ENABLED")
 @user_passes_test(lambda u: not u.is_job_seeker, login_url=reverse_lazy("dashboard:index"), redirect_field_name=None)
 def join_group(request, template_name="gps/join_group.html"):
-
     form = GpsUserSearchForm(data=request.POST or None)
 
     my_groups_url = reverse("gps:my_groups")

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,6 @@
 [project]
 requires-python = ">=3.11"
 
-[tool.black]
-line_length = 119
-
 [tool.ruff]
 line-length = 119
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,30 +59,6 @@ beautifulsoup4==4.12.3 \
     --hash=sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051 \
     --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
     # via -r requirements/test.txt
-black==24.4.2 \
-    --hash=sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474 \
-    --hash=sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1 \
-    --hash=sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0 \
-    --hash=sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8 \
-    --hash=sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96 \
-    --hash=sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1 \
-    --hash=sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04 \
-    --hash=sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021 \
-    --hash=sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94 \
-    --hash=sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d \
-    --hash=sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c \
-    --hash=sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7 \
-    --hash=sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c \
-    --hash=sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc \
-    --hash=sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7 \
-    --hash=sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d \
-    --hash=sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c \
-    --hash=sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741 \
-    --hash=sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce \
-    --hash=sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb \
-    --hash=sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063 \
-    --hash=sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e
-    # via -r requirements/test.txt
 boto3==1.28.54 \
     --hash=sha256:22e37d8c4f2d97b5e5c6ccc1d9edc7760717990b0ba8b8ea17a58cc87e57c5c9 \
     --hash=sha256:3cb2aee317a1b8686e3b23674e4099b8ff7451bd8acc61b9719acff86fa024d1
@@ -353,7 +329,6 @@ click==8.1.6 \
     --hash=sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5
     # via
     #   -r requirements/test.txt
-    #   black
     #   djlint
     #   pip-tools
 colorama==0.4.6 \
@@ -1137,12 +1112,6 @@ multivolumefile==0.2.3 \
     # via
     #   -r requirements/test.txt
     #   py7zr
-mypy-extensions==1.0.0 \
-    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
-    --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-    # via
-    #   -r requirements/test.txt
-    #   black
 nodeenv==1.8.0 \
     --hash=sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2 \
     --hash=sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec
@@ -1185,7 +1154,6 @@ packaging==23.1 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
     # via
     #   -r requirements/test.txt
-    #   black
     #   build
     #   pytest
 pandas==1.5.3 \
@@ -1234,7 +1202,6 @@ pathspec==0.11.1 \
     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293
     # via
     #   -r requirements/test.txt
-    #   black
     #   djlint
 pexpect==4.8.0 \
     --hash=sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937 \
@@ -1247,10 +1214,7 @@ pip-tools==7.3.0 \
 platformdirs==3.9.1 \
     --hash=sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421 \
     --hash=sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f
-    # via
-    #   -r requirements/test.txt
-    #   black
-    #   virtualenv
+    # via virtualenv
 pluggy==1.2.0 \
     --hash=sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849 \
     --hash=sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3
@@ -1288,7 +1252,9 @@ psutil==5.9.8 \
 psycopg[binary]==3.1.10 \
     --hash=sha256:15b25741494344c24066dc2479b0f383dd1b82fa5e75612fa4fa5bb30726e9b6 \
     --hash=sha256:8bbeddae5075c7890b2fa3e3553440376d3c5e28418335dee3c3656b06fa2b52
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   psycopg
 psycopg-binary==3.1.10 \
     --hash=sha256:0471869e658d0c6b8c3ed53153794739c18d7dad2dd5b8e6ff023a364c20f7df \
     --hash=sha256:0f062f20256708929a58c41d44f350efced4c00a603323d1413f6dc0b84d95a5 \

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -4,7 +4,6 @@ pip-tools  # https://github.com/jazzband/pip-tools/
 
 # Code quality
 # ------------------------------------------------------------------------------
-black  # https://github.com/psf/black
 djlint  # https://www.djlint.com
 ruff  # https://github.com/charliermarsh/ruff
 shellcheck-py  # https://github.com/shellcheck-py/shellcheck-py

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -55,30 +55,6 @@ beautifulsoup4==4.12.3 \
     --hash=sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051 \
     --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
     # via -r requirements/test.in
-black==24.4.2 \
-    --hash=sha256:257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474 \
-    --hash=sha256:37aae07b029fa0174d39daf02748b379399b909652a806e5708199bd93899da1 \
-    --hash=sha256:415e686e87dbbe6f4cd5ef0fbf764af7b89f9057b97c908742b6008cc554b9c0 \
-    --hash=sha256:48a85f2cb5e6799a9ef05347b476cce6c182d6c71ee36925a6c194d074336ef8 \
-    --hash=sha256:7768a0dbf16a39aa5e9a3ded568bb545c8c2727396d063bbaf847df05b08cd96 \
-    --hash=sha256:7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1 \
-    --hash=sha256:88c57dc656038f1ab9f92b3eb5335ee9b021412feaa46330d5eba4e51fe49b04 \
-    --hash=sha256:8e537d281831ad0e71007dcdcbe50a71470b978c453fa41ce77186bbe0ed6021 \
-    --hash=sha256:98e123f1d5cfd42f886624d84464f7756f60ff6eab89ae845210631714f6db94 \
-    --hash=sha256:accf49e151c8ed2c0cdc528691838afd217c50412534e876a19270fea1e28e2d \
-    --hash=sha256:b1530ae42e9d6d5b670a34db49a94115a64596bc77710b1d05e9801e62ca0a7c \
-    --hash=sha256:b9176b9832e84308818a99a561e90aa479e73c523b3f77afd07913380ae2eab7 \
-    --hash=sha256:bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c \
-    --hash=sha256:be8bef99eb46d5021bf053114442914baeb3649a89dc5f3a555c88737e5e98fc \
-    --hash=sha256:bf10f7310db693bb62692609b397e8d67257c55f949abde4c67f9cc574492cc7 \
-    --hash=sha256:c872b53057f000085da66a19c55d68f6f8ddcac2642392ad3a355878406fbd4d \
-    --hash=sha256:d36ed1124bb81b32f8614555b34cc4259c3fbc7eec17870e8ff8ded335b58d8c \
-    --hash=sha256:da33a1a5e49c4122ccdfd56cd021ff1ebc4a1ec4e2d01594fef9b6f267a9e741 \
-    --hash=sha256:dd1b5a14e417189db4c7b64a6540f31730713d173f0b63e55fabd52d61d8fdce \
-    --hash=sha256:e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb \
-    --hash=sha256:eaea3008c281f1038edb473c1aa8ed8143a5535ff18f978a318f10302b254063 \
-    --hash=sha256:ef703f83fc32e131e9bcc0a5094cfe85599e7109f896fe8bc96cc402f3eb4b6e
-    # via -r requirements/test.in
 boto3==1.28.54 \
     --hash=sha256:22e37d8c4f2d97b5e5c6ccc1d9edc7760717990b0ba8b8ea17a58cc87e57c5c9 \
     --hash=sha256:3cb2aee317a1b8686e3b23674e4099b8ff7451bd8acc61b9719acff86fa024d1
@@ -342,7 +318,6 @@ click==8.1.6 \
     --hash=sha256:48ee849951919527a045bfe3bf7baa8a959c423134e1a5b98c05c20ba75a1cbd \
     --hash=sha256:fa244bb30b3b5ee2cae3da8f55c9e5e0c0e86093306301fb418eb9dc40fbded5
     # via
-    #   black
     #   djlint
     #   pip-tools
 colorama==0.4.6 \
@@ -1060,10 +1035,6 @@ multivolumefile==0.2.3 \
     # via
     #   -r requirements/base.txt
     #   py7zr
-mypy-extensions==1.0.0 \
-    --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
-    --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
-    # via black
 numpy==1.25.1 \
     --hash=sha256:012097b5b0d00a11070e8f2e261128c44157a8689f7dedcf35576e525893f4fe \
     --hash=sha256:0d3fe3dd0506a28493d82dc3cf254be8cd0d26f4008a417385cbf1ae95b54004 \
@@ -1101,7 +1072,6 @@ packaging==23.1 \
     --hash=sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61 \
     --hash=sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f
     # via
-    #   black
     #   build
     #   pytest
 pandas==1.5.3 \
@@ -1144,17 +1114,11 @@ patchy==2.8.0 \
 pathspec==0.11.1 \
     --hash=sha256:2798de800fa92780e33acca925945e9a19a133b715067cf165b8866c15a31687 \
     --hash=sha256:d8af70af76652554bd134c22b3e8a1cc46ed7d91edcdd721ef1a0c51a84a5293
-    # via
-    #   black
-    #   djlint
+    # via djlint
 pip-tools==7.3.0 \
     --hash=sha256:8717693288720a8c6ebd07149c93ab0be1fced0b5191df9e9decd3263e20d85e \
     --hash=sha256:8e9c99127fe024c025b46a0b2d15c7bd47f18f33226cf7330d35493663fc1d1d
     # via -r requirements/test.in
-platformdirs==3.9.1 \
-    --hash=sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421 \
-    --hash=sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f
-    # via black
 pluggy==1.2.0 \
     --hash=sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849 \
     --hash=sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3
@@ -1182,7 +1146,9 @@ psutil==5.9.8 \
 psycopg[binary]==3.1.10 \
     --hash=sha256:15b25741494344c24066dc2479b0f383dd1b82fa5e75612fa4fa5bb30726e9b6 \
     --hash=sha256:8bbeddae5075c7890b2fa3e3553440376d3c5e28418335dee3c3656b06fa2b52
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   psycopg
 psycopg-binary==3.1.10 \
     --hash=sha256:0471869e658d0c6b8c3ed53153794739c18d7dad2dd5b8e6ff023a364c20f7df \
     --hash=sha256:0f062f20256708929a58c41d44f350efced4c00a603323d1413f6dc0b84d95a5 \

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -36,7 +36,6 @@ from tests.utils.test import TestCase
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class ImportSiaeManagementCommandsTest(TestCase):
-
     def setUp(self):
         super().setUp()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,8 +112,8 @@ def test_bucket():
         +           return
                  super().__call__(value)
              except ValidationError as e:
-        ''',  # fmt: skip
-    )
+        ''',
+    )  # fmt: skip
 
     call_command("configure_bucket", autoexpire=True)
     yield

--- a/tests/gps/tests.py
+++ b/tests/gps/tests.py
@@ -12,7 +12,6 @@ from tests.utils.test import parse_response_to_soup
 
 
 def test_user_autocomplete():
-
     member = PrescriberFactory(first_name="gps member first_name")
     beneficiary = JobSeekerFactory(first_name="gps beneficiary first_name")
     another_beneficiary = JobSeekerFactory(first_name="gps another beneficiary first_name")
@@ -111,7 +110,6 @@ def test_join_group_as_prescriber(client):
 
 
 def test_navigation(snapshot, client):
-
     member = PrescriberFactory(first_name="gps member first_name")
     member_first_beneficiary = JobSeekerFactory(first_name="gps first beneficiary first_name")
     member_second_beneficiary = JobSeekerFactory(first_name="gps second beneficiary first_name")
@@ -139,7 +137,6 @@ def test_navigation(snapshot, client):
 
 
 def test_access_as_jobseeker(client):
-
     user = JobSeekerFactory()
     client.force_login(user)
 
@@ -152,7 +149,6 @@ def test_access_as_jobseeker(client):
 
 @override_settings(GPS_ENABLED=True)
 def test_access_gps_enabled(client, snapshot):
-
     user = PrescriberFactory()
     client.force_login(user)
 
@@ -173,7 +169,6 @@ def test_access_gps_enabled(client, snapshot):
 
 @override_settings(GPS_ENABLED=False)
 def test_access_gps_disabled(client):
-
     user = PrescriberFactory()
     client.force_login(user)
 

--- a/tests/jobs/management/test_sync_romes_and_appellations.py
+++ b/tests/jobs/management/test_sync_romes_and_appellations.py
@@ -45,23 +45,26 @@ def test_sync_rome_appellation(capsys, respx_mock):
     management.call_command("sync_romes_and_appellations", wet_run=True)
     stdout, stderr = capsys.readouterr()
     assert stderr == ""
-    assert stdout.splitlines() == [
-        "count=1 label=Rome had the same key in collection and queryset",
-        "\tCHANGED name=Patisserie changed to value=Pâtisserie avec accent",
-        "count=1 label=Rome added by collection",
-        '\tADDED {"code": "MET01", "libelle": "Edition"}',
-        "count=2 label=Rome removed by collection",
-        "\tREMOVED Métiers du corps (B001)",
-        "\tREMOVED Arts de la table (F002)",  # not really removed though by our command, see docstring
-        "len=2 ROME entries have been created or updated.",
-        "count=2 label=Appellation had the same key in collection and queryset",
-        "\tCHANGED name=Entraîneur sportif changed to value=Entraîneur sportif " "avéré",
-        "\tCHANGED name=Chef cuistot d'élite changed to value=Chef cuistor d'élite",
-        "count=1 label=Appellation added by collection",
-        '\tADDED {"code": "JOB32", "libelle": "Ecriveur de bouquins", "metier": ' '{"code": "MET01"}}',
-        "count=0 label=Appellation removed by collection",
-        "len=3 Appellation entries have been created or updated.",
-    ]
+    assert (
+        stdout.splitlines()
+        == [
+            "count=1 label=Rome had the same key in collection and queryset",
+            "\tCHANGED name=Patisserie changed to value=Pâtisserie avec accent",
+            "count=1 label=Rome added by collection",
+            '\tADDED {"code": "MET01", "libelle": "Edition"}',
+            "count=2 label=Rome removed by collection",
+            "\tREMOVED Métiers du corps (B001)",
+            "\tREMOVED Arts de la table (F002)",  # not really removed though by our command, see docstring
+            "len=2 ROME entries have been created or updated.",
+            "count=2 label=Appellation had the same key in collection and queryset",
+            "\tCHANGED name=Entraîneur sportif changed to value=Entraîneur sportif " "avéré",
+            "\tCHANGED name=Chef cuistot d'élite changed to value=Chef cuistor d'élite",
+            "count=1 label=Appellation added by collection",
+            '\tADDED {"code": "JOB32", "libelle": "Ecriveur de bouquins", "metier": ' '{"code": "MET01"}}',
+            "count=0 label=Appellation removed by collection",
+            "len=3 Appellation entries have been created or updated.",
+        ]
+    )
     rome_3 = Rome(code="MET01", name="Edition")
     assert list(Rome.objects.all().order_by("code")) == [
         Rome(code="B001", name="Métiers du corps"),

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -971,13 +971,13 @@ class EvaluatedSiaeModelTest(TestCase):
 
         # NOT REVIEWED
         # one Pending, one Refused, one Accepted
-        evaluated_administrative_criteria[1].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
-        )
+        evaluated_administrative_criteria[
+            1
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
         evaluated_administrative_criteria[1].save(update_fields=["review_state"])
-        evaluated_administrative_criteria[2].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            2
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[2].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.SUBMITTED == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -985,9 +985,9 @@ class EvaluatedSiaeModelTest(TestCase):
         # one Refused, two Accepted
         evaluated_siae.reviewed_at = fake_now
         evaluated_siae.save(update_fields=["reviewed_at"])
-        evaluated_administrative_criteria[0].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            0
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[0].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -995,9 +995,9 @@ class EvaluatedSiaeModelTest(TestCase):
         # three Accepted
         evaluated_siae.final_reviewed_at = fake_now
         evaluated_siae.save(update_fields=["final_reviewed_at"])
-        evaluated_administrative_criteria[1].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            1
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[1].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.ACCEPTED == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -1009,25 +1009,25 @@ class EvaluatedSiaeModelTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at"])
 
         # one Pending, one Refused, one Accepted
-        evaluated_administrative_criteria[0].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
-        )
+        evaluated_administrative_criteria[
+            0
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
         evaluated_administrative_criteria[0].save(update_fields=["review_state"])
-        evaluated_administrative_criteria[1].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
-        )
+        evaluated_administrative_criteria[
+            1
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
         evaluated_administrative_criteria[1].save(update_fields=["review_state"])
-        evaluated_administrative_criteria[2].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            2
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[2].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.SUBMITTED == evaluated_siae.state
         del evaluated_siae.state_from_applications
 
         # one Refused, two Accepted
-        evaluated_administrative_criteria[0].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            0
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[0].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -1035,9 +1035,9 @@ class EvaluatedSiaeModelTest(TestCase):
         # three Accepted
         evaluated_siae.final_reviewed_at = evaluated_siae.reviewed_at + relativedelta(days=1)
         evaluated_siae.save(update_fields=["final_reviewed_at"])
-        evaluated_administrative_criteria[1].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            1
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[1].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.ACCEPTED == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -1049,25 +1049,25 @@ class EvaluatedSiaeModelTest(TestCase):
         evaluated_siae.save(update_fields=["reviewed_at"])
 
         # one Pending, one Refused, one Accepted
-        evaluated_administrative_criteria[0].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
-        )
+        evaluated_administrative_criteria[
+            0
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
         evaluated_administrative_criteria[0].save(update_fields=["review_state"])
-        evaluated_administrative_criteria[1].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
-        )
+        evaluated_administrative_criteria[
+            1
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED
         evaluated_administrative_criteria[1].save(update_fields=["review_state"])
-        evaluated_administrative_criteria[2].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            2
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[2].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.SUBMITTED == evaluated_siae.state
         del evaluated_siae.state_from_applications
 
         # one Refused, two Accepted
-        evaluated_administrative_criteria[0].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            0
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[0].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE == evaluated_siae.state
         del evaluated_siae.state_from_applications
@@ -1075,9 +1075,9 @@ class EvaluatedSiaeModelTest(TestCase):
         # three Accepted
         evaluated_siae.final_reviewed_at = fake_now
         evaluated_siae.save(update_fields=["final_reviewed_at"])
-        evaluated_administrative_criteria[1].review_state = (
-            evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
-        )
+        evaluated_administrative_criteria[
+            1
+        ].review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
         evaluated_administrative_criteria[1].save(update_fields=["review_state"])
         assert evaluation_enums.EvaluatedSiaeState.ACCEPTED == evaluated_siae.state
         del evaluated_siae.state_from_applications

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -3424,7 +3424,6 @@ def test_select_job_description_for_job_application(client):
 
 @override_settings(API_BAN_BASE_URL="http://ban-api")
 def test_select_other_job_description_for_job_application(client, mocker):
-
     mocker.patch(
         "itou.utils.apis.geocoding.get_geocoding_data",
         side_effect=mock_get_geocoding_data_by_ban_api_resolved,

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2183,7 +2183,6 @@ class ApplyAsCompanyTest(TestCase):
 
 
 class DirectHireFullProcessTest(TestCase):
-
     def test_perms_for_company(self):
         """A company can hire only for itself."""
         company_1 = CompanyFactory(with_membership=True)

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -254,7 +254,6 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class CreateEmployeeRecordStep2Test(AbstractCreateEmployeeRecordTest):
-
     NO_ADDRESS_FILLED_IN = "Aucune adresse n'a été saisie sur les emplois de l'inclusion !"
     ADDRESS_COULD_NOT_BE_AUTO_CHECKED = "L'adresse du salarié n'a pu être vérifiée automatiquement."
 

--- a/tests/www/login/tests.py
+++ b/tests/www/login/tests.py
@@ -121,7 +121,6 @@ class PrescriberLoginTest(InclusionConnectBaseTestCase):
 
 
 class EmployerLoginTest(InclusionConnectBaseTestCase):
-
     def test_login_options(self):
         url = reverse("login:employer")
         response = self.client.get(url)


### PR DESCRIPTION
## :thinking: Pourquoi ?

On installe déjà `ruff` qui est capable de faire le même formatting que `black` à peu de choses près (https://docs.astral.sh/ruff/formatter/black/), autant n'utiliser qu'un seul outil.

Et de manière anecdotique on a également un léger gain de perf:
```
❯ time black config itou scripts tests
All done! ✨ 🍰 ✨
816 files left unchanged.

real    0m0,700s
user    0m0,636s
sys     0m0,063s

❯ time ruff format config itou scripts tests
816 files left unchanged

real    0m0,032s
user    0m0,032s
sys     0m0,028s
```

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._
