### PR TITLE
UX/UI : Postuler pour une entreprise directement depuis les résultats de recherche employeur [GEN-1645]

### DIFF
--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -52,19 +52,17 @@
         </div>
     </div>
     {% if siae.active_job_descriptions %}
-        <div class="d-none matomo-PostulerEmployeurAvecMetier">
-            <hr class="m-0">
-            <div class="c-box--results__body">
-                <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
-                    <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
-                    <a class="btn btn-ico btn-primary"
-                       href="{% url 'apply:start' company_pk=siae.pk %}"
-                       {% matomo_event "candidature" "clic" "start_application" %}
-                       aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri ri-draft-line" aria-hidden="true"></i>
-                        <span>Postuler</span>
-                    </a>
-                </div>
+        <hr class="m-0">
+        <div class="c-box--results__body">
+            <div class="d-flex flex-column flex-md-row justify-content-md-between align-items-md-center">
+                <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
+                <a class="btn btn-ico btn-primary"
+                   href="{% url 'apply:start' company_pk=siae.pk %}"
+                   {% matomo_event "candidature" "clic" "start_application" %}
+                   aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
+                    <i class="ri ri-draft-line" aria-hidden="true"></i>
+                    <span>Postuler</span>
+                </a>
             </div>
         </div>
     {% endif %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -44,33 +44,4 @@
 {% block script %}
     {{ block.super }}
     <script src='{% static "js/htmx_compat.js" %}'></script>
-    {# A / B testing: apply to company with job descriptions #}
-    <script nonce="{{ CSP_NONCE }}">
-        var _paq = _paq || [];
-        _paq.push(['AbTesting::create', {
-            name: 'PostulerEmployeurAvecMetier',
-            percentage: 100,
-            includedTargets: [{
-                "attribute": "path",
-                "inverted": "0",
-                "type": "starts_with",
-                "value": "\/search\/employers\/results"
-            }],
-            excludedTargets: [],
-            variations: [{
-                name: 'original',
-                activate: function() {}
-            }, {
-                name: 'apply-employer',
-                percentage: 50,
-                activate: function() {
-                    document.getElementsByClassName("matomo-PostulerEmployeurAvecMetier")
-                        .forEach((elt) => {
-                            elt.classList.remove("d-none")
-                        });
-                }
-            }],
-            trigger: () => document.getElementsByClassName("matomo-PostulerEmployeurAvecMetier").length,
-        }]);
-    </script>
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de devoir consulter les métiers de l’entreprise pour envoyer une candidature à une entreprise.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/9c34efbe-fd6b-474f-a7bd-f33d564ff038)

## :desert_island: Comment tester

1. Faire une recherche d’employeur depuis la page d’accueil
2. Constater la présence du bouton postuler sur chaque entreprise dans les résultats
