### PR TITLE
Correction d’un échec de test_details_for_unauthorized_prescriber

### DIFF
--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -354,6 +354,8 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
             job_seeker_with_address=True,
             job_seeker__first_name="Supersecretname",
             job_seeker__last_name="Unknown",
+            job_seeker__jobseeker_profile__nir="11111111111111",
+            job_seeker__post_code="59140",
             sender=prescriber,
             sender_kind=job_applications_enums.SenderKind.PRESCRIBER,
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

```
__________ ProcessViewsTest.test_details_for_unauthorized_prescriber ___________
[gw0] linux -- Python 3.11.9 /home/runner/work/les-emplois/les-emplois/.venv/bin/python3.11

self = <tests.www.apply.test_process.ProcessViewsTest testMethod=test_details_for_unauthorized_prescriber>
args = (), kwargs = {}
prescriber = <User: Helen GRIFFIN — email1226@domain.com>
job_application = <JobApplication: b74a28c7-c4af-41d7-92a1-ff911dfae110>
url = '/apply/b74a28c7-c4af-41d7-92a1-ff911dfae110/prescriber/details'
response = <HttpResponse status_code=200, "text/html; charset=utf-8">

    def test_details_for_unauthorized_prescriber(self, *args, **kwargs):
        """As an unauthorized prescriber I cannot access personnal information of arbitrary job seekers"""
        prescriber = PrescriberFactory()
        job_application = JobApplicationFactory(
            job_seeker_with_address=True,
            job_seeker__first_name="Supersecretname",
            job_seeker__last_name="Unknown",
            sender=prescriber,
            sender_kind=job_applications_enums.SenderKind.PRESCRIBER,
        )
        self.client.force_login(prescriber)
        url = reverse("apply:details_for_prescriber", kwargs={"job_application_id": job_application.pk})
        response = self.client.get(url)
        self.assertContains(response, format_nir(job_application.job_seeker.jobseeker_profile.nir))
        self.assertContains(response, "<small>Prénom</small><strong>S…</strong>", html=True)
        self.assertContains(response, "<small>Nom</small><strong>U…</strong>", html=True)
        self.assertContains(response, "S… U…")
        self.assertNotContains(response, job_application.job_seeker.email)
        self.assertNotContains(response, job_application.job_seeker.phone)
>       self.assertNotContains(response, job_application.job_seeker.post_code)

tests/www/apply/test_process.py:369:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.11/site-packages/django/test/testcases.py:553: in assertNotContains
    self.assertEqual(
E   AssertionError: 1 != 0 : Response should not contain '58160'
----------------------------- Captured stderr call -----------------------------
{"message": "HTTP 200 OK", "logger.name": "django_datadog_logger.middleware.request_log", "logger.thread_name": "MainThread", "logger.method_name": "log_response", "date": "2024-05-13T12:51:39.025525+00:00", "status": "INFO", "network.client.ip": "127.0.0.1", "http.url": "/apply/b74a28c7-c4af-41d7-92a1-ff911dfae110/prescriber/details", "http.url_details.host": "testserver", "http.url_details.port": null, "http.url_details.path": "/apply/b74a28c7-c4af-41d7-92a1-ff911dfae110/prescriber/details", "http.url_details.queryString": {}, "http.url_details.scheme": "http", "http.url_details.view_name": "apply:details_for_prescriber", "http.method": "GET", "http.accept": null, "http.referer": null, "http.useragent": null, "http.request_version": null, "http.request_id": "b37f3bdc-6ada-4024-a7c4-da6374671b14", "usr.id": 1225, "duration": 62362670.8984375, "http.status_code": 200}
------------------------------ Captured log call -------------------------------
INFO     django_datadog_logger.middleware.request_log:request_log.py:46 HTTP 200 OK
=========================== short test summary info ============================
FAILED tests/www/apply/test_process.py::ProcessViewsTest::test_details_for_unauthorized_prescriber - AssertionError: 1 != 0 : Response should not contain '58160'
```

## :desert_island: Comment tester

```
pytest --randomly-seed=504696430 tests/www/apply/test_process.py::ProcessViewsTest::test_details_for_unauthorized_prescriber
```
