### PR TITLE
tests: correction d'un appel à create_test_romes_and_appellations call

### DIFF
--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -248,7 +248,7 @@ class JobDescriptionCardViewTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        create_test_romes_and_appellations(("N1101"))
+        create_test_romes_and_appellations(["N1101"])
 
     def test_job_description_card(self):
         company = CompanyWithMembershipAndJobsFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

C'est a priori ce qui était souhaité même si en l’état du code, l'ancienne forme fonctionne également car on fait `rome_code not in rome_codes` et  `"N1101" not in "N1101"` ou `"N1101" not in ("N1101",)` retournent la même chose

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | RGPD                     |
 | Demandeur d’emploi       | Recherche employeur      |
 | Employeur                | Recherche fiche de poste |
 | Fiche de poste           | Recherche prescripteur   |
 | Fiche entreprise         | Stabilité                |
 | Fiches salarié           | Statistiques             |
 | GEIQ                     | Tableau de bord          |
 | Inscription              | UX/UI                    |
 +--------------------------|--------------------------+

-->
