### PR TITLE
Ajouter des context processors à www/error.py

### DIFF
--- a/itou/www/error.py
+++ b/itou/www/error.py
@@ -1,13 +1,11 @@
 import logging
 
-from csp.context_processors import nonce
+from django.conf import settings
 from django.http import HttpResponseServerError
 from django.template import TemplateDoesNotExist, loader
+from django.utils.module_loading import import_string
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME, ERROR_PAGE_TEMPLATE
-
-from itou.utils.context_processors import matomo
-from itou.utils.settings_context_processors import expose_settings
 
 
 @requires_csrf_token
@@ -21,9 +19,13 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
         return HttpResponseServerError(
             ERROR_PAGE_TEMPLATE % {"title": "Server Error (500)", "details": ""},
         )
+    [template_settings] = settings.TEMPLATES
+    context_processors_path = template_settings["OPTIONS"]["context_processors"]
+    context_processors = [import_string(processor_path) for processor_path in context_processors_path]
+    context = {}
     try:
-        # Those context processors are needed for layout/base.html
-        context = matomo(request) | expose_settings(request) | nonce(request)
+        for context_processor in context_processors:
+            context |= context_processor(request)
     except Exception:
         # This shouldn't happen, but we really don't want the error page to also crash
         logging.getLogger("itou.www").exception("Unable to create error page context.")

--- a/tests/www/test_error.py
+++ b/tests/www/test_error.py
@@ -15,7 +15,6 @@ class FailingForm:
         raise Exception("Something bad")
 
 
-@pytest.mark.ignore_unknown_variable_template_error("messages", "request")
 def test_error_handling(client, mocker):
     mocker.patch("itou.www.search.views.SiaeSearchForm", FailingForm)
 
@@ -28,7 +27,6 @@ def test_error_handling(client, mocker):
         client.get(reverse("search:employers_home"))
 
 
-@pytest.mark.ignore_unknown_variable_template_error("messages", "request")
 def test_handler500_view():
     factory = RequestFactory()
     request = factory.get("/")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Des échecs de test plus clairs.
