### PR TITLE
Fiche entreprise / Fiche de poste : appel GET à data.inclusion au clic d'un lien

### DIFF
--- a/itou/templates/companies/hx_dora_services.html
+++ b/itou/templates/companies/hx_dora_services.html
@@ -22,7 +22,7 @@
                                     {% for service in data_inclusion_services %}
                                         <div class="card c-card has-links-inside">
                                             <div class="card-body">
-                                                <a href="{{ service.di_service_redirect_url }}" rel="noopener" target="_blank" class="btn-link mb-2">{{ service.nom | truncatechars:60 }}</a>
+                                                <a href="{{ service.dora_service_redirect_url }}" rel="noopener" target="_blank" class="btn-link mb-2">{{ service.nom | truncatechars:60 }}</a>
                                                 <ul class="list-unstyled list-inline fs-sm">
                                                     <li class="list-inline-item">{{ service.structure.nom | truncatechars:60 }}</li>
                                                     {% if service.code_postal and service.commune %}

--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -31,7 +31,7 @@ class DataInclusionApiClient:
             timeout=API_TIMEOUT_SECONDS,
         )
 
-    def services(self, code_insee: str) -> list[dict]:
+    def search_services(self, code_insee: str) -> list[dict]:
         try:
             response = self.client.get(
                 "/search/services",
@@ -51,6 +51,18 @@ class DataInclusionApiClient:
         except KeyError as exc:
             logger.info("data.inclusion result error code_insee=%s error=%s", code_insee, exc)
             raise DataInclusionApiException()
+
+    def retrieve_service(self, source: str, id_: str) -> dict:
+        try:
+            response = self.client.get(
+                f"/services/{source}/{id_}",
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.info("data.inclusion request error source=%s service_id=%s error=%s", source, id_, exc)
+            raise DataInclusionApiException()
+
+        return response.json()
 
 
 def make_service_redirect_url(source: str, service_id: str) -> str:

--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import urljoin
 
 import httpx
 from django.conf import settings
@@ -63,7 +62,3 @@ class DataInclusionApiClient:
             raise DataInclusionApiException()
 
         return response.json()
-
-
-def make_service_redirect_url(source: str, service_id: str) -> str:
-    return urljoin(settings.API_DATA_INCLUSION_BASE_URL, f"services/{source}/{service_id}/redirige?depuis=les-emplois")

--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -67,10 +67,3 @@ class DataInclusionApiClient:
 
 def make_service_redirect_url(source: str, service_id: str) -> str:
     return urljoin(settings.API_DATA_INCLUSION_BASE_URL, f"services/{source}/{service_id}/redirige?depuis=les-emplois")
-
-
-def di_client_factory() -> DataInclusionApiClient:
-    return DataInclusionApiClient(
-        settings.API_DATA_INCLUSION_BASE_URL,
-        settings.API_DATA_INCLUSION_TOKEN,
-    )

--- a/itou/www/companies_views/urls.py
+++ b/itou/www/companies_views/urls.py
@@ -37,4 +37,9 @@ urlpatterns = [
         "admin_role/(?P<action>add|remove)/(?P<user_id>[0-9]+)", views.update_admin_role, name="update_admin_role"
     ),
     path("dora-services/<str:code_insee>", views.hx_dora_services, name="hx_dora_services"),
+    path(
+        "dora-service-redirect/<str:source>/<str:service_id>",
+        views.dora_service_redirect,
+        name="dora_service_redirect",
+    ),
 ]

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -78,6 +78,9 @@ def get_data_inclusion_services(code_insee):
             }
             for r in results
         ]
+        # 6 hours is reasonable enough to get fresh results while still avoiding
+        # hitting the API too much. The API content is updated daily or hourly;
+        # we want changes to be propagated at a reasonable time.
         cache.set(cache_key, results, 60 * 60 * 6)
     return results
 

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -19,7 +19,7 @@ from itou.companies.models import Company, CompanyMembership, JobDescription, Si
 from itou.jobs.models import Appellation
 from itou.users.models import User
 from itou.utils import constants as global_constants
-from itou.utils.apis.data_inclusion import DataInclusionApiException, di_client_factory, make_service_redirect_url
+from itou.utils.apis.data_inclusion import DataInclusionApiClient, DataInclusionApiException, make_service_redirect_url
 from itou.utils.apis.exceptions import GeocodingDataError
 from itou.utils.pagination import pager
 from itou.utils.perms.company import get_current_company_or_404
@@ -57,7 +57,10 @@ def get_data_inclusion_services(code_insee):
     cache = caches["failsafe"]
     results = cache.get(cache_key)
     if results is None:
-        client = di_client_factory()
+        client = DataInclusionApiClient(
+            settings.API_DATA_INCLUSION_BASE_URL,
+            settings.API_DATA_INCLUSION_TOKEN,
+        )
         try:
             services = client.search_services(code_insee)
         except DataInclusionApiException:

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -59,7 +59,7 @@ def get_data_inclusion_services(code_insee):
     if results is None:
         client = di_client_factory()
         try:
-            services = client.services(code_insee)
+            services = client.search_services(code_insee)
         except DataInclusionApiException:
             # 15 minutes seems like a reasonable amount of time for DI to get back on track
             cache.set(cache_key, [], 60 * 15)

--- a/tests/www/companies_views/__snapshots__/test_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_views.ambr
@@ -605,7 +605,7 @@
 # name: test_hx_dora_services[Dora service card]
   '''
   <div class="card-body">
-                                                  <a class="btn-link mb-2" href="https://fake.api.gouv.fr/services/dora/svc1/redirige?depuis=les-emplois&amp;mtm_campaign=LesEmplois&amp;mtm_kwd=GeneriqueDecouvrirService" rel="noopener" target="_blank">Coupe les cheveux</a>
+                                                  <a class="btn-link mb-2" href="/company/dora-service-redirect/dora/svc1" rel="noopener" target="_blank">Coupe les cheveux</a>
                                                   <ul class="list-unstyled list-inline fs-sm">
                                                       <li class="list-inline-item">Coiffeur</li>
                                                       
@@ -621,7 +621,7 @@
 # name: test_hx_dora_services_with_address[Dora service card with address]
   '''
   <div class="card-body">
-                                                  <a class="btn-link mb-2" href="https://fake.api.gouv.fr/services/dora/svc1/redirige?depuis=les-emplois&amp;mtm_campaign=LesEmplois&amp;mtm_kwd=GeneriqueDecouvrirService" rel="noopener" target="_blank">Coupe les cheveux</a>
+                                                  <a class="btn-link mb-2" href="/company/dora-service-redirect/dora/svc1" rel="noopener" target="_blank">Coupe les cheveux</a>
                                                   <ul class="list-unstyled list-inline fs-sm">
                                                       <li class="list-inline-item">Coiffeur</li>
                                                       


### PR DESCRIPTION
## :thinking: Pourquoi ?

Data.Inclusion change ses métriques et son mode de consommation des APIs.
Les endpoints de recherche et d eliste sont soit dépréciés, soit ils vont significativement réduire les champs disponibles.
Les appels à l'endpoint de détail d'un service sont qualifiants et sont la méthode préconisée à tous nos clients (dont Les Emplois) pour appeler data⋅inclusion.

Par simplicité nous préférons éviter de recourir à un proxy; la logique étant que de toutes manières, un client devra faire un appel pour récupérer des champs étendus (contact info, etc)

Ceci permet de comptabiliser les appels réellement qualifiants.
Le champ `lien_source`  en particulier va disparaître; nous allons donc devoir modifier la proposition initiale de Valentin pour effectuer un appel RETRIEVE avant de renvoyer vers ce dernier.

## :cake: Comment ? <!-- optionnel -->
Cf les commits.

Au clic sur un lien, un appel est fait sur l'API (via une vue interne)  pour récupérer le fameux "lien source" non disponible sur l'endpoint de recherche. On renvoie ce lien au front via un HTTPResponseRedirect, qui est catché par le lien et ouvre un nouvel onglet.

## :computer: Captures d'écran <!-- optionnel -->

Aucune.

Pas de breaking changes.

## :desert_island: Comment tester
Cliquer sur un lien d'un service DI dans une page de Company ou de Job Description vous renvoie comme auparavant vers la page du service dans Dora ou sur son lien d'origine.

On comptabilise un appel HTTP à l'endpoint de détail de service sur DI.

Exemple de page https://c1-review-vperron-reapply-di-proxy.cleverapps.io/company/9/card
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
