### PR TITLE
Envoyer les emails lors que la transaction en cours `commit`

### DIFF
--- a/itou/common_apps/organizations/admin.py
+++ b/itou/common_apps/organizations/admin.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.contrib import admin, messages
-from django.db import transaction
 from django.db.models import Count
 from django.forms import BaseInlineFormSet, ModelForm
 
@@ -29,9 +28,9 @@ class MembersInlineForm(ModelForm):
             structure = get_membership_structure(instance)
             if structure is not None:
                 if instance.is_admin:
-                    transaction.on_commit(lambda: structure.add_admin_email(instance.user).send())
+                    structure.add_admin_email(instance.user).send()
                 else:
-                    transaction.on_commit(lambda: structure.remove_admin_email(instance.user).send())
+                    structure.remove_admin_email(instance.user).send()
         return instance
 
 
@@ -40,7 +39,7 @@ class MembersInlineFormSet(BaseInlineFormSet):
         if obj.is_admin is True:
             structure = get_membership_structure(obj)
             if structure is not None:
-                transaction.on_commit(lambda: structure.remove_admin_email(obj.user).send())
+                structure.remove_admin_email(obj.user).send()
         super().delete_existing(obj, commit=commit)
 
 

--- a/itou/common_apps/organizations/views.py
+++ b/itou/common_apps/organizations/views.py
@@ -4,7 +4,6 @@ Functions used in organization views.
 
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
-from django.db import transaction
 
 
 def deactivate_org_member(request, target_member):
@@ -22,9 +21,7 @@ def deactivate_org_member(request, target_member):
                 messages.success(
                     request, f"{target_member.get_full_name()} a été retiré(e) des membres actifs de cette structure."
                 )
-                transaction.on_commit(
-                    lambda: request.current_organization.member_deactivation_email(membership.user).send()
-                )
+                request.current_organization.member_deactivation_email(membership.user).send()
         else:
             raise PermissionDenied
         return True
@@ -45,13 +42,13 @@ def update_org_admin_role(request, target_member, action):
                 messages.success(
                     request, f"{target_member.get_full_name()} a été ajouté(e) aux administrateurs de cette structure."
                 )
-                transaction.on_commit(lambda: request.current_organization.add_admin_email(target_member).send())
+                request.current_organization.add_admin_email(target_member).send()
             if action == "remove":
                 membership.set_admin_role(is_admin=False, updated_by=request.user)
                 messages.success(
                     request, f"{target_member.get_full_name()} a été retiré(e) des administrateurs de cette structure."
                 )
-                transaction.on_commit(lambda: request.current_organization.remove_admin_email(target_member).send())
+                request.current_organization.remove_admin_email(target_member).send()
             membership.save()
         else:
             raise PermissionDenied

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -6,7 +6,6 @@ All these helpers are specific to SIAE logic (not GEIQ, EA, EATT).
 
 """
 
-from django.db import transaction
 from django.utils import timezone
 
 from itou.common_apps.address.departments import department_from_postcode
@@ -182,7 +181,7 @@ def create_new_siaes(siret_to_siae_row, conventions_by_siae_key):
         siae.save()
     print("--- end of CSV output of all creatable_siaes ---")
 
-    transaction.on_commit(lambda: send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes))
+    send_email_messages(siae.activate_your_account_email() for siae in creatable_siaes)
 
     print(f"{len(creatable_siaes)} structures have been created")
     print(f"{len([s for s in creatable_siaes if s.coords])} structures will have geolocation")

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -1,6 +1,7 @@
 import datetime
 
 from dateutil.relativedelta import relativedelta
+from django.db import transaction
 from django.db.models import Exists, F, Max, OuterRef, Q
 from django.utils import timezone
 
@@ -12,6 +13,7 @@ from itou.utils.emails import send_email_messages
 
 
 class Command(BaseCommand):
+    @transaction.atomic
     def handle(self, **options):
         today = timezone.localdate()
         campaigns = EvaluationCampaign.objects.filter(ended_at=None).select_related("institution")

--- a/tests/common_apps/notifications/tests.py
+++ b/tests/common_apps/notifications/tests.py
@@ -75,7 +75,8 @@ class NotificationsBaseClassTest(TestCase):
         assert len(recipients) == 0
 
     def test_send(self):
-        self.notification.send()
+        with self.captureOnCommitCallbacks(execute=True):
+            self.notification.send()
 
         receivers = [receiver for message in mail.outbox for receiver in message.to]
         assert self.notification.email.to == receivers

--- a/tests/communications/test_dispatch.py
+++ b/tests/communications/test_dispatch.py
@@ -195,7 +195,8 @@ class EmailNotificationTest(FakeNotificationClassesMixin, TestCase):
         assert "Cet email est envoyé depuis un environnement de démonstration" in email.body
 
     def test_method_send(self):
-        self.ManageableNotification(self.user, self.organization).send()
+        with self.captureOnCommitCallbacks(execute=True):
+            self.ManageableNotification(self.user, self.organization).send()
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == [self.user.email]
         assert "Cet email est envoyé depuis un environnement de démonstration" in mail.outbox[0].body

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -31,7 +31,7 @@ class TestCompanyAdmin:
         response = parse_response_to_soup(response, selector=".field-approvals_list")
         assert str(response) == snapshot
 
-    def test_deactivate_last_admin(self, admin_client, django_capture_on_commit_callbacks):
+    def test_deactivate_last_admin(self, admin_client):
         company = CompanyFactory(with_membership=True)
         membership = company.memberships.first()
         assert membership.is_admin
@@ -40,31 +40,30 @@ class TestCompanyAdmin:
         response = admin_client.get(change_url)
         assert response.status_code == 200
 
-        with django_capture_on_commit_callbacks(execute=True):
-            response = admin_client.post(
-                change_url,
-                data={
-                    "id": company.id,
-                    "siret": company.siret,
-                    "kind": company.kind.value,
-                    "name": company.name,
-                    "phone": company.phone,
-                    "email": company.email,
-                    "companymembership_set-TOTAL_FORMS": "2",
-                    "companymembership_set-INITIAL_FORMS": "1",
-                    "companymembership_set-MIN_NUM_FORMS": "0",
-                    "companymembership_set-MAX_NUM_FORMS": "1000",
-                    "companymembership_set-0-id": membership.pk,
-                    "companymembership_set-0-company": company.pk,
-                    "companymembership_set-0-user": membership.user.pk,
-                    # companymembership_pet-0-is_admin is absent
-                    "job_description_through-TOTAL_FORMS": "0",
-                    "job_description_through-INITIAL_FORMS": "0",
-                    "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": 1,
-                    "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": 0,
-                    "_continue": "Enregistrer+et+continuer+les+modifications",
-                },
-            )
+        response = admin_client.post(
+            change_url,
+            data={
+                "id": company.id,
+                "siret": company.siret,
+                "kind": company.kind.value,
+                "name": company.name,
+                "phone": company.phone,
+                "email": company.email,
+                "companymembership_set-TOTAL_FORMS": "2",
+                "companymembership_set-INITIAL_FORMS": "1",
+                "companymembership_set-MIN_NUM_FORMS": "0",
+                "companymembership_set-MAX_NUM_FORMS": "1000",
+                "companymembership_set-0-id": membership.pk,
+                "companymembership_set-0-company": company.pk,
+                "companymembership_set-0-user": membership.user.pk,
+                # companymembership_pet-0-is_admin is absent
+                "job_description_through-TOTAL_FORMS": "0",
+                "job_description_through-INITIAL_FORMS": "0",
+                "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": 1,
+                "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": 0,
+                "_continue": "Enregistrer+et+continuer+les+modifications",
+            },
+        )
         assertRedirects(response, change_url, fetch_redirect_response=False)
         response = admin_client.get(change_url)
         assertContains(
@@ -77,7 +76,7 @@ class TestCompanyAdmin:
 
         assert_set_admin_role__removal(membership.user, company)
 
-    def test_delete_admin(self, admin_client, django_capture_on_commit_callbacks):
+    def test_delete_admin(self, admin_client):
         company = CompanyFactory(with_membership=True)
         membership = company.memberships.first()
         assert membership.is_admin
@@ -86,38 +85,37 @@ class TestCompanyAdmin:
         response = admin_client.get(change_url)
         assert response.status_code == 200
 
-        with django_capture_on_commit_callbacks(execute=True):
-            response = admin_client.post(
-                change_url,
-                data={
-                    "id": company.id,
-                    "siret": company.siret,
-                    "kind": company.kind.value,
-                    "name": company.name,
-                    "phone": company.phone,
-                    "email": company.email,
-                    "companymembership_set-TOTAL_FORMS": "2",
-                    "companymembership_set-INITIAL_FORMS": "1",
-                    "companymembership_set-MIN_NUM_FORMS": "0",
-                    "companymembership_set-MAX_NUM_FORMS": "1000",
-                    "companymembership_set-0-id": membership.pk,
-                    "companymembership_set-0-company": company.pk,
-                    "companymembership_set-0-user": membership.user.pk,
-                    "companymembership_set-0-is_admin": "on",
-                    "companymembership_set-0-DELETE": "on",
-                    "job_description_through-TOTAL_FORMS": "0",
-                    "job_description_through-INITIAL_FORMS": "0",
-                    "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": 1,
-                    "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": 0,
-                    "_continue": "Enregistrer+et+continuer+les+modifications",
-                },
-            )
+        response = admin_client.post(
+            change_url,
+            data={
+                "id": company.id,
+                "siret": company.siret,
+                "kind": company.kind.value,
+                "name": company.name,
+                "phone": company.phone,
+                "email": company.email,
+                "companymembership_set-TOTAL_FORMS": "2",
+                "companymembership_set-INITIAL_FORMS": "1",
+                "companymembership_set-MIN_NUM_FORMS": "0",
+                "companymembership_set-MAX_NUM_FORMS": "1000",
+                "companymembership_set-0-id": membership.pk,
+                "companymembership_set-0-company": company.pk,
+                "companymembership_set-0-user": membership.user.pk,
+                "companymembership_set-0-is_admin": "on",
+                "companymembership_set-0-DELETE": "on",
+                "job_description_through-TOTAL_FORMS": "0",
+                "job_description_through-INITIAL_FORMS": "0",
+                "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": 1,
+                "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": 0,
+                "_continue": "Enregistrer+et+continuer+les+modifications",
+            },
+        )
         assertRedirects(response, change_url, fetch_redirect_response=False)
         response = admin_client.get(change_url)
 
         assert_set_admin_role__removal(membership.user, company)
 
-    def test_add_admin(self, admin_client, django_capture_on_commit_callbacks):
+    def test_add_admin(self, admin_client):
         company = CompanyFactory(with_membership=True)
         membership = company.memberships.first()
         employer = EmployerFactory()
@@ -127,34 +125,33 @@ class TestCompanyAdmin:
         response = admin_client.get(change_url)
         assert response.status_code == 200
 
-        with django_capture_on_commit_callbacks(execute=True):
-            response = admin_client.post(
-                change_url,
-                data={
-                    "id": company.id,
-                    "siret": company.siret,
-                    "kind": company.kind.value,
-                    "name": company.name,
-                    "phone": company.phone,
-                    "email": company.email,
-                    "companymembership_set-TOTAL_FORMS": "2",
-                    "companymembership_set-INITIAL_FORMS": "1",
-                    "companymembership_set-MIN_NUM_FORMS": "0",
-                    "companymembership_set-MAX_NUM_FORMS": "1000",
-                    "companymembership_set-0-id": membership.pk,
-                    "companymembership_set-0-company": company.pk,
-                    "companymembership_set-0-user": membership.user.pk,
-                    "companymembership_set-0-is_admin": "on",
-                    "companymembership_set-1-company": company.pk,
-                    "companymembership_set-1-user": employer.pk,
-                    "companymembership_set-1-is_admin": "on",
-                    "job_description_through-TOTAL_FORMS": "0",
-                    "job_description_through-INITIAL_FORMS": "0",
-                    "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": 1,
-                    "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": 0,
-                    "_continue": "Enregistrer+et+continuer+les+modifications",
-                },
-            )
+        response = admin_client.post(
+            change_url,
+            data={
+                "id": company.id,
+                "siret": company.siret,
+                "kind": company.kind.value,
+                "name": company.name,
+                "phone": company.phone,
+                "email": company.email,
+                "companymembership_set-TOTAL_FORMS": "2",
+                "companymembership_set-INITIAL_FORMS": "1",
+                "companymembership_set-MIN_NUM_FORMS": "0",
+                "companymembership_set-MAX_NUM_FORMS": "1000",
+                "companymembership_set-0-id": membership.pk,
+                "companymembership_set-0-company": company.pk,
+                "companymembership_set-0-user": membership.user.pk,
+                "companymembership_set-0-is_admin": "on",
+                "companymembership_set-1-company": company.pk,
+                "companymembership_set-1-user": employer.pk,
+                "companymembership_set-1-is_admin": "on",
+                "job_description_through-TOTAL_FORMS": "0",
+                "job_description_through-INITIAL_FORMS": "0",
+                "utils-pksupportremark-content_type-object_id-TOTAL_FORMS": 1,
+                "utils-pksupportremark-content_type-object_id-INITIAL_FORMS": 0,
+                "_continue": "Enregistrer+et+continuer+les+modifications",
+            },
+        )
         assertRedirects(response, change_url, fetch_redirect_response=False)
         response = admin_client.get(change_url)
 

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -211,7 +211,7 @@ class ImportSiaeManagementCommandsTest(TestCase):
                 get_siret_to_siae_row(get_vue_structure_df()),
                 get_conventions_by_siae_key(get_vue_af_df()),
             )
-        assert len(commit_callbacks) == 1
+        assert len(commit_callbacks) == 6
         assert len(mail.outbox) == 6
         assert reverse("signup:company_select") in mail.outbox[0].body
         assert collections.Counter(mail.subject for mail in mail.outbox) == collections.Counter(

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -171,7 +171,8 @@ class SiaeModelTest(TestCase):
             request = factory.get("/")
 
             message = company.new_signup_activation_email_to_official_contact(request)
-            message.send()
+            with self.captureOnCommitCallbacks(execute=True):
+                message.send()
 
             assert len(mail.outbox) == 1
             email = mail.outbox[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from itou.utils import faker_providers  # noqa: E402
 from itou.utils.storage.s3 import s3_client  # noqa: E402
 from tests.users.factories import ItouStaffFactory  # noqa: E402
 from tests.utils.htmx.test import HtmxClient  # noqa: E402
-from tests.utils.test import NoInlineClient  # noqa: E402
+from tests.utils.test import ItouClient  # noqa: E402
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -60,14 +60,14 @@ def pytest_configure(config) -> None:
 
 @pytest.fixture
 def admin_client():
-    client = NoInlineClient()
+    client = ItouClient()
     client.force_login(ItouStaffFactory(is_superuser=True))
     return client
 
 
 @pytest.fixture
 def client():
-    return NoInlineClient()
+    return ItouClient()
 
 
 @pytest.fixture()

--- a/tests/geo/test_zrr.py
+++ b/tests/geo/test_zrr.py
@@ -1,7 +1,6 @@
-from django.test import TestCase
-
 from itou.geo.enums import ZRRStatus
 from tests.geo.factories import ZRRFactory
+from tests.utils.test import TestCase
 
 
 class ZRRModelTest(TestCase):

--- a/tests/institutions/tests.py
+++ b/tests/institutions/tests.py
@@ -44,7 +44,7 @@ class InstitutionModelTest(TestCase):
         assert active_user_with_active_membership not in institution.active_members
 
 
-def test_deactivate_last_admin(admin_client, django_capture_on_commit_callbacks):
+def test_deactivate_last_admin(admin_client):
     institution = InstitutionWithMembershipFactory(department="")
     membership = institution.memberships.first()
     assert membership.is_admin
@@ -53,29 +53,28 @@ def test_deactivate_last_admin(admin_client, django_capture_on_commit_callbacks)
     response = admin_client.get(change_url)
     assert response.status_code == 200
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = admin_client.post(
-            change_url,
-            data={
-                "kind": institution.kind.value,
-                "name": institution.name,
-                "address_line_1": institution.address_line_1,
-                "address_line_2": institution.address_line_2,
-                "post_code": institution.post_code,
-                "city": institution.city,
-                "department": institution.department,
-                "coords": "",
-                "institutionmembership_set-TOTAL_FORMS": "2",
-                "institutionmembership_set-INITIAL_FORMS": "1",
-                "institutionmembership_set-MIN_NUM_FORMS": "0",
-                "institutionmembership_set-MAX_NUM_FORMS": "1000",
-                "institutionmembership_set-0-id": membership.pk,
-                "institutionmembership_set-0-institution": institution.pk,
-                "institutionmembership_set-0-user": membership.user.pk,
-                # institutionmembership_set-0-is_admin is absent
-                "_continue": "Enregistrer+et+continuer+les+modifications",
-            },
-        )
+    response = admin_client.post(
+        change_url,
+        data={
+            "kind": institution.kind.value,
+            "name": institution.name,
+            "address_line_1": institution.address_line_1,
+            "address_line_2": institution.address_line_2,
+            "post_code": institution.post_code,
+            "city": institution.city,
+            "department": institution.department,
+            "coords": "",
+            "institutionmembership_set-TOTAL_FORMS": "2",
+            "institutionmembership_set-INITIAL_FORMS": "1",
+            "institutionmembership_set-MIN_NUM_FORMS": "0",
+            "institutionmembership_set-MAX_NUM_FORMS": "1000",
+            "institutionmembership_set-0-id": membership.pk,
+            "institutionmembership_set-0-institution": institution.pk,
+            "institutionmembership_set-0-user": membership.user.pk,
+            # institutionmembership_set-0-is_admin is absent
+            "_continue": "Enregistrer+et+continuer+les+modifications",
+        },
+    )
     assertRedirects(response, change_url, fetch_redirect_response=False)
     response = admin_client.get(change_url)
     assertContains(
@@ -89,7 +88,7 @@ def test_deactivate_last_admin(admin_client, django_capture_on_commit_callbacks)
     assert_set_admin_role__removal(membership.user, institution)
 
 
-def test_delete_admin(admin_client, django_capture_on_commit_callbacks):
+def test_delete_admin(admin_client):
     institution = InstitutionWithMembershipFactory(department="")
     membership = institution.memberships.first()
     assert membership.is_admin
@@ -98,37 +97,36 @@ def test_delete_admin(admin_client, django_capture_on_commit_callbacks):
     response = admin_client.get(change_url)
     assert response.status_code == 200
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = admin_client.post(
-            change_url,
-            data={
-                "kind": institution.kind.value,
-                "name": institution.name,
-                "address_line_1": institution.address_line_1,
-                "address_line_2": institution.address_line_2,
-                "post_code": institution.post_code,
-                "city": institution.city,
-                "department": institution.department,
-                "coords": "",
-                "institutionmembership_set-TOTAL_FORMS": "2",
-                "institutionmembership_set-INITIAL_FORMS": "1",
-                "institutionmembership_set-MIN_NUM_FORMS": "0",
-                "institutionmembership_set-MAX_NUM_FORMS": "1000",
-                "institutionmembership_set-0-id": membership.pk,
-                "institutionmembership_set-0-institution": institution.pk,
-                "institutionmembership_set-0-user": membership.user.pk,
-                "institutionmembership_set-0-is_admin": "on",
-                "institutionmembership_set-0-DELETE": "on",
-                "_continue": "Enregistrer+et+continuer+les+modifications",
-            },
-        )
+    response = admin_client.post(
+        change_url,
+        data={
+            "kind": institution.kind.value,
+            "name": institution.name,
+            "address_line_1": institution.address_line_1,
+            "address_line_2": institution.address_line_2,
+            "post_code": institution.post_code,
+            "city": institution.city,
+            "department": institution.department,
+            "coords": "",
+            "institutionmembership_set-TOTAL_FORMS": "2",
+            "institutionmembership_set-INITIAL_FORMS": "1",
+            "institutionmembership_set-MIN_NUM_FORMS": "0",
+            "institutionmembership_set-MAX_NUM_FORMS": "1000",
+            "institutionmembership_set-0-id": membership.pk,
+            "institutionmembership_set-0-institution": institution.pk,
+            "institutionmembership_set-0-user": membership.user.pk,
+            "institutionmembership_set-0-is_admin": "on",
+            "institutionmembership_set-0-DELETE": "on",
+            "_continue": "Enregistrer+et+continuer+les+modifications",
+        },
+    )
     assertRedirects(response, change_url, fetch_redirect_response=False)
     response = admin_client.get(change_url)
 
     assert_set_admin_role__removal(membership.user, institution)
 
 
-def test_add_admin(admin_client, django_capture_on_commit_callbacks):
+def test_add_admin(admin_client):
     institution = InstitutionWithMembershipFactory(department="")
     membership = institution.memberships.first()
     labor_inspector = LaborInspectorFactory()
@@ -138,32 +136,31 @@ def test_add_admin(admin_client, django_capture_on_commit_callbacks):
     response = admin_client.get(change_url)
     assert response.status_code == 200
 
-    with django_capture_on_commit_callbacks(execute=True):
-        response = admin_client.post(
-            change_url,
-            data={
-                "kind": institution.kind.value,
-                "name": institution.name,
-                "address_line_1": institution.address_line_1,
-                "address_line_2": institution.address_line_2,
-                "post_code": institution.post_code,
-                "city": institution.city,
-                "department": institution.department,
-                "coords": "",
-                "institutionmembership_set-TOTAL_FORMS": "2",
-                "institutionmembership_set-INITIAL_FORMS": "1",
-                "institutionmembership_set-MIN_NUM_FORMS": "0",
-                "institutionmembership_set-MAX_NUM_FORMS": "1000",
-                "institutionmembership_set-0-id": membership.pk,
-                "institutionmembership_set-0-institution": institution.pk,
-                "institutionmembership_set-0-user": membership.user.pk,
-                "institutionmembership_set-0-is_admin": "on",
-                "institutionmembership_set-1-institution": institution.pk,
-                "institutionmembership_set-1-user": labor_inspector.pk,
-                "institutionmembership_set-1-is_admin": "on",
-                "_continue": "Enregistrer+et+continuer+les+modifications",
-            },
-        )
+    response = admin_client.post(
+        change_url,
+        data={
+            "kind": institution.kind.value,
+            "name": institution.name,
+            "address_line_1": institution.address_line_1,
+            "address_line_2": institution.address_line_2,
+            "post_code": institution.post_code,
+            "city": institution.city,
+            "department": institution.department,
+            "coords": "",
+            "institutionmembership_set-TOTAL_FORMS": "2",
+            "institutionmembership_set-INITIAL_FORMS": "1",
+            "institutionmembership_set-MIN_NUM_FORMS": "0",
+            "institutionmembership_set-MAX_NUM_FORMS": "1000",
+            "institutionmembership_set-0-id": membership.pk,
+            "institutionmembership_set-0-institution": institution.pk,
+            "institutionmembership_set-0-user": membership.user.pk,
+            "institutionmembership_set-0-is_admin": "on",
+            "institutionmembership_set-1-institution": institution.pk,
+            "institutionmembership_set-1-user": labor_inspector.pk,
+            "institutionmembership_set-1-is_admin": "on",
+            "_continue": "Enregistrer+et+continuer+les+modifications",
+        },
+    )
     assertRedirects(response, change_url, fetch_redirect_response=False)
     response = admin_client.get(change_url)
 

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -220,7 +220,8 @@ class JobApplicationTransferModelTest(TestCase):
         )
         job_seeker = job_application.job_seeker
 
-        job_application.transfer_to(origin_user, target_company)
+        with self.captureOnCommitCallbacks(execute=True):
+            job_application.transfer_to(origin_user, target_company)
 
         # Eligigibility diagnosis is done by SIAE : must not send an email
         assert len(mail.outbox) == 2
@@ -252,7 +253,8 @@ class JobApplicationTransferModelTest(TestCase):
         )
         job_seeker = job_application.job_seeker
 
-        job_application.transfer_to(origin_user, target_company)
+        with self.captureOnCommitCallbacks(execute=True):
+            job_application.transfer_to(origin_user, target_company)
 
         assert len(mail.outbox) == 3
 
@@ -279,7 +281,8 @@ class JobApplicationTransferModelTest(TestCase):
         )
         job_seeker = job_application.job_seeker
 
-        job_application.transfer_to(origin_user_1, target_company)
+        with self.captureOnCommitCallbacks(execute=True):
+            job_application.transfer_to(origin_user_1, target_company)
 
         # Only checking SIAE email
         assert len(mail.outbox) == 3

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from django.contrib.gis.geos import Point
 from django.core import management
-from django.db import connection
+from django.db import connection, transaction
 from django.utils import timezone
 from freezegun import freeze_time
 from pytest_django.asserts import assertNumQueries
@@ -618,7 +618,8 @@ def test_populate_prolongation_requests():
     prolongation_request = prolongation.request
 
     deny_information = ProlongationRequestDenyInformationFactory.build(request=None)
-    prolongation_request.deny(prolongation_request.validated_by, deny_information)
+    with transaction.atomic():
+        prolongation_request.deny(prolongation_request.validated_by, deny_information)
 
     ProlongationWithRequestFactory()  # add another one to ensure we don't fail without a deny_information
 

--- a/tests/siae_evaluations/test_emails.py
+++ b/tests/siae_evaluations/test_emails.py
@@ -61,7 +61,7 @@ class TestInstitutionEmailFactory:
     # did not send proofs.
 
     @freeze_time("2023-01-23")
-    def test_close_notifies_when_siae_has_negative_result(self, mailoutbox):
+    def test_close_notifies_when_siae_has_negative_result(self, django_capture_on_commit_callbacks, mailoutbox):
         institution = InstitutionWith2MembershipFactory(name="DDETS 01")
         campaign = EvaluationCampaignFactory(pk=1, institution=institution)
         company = CompanyWith2MembershipsFactory(pk=1000, name="les petits jardins")
@@ -79,7 +79,8 @@ class TestInstitutionEmailFactory:
             review_state=EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
 
-        campaign.close()
+        with django_capture_on_commit_callbacks(execute=True):
+            campaign.close()
 
         [siae_refused_email, institution_email] = mailoutbox
 
@@ -90,7 +91,7 @@ class TestInstitutionEmailFactory:
         assert siae_refused_email.subject == "Résultat du contrôle - EI les petits jardins ID-1000"
         assert siae_refused_email.body == self.snapshot(name="refused result email")
 
-    def test_close_does_not_notify_when_siae_has_been_notified(self, mailoutbox):
+    def test_close_does_not_notify_when_siae_has_been_notified(self, django_capture_on_commit_callbacks, mailoutbox):
         institution = InstitutionWith2MembershipFactory(name="DDETS 01")
         campaign = EvaluationCampaignFactory(institution=institution)
         company = CompanyWith2MembershipsFactory(name="les petits jardins")
@@ -109,12 +110,15 @@ class TestInstitutionEmailFactory:
             review_state=EvaluatedAdministrativeCriteriaState.REFUSED_2,
         )
 
-        campaign.close()
+        with django_capture_on_commit_callbacks(execute=True):
+            campaign.close()
 
         assert [] == mailoutbox
 
     @freeze_time("2023-06-07")
-    def test_close_notify_when_siae_has_positive_result_in_adversarial_phase(self, mailoutbox):
+    def test_close_notify_when_siae_has_positive_result_in_adversarial_phase(
+        self, django_capture_on_commit_callbacks, mailoutbox
+    ):
         institution = InstitutionWith2MembershipFactory(name="DDETS 01")
         campaign = EvaluationCampaignFactory(institution=institution)
         company = CompanyWith2MembershipsFactory(pk=1000, name="les petits jardins")
@@ -132,13 +136,16 @@ class TestInstitutionEmailFactory:
             review_state=EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 
-        campaign.close()
+        with django_capture_on_commit_callbacks(execute=True):
+            campaign.close()
 
         [siae_accepted_email] = mailoutbox
         assert siae_accepted_email.subject == "Résultat du contrôle - EI les petits jardins ID-1000"
         assert siae_accepted_email.body == self.snapshot(name="accepted result email")
 
-    def test_close_does_not_notify_when_siae_has_positive_result_in_amicable_phase(self, mailoutbox):
+    def test_close_does_not_notify_when_siae_has_positive_result_in_amicable_phase(
+        self, django_capture_on_commit_callbacks, mailoutbox
+    ):
         institution = InstitutionWith2MembershipFactory(name="DDETS 01")
         campaign = EvaluationCampaignFactory(institution=institution)
         company = CompanyWith2MembershipsFactory(pk=1000, name="les petits jardins")
@@ -157,7 +164,8 @@ class TestInstitutionEmailFactory:
             review_state=EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 
-        campaign.close()
+        with django_capture_on_commit_callbacks(execute=True):
+            campaign.close()
         assert mailoutbox == []
 
     def test_submitted_by_siae(self):

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -279,18 +279,20 @@ class EvaluationCampaignManagerTest(TestCase):
         for kind in [k for k in InstitutionKind if k != InstitutionKind.DDETS_IAE]:
             with self.subTest(kind=kind):
                 InstitutionFactory(kind=kind)
-                assert 0 == create_campaigns_and_calendar(
-                    evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start
-                )
+                with self.captureOnCommitCallbacks(execute=True):
+                    assert 0 == create_campaigns_and_calendar(
+                        evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start
+                    )
                 assert 0 == EvaluationCampaign.objects.all().count()
                 assert 1 == Calendar.objects.all().count()
                 assert len(mail.outbox) == 0
 
         # institution DDETS IAE
         InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS_IAE)
-        assert 2 == create_campaigns_and_calendar(
-            evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            assert 2 == create_campaigns_and_calendar(
+                evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start
+            )
         assert 2 == EvaluationCampaign.objects.all().count()
         assert 1 == Calendar.objects.all().count()
 
@@ -489,7 +491,8 @@ class EvaluationCampaignManagerTest(TestCase):
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
         )
 
-        campaign.transition_to_adversarial_phase()
+        with self.captureOnCommitCallbacks(execute=True):
+            campaign.transition_to_adversarial_phase()
 
         assert ignored_siae == EvaluatedSiae.objects.get(reviewed_at__isnull=True)
 
@@ -562,7 +565,8 @@ class EvaluationCampaignManagerTest(TestCase):
         )
         EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae_no_response)
 
-        campaign.transition_to_adversarial_phase()
+        with self.captureOnCommitCallbacks(execute=True):
+            campaign.transition_to_adversarial_phase()
 
         evaluated_siae_no_response.refresh_from_db()
         assert evaluated_siae_no_response.reviewed_at == timezone.now()
@@ -590,7 +594,8 @@ class EvaluationCampaignManagerTest(TestCase):
             # default review_state is PENDING
         )
 
-        campaign.transition_to_adversarial_phase()
+        with self.captureOnCommitCallbacks(execute=True):
+            campaign.transition_to_adversarial_phase()
 
         # Transitioned to ACCEPTED, the DDETS IAE did not review the documents
         # submitted by SIAE before the transition.
@@ -623,7 +628,8 @@ class EvaluationCampaignManagerTest(TestCase):
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED,
         )
 
-        campaign.transition_to_adversarial_phase()
+        with self.captureOnCommitCallbacks(execute=True):
+            campaign.transition_to_adversarial_phase()
 
         # Transitioned to ACCEPTED, the DDETS IAE review was automatically validated
         evaluated_siae_submitted.refresh_from_db()
@@ -653,7 +659,8 @@ class EvaluationCampaignManagerTest(TestCase):
             review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.REFUSED,
         )
 
-        campaign.transition_to_adversarial_phase()
+        with self.captureOnCommitCallbacks(execute=True):
+            campaign.transition_to_adversarial_phase()
 
         # Transitioned to REFUSED, the DDETS IAE review was automatically validated
         evaluated_siae_submitted.refresh_from_db()
@@ -678,7 +685,8 @@ class EvaluationCampaignManagerTest(TestCase):
         )
         assert evaluation_campaign.ended_at is None
 
-        evaluation_campaign.close()
+        with self.captureOnCommitCallbacks(execute=True):
+            evaluation_campaign.close()
         assert evaluation_campaign.ended_at is not None
         ended_at = evaluation_campaign.ended_at
 
@@ -695,7 +703,8 @@ class EvaluationCampaignManagerTest(TestCase):
         assert institution_email.subject == "[Contrôle a posteriori] Notification des sanctions"
         assert institution_email.body == self.snapshot(name="sanction notification email body")
 
-        evaluation_campaign.close()
+        with self.captureOnCommitCallbacks(execute=True):
+            evaluation_campaign.close()
         assert ended_at == evaluation_campaign.ended_at
         # No new mail.
         assert len(mail.outbox) == 2
@@ -722,7 +731,8 @@ class EvaluationCampaignManagerTest(TestCase):
         assert evaluated_siae.final_reviewed_at is None
         assert evaluation_campaign.ended_at is None
 
-        evaluation_campaign.close()
+        with self.captureOnCommitCallbacks(execute=True):
+            evaluation_campaign.close()
         assert evaluation_campaign.ended_at is not None
         # DDETS review was automatically validated
         evaluated_siae.refresh_from_db()
@@ -736,7 +746,8 @@ class EvaluationCampaignManagerTest(TestCase):
         )
         assert accepted_siae_email.body == self.snapshot(name="accepted email body")
 
-        evaluation_campaign.close()
+        with self.captureOnCommitCallbacks(execute=True):
+            evaluation_campaign.close()
         assert ended_at == evaluation_campaign.ended_at
         # No new mail.
         assert len(mail.outbox) == 1
@@ -764,7 +775,8 @@ class EvaluationCampaignManagerTest(TestCase):
         assert evaluated_siae.final_reviewed_at is None
         assert evaluation_campaign.ended_at is None
 
-        evaluation_campaign.close()
+        with self.captureOnCommitCallbacks(execute=True):
+            evaluation_campaign.close()
         assert evaluation_campaign.ended_at is not None
         # DDETS review was automatically validated
         evaluated_siae.refresh_from_db()
@@ -784,7 +796,8 @@ class EvaluationCampaignManagerTest(TestCase):
         assert institution_email.subject == "[Contrôle a posteriori] Notification des sanctions"
         assert institution_email.body == self.snapshot(name="sanction notification email body")
 
-        evaluation_campaign.close()
+        with self.captureOnCommitCallbacks(execute=True):
+            evaluation_campaign.close()
         assert ended_at == evaluation_campaign.ended_at
         # No new mail.
         assert len(mail.outbox) == 2

--- a/tests/utils/htmx/test.py
+++ b/tests/utils/htmx/test.py
@@ -1,12 +1,11 @@
 from urllib.parse import urlparse
 
 import pytest
-from django.test.client import Client
 
-from tests.utils.test import TestCase, parse_response_to_soup
+from tests.utils.test import ItouClient, TestCase, parse_response_to_soup
 
 
-class HtmxClient(Client):
+class HtmxClient(ItouClient):
     def generic(self, method, path, data="", content_type="application/octet-stream", secure=False, **extra):
         # Add HTMX-specific headers according to your needs.
         # https://htmx.org/reference/#request_headers

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -106,8 +106,14 @@ class NoInlineClient(Client):
         return response
 
 
+class ItouClient(NoInlineClient):
+    def request(self, *args, **kwargs):
+        with TestCase.captureOnCommitCallbacks(execute=True):
+            return super().request(*args, **kwargs)
+
+
 class TestCase(BaseTestCase):
-    client_class = NoInlineClient
+    client_class = ItouClient
 
 
 class reload_module(TestContextDecorator):

--- a/tests/utils/test_emails.py
+++ b/tests/utils/test_emails.py
@@ -5,7 +5,7 @@ from itou.utils.tasks import AsyncEmailBackend
 
 
 class TestAsyncEmailBackend:
-    def test_send_messages_splits_recipients(self, mailoutbox):
+    def test_send_messages_splits_recipients(self, django_capture_on_commit_callbacks, mailoutbox):
         # 2 emails are needed; one with 50 the other with 25
         recipients = [Faker("email", locale="fr_FR") for _ in range(75)]
         message = EmailMessage(
@@ -17,7 +17,8 @@ class TestAsyncEmailBackend:
 
         backend = AsyncEmailBackend()
         # Huey runs in immediate mode.
-        sent = backend.send_messages([message])
+        with django_capture_on_commit_callbacks(execute=True):
+            sent = backend.send_messages([message])
 
         assert sent == 2
         [email1, email2] = mailoutbox

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -1,5 +1,4 @@
 from dateutil.relativedelta import relativedelta
-from django.test import TestCase
 from django.urls import reverse
 from django.utils import dateformat, timezone
 from freezegun import freeze_time
@@ -12,6 +11,7 @@ from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import JobSeekerFactory, JobSeekerWithAddressFactory
+from tests.utils.test import TestCase
 
 
 @freeze_time("2024-02-15")

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.core import mail
-from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escape
@@ -18,7 +17,7 @@ from tests.approvals.factories import ProlongationFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationWithMembershipFactory
 from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
-from tests.utils.test import parse_response_to_soup
+from tests.utils.test import TestCase, parse_response_to_soup
 
 
 @pytest.mark.ignore_unknown_variable_template_error("job_application", "hiring_pending")

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -932,8 +932,7 @@ class UserMembershipDeactivationTest(TestCase):
 
         self.client.force_login(admin)
         url = reverse("companies_views:deactivate_member", kwargs={"user_id": guest.id})
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         # User should be deactivated now
@@ -1036,8 +1035,7 @@ class CompanyAdminMembersManagementTest(TestCase):
         assert response.status_code == 200
 
         # Confirm action
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         company.refresh_from_db()
@@ -1064,8 +1062,7 @@ class CompanyAdminMembersManagementTest(TestCase):
         assert response.status_code == 200
 
         # Confirm action
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         company.refresh_from_db()

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -88,8 +88,7 @@ class MembersTest(TestCase):
         assert response.status_code == 200
 
         # Confirm action
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         institution.refresh_from_db()
@@ -116,8 +115,7 @@ class MembersTest(TestCase):
         assert response.status_code == 200
 
         # Confirm action
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         institution.refresh_from_db()

--- a/tests/www/invitations_views/test_company_accept.py
+++ b/tests/www/invitations_views/test_company_accept.py
@@ -6,7 +6,6 @@ from django.contrib import messages
 from django.contrib.messages.test import MessagesTestMixin
 from django.core import mail
 from django.shortcuts import reverse
-from django.test import Client
 from django.utils.html import escape
 
 from itou.users.enums import KIND_EMPLOYER, UserKind
@@ -20,6 +19,7 @@ from tests.openid_connect.inclusion_connect.test import InclusionConnectBaseTest
 from tests.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oauth_dance
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import EmployerFactory
+from tests.utils.test import ItouClient
 
 
 class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
@@ -106,7 +106,7 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
 
         total_users_before = User.objects.count()
 
-        other_client = Client()
+        other_client = ItouClient()
         response = mock_oauth_dance(
             self.client,
             KIND_EMPLOYER,

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -9,7 +9,6 @@ from django.contrib import messages
 from django.contrib.messages.test import MessagesTestMixin
 from django.core import mail
 from django.shortcuts import reverse
-from django.test import Client
 from django.utils.html import escape
 from pytest_django.asserts import assertRedirects
 
@@ -27,7 +26,7 @@ from tests.openid_connect.inclusion_connect.test import InclusionConnectBaseTest
 from tests.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oauth_dance
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory, PrescriberPoleEmploiFactory
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory
-from tests.utils.test import TestCase, assert_previous_step
+from tests.utils.test import ItouClient, TestCase, assert_previous_step
 
 
 INVITATION_URL = reverse("invitations_views:invite_prescriber_with_org")
@@ -345,7 +344,7 @@ class TestAcceptPrescriberWithOrgInvitation(MessagesTestMixin, InclusionConnectB
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        other_client = Client()
+        other_client = ItouClient()
         invitation.email = OIDC_USERINFO["email"]
         invitation.save()
         response = mock_oauth_dance(

--- a/tests/www/prescribers_views/test_admins.py
+++ b/tests/www/prescribers_views/test_admins.py
@@ -24,8 +24,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         assert response.status_code == 200
 
         # Confirm action
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         organization.refresh_from_db()
@@ -52,8 +51,7 @@ class PrescribersOrganizationAdminMembersManagementTest(TestCase):
         assert response.status_code == 200
 
         # Confirm action
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         organization.refresh_from_db()

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -109,8 +109,7 @@ class UserMembershipDeactivationTest(TestCase):
 
         self.client.force_login(admin)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
-        with self.captureOnCommitCallbacks(execute=True):
-            response = self.client.post(url)
+        response = self.client.post(url)
         assert response.status_code == 302
 
         # User should be deactivated now

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib import auth, messages
 from django.contrib.messages.test import MessagesTestMixin
 from django.core import mail
-from django.test import Client, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.http import urlencode
@@ -30,6 +30,7 @@ from tests.prescribers.factories import (
     PrescriberPoleEmploiFactory,
 )
 from tests.users.factories import EmployerFactory, PrescriberFactory
+from tests.utils.test import ItouClient
 
 
 @override_settings(
@@ -189,7 +190,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        other_client = Client()
+        other_client = ItouClient()
         response = mock_oauth_dance(
             self.client,
             KIND_PRESCRIBER,

--- a/tests/www/signup/test_siae.py
+++ b/tests/www/signup/test_siae.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.test import MessagesTestMixin
 from django.core import mail
-from django.test import Client, override_settings
+from django.test import override_settings
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.http import urlencode
@@ -26,7 +26,7 @@ from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, 
 from tests.openid_connect.inclusion_connect.test import InclusionConnectBaseTestCase
 from tests.openid_connect.inclusion_connect.tests import OIDC_USERINFO, mock_oauth_dance
 from tests.users.factories import DEFAULT_PASSWORD, EmployerFactory, PrescriberFactory
-from tests.utils.test import BASE_NUM_QUERIES, TestCase
+from tests.utils.test import BASE_NUM_QUERIES, ItouClient, TestCase
 
 
 class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
@@ -189,7 +189,7 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
         url = escape(f"{reverse('inclusion_connect:authorize')}?{urlencode(params)}")
         self.assertContains(response, url + '"')
 
-        other_client = Client()
+        other_client = ItouClient()
         response = mock_oauth_dance(
             self.client,
             KIND_EMPLOYER,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter d’envoyer des emails pour une opération qu’on annule après coup.

## :cake: Comment ? <!-- optionnel -->

`create_new_siae` et les fonctions auxiliaires utilisée lors des changements de membres d’une organisation prenaient en compte la possibilité que la transaction soit _rollbackée_.

Maintenant, `AsyncEmailBackend.send_messages` requiert une transaction, pour forcer les développeurs à attacher l’envoi de mails à une transaction.
Une transaction n’est pas requise pour envoyer des emails, mais en pratique, l’application s’appuie toujours sur la base de données pour identifier les destinataires, ou l’envoi d’email est lié à une requête web donc le SQL peut-être _rollbacké_.
Il est également prévu à court terme d’enregistrer chaque email envoyé dans la base de données, pour faciliter l’investigation des envois. Cet enregistrement sera plus sûr avec une transaction.

Les clients de tests ont été unifiés pour toujours utiliser `ItouClient` (qui exécute les `on_commit` _hooks_) et se comporte d’une manière assez similaire à la production. Ceci a permis de simplifier quelques tests, qui géraient seuls l’exécution des `on_commit` _hooks_.

Le motif `mail\.?outbox\) ==` a été cherché pour être sûr d’encapsuler les opérations où aucun email ne devrait être envoyé dans un `captureOnCommitCallbacks(execute=True)`.
