### PR TITLE
Recommander d’utiliser direnv pour le dev local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,7 +70,7 @@ coverage.xml
 # dotenv
 .env
 # direnv
-/.envrc.local
+/.envrc
 
 # virtualenv
 .venv*

--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -1,4 +1,16 @@
 # Journal des changements techniques majeurs
+## 2024-06-06
+
+- Utilisation de `.envrc`: retrait du hack `.envrc.local`, ce qui permettra de
+  recharger l’environnement dès le changement du `.envrc`, et de bénéficier du
+  mécanisme de vérification du contenu du fichier.
+
+  Pour migrer : `cp .envrc{.local,}`.
+
+  **Note** : Le fichier `.envrc.local` n’est plus utile. Cependant, attendre
+  quelques semaines avant de le supprimer permet d’éviter de perdre le contenu
+  du `.envrc` lorsqu’on change vers une branche dont le `.envrc` était suivi
+  par `git`.
 
 ## 2024-05-28
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,0 +1,47 @@
+# Développement local
+
+## direnv
+
+Nous conseillons d'installer le minuscule utilitaire `direnv` pour charger et
+décharger automatiquement des variables d'environnement à l'entrée dans un
+répertoire.
+
+Une fois muni de cet outil (avec `apt`, `brew` ou autre, et sans oublier de
+[mettre le hook](https://direnv.net/#basic-installation)) il suffit de créer un
+fichier de variables d'environnement local:
+
+```sh
+cat <<EOF >.envrc
+# Activate the virtual environment
+source .venv/bin/activate
+
+# Setting environment variables for the application
+export DJANGO_DEBUG=True
+export DJANGO_LOG_LEVEL=WARNING
+export SQL_LOG_LEVEL=INFO
+export DJANGO_SECRET_KEY=foobar
+
+# For psql
+export PGHOST=localhost
+export PGUSER=postgres
+export PGPASSWORD=password
+export PGDATABASE=itou
+EOF
+```
+
+La [liste des variables d’environnement fréquemment
+utilisées](./environment.md) est disponible dans cette documentation.
+
+Une fois le fichier `.envrc` saisit, il suffit de l'autoriser dans `direnv`:
+
+```sh
+direnv allow .envrc
+```
+
+Et c’est bon, vos variables seront chargées à chaque entrée dans le dossier et
+retirées en sortant.
+
+```sh
+psql  # connects directly to the itou database
+./manage.py xxxx  # any commands work immediately
+```

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -8,7 +8,19 @@ L’inspection des [settings Django](../config/settings/) permet d’avoir la
 référence complète des variables d’environnement. Les variables souvent
 utilisées sont recensées dans ce document.
 
-## Confort
+## Définir les variables d’environnement
+
+Dans votre environnement de développement, l’utilisation de
+[direnv](./direnv.md) est recommandée.
+
+En production, un fichier `.env` est généré au déploiement et chargé avec
+l’utilitaire [`dotenv`](https://pypi.org/project/python-dotenv/). Cette
+configuration est moins flexible que direnv, car les variables d’environnement
+ne sont pas disponibles pour votre shell, ce qui empêche le chargement
+automatique de l’environnement virtuel, ou de lancer `psql` sans spécifier les
+arguments pour se connecter à la base de données.
+
+## Variables de confort
 
 ### PostgreSQL
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter la mise en place de l’environnement de dev.
