### PR TITLE
Notifications : Réessayer d’envoyer les emails lorsque Mailjet indique un problème

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1300,6 +1300,11 @@ requests==2.32.0 \
     # via
     #   -r requirements/test.txt
     #   django-anymail
+    #   requests-mock
+requests-mock==1.12.1 \
+    --hash=sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563 \
+    --hash=sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401
+    # via -r requirements/test.txt
 respx==0.21.1 \
     --hash=sha256:05f45de23f0c785862a2c92a3e173916e8ca88e4caad715dd5f68584d6053c20 \
     --hash=sha256:0bd7fe21bfaa52106caa1223ce61224cf30786985f17c63c5d71eff0307ee8af

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -21,5 +21,7 @@ pytest-randomly  # https://github.com/pytest-dev/pytest-randomly
 pytest-subtests  # https://github.com/pytest-dev/pytest-subtests
 pytest-xdist  # https://pypi.org/project/pytest-xdist/
 unittest-parametrize  # https://github.com/adamchainz/unittest-parametrize
+# Mock Anymail requests.
+requests-mock  # https://github.com/jamielennox/requests-mock
 respx  # https://lundberg.github.io/respx/
 syrupy  # https://github.com/tophat/syrupy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1177,6 +1177,11 @@ requests==2.32.0 \
     # via
     #   -r requirements/base.txt
     #   django-anymail
+    #   requests-mock
+requests-mock==1.12.1 \
+    --hash=sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563 \
+    --hash=sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401
+    # via -r requirements/test.in
 respx==0.21.1 \
     --hash=sha256:05f45de23f0c785862a2c92a3e173916e8ca88e4caad715dd5f68584d6053c20 \
     --hash=sha256:0bd7fe21bfaa52106caa1223ce61224cf30786985f17c63c5d71eff0307ee8af

--- a/tests/utils/test_emails.py
+++ b/tests/utils/test_emails.py
@@ -1,7 +1,8 @@
+import pytest
 from django.core.mail.message import EmailMessage
 from factory import Faker
 
-from itou.utils.tasks import AsyncEmailBackend
+from itou.utils.tasks import AsyncEmailBackend, _async_send_message
 
 
 class TestAsyncEmailBackend:
@@ -28,3 +29,91 @@ class TestAsyncEmailBackend:
             assert email.from_email == "unit-test@tests.com"
             assert email.subject == "subject"
             assert email.body == "body"
+
+
+@pytest.fixture
+def anymail_mailjet_settings(settings):
+    settings.ASYNC_EMAIL_BACKEND = "anymail.backends.mailjet.EmailBackend"
+    settings.ANYMAIL = {
+        "MAILJET_API_URL": settings.ANYMAIL["MAILJET_API_URL"],
+        "MAILJET_API_KEY": "MAILJET_API_SECRET",
+        "MAILJET_SECRET_KEY": "MAILJET_SECRET_KEY",
+    }
+    return settings
+
+
+class TestAsyncSendMessage:
+    EXC_TEXT = "Exception: Huey, please retry this task."
+
+    def test_send_ok(self, anymail_mailjet_settings, caplog, requests_mock):
+        requests_mock.post(
+            f"{anymail_mailjet_settings.ANYMAIL['MAILJET_API_URL']}send",
+            # https://dev.mailjet.com/email/guides/send-api-v31/#send-in-bulk
+            json={
+                "Messages": [
+                    {
+                        "Status": "success",
+                        "To": [
+                            {
+                                "Email": "passenger2@mailjet.com",
+                                "MessageUUID": "124",
+                                "MessageID": 20547681647433001,
+                                "MessageHref": "https://api.mailjet.com/v3/message/20547681647433001",
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        _async_send_message({"to": ["you@test.local"], "cc": [], "bcc": [], "subject": "Hi", "body": "Hello"})
+        assert self.EXC_TEXT not in caplog.text
+
+    def test_raises_on_error(self, anymail_mailjet_settings, caplog, requests_mock):
+        """An exception is raised, to make Huey retry the task."""
+        requests_mock.post(
+            f"{anymail_mailjet_settings.ANYMAIL['MAILJET_API_URL']}send",
+            # https://dev.mailjet.com/email/guides/send-api-v31/#send-in-bulk
+            json={
+                "Messages": [
+                    {
+                        "Errors": [
+                            {
+                                "ErrorIdentifier": "88b5ca9f-5f1f-42e7-a45e-9ecbad0c285e",
+                                "ErrorCode": "send-0003",
+                                "StatusCode": 400,
+                                "ErrorMessage": 'At least "HTMLPart", "TextPart" or "TemplateID" must be provided.',
+                                "ErrorRelatedTo": ["HTMLPart", "TextPart"],
+                            },
+                        ],
+                        "Status": "error",
+                    },
+                ],
+            },
+        )
+        _async_send_message({"to": ["you@test.local"], "cc": [], "bcc": [], "subject": "Hi", "body": "Hello"})
+        assert self.EXC_TEXT in caplog.text
+
+    def test_logs_to_sentry_after_using_all_retries(self, anymail_mailjet_settings, caplog, requests_mock, mocker):
+        error_payload = {
+            "Errors": [
+                {
+                    "ErrorIdentifier": "88b5ca9f-5f1f-42e7-a45e-9ecbad0c285e",
+                    "ErrorCode": "send-0003",
+                    "StatusCode": 400,
+                    "ErrorMessage": 'At least "HTMLPart", "TextPart" or "TemplateID" must be provided.',
+                    "ErrorRelatedTo": ["HTMLPart", "TextPart"],
+                },
+            ],
+            "Status": "error",
+        }
+        requests_mock.post(
+            f"{anymail_mailjet_settings.ANYMAIL['MAILJET_API_URL']}send",
+            # https://dev.mailjet.com/email/guides/send-api-v31/#send-in-bulk
+            json={"Messages": [error_payload]},
+        )
+        sentry_mock = mocker.patch("itou.utils.tasks.sentry_sdk.capture_message")
+        _async_send_message(
+            {"to": ["you@test.local"], "cc": [], "bcc": [], "subject": "Hi", "body": "Hello"}, retries=0
+        )
+        sentry_mock.assert_called_once_with(f"Could not send email: {error_payload}", "error")
+        assert self.EXC_TEXT not in caplog.text


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de perdre des emails, ce qui peut-être très gênant pour les utilisateurs.

## :cake: Comment ? <!-- optionnel -->

https://anymail.dev/en/stable/sending/django_email/#refused-recipients
https://anymail.dev/en/stable/sending/anymail_additions/#anymail.message.AnymailStatus
