### PR TITLE
logging: ajout de l'organisation courante de l'utilisateur dans les logs JSON

### DIFF
--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -10,4 +10,7 @@ class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):
         for log_key in self.LOG_KEYS_TO_REMOVE:
             if log_key in log_entry_dict:
                 del log_entry_dict[log_key]
+        wsgi_request = self.get_wsgi_request()
+        if wsgi_request is not None and (current_org := getattr(wsgi_request, "current_organization", None)):
+            log_entry_dict["usr.organization_id"] = current_org.pk
         return log_entry_dict


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin de faciliter le debug, ou pour sortir des stats d'utilisation de fonctionnalité par structure.

## :cake: Comment ? <!-- optionnel -->

Assez facilement avec la méthode `json_record`.
Malheureusement la partie test a été plus laborieuse car `caplog` ne peut pas être utilisé (l'enrichissement du log se passe dans le formatter) et `capfd`/`capsys` n'ont pas voulues fonctionner: https://github.com/pytest-dev/pytest/issues/5997

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Commenter cette ligne:
https://github.com/gip-inclusion/les-emplois/blob/9e446412ed76ecd31342da3d6e4e3f427adb0ead/config/settings/dev.py#L73
et faire des requêtes avec un utilisateur ayant une organisation active.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | RGPD                     |
 | Demandeur d’emploi       | Recherche employeur      |
 | Employeur                | Recherche fiche de poste |
 | Fiche de poste           | Recherche prescripteur   |
 | Fiche entreprise         | Stabilité                |
 | Fiches salarié           | Statistiques             |
 | GEIQ                     | Tableau de bord          |
 | Inscription              | UX/UI                    |
 +--------------------------|--------------------------+

-->
