### PR TITLE
Correction de l’URL MinIO dans `configure_bucket`

### DIFF
--- a/itou/files/management/commands/configure_bucket.py
+++ b/itou/files/management/commands/configure_bucket.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urljoin
 
 import httpx
 from django.conf import settings
@@ -79,8 +80,9 @@ class Command(BaseCommand):
         )
 
     def check_minio(self):
-        response = httpx.head(settings.AWS_S3_ENDPOINT_URL)
-        # Response has a bad request status code, but we don’t care.
+        # https://min.io/docs/minio/linux/operations/monitoring/healthcheck-probe.html#node-liveness
+        livecheck_url = urljoin(settings.AWS_S3_ENDPOINT_URL, "minio/health/live")
+        response = httpx.head(livecheck_url)
         try:
             return response.headers["Server"] == "MinIO"
         except KeyError:


### PR DESCRIPTION
https://github.com/gip-inclusion/les-emplois/pull/4089
