### PR TITLE
API : Correction d’une typo dans les URLs d’exemple de l’API candidats

### DIFF
--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -115,7 +115,7 @@ et cliquez sur « Mon espace » > « Accès aux APIs ».
 
 ```bash
 curl
-'{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?structures_uid=<uid_1>' \
+'{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?uid_structures=<uid_1>' \
 --header 'Authorization: Token [token]'
 ```
 
@@ -125,7 +125,7 @@ Séparez les identifiants par des virgules.
 
 ```bash
 curl
-'{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?structures_uid=<uid_1>,<uid_2>' \
+'{settings.ITOU_PROTOCOL}://{settings.ITOU_FQDN}/api/v1/candidats/?uid_structures=<uid_1>,<uid_2>' \
 --header 'Authorization: Token [token]'
 ```
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour que les utilisateurs puissent copier/coller des requêtes qui fonctionnent.
