### PR TITLE
Modification du nom de la table utilisateurs et ajout des champs nom et prénom

### DIFF
--- a/itou/metabase/tables/users.py
+++ b/itou/metabase/tables/users.py
@@ -6,11 +6,13 @@ def get_field(name):
     return User._meta.get_field(name)
 
 
-TABLE = MetabaseTable(name="utilisateurs")
+TABLE = MetabaseTable(name="utilisateurs_v0")
 TABLE.add_columns(
     [
         get_column_from_field(get_field("id"), name="id"),
         get_column_from_field(get_field("email"), name="email"),
         get_column_from_field(get_field("kind"), name="type"),
+        get_column_from_field(get_field("first_name"), name="prenom"),
+        get_column_from_field(get_field("last_name"), name="nom"),
     ]
 )

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -79,7 +79,7 @@ def get_column_from_field(field, name):
     return {
         "name": name,
         "type": get_field_type_from_field(field),
-        "comment": field.verbose_name,
+        "comment": str(field.verbose_name),  # Force str() to handle _() lazyness
         "fn": lambda o: getattr(o, field_name),
     }
 

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -849,7 +849,7 @@ def test_populate_users_exclude_job_seekers():
     JobSeekerFactory()
     management.call_command("populate_metabase_emplois", mode="users")
     with connection.cursor() as cursor:
-        cursor.execute("SELECT * FROM utilisateurs ORDER BY id")
+        cursor.execute("SELECT * FROM utilisateurs_v0 ORDER BY id")
         rows = cursor.fetchall()
         assert len(rows) == 0
 
@@ -874,13 +874,15 @@ def test_populate_users():
         management.call_command("populate_metabase_emplois", mode="users")
 
     with connection.cursor() as cursor:
-        cursor.execute("SELECT * FROM utilisateurs ORDER BY id")
+        cursor.execute("SELECT * FROM utilisateurs_v0 ORDER BY id")
         rows = cursor.fetchall()
         assert rows == [
             (
                 pro_user.id,
                 pro_user.email,
                 "employer",
+                pro_user.first_name,
+                pro_user.last_name,
                 datetime.date(2023, 2, 1),
             ),
         ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour pouvoir ajouter des informations à la table `utilisateurs` utilisée par le pilotage
Pour permettre les actions de mailing personnalisés avec le nom et prénom

## :cake: Comment ? <!-- optionnel -->

On renomme la source en `utilisateurs_v0` et on garde le nom `utilisateurs` pour la table enrichie côté pilotage
On ajoute les champs nom et prénom


## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
