### PR TITLE
Ne pas afficher le message d'erreur httpx lors de la commande django `configure_bucket`

### DIFF
--- a/itou/files/management/commands/configure_bucket.py
+++ b/itou/files/management/commands/configure_bucket.py
@@ -79,8 +79,9 @@ class Command(BaseCommand):
         )
 
     def check_minio(self):
-        response = httpx.head(settings.AWS_S3_ENDPOINT_URL)
-        # Response has a bad request status code, but we don’t care.
+        # https://min.io/docs/minio/linux/operations/monitoring/healthcheck-probe.html#node-liveness
+        livecheck_url = urljoin(settings.AWS_S3_ENDPOINT_URL, "minio/health/live")
+        response = httpx.head(livecheck_url)
         try:
             return response.headers["Server"] == "MinIO"
         except KeyError:


### PR DESCRIPTION
Le message d'erreur httpx "400 bad request" est supprimé.

## :thinking: Pourquoi ?

La requête qui est faite à la fin de la commande django `configure_bucket.py` affiche un log d'erreur :
```
HTTP Request: HEAD http://localhost:9000/ "HTTP/1.1 400 Bad Request"
```

Or le but de cette requête est uniquement de valider que le serveur est démarré, ce message d'erreur est donc inutile et peut faire croire que la commande a échoué.

## :cake: Comment ?

En changeant le niveau du logging des erreurs levées par `httpx`, il est possible d'ignorer tous les messages qui ne sont pas `CRITICAL`. Le niveau de logging est ensuite remis à sa valeur initiale.

## :computer: Captures d'écran

Avant :
<img width="1493" alt="Capture d’écran 2024-05-15 à 11 56 42" src="https://github.com/gip-inclusion/les-emplois/assets/167767/640de6a6-b48d-4fc1-8bfe-992fcb58d9cf">

Après :
<img width="1492" alt="Capture d’écran 2024-05-15 à 11 58 00" src="https://github.com/gip-inclusion/les-emplois/assets/167767/fcbb097e-7c02-48f9-9946-ec5ee2f56b3e">


## :rotating_light: À vérifier

Inutile de mettre à jour le CHANGELOG_breaking_changes.md, c'est simplement un changement de logging dans la console lors de l'exécution d'une commande django.

## :desert_island: Comment tester

Lancer la commande `make buckets` et valider que le message d'erreur n'est plus affiché.
