### PR TITLE
Demandeur d’emploi: empêcher la saisie d'un identifiant France Travail invalide

### DIFF
--- a/itou/users/forms.py
+++ b/itou/users/forms.py
@@ -52,6 +52,14 @@ class JobSeekerProfileFieldsMixin:
             jobseeker_profile = JobSeekerProfile()
         for k, v in self.cleaned_data_from_profile_fields.items():
             setattr(jobseeker_profile, k, v)
+        # super()._post_clean() calls full_clean() on self.instance, which calls self.instance.clean_fields()
+        # Let's do the same on self.instance.jobseeker_profile (but only for our fields)
+        try:
+            jobseeker_profile.clean_fields(
+                exclude={f.name for f in JobSeekerProfile._meta.fields if f.name not in self.PROFILE_FIELDS}
+            )
+        except ValidationError as e:
+            self._update_errors(e)
         try:
             jobseeker_profile.validate_constraints()
         except ValidationError as e:

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -1190,6 +1190,17 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
             None,
             "Renseignez soit un identifiant France Travail (ex pôle emploi), soit la raison de son absence.",
         )
+        post_data["pole_emploi_id"] = "invalide"  # No length issue but validate_pole_emploi_id shouldn't be happy
+        response = self.client.post(url, data=post_data)
+        assert response.status_code == 200
+        self.assertFormError(
+            response.context["form"],
+            "pole_emploi_id",
+            (
+                "L'identifiant France Travail (ex pôle emploi) doit être composé de 8 caractères : "
+                "7 chiffres suivis d'une 1 lettre ou d'un chiffre."
+            ),
+        )
 
     def test_edit_as_prescriber(self):
         user = PrescriberFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter la saisie d'identifiant invalide, pouvant notamment bloquer l'envoi des fiches salarié à l'ASP.

## :cake: Comment ? <!-- optionnel -->

Depuis https://github.com/gip-inclusion/les-emplois/pull/3485 et le déplacement des champs du modèle `User` au modèle `JobSeekerProfile`, les validateurs du champs `pole_emploi_id` n'étaient plus appelés à la validation du formulaire.

La modification du mixin `JobSeekerProfileFieldsMixin` corrige cela.

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Se connecter en tant que candidat et ne pas réussir à saisir un identifiant invalide (contrairement à ce qu'il se passe sur la démo).

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
