### PR TITLE
PASS IAE: Permettre de suspendre un PASS quand le candidat a été embauché dans une structure hors IAE (GEIQ par exemple) [GEN-1665]

### DIFF
--- a/itou/approvals/utils.py
+++ b/itou/approvals/utils.py
@@ -1,0 +1,23 @@
+from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
+
+
+def get_user_last_accepted_siae_job_application(user):
+    if not user.is_job_seeker:
+        return None
+
+    # Some candidates may not have accepted job applications
+    # Assuming it's the case can lead to issues downstream
+    return (
+        user.job_applications.accepted()
+        .filter(to_company__kind__in=SIAE_WITH_CONVENTION_KINDS)
+        .with_accepted_at()
+        .order_by("-accepted_at", "-hiring_start_at")
+        .first()
+    )
+
+
+def last_hire_was_made_by_siae(user, siae):
+    if not user.is_job_seeker:
+        return False
+    last_accepted_job_application = get_user_last_accepted_siae_job_application(user)
+    return last_accepted_job_application and last_accepted_job_application.to_company_id == siae.pk

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -29,7 +29,7 @@
                                             Suspendre
                                         </a>
                                     </div>
-                                {% elif hire_by_other_siae %}
+                                {% elif approval.can_be_suspended %}
                                     <div class="col-12 col-lg-auto">
                                         <div class="btn btn-ico">
                                             <span class="disabled">Suspendre</span>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -693,20 +693,6 @@ class User(AbstractUser, AddressMixin):
             has_performed_update = True
         return has_performed_update
 
-    @cached_property
-    def last_accepted_job_application(self):
-        if not self.is_job_seeker:
-            return None
-
-        # Some candidates may not have accepted job applications
-        # Assuming its the case can lead to issues downstream
-        return self.job_applications.accepted().with_accepted_at().order_by("-accepted_at", "-hiring_start_at").first()
-
-    def last_hire_was_made_by_company(self, company):
-        if not self.is_job_seeker:
-            return False
-        return self.last_accepted_job_application and self.last_accepted_job_application.to_company == company
-
     @classmethod
     def create_job_seeker_by_proxy(cls, proxy_user, **fields):
         """

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -26,6 +26,7 @@ from itou.approvals.models import (
     ProlongationRequestDenyInformation,
     Suspension,
 )
+from itou.approvals.utils import get_user_last_accepted_siae_job_application
 from itou.files.models import File
 from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
 from itou.job_applications.models import JobApplication
@@ -111,7 +112,6 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
         context["can_view_personal_information"] = True  # SIAE members have access to personal info
         context["can_edit_personal_information"] = self.request.user.can_edit_personal_information(approval.user)
         context["approval_can_be_suspended_by_siae"] = approval.can_be_suspended_by_siae(self.siae)
-        context["hire_by_other_siae"] = not approval.user.last_hire_was_made_by_company(self.siae)
         context["approval_can_be_prolonged"] = approval.can_be_prolonged
         context["job_application"] = job_application
         context["hiring_pending"] = job_application and job_application.is_pending
@@ -711,7 +711,7 @@ def pe_approval_search(request, template_name="approvals/pe_approval_search.html
         # first try to get a matching PASS IAE, and guide the user towards eventual different paths
         approval = Approval.objects.filter(number=number).first()
         if approval:
-            job_application = approval.user.last_accepted_job_application
+            job_application = get_user_last_accepted_siae_job_application(approval.user)
             if job_application and job_application.to_company == siae:
                 # Suspensions and prolongations links are available in the job application details page.
                 application_details_url = reverse(

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -123,7 +123,7 @@ class TestApprovalDetailView:
             + 1  # job_seeker.approval
             + 1  # job_application.with_accepted_at annotation coming from next query
             + 1  # approval.suspension active today
-            + 1  # Suspension.can_be_handled_by_siae >> User.last_accepted_job_application
+            + 1  # Suspension.can_be_handled_by_siae >> get_user_last_accepted_siae_job_application()
             + 1  # select latest approval for user (can_be_prolonged)
             + 1  # approval.remainder fetches approval suspensions to compute remaining days.
             + 1  # release savepoint before the template rendering
@@ -200,8 +200,7 @@ class TestApprovalDetailView:
             # get_context_data
             + 1  # for every *active* suspension, check if there is an accepted job application after it
             + 1  # approval.suspension_set.end_at >= today >= approval.suspension_set.start_at (.can_be_suspended)
-            + 1  # job_application.with_accepted_at annotation coming from (.last_hire_was_made_by_company)
-            + 1  # siae infos (.last_hire_was_made_by_company)
+            + 1  # last_hire_was_made_by_siae() >> get_user_last_accepted_siae_job_application()
             + 1  # user approvals (.is_last_for_user)
             + 1  # siae infos (job_application.get_eligibility_diagnosis())
             + 1  # approval.suspensions_for_status_card lists approval suspensions

--- a/tests/www/approvals_views/test_suspend.py
+++ b/tests/www/approvals_views/test_suspend.py
@@ -174,9 +174,10 @@ class ApprovalSuspendViewTest(TestCase):
             + 1  # get the session
             + 3  # get the user, its memberships, and the SIAEs (middleware)
             + 1  # get suspension (get_object_or_404)
-            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_company)
-            + 1  # get company info (can_be_handled_by_siae -> last_hire_was_made_by_company)
+            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_siae)
             + 1  # get suspension (SuspensionForm -> Suspension.next_min_start_at)
+            # There's a dupplicated query here, but it's only in this form, so maybe not add a lru_cache
+            + 1  # get job applications (SuspensionForm -> Suspension.next_min_start_at -> last_hire_was_made_by_siae)
             + 3  # update session in savepoints
         ):
             response = self.client.get(url)
@@ -233,8 +234,7 @@ class ApprovalSuspendViewTest(TestCase):
             + 1  # get the session
             + 3  # get the user, its memberships, and the SIAEs (middleware)
             + 1  # get suspension (get_object_or_404)
-            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_company)
-            + 1  # get company info (can_be_handled_by_siae -> last_hire_was_made_by_company)
+            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_siae)
             + 3  # update session in savepoints
         ):
             response = self.client.get(url)
@@ -310,8 +310,7 @@ class ApprovalSuspendActionChoiceViewTest(TestCase):
             + 1  # get the session
             + 3  # get the user, its memberships, and the SIAEs (middleware)
             + 1  # get suspension (get_object_or_404)
-            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_company)
-            + 1  # get company info (can_be_handled_by_siae -> last_hire_was_made_by_company)
+            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_siae)
             + 3  # update session in savepoints
         ):
             response = self.client.get(self.url)
@@ -405,8 +404,7 @@ class ApprovalSuspendUpdateEndDateViewTest(TestCase):
             + 1  # get the session
             + 3  # get the user, its memberships, and the SIAEs (middleware)
             + 1  # get suspension (get_object_or_404)
-            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_company)
-            + 1  # get company info (can_be_handled_by_siae -> last_hire_was_made_by_company)
+            + 1  # get job applications (can_be_handled_by_siae -> last_hire_was_made_by_siae)
             + 3  # update session in savepoints
         ):
             response = self.client.get(self.url)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter de consommer pour rien un PASS et de solliciter le support

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
