### PR TITLE
Vie privée : retrait de la mention des publicités Google, qui n’ont jamais été servies par le site

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,14 +27,14 @@
  | Candidature              | Pilotage                 |
  | Connexion                | Profil salarié           |
  | Contrôle a posteriori    | Prescripteur             |
- | Demandes de prolongation | RGPD                     |
- | Demandeur d’emploi       | Recherche employeur      |
- | Employeur                | Recherche fiche de poste |
- | Fiche de poste           | Recherche prescripteur   |
- | Fiche entreprise         | Stabilité                |
- | Fiches salarié           | Statistiques             |
- | GEIQ                     | Tableau de bord          |
- | Inscription              | UX/UI                    |
+ | Demandes de prolongation | Recherche employeur      |
+ | Demandeur d’emploi       | Recherche fiche de poste |
+ | Employeur                | Recherche prescripteur   |
+ | Fiche de poste           | Stabilité                |
+ | Fiche entreprise         | Statistiques             |
+ | Fiches salarié           | Tableau de bord          |
+ | GEIQ                     | UX/UI                    |
+ | Inscription              | Vie privée               |
  +--------------------------|--------------------------+
 
 -->

--- a/itou/templates/static/legal/privacy.html
+++ b/itou/templates/static/legal/privacy.html
@@ -224,17 +224,9 @@
                                 </td>
                             </tr>
                             <tr>
-                                <td>Google Webfonts</td>
+                                <td>Google</td>
                                 <td>États-Unis</td>
                                 <td>Service d’hébergement de police d’écriture</td>
-                                <td>
-                                    <a href="https://policies.google.com/privacy?hl=fr">https://policies.google.com/privacy?hl=fr</a>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>Gstatic</td>
-                                <td>États-Unis</td>
-                                <td>Publicités google</td>
                                 <td>
                                     <a href="https://policies.google.com/privacy?hl=fr">https://policies.google.com/privacy?hl=fr</a>
                                 </td>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ne pas laisser croire aux utilisateurs que le service tire des revenus de la publicité.
