### PR TITLE
Demandeur d’emploi : les champs prénom, nom et adresse sont requis [GEN-1620]

### DIFF
--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -182,9 +182,11 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
             else:
                 context["closed_campaigns"].append(campaign)
     elif request.user.is_job_seeker:
-        # Force the job seeker to fill its title to use the site
-        if not request.user.title:
-            return HttpResponseRedirect(reverse("dashboard:edit_user_info"))
+        # Force job seekers to complete their profile.
+        required_attributes = ["title", "first_name", "last_name", "address_line_1", "post_code", "city"]
+        for attr in required_attributes:
+            if not getattr(request.user, attr):
+                return HttpResponseRedirect(reverse("dashboard:edit_user_info"))
 
     return render(request, template_name, context)
 

--- a/tests/gps/tests.py
+++ b/tests/gps/tests.py
@@ -8,7 +8,11 @@ from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
 from itou.users.enums import UserKind
 from itou.users.models import User
 from tests.gps.factories import FollowUpGroupFactory
-from tests.users.factories import JobSeekerFactory, PrescriberFactory
+from tests.users.factories import (
+    JobSeekerFactory,
+    JobSeekerWithAddressFactory,
+    PrescriberFactory,
+)
 from tests.utils.test import TestCase, parse_response_to_soup
 
 
@@ -159,7 +163,7 @@ def test_navigation(snapshot, client):
 
 
 def test_access_as_jobseeker(client):
-    user = JobSeekerFactory()
+    user = JobSeekerWithAddressFactory()
     client.force_login(user)
 
     response = client.get(reverse("gps:my_groups"))
@@ -183,7 +187,7 @@ def test_access_gps_enabled(client, snapshot):
     response = client.get(reverse("dashboard:index"))
     assert str(parse_response_to_soup(response, "#gps-card")) == snapshot
 
-    user = JobSeekerFactory()
+    user = JobSeekerWithAddressFactory()
     client.force_login(user)
     response = client.get(reverse("dashboard:index"))
     assertNotContains(response, "gps-card")

--- a/tests/www/signup/test_password.py
+++ b/tests/www/signup/test_password.py
@@ -5,7 +5,7 @@ from django.core import mail
 from django.urls import reverse
 from django.utils.http import urlencode
 
-from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
+from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, JobSeekerWithAddressFactory
 from tests.utils.test import TestCase
 
 
@@ -71,7 +71,7 @@ class PasswordChangeTest(TestCase):
         and redirects to the right place.
         """
 
-        user = JobSeekerFactory()
+        user = JobSeekerWithAddressFactory()
         self.client.force_login(user)
 
         # Change password.


### PR DESCRIPTION
## 🤔 Pourquoi ?

Compléter les données, faciliter les échanges avec les autres plateformes étatiques.

## 🏝️ Comment tester

1. Saisir une civilité pour Jacques Henry via l’admin http://localhost:8000/admin/users/user/2/change/
2. Se connecter en tant que Jacques Henry (compte candidat de la démo)
3. Vérifier que le candidat est redirigé vers la page de profil, où l’adresse, le prénom et le nom sont requis.

