### PR TITLE
Ajouts dans le README pour les nouveaux venus

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Sur Ubuntu :
 $ apt-get install gdal-bin
 ```
 
-
 #### Virtualenv
 
 La commande `make` suivante crée un


### PR DESCRIPTION
Pour un nouveau venu sur le projet, qui suit les instructions du README, il manque quelques instructions.

## :thinking: Pourquoi ?

Sans l'activation du virtualenv, la commande `make buckets` va échouer :

```
➜  les-emplois git:(README-additions-for-newcomer) make buckets
python manage.py configure_bucket
make: python: No such file or directory
make: *** [buckets] Error 1
```

Et cette même commande échouera si `GDAL` n'est pas installé localement : l'installation de `libpq` n'est pas suffisante.

## :desert_island: Comment tester

Désactiver son virtualenv, et désinstaller GDAL, puis lancer `make buckets` ;)