### PR TITLE
Admin : Ignorer les accents lors de la recherche par prénom ou nom [GEN-1627]

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -196,8 +196,8 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
     search_fields = (
         "pk",
         "number",
-        "user__first_name",
-        "user__last_name",
+        "user__first_name__unaccent",
+        "user__last_name__unaccent",
         "user__email",
         "user__jobseeker_profile__nir",
     )
@@ -567,8 +567,8 @@ class PoleEmploiApprovalAdmin(ItouModelAdmin):
         "pole_emploi_id",
         "nir",
         "number",
-        "first_name",
-        "last_name",
+        "first_name__unaccent",
+        "last_name__unaccent",
         "birth_name",
     )
     list_filter = (IsValidFilter,)
@@ -593,8 +593,8 @@ class CancelledApprovalAdmin(ItouModelAdmin):
     )
     search_fields = (
         "number",
-        "user_first_name",
-        "user_last_name",
+        "user_first_name__unaccent",
+        "user_last_name__unaccent",
         "user_nir",
         "origin_siae_siret",
     )

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -545,8 +545,8 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
         else:
             search_fields.append("email")
             if "@" not in search_term:
-                search_fields.append("first_name")
-                search_fields.append("last_name")
+                search_fields.append("first_name__unaccent")
+                search_fields.append("last_name__unaccent")
         return search_fields
 
     def get_inlines(self, request, obj):
@@ -858,8 +858,8 @@ class JobSeekerProfileAdmin(DisabledNotificationsMixin, InconsistencyCheckMixin,
         else:
             search_fields.append("user__email")
             if "@" not in search_term:
-                search_fields.append("user__first_name")
-                search_fields.append("user__last_name")
+                search_fields.append("user__first_name__unaccent")
+                search_fields.append("user__last_name__unaccent")
         return search_fields
 
     def get_form(self, request, obj=None, **kwargs):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter l’identification des doublons pour le support, et la recherche dans l’admin en général.

## :cake: Comment ? <!-- optionnel -->

En ignorant les accents dans les prénoms et noms.

## :desert_island: Comment tester

Débrouillez-vous, c’est l’admin django 🙊.
