### PR TITLE
UX/UI: Améliorer le titre de section de connexion avec France Travail

### DIFF
--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -12,7 +12,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-lg-6">
                     <div class="c-form mb-5">
-                        <p class="h4">FranceConnect</p>
+                        <p class="h4">Se connecter avec FranceConnect</p>
                         {% if show_france_connect %}
                             <div class="mt-4">{% include "signup/includes/france_connect_button.html" %}</div>
                         {% else %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Voir https://www.notion.so/plateforme-inclusion/BOOST-France-Travail-Changer-le-logo-Pole-emploi-connect-a3bd75cbcc2348eb9d406b5ee55b872e?pvs=4
Je ne lie pas la PR parce que la grande partie du ticket n'est pas encore faisable (changer le logo PE connect)

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/gip-inclusion/les-emplois/assets/7632730/29c5e021-1361-49ce-a605-7ab292c5e98e)


## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Cliquer sur "Se connecter" -> "Candidat"

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
