### PR TITLE
Admin : Ajout du reliquat pour les PASS IAE et de la durée pour les suspensions et prolongations

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -322,10 +322,6 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
 
         super().save_model(request, obj, form, change)
 
-    @admin.display(boolean=True, description="en cours de validité")
-    def is_valid(self, obj):
-        return obj.is_valid()
-
     def manually_add_approval(self, request, job_application_id):
         """
         Custom admin view to manually add an approval.
@@ -357,6 +353,10 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
             ),
         ]
         return additional_urls + super().get_urls()
+
+    @admin.display(boolean=True, description="en cours de validité")
+    def is_valid(self, obj):
+        return obj.is_valid()
 
     @admin.display(description="date de naissance")
     def birthdate(self, obj):

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -21,6 +21,7 @@ from itou.utils.admin import (
     PkSupportRemarkInline,
     get_admin_view_link,
 )
+from itou.utils.templatetags.str_filters import pluralizefr
 
 
 class JobApplicationInline(ItouStackedInline):
@@ -220,6 +221,7 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
         "origin_sender_kind",
         "origin_siae_kind",
         "origin_siae_siret",
+        "remainder",
     )
     fieldsets = (
         (
@@ -229,6 +231,7 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
                     "number",
                     "start_at",
                     "end_at",
+                    "remainder",
                     "user",
                     "eligibility_diagnosis",
                     "assigned_company",
@@ -376,6 +379,10 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
                 company.siret,
             )
         return "-"
+
+    @admin.display(description="Reliquat")
+    def remainder(self, obj):
+        return f"{obj.remainder.days} jour{pluralizefr(obj.duration.days)}"
 
 
 class IsInProgressFilter(admin.SimpleListFilter):

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -113,14 +113,19 @@ class SuspensionInline(ItouTabularInline):
     extra = 0
     show_change_link = True
     can_delete = False
-    fields = ("start_at", "end_at", "reason", "created_by", "siae")
+    fields = ("start_at", "end_at", "duration", "reason", "created_by", "siae")
     raw_id_fields = ("approval", "siae", "created_by", "updated_by")
+    readonly_fields = ("duration",)
 
     def has_change_permission(self, request, obj=None):
         return False
 
     def has_add_permission(self, request, obj=None):
         return False
+
+    @admin.display(description="Durée")
+    def duration(self, obj):
+        return f"{obj.duration.days} jour{pluralizefr(obj.duration.days)}"
 
 
 class ProlongationInline(ItouTabularInline):
@@ -128,14 +133,19 @@ class ProlongationInline(ItouTabularInline):
     extra = 0
     show_change_link = True
     can_delete = False
-    fields = ("start_at", "end_at", "reason", "declared_by", "validated_by")
+    fields = ("start_at", "end_at", "duration", "reason", "declared_by", "validated_by")
     raw_id_fields = ("declared_by", "validated_by")
+    readonly_fields = ("duration",)
 
     def has_change_permission(self, request, obj=None):
         return False
 
     def has_add_permission(self, request, obj=None):
         return False
+
+    @admin.display(description="Durée")
+    def duration(self, obj):
+        return f"{obj.duration.days} jour{pluralizefr(obj.duration.days)}"
 
 
 class ProlongationRequestInline(ProlongationInline):

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -221,6 +221,47 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
         "origin_siae_kind",
         "origin_siae_siret",
     )
+    fieldsets = (
+        (
+            "Informations",
+            {
+                "fields": (
+                    "number",
+                    "start_at",
+                    "end_at",
+                    "user",
+                    "eligibility_diagnosis",
+                    "assigned_company",
+                    "origin",
+                    "origin_prescriber_organization_kind",
+                    "origin_sender_kind",
+                    "origin_siae_kind",
+                    "origin_siae_siret",
+                )
+            },
+        ),
+        (
+            "Audit",
+            {
+                "fields": (
+                    "created_at",
+                    "created_by",
+                    "updated_at",
+                )
+            },
+        ),
+        (
+            "Notification à France Travail",
+            {
+                "fields": (
+                    "pe_notification_status",
+                    "pe_notification_time",
+                    "pe_notification_endpoint",
+                    "pe_notification_exit_code",
+                )
+            },
+        ),
+    )
     date_hierarchy = "start_at"
     inlines = (
         SuspensionInline,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Simplifier la vie du support en n'ayant moins besoin de faire des calculs de dates à la main.

## :cake: Comment ? <!-- optionnel -->

Champs supplémentaires dans le `ModelAdmin` et les `Inlines`.


## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/af345d46-9407-4b21-a85e-a1eff82006bf)
![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/9e37f590-4fed-44c8-9374-09a72764c32f)


## :desert_island: Comment tester

- Se connecter sur l'admin
- Regarder un ou plusieurs PASS IAE ayant des suspensions/prolongations

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
