### PR TITLE
Ajout du numéro de PASS dans les représentations techniques des Supension & Prolongation

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1186,7 +1186,7 @@ class Suspension(models.Model):
         ]
 
     def __str__(self):
-        return f"{self.pk} {self.start_at:%d/%m/%Y} - {self.end_at:%d/%m/%Y}"
+        return f"{self.pk} {self.start_at:%d/%m/%Y} - {self.end_at:%d/%m/%Y} [{self.approval.number}]"
 
     def clean(self):
         if self.reason == self.Reason.FORCE_MAJEURE and not self.reason_explanation:
@@ -1440,7 +1440,7 @@ class CommonProlongation(models.Model):
         ]
 
     def __str__(self):
-        return f"{self.pk} {self.start_at:%d/%m/%Y} - {self.end_at:%d/%m/%Y}"
+        return f"{self.pk} {self.start_at:%d/%m/%Y} - {self.end_at:%d/%m/%Y} [{self.approval.number}]"
 
     def clean(self):
         if not self.end_at:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin de pouvoir retrouver le PASS lié à des suspensions/prolongations supprimés dans l'admin (car les logs de l'admin Django contienne le champ `object_repr`)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Supprimer une prolongation dans l'admin et aller regarder dans la table des logs.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | RGPD                     |
 | Demandeur d’emploi       | Recherche employeur      |
 | Employeur                | Recherche fiche de poste |
 | Fiche de poste           | Recherche prescripteur   |
 | Fiche entreprise         | Stabilité                |
 | Fiches salarié           | Statistiques             |
 | GEIQ                     | Tableau de bord          |
 | Inscription              | UX/UI                    |
 +--------------------------|--------------------------+

-->
