### PR TITLE
tests: association de quelques `assertNotContains` de plus à leur `assertContains`

### DIFF
--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -16,6 +16,8 @@ from tests.users.factories import JobSeekerFactory, JobSeekerWithAddressFactory
 
 @freeze_time("2024-02-15")
 class JobApplicationGEIQEligibilityDetailsTest(TestCase):
+    EXPIRED_DIAGNOSIS_EXPLANATION = "Le diagnostic du candidat a expiré"
+
     @classmethod
     def setUpTestData(cls):
         cls.geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ)
@@ -81,7 +83,7 @@ class JobApplicationGEIQEligibilityDetailsTest(TestCase):
             response,
             "Les critères que vous avez sélectionnés ne vous permettent pas de bénéficier d’une aide financière de l’État.",  # noqa: E501
         )
-        self.assertNotContains(response, "Le diagnostic du candidat a expiré")
+        self.assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
         # More in `test_allowance_details_for_geiq`
 
     def test_details_as_geiq_with_expired_eligibility_diagnosis(self):
@@ -101,7 +103,7 @@ class JobApplicationGEIQEligibilityDetailsTest(TestCase):
         )
 
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        self.assertContains(response, "Le diagnostic du candidat a expiré")
+        self.assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
         self.assertContains(
             response,
             "Éligibilité public prioritaire GEIQ non confirmée",
@@ -127,7 +129,7 @@ class JobApplicationGEIQEligibilityDetailsTest(TestCase):
 
         self.assertContains(
             response,
-            f"Le diagnostic du candidat a expiré le {dateformat.format(self.expired_diagnosis.expires_at, 'd F Y')}",
+            f"{self.EXPIRED_DIAGNOSIS_EXPLANATION} le {dateformat.format(self.expired_diagnosis.expires_at, 'd F Y')}",
         )
 
     def test_allowance_details_for_prescriber(self):

--- a/tests/www/approvals_views/test_pe_approval.py
+++ b/tests/www/approvals_views/test_pe_approval.py
@@ -15,6 +15,7 @@ from tests.utils.test import TestCase
 
 class PoleEmploiApprovalSearchTest(MessagesTestMixin, TestCase):
     URL = reverse_lazy("approvals:pe_approval_search")
+    CONTINUE_LINK = "<span>Continuer</span>"
 
     def set_up_pe_approval(self, with_job_application=True):
         self.pe_approval = PoleEmploiApprovalFactory()
@@ -55,7 +56,7 @@ class PoleEmploiApprovalSearchTest(MessagesTestMixin, TestCase):
         self.client.force_login(self.employer)
 
         response = self.client.get(self.URL, {"number": self.pe_approval.number})
-        self.assertContains(response, "Continuer")
+        self.assertContains(response, self.CONTINUE_LINK)
 
     def test_number_length(self):
         """
@@ -76,7 +77,7 @@ class PoleEmploiApprovalSearchTest(MessagesTestMixin, TestCase):
         self.client.force_login(membership.user)
 
         response = self.client.get(self.URL, {"number": 123123123123})
-        self.assertNotContains(response, "Continuer")
+        self.assertNotContains(response, self.CONTINUE_LINK)
 
     def test_has_matching_pass_iae(self):
         """
@@ -105,7 +106,7 @@ class PoleEmploiApprovalSearchTest(MessagesTestMixin, TestCase):
         self.client.force_login(self.employer)
         # Our approval should not be usable without a job application
         response = self.client.get(self.URL, {"number": self.approval.number})
-        self.assertNotContains(response, "Continuer")
+        self.assertNotContains(response, self.CONTINUE_LINK)
 
     def test_has_matching_pass_iae_that_belongs_to_another_siae(self):
         """
@@ -137,7 +138,7 @@ class PoleEmploiApprovalSearchTest(MessagesTestMixin, TestCase):
 
         # The current user should not be able to use the PASS IAE used by another SIAE.
         response = self.client.get(self.URL, {"number": job_application.approval.number})
-        self.assertNotContains(response, "Continuer")
+        self.assertNotContains(response, self.CONTINUE_LINK)
 
     def test_unlogged_is_not_authorized(self):
         """


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour que les `assertNotContains` restent pertinents.


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | RGPD                     |
 | Demandeur d’emploi       | Recherche employeur      |
 | Employeur                | Recherche fiche de poste |
 | Fiche de poste           | Recherche prescripteur   |
 | Fiche entreprise         | Stabilité                |
 | Fiches salarié           | Statistiques             |
 | GEIQ                     | Tableau de bord          |
 | Inscription              | UX/UI                    |
 +--------------------------|--------------------------+

-->
