### PR TITLE
ruff: activation des règles de pyupgrade

### DIFF
--- a/itou/api/geiq/serializers.py
+++ b/itou/api/geiq/serializers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.db import models
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -288,7 +286,7 @@ class GeiqJobApplicationSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     @extend_schema_field(LazyChoiceField(choices=lazy_administrative_criteria_choices))
-    def get_criteres_eligibilite(self, obj) -> List[str]:
+    def get_criteres_eligibilite(self, obj) -> list[str]:
         if diag := obj.geiq_eligibility_diagnosis:
             return sorted({crit.api_code for crit in diag.administrative_criteria.all()})
         return []

--- a/itou/asp/management/commands/sync_communes.py
+++ b/itou/asp/management/commands/sync_communes.py
@@ -19,7 +19,7 @@ ASP_DATE_FORMAT = "%d/%m/%Y"
 
 
 def csv_import_communes(filename):
-    with open(filename, "r", encoding="utf-8") as f:
+    with open(filename, encoding="utf-8") as f:
         reader = csv.reader(f, delimiter=";")
         next(reader)
         for line in reader:

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -371,7 +371,7 @@ class User(AbstractUser, AddressMixin):
         """
         Return the first_name plus the last_name, with a space in between.
         """
-        full_name = "%s %s" % (self.first_name.strip().title(), self.last_name.upper())
+        full_name = f"{self.first_name.strip().title()} {self.last_name.upper()}"
         return full_name.strip()
 
     @property

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -269,7 +269,7 @@ def compute_moves(existing_filenames, extract_infos):
     files_to_extract = set()
     globs_to_extract = set()
     for name in extract_infos["files"]:
-        if isinstance(name, (tuple, list)):
+        if isinstance(name, tuple | list):
             name, new_name = name
         else:
             new_name = name

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -106,7 +106,7 @@ class RemoteAutocompleteSelect2Widget(Select2Widget):
             return super().optgroups(name, value, attrs=attrs)
         selected_choices = {c for c in selected_choices if c not in self.choices.field.empty_values}
         field_name = self.choices.field.to_field_name or "pk"
-        query = Q(**{"%s__in" % field_name: selected_choices})
+        query = Q(**{f"{field_name}__in": selected_choices})
         for obj in self.choices.queryset.filter(query):
             option_value = self.choices.choice(obj)[0]
             option_label = self.label_from_instance(obj)

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -102,10 +102,7 @@ def new_user(request, invitation_type, invitation_id):
 
         # The user exists but he should log in first.
         login_url = reverse(f"login:{invitation.USER_KIND}")
-        next_step_url = "{url}?next={redirect_to}".format(
-            url=login_url,
-            redirect_to=invitation.acceptance_url_for_existing_user,
-        )
+        next_step_url = f"{login_url}?next={invitation.acceptance_url_for_existing_user}"
         return redirect(next_step_url)
 
     # A new user should be created before joining

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
     "I",  # isort
+    "UP",  # pyupgrade
 ]
 
 [tool.ruff.lint.isort]

--- a/tests/approvals/test_notify_pole_emploi.py
+++ b/tests/approvals/test_notify_pole_emploi.py
@@ -102,7 +102,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         approval.user.jobseeker_profile.refresh_from_db()
         assert approval.user.jobseeker_profile.pe_obfuscated_nir == "ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ"
         assert approval.user.jobseeker_profile.pe_last_certification_attempt_at == datetime.datetime(
-            2021, 6, 21, 0, 0, 0, tzinfo=datetime.timezone.utc
+            2021, 6, 21, 0, 0, 0, tzinfo=datetime.UTC
         )
 
     @respx.mock
@@ -333,7 +333,7 @@ class ApprovalNotifyPoleEmploiIntegrationTest(TestCase):
         approval.user.jobseeker_profile.refresh_from_db()
         assert approval.user.jobseeker_profile.pe_obfuscated_nir == "ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ"
         assert approval.user.jobseeker_profile.pe_last_certification_attempt_at == datetime.datetime(
-            2021, 6, 21, 0, 0, 0, tzinfo=datetime.timezone.utc
+            2021, 6, 21, 0, 0, 0, tzinfo=datetime.UTC
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,14 +208,14 @@ def django_ensure_matomo_titles(monkeypatch) -> None:
     original_render = loader.render_to_string
 
     def assertive_render(template_name, context=None, request=None, using=None):
-        if isinstance(template_name, (list, tuple)):
+        if isinstance(template_name, list | tuple):
             template = loader.select_template(template_name, using=using)
         else:
             template = loader.get_template(template_name, using=using)
 
         def _walk_template_nodes(nodelist, condition_fn):
             for node in nodelist:
-                if isinstance(node, (loader_tags.ExtendsNode, defaulttags.IfNode)):
+                if isinstance(node, loader_tags.ExtendsNode | defaulttags.IfNode):
                     return _walk_template_nodes(node.nodelist, condition_fn)
                 if condition_fn(node):
                     return node

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import factory
 import factory.fuzzy
@@ -98,8 +98,8 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
     to_company = factory.SubFactory(CompanyFactory, with_membership=True)
     message = factory.Faker("sentence", nb_words=40)
     answer = factory.Faker("sentence", nb_words=40)
-    hiring_start_at = factory.LazyFunction(lambda: datetime.now(timezone.utc).date())
-    hiring_end_at = factory.LazyFunction(lambda: datetime.now(timezone.utc).date() + relativedelta(years=2))
+    hiring_start_at = factory.LazyFunction(lambda: datetime.now(UTC).date())
+    hiring_end_at = factory.LazyFunction(lambda: datetime.now(UTC).date() + relativedelta(years=2))
     resume_link = "https://server.com/rockie-balboa.pdf"
     sender_kind = SenderKind.PRESCRIBER  # Make explicit the model's default value
     sender = factory.SubFactory(PrescriberFactory)
@@ -142,8 +142,8 @@ class PriorActionFactory(factory.django.DjangoModelFactory):
     action = factory.fuzzy.FuzzyChoice(Prequalification.values + ProfessionalSituationExperience.values)
     dates = factory.LazyFunction(
         lambda: InclusiveDateRange(
-            datetime.now(timezone.utc).date(),
-            datetime.now(timezone.utc).date() + relativedelta(years=2),
+            datetime.now(UTC).date(),
+            datetime.now(UTC).date() + relativedelta(years=2),
         )
     )
 
@@ -195,8 +195,8 @@ class JobApplicationWithoutApprovalFactory(JobApplicationSentByPrescriberFactory
 
 class JobApplicationWithApprovalNotCancellableFactory(JobApplicationFactory):
     with_approval = True
-    hiring_start_at = factory.LazyFunction(lambda: datetime.now(timezone.utc).date() - relativedelta(days=5))
-    hiring_end_at = factory.LazyFunction(lambda: datetime.now(timezone.utc).date() + relativedelta(years=2, days=-5))
+    hiring_start_at = factory.LazyFunction(lambda: datetime.now(UTC).date() - relativedelta(days=5))
+    hiring_end_at = factory.LazyFunction(lambda: datetime.now(UTC).date() + relativedelta(years=2, days=-5))
 
 
 class JobApplicationWithCompleteJobSeekerProfileFactory(JobApplicationWithApprovalNotCancellableFactory):

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1297,7 +1297,7 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     user.jobseeker_profile.save()
     assert user.jobseeker_profile.pe_obfuscated_nir == "XXX_1234567890123_YYY"
     assert user.jobseeker_profile.pe_last_certification_attempt_at == datetime.datetime(
-        2022, 8, 10, 0, 0, 0, 0, tzinfo=datetime.timezone.utc
+        2022, 8, 10, 0, 0, 0, 0, tzinfo=datetime.UTC
     )
 
 

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -60,10 +60,8 @@ class TestButtonsForm:
 
     def test_itou_buttons_with_secondary_name_and_value(self, snapshot):
         template = Template(
-            (
-                '{% load buttons_form %}{% itou_buttons_form secondary_url="/do" '
-                'secondary_name="name" secondary_value="1" %}'
-            )
+            '{% load buttons_form %}{% itou_buttons_form secondary_url="/do" '
+            'secondary_name="name" secondary_value="1" %}'
         )
         assert template.render(Context({})) == snapshot(name="with_secondary_name_and_value")
 

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -2848,7 +2848,7 @@ def test_add_prior_action_processing(client, snapshot):
         for_snapshot=True,
         to_company__kind=CompanyKind.GEIQ,
         state=job_applications_enums.JobApplicationState.PROCESSING,
-        created_at=datetime.datetime(2023, 12, 10, 10, 11, 11, tzinfo=datetime.timezone.utc),
+        created_at=datetime.datetime(2023, 12, 10, 10, 11, 11, tzinfo=datetime.UTC),
     )
     client.force_login(job_application.to_company.members.first())
     add_prior_action_url = reverse("apply:add_prior_action", kwargs={"job_application_id": job_application.pk})
@@ -2971,7 +2971,7 @@ def test_delete_prior_action(client, snapshot, with_geiq_diagnosis):
         for_snapshot=True,
         to_company__kind=CompanyKind.GEIQ,
         state=job_applications_enums.JobApplicationState.PROCESSING,
-        created_at=datetime.datetime(2023, 12, 10, 10, 11, 11, tzinfo=datetime.timezone.utc),
+        created_at=datetime.datetime(2023, 12, 10, 10, 11, 11, tzinfo=datetime.UTC),
     )
     prior_action1 = PriorActionFactory(
         job_application=job_application, action=job_applications_enums.Prequalification.AFPR

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1,5 +1,5 @@
 import math
-from datetime import date, datetime, timezone as datetime_tz
+from datetime import UTC, date, datetime
 from functools import partial
 from unittest import mock
 from urllib.parse import urlencode
@@ -796,8 +796,8 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         assert math.isclose(user.latitude, geocoding_data.get("latitude"), abs_tol=1e-5)
         assert math.isclose(user.longitude, geocoding_data.get("longitude"), abs_tol=1e-5)
         if ban_api_resolved_address:
-            assert user.address_filled_at == datetime(2023, 3, 10, tzinfo=datetime_tz.utc)
-            assert user.geocoding_updated_at == datetime(2023, 3, 10, tzinfo=datetime_tz.utc)
+            assert user.address_filled_at == datetime(2023, 3, 10, tzinfo=UTC)
+            assert user.geocoding_updated_at == datetime(2023, 3, 10, tzinfo=UTC)
 
     @override_settings(TALLY_URL="https://tally.so")
     @freeze_time("2023-03-10")

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import factory
 import pytest
@@ -100,7 +100,7 @@ def test_stats_pe_log_visit(client, view_name):
             None,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -136,7 +136,7 @@ def test_stats_cd_log_visit(client, settings, view_name):
             None,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -173,7 +173,7 @@ def test_stats_siae_log_visit(client, settings, view_name):
             None,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -212,7 +212,7 @@ def test_stats_ddets_iae_log_visit(client, settings, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -245,7 +245,7 @@ def test_stats_ddets_log_log_visit(client, settings, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -279,7 +279,7 @@ def test_stats_dreets_iae_log_visit(client, settings, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -311,7 +311,7 @@ def test_stats_dgefp_log_visit(client, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -343,7 +343,7 @@ def test_stats_dihal_log_visit(client, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -375,7 +375,7 @@ def test_stats_drihl_log_visit(client, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 
@@ -407,7 +407,7 @@ def test_stats_iae_network_log_visit(client, view_name):
             institution.pk,
             user.kind,
             user.pk,
-            datetime(2023, 3, 10, tzinfo=timezone.utc),
+            datetime(2023, 3, 10, tzinfo=UTC),
         ),
     )
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -16,4 +16,4 @@ def test_security_txt_is_valid(client):
             expiry = datetime.datetime.fromisoformat(expiry)
             break
 
-    assert expiry - datetime.datetime.now(tz=datetime.timezone.utc) >= datetime.timedelta(days=14)
+    assert expiry - datetime.datetime.now(tz=datetime.UTC) >= datetime.timedelta(days=14)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour utiliser du python moderne souvent plus concis (sachant que beaucoup des règles sont gérées par le `--fix`)

## :cake: Comment ? <!-- optionnel -->

Plus de conf dans `pyproject.toml`.

## :desert_island: Comment tester

Écrire l'ancienne version et lancer `ruff check`/`ruff check --fix`.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | RGPD                     |
 | Demandeur d’emploi       | Recherche employeur      |
 | Employeur                | Recherche fiche de poste |
 | Fiche de poste           | Recherche prescripteur   |
 | Fiche entreprise         | Stabilité                |
 | Fiches salarié           | Statistiques             |
 | GEIQ                     | Tableau de bord          |
 | Inscription              | UX/UI                    |
 +--------------------------|--------------------------+

-->
