### PR TITLE
Utiliser dbshell pour charger les fixtures SQL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ fix: fast_fix
 .PHONY: populate_db populate_db_with_cities populate_db_minimal
 
 # After migrate
-populate_db_with_cities:
-	psql -d $(PGDATABASE) --quiet --file itou/fixtures/postgres/cities.sql
+populate_db_with_cities: $(VENV_REQUIREMENT)
+	python manage.py dbshell <itou/fixtures/postgres/cities.sql
 
 populate_db: populate_db_with_cities
 	# Split loaddata_bulk into parts to avoid OOM errors in review apps


### PR DESCRIPTION
## :thinking: Pourquoi ?

Définir l’environnement via les settings Django au lieu de se baser sur les variables `PG*`.

Refs https://github.com/gip-inclusion/les-emplois/pull/4093

## :cake: Comment ? <!-- optionnel -->

Utilisation de l’outil `dbshell` de Django.

## :desert_island: Comment tester

Désactiver les variables `PG*` de son environnement (cas d’un dev arrivant sur le projet).
