### PR TITLE
UX/UI : Correction des cartes postes ouverts au recrutement sur mobile

### DIFF
--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -27,51 +27,53 @@
     <div class="c-box--results__body">
         <ul class="list-group list-group-flush list-group-link">
             <li class="list-group-item list-group-item-action">
-                <div>
-                    <a href="{{ job_description.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}"
-                       class="font-weight-bold text-decoration-none {% if job_description.is_external %}has-external-link{% else %}stretched-link{% endif %}"
-                       {% if job_description.is_external %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte-externe" %} rel="noopener" target="_blank" aria-label="Visiter l'offre sur le site d'origine" {% else %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte" %} aria-label="Aller vers la description de ce poste" {% endif %}>
-                        {{ job_description.display_name | capfirst }}
-                    </a>
-                    {% if job_description.is_popular %}
-                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
-                            <i class="ri-group-line me-1" aria-hidden="true"></i>
-                            {{ job_description.POPULAR_THRESHOLD }}+<span class="ms-1">candidatures</span>
-                        </span>
-                    {% endif %}
-                    <ul class="c-box--results__list-contact flex-md-grow-1 mt-1">
-                        <li>
-                            <i class="ri-navigation-line font-weight-normal me-1"></i>
-                            à <strong class="text-info mx-1">{{ job_description.distance | floatformat:"-1" }}&nbsp;km</strong> de votre lieu de recherche
-                        </li>
-                        <li>
-                            <i class="ri-map-pin-2-line font-weight-normal me-1"></i>
-                            <address class="m-0">
-                                {% if job_description.location %}
-                                    {{ job_description.location }}
-                                {% else %}
-                                    {{ job_description.company.city | title }} - {{ job_description.company.department }}
-                                {% endif %}
-                            </address>
-                        </li>
-                    </ul>
-                    {% if job_description.is_from_pole_emploi %}
-                        <p class="d-flex align-items-center fs-sm mb-0 mt-1 gap-2">
-                            <span>Offre proposée et gérée par <span class="visually-hidden">France Travail</span></span>
-                            <img height="35" src="{% static 'img/logo-france-travail.svg' %}" alt="Logo France Travail">
-                        </p>
-                    {% endif %}
-                </div>
-                {% if job_description.display_contract_type or job_description.hours_per_week %}
-                    <div class="badge-group d-flex flex-column align-items-end">
-                        {% if job_description.display_contract_type %}
-                            <span class="badge badge-xs rounded-pill bg-accent-02-light text-primary">{{ job_description.display_contract_type }}</span>
+                <div class="d-flex flex-column flex-md-row justify-content-md-between">
+                    <div class="order-2 order-md-1">
+                        <a href="{{ job_description.get_absolute_url }}?back_url={{ request.get_full_path|urlencode }}"
+                           class="font-weight-bold text-decoration-none {% if job_description.is_external %}has-external-link{% else %}stretched-link{% endif %}"
+                           {% if job_description.is_external %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte-externe" %} rel="noopener" target="_blank" aria-label="Visiter l'offre sur le site d'origine" {% else %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte" %} aria-label="Aller vers la description de ce poste" {% endif %}>
+                            {{ job_description.display_name | capfirst }}
+                        </a>
+                        {% if job_description.is_popular %}
+                            <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
+                                <i class="ri-group-line me-1" aria-hidden="true"></i>
+                                {{ job_description.POPULAR_THRESHOLD }}+<span class="ms-1">candidatures</span>
+                            </span>
                         {% endif %}
-                        {% if job_description.hours_per_week %}
-                            <span class="badge badge-xs rounded-pill bg-accent-02-light text-primary">{{ job_description.hours_per_week }}h/semaine</span>
+                        <ul class="c-box--results__list-contact flex-md-grow-1 mt-1">
+                            <li class="d-block d-md-inline-flex">
+                                <i class="ri-navigation-line font-weight-normal me-1"></i>
+                                à <strong class="text-info mx-md-1">{{ job_description.distance | floatformat:"-1" }}&nbsp;km</strong> de votre lieu de recherche
+                            </li>
+                            <li class="d-block d-md-inline-flex">
+                                <i class="ri-map-pin-2-line font-weight-normal me-1"></i>
+                                <address class="d-inline m-0">
+                                    {% if job_description.location %}
+                                        {{ job_description.location }}
+                                    {% else %}
+                                        {{ job_description.company.city | title }} - {{ job_description.company.department }}
+                                    {% endif %}
+                                </address>
+                            </li>
+                        </ul>
+                        {% if job_description.is_from_pole_emploi %}
+                            <p class="d-sm-flex align-items-sm-center fs-sm mb-0 mt-1 gap-2">
+                                <span>Offre proposée et gérée par <span class="visually-hidden">France Travail</span></span>
+                                <img height="35" src="{% static 'img/logo-france-travail.svg' %}" alt="Logo France Travail">
+                            </p>
                         {% endif %}
                     </div>
-                {% endif %}
+                    {% if job_description.display_contract_type or job_description.hours_per_week %}
+                        <div class="badge-group d-md-flex flex-md-column align-items-md-end order-1 order-md-2 mb-1 mb-md-0">
+                            {% if job_description.display_contract_type %}
+                                <span class="badge badge-xs rounded-pill bg-accent-02-light text-primary">{{ job_description.display_contract_type }}</span>
+                            {% endif %}
+                            {% if job_description.hours_per_week %}
+                                <span class="badge badge-xs rounded-pill bg-accent-02-light text-primary">{{ job_description.hours_per_week }}h/semaine</span>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                </div>
             </li>
         </ul>
         {% if job_description.is_pec_offer %}

--- a/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
@@ -1,7 +1,6 @@
 {% load matomo %}
 
 <li class="list-group-item list-group-item-action">
-
     <div>
         <a href="{% if job.pk %}{{ job.get_absolute_url }}{% else %}#{% endif %}?back_url={{ request.get_full_path|urlencode }}"
            class="font-weight-bold text-decoration-none stretched-link"
@@ -12,7 +11,6 @@
                 {{ job.POPULAR_THRESHOLD }}+<span class="ms-1">candidatures</span>
             </span>
         {% endif %}
-
         <p class="fs-sm mb-0 mt-1">
             <i class="ri-map-pin-2-line ri-sm" aria-hidden="true"></i>
             {% if job.location %}
@@ -20,8 +18,6 @@
             {% else %}
                 {{ job.company.city|title }} - {{ job.company.department }}
             {% endif %}
-
         </p>
-
     </div>
 </li>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -205,11 +205,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.6.5.zip",
-            "sha256": "93590151fb092caf8c393da3d7b05e59b0eb1a51a59e29ffd614df996167d95d",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v1.6.6.zip",
+            "sha256": "e243d8412885a4c180f80ed2db6798e7e7df32636707c22866ef69f03285299d",
         },
         "extract": {
-            "origin": "itou-theme-1.6.5/dist",
+            "origin": "itou-theme-1.6.6/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mauvais rendu en mobile des cartes de résultats “cartes postes ouverts au recrutement"

## :cake: Comment ?

Mise a jour du theme et du DOM

## :computer: Captures d'écran
**Avant**
![capture 2024-05-29 à 15 28 19](https://github.com/gip-inclusion/les-emplois/assets/3874024/c4cf62c5-023d-4051-81a3-f0cbe3e28328)

**Apres**
![capture 2024-05-29 à 15 29 38](https://github.com/gip-inclusion/les-emplois/assets/3874024/dda35ddb-e4d0-483a-bcf7-3b20c5f3f2af)
