### PR TITLE
Transformer eligibility_diagnosis_by_siae_required en une méthode

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -775,7 +775,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     def is_spontaneous(self):
         return not self.selected_jobs.exists()
 
-    @property
     def eligibility_diagnosis_by_siae_required(self):
         """
         Returns True if an eligibility diagnosis must be made by an SIAE

--- a/itou/templates/apply/includes/list_card_body_company.html
+++ b/itou/templates/apply/includes/list_card_body_company.html
@@ -22,7 +22,7 @@
                                 PASS IAE {{ approval.get_state_display|lower }}
                             </span>
                         {% else %}
-                            {% if job_application.eligibility_diagnosis_by_siae_required %}
+                            {% if job_application.iae_eligibility_diagnosis_required %}
                                 <span class="badge badge-xs rounded-pill bg-accent-02-lighter text-primary">
                                     <i class="ri-error-warning-line" aria-hidden="true"></i>
                                     Éligibilité IAE à valider

--- a/itou/templates/apply/includes/siae_hiring_actions.html
+++ b/itou/templates/apply/includes/siae_hiring_actions.html
@@ -20,7 +20,7 @@
 
         {# Possible next steps when the state is processing / prior_to_hire ------------------------------------- #}
         {% if job_application.state.is_processing or job_application.state.is_prior_to_hire %}
-            {% if job_application.eligibility_diagnosis_by_siae_required %}
+            {% if eligibility_diagnosis_by_siae_required %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/new_diagnosis.html" %}</div>
             {% else %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/accept.html" %}</div>
@@ -31,7 +31,7 @@
 
         {# Possible next steps when the state is postponed ------------------------------------------------------ #}
         {% if job_application.state.is_postponed %}
-            {% if job_application.eligibility_diagnosis_by_siae_required %}
+            {% if eligibility_diagnosis_by_siae_required %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/new_diagnosis.html" %}</div>
             {% else %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/accept.html" %}</div>
@@ -41,7 +41,7 @@
 
         {# Possible next steps when the state is obsolete, refused or cancelled --------------------------------- #}
         {% if job_application.state.is_obsolete or job_application.state.is_refused or job_application.state.is_cancelled %}
-            {% if job_application.eligibility_diagnosis_by_siae_required %}
+            {% if eligibility_diagnosis_by_siae_required %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/new_diagnosis.html" %}</div>
             {% else %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/accept.html" %}</div>

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -66,6 +66,11 @@ def _add_administrative_criteria(job_applications):
         job_application.preloaded_administrative_criteria_extra_nb = extra_nb
 
 
+def _add_eligibility_diagnosis_required(job_applications):
+    for job_app in job_applications:
+        job_app.iae_eligibility_diagnosis_required = job_app.eligibility_diagnosis_by_siae_required()
+
+
 @login_required
 @user_passes_test(lambda u: u.is_job_seeker, login_url=reverse_lazy("search:employers_home"), redirect_field_name=None)
 def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html"):
@@ -121,6 +126,7 @@ def list_for_prescriber(request, template_name="apply/list_for_prescriber.html")
     _add_pending_for_weeks(job_applications_page)
     _add_user_can_view_personal_information(job_applications_page, request.user.can_view_personal_information)
     _add_administrative_criteria(job_applications_page)
+    _add_eligibility_diagnosis_required(job_applications_page)
 
     context = {
         "job_applications_page": job_applications_page,
@@ -202,8 +208,10 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
     # SIAE members have access to personal info
     _add_user_can_view_personal_information(job_applications_page, lambda ja: True)
 
-    if company.kind in SIAE_WITH_CONVENTION_KINDS:
+    iae_company = company.kind in SIAE_WITH_CONVENTION_KINDS
+    if iae_company:
         _add_administrative_criteria(job_applications_page)
+    _add_eligibility_diagnosis_required(job_applications_page)
 
     context = {
         "siae": company,

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -152,6 +152,7 @@ def details_for_company(request, job_application_id, template_name="apply/proces
         "can_edit_personal_information": request.user.can_edit_personal_information(job_application.job_seeker),
         "display_refusal_info": False,
         "eligibility_diagnosis": job_application.get_eligibility_diagnosis(),
+        "eligibility_diagnosis_by_siae_required": job_application.eligibility_diagnosis_by_siae_required(),
         "expired_eligibility_diagnosis": expired_eligibility_diagnosis,
         "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
         "job_application": job_application,
@@ -417,7 +418,7 @@ def accept(request, job_application_id, template_name="apply/process_accept.html
     job_application = get_object_or_404(queryset, id=job_application_id)
     check_waiting_period(job_application)
     next_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-    if not job_application.hiring_without_approval and job_application.eligibility_diagnosis_by_siae_required:
+    if not job_application.hiring_without_approval and job_application.eligibility_diagnosis_by_siae_required():
         messages.error(request, "Cette candidature requiert un diagnostic d'éligibilité pour être acceptée.")
         return HttpResponseRedirect(next_url)
 
@@ -676,6 +677,8 @@ def delete_prior_action(request, job_application_id, prior_action_id):
             context={
                 "job_application": job_application,
                 "transition_logs": job_application.logs.select_related("user").all(),
+                # GEIQ cannot require IAE eligibility diagnosis, but shared templates need this variable.
+                "eligibility_diagnosis_by_siae_required": False,
                 "geiq_eligibility_diagnosis": (
                     _get_geiq_eligibility_diagnosis_for_company(job_application)
                     if job_application.to_company.kind == CompanyKind.GEIQ
@@ -717,6 +720,8 @@ def add_or_modify_prior_action(request, job_application_id, prior_action_id=None
             {
                 "job_application": job_application,
                 "prior_action": prior_action,
+                # GEIQ cannot require IAE eligibility diagnosis, but shared templates need this variable.
+                "eligibility_diagnosis_by_siae_required": False,
             },
         )
 
@@ -756,6 +761,8 @@ def add_or_modify_prior_action(request, job_application_id, prior_action_id=None
                     # If out-of-band changes are needed
                     "with_oob_state_update": state_update,
                     "transition_logs": job_application.logs.select_related("user").all() if state_update else None,
+                    # GEIQ cannot require IAE eligibility diagnosis, but shared templates need this variable.
+                    "eligibility_diagnosis_by_siae_required": False,
                     "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,
                 },
             )

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -80,7 +80,7 @@ class JobApplicationModelTest(TestCase):
             job_application.job_seeker, for_siae=job_application.to_company
         )
         assert not has_considered_valid_diagnoses
-        assert not job_application.eligibility_diagnosis_by_siae_required
+        assert not job_application.eligibility_diagnosis_by_siae_required()
 
         job_application = JobApplicationFactory(
             state=JobApplicationState.PROCESSING,
@@ -91,7 +91,7 @@ class JobApplicationModelTest(TestCase):
             job_application.job_seeker, for_siae=job_application.to_company
         )
         assert not has_considered_valid_diagnoses
-        assert job_application.eligibility_diagnosis_by_siae_required
+        assert job_application.eligibility_diagnosis_by_siae_required()
 
     def test_accepted_by(self):
         job_application = JobApplicationFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Bientôt, pour savoir si une SIAE a besoin d’un diag, nous aurons besoin de savoir quel utilisateur se pose la question:

- les prescripteurs ne doivent pas voir que la SIAE a déjà établi un diag, car le diag d’un prescripteur aidera plus les candidats car il est valide chez tous les employeurs
- les employeurs doivent voir leurs diags, et ceux des prescripteurs
