### PR TITLE
API : Retrait de la section Nouveautés

### DIFF
--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -25,14 +25,6 @@
                 </div>
             </div>
             <div class="row mt-5">
-                <div class="col-12">
-                    <h3 class="h2 mb-3">Dernières Nouveautés</h3>
-                    <dl class="row">
-                        <dt class="col-sm-3">Ajout de l’API Candidats</dt>
-                    </dl>
-                </div>
-            </div>
-            <div class="row mt-5">
                 <div class="col-md-12">
                     <h2 class="h1">Documentation</h2>
                     <p>Cette documentation est générée automatiquement à partir du code.</p>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La dernière nouveauté a deux ans. Elle n’est plus très nouvelle.
