### PR TITLE
Limiter la suppression des SIAE inactives dans l’import ASP

### DIFF
--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -230,17 +230,18 @@ def test_hashed_approval_number():
     assert "salarie_agrement" not in df
 
 
-def test_could_siae_be_deleted_with_eligibility_diagnosis():
-    # Check that eligibility diagnoses made by SIAE are blocking its deletion
+class TestCouldSiaeBeDeleted:
+    def test_with_eligibility_diagnosis(self):
+        # Check that eligibility diagnoses made by SIAE are blocking its deletion
 
-    # No eligibility diagnosis linked
-    company = CompanyWith2MembershipsFactory()
-    assert could_siae_be_deleted(company)
+        # No eligibility diagnosis linked
+        company = CompanyWith2MembershipsFactory()
+        assert could_siae_be_deleted(company)
 
-    # An eligibility diagnosis without related approval
-    EligibilityDiagnosisMadeBySiaeFactory(author_siae=company, author=company.members.first())
-    assert could_siae_be_deleted(company)
+        # An eligibility diagnosis without related approval
+        EligibilityDiagnosisMadeBySiaeFactory(author_siae=company, author=company.members.first())
+        assert could_siae_be_deleted(company)
 
-    # Approval with eligibility diagnosis authored by SIAE
-    ApprovalFactory(eligibility_diagnosis__author_siae=company)
-    assert not could_siae_be_deleted(company)
+        # Approval with eligibility diagnosis authored by SIAE
+        ApprovalFactory(eligibility_diagnosis__author_siae=company)
+        assert not could_siae_be_deleted(company)

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -31,6 +31,7 @@ from itou.companies.models import Company
 from tests.approvals.factories import ApprovalFactory
 from tests.companies.factories import CompanyFactory, CompanyWith2MembershipsFactory, SiaeConventionFactory
 from tests.eligibility.factories import EligibilityDiagnosisMadeBySiaeFactory
+from tests.job_applications.factories import JobApplicationFactory
 from tests.utils.test import TestCase
 
 
@@ -244,4 +245,8 @@ class TestCouldSiaeBeDeleted:
 
         # Approval with eligibility diagnosis authored by SIAE
         ApprovalFactory(eligibility_diagnosis__author_siae=company)
+        assert not could_siae_be_deleted(company)
+
+    def test_with_job_app(self):
+        company = JobApplicationFactory().to_company
         assert not could_siae_be_deleted(company)


### PR DESCRIPTION
## :thinking: Pourquoi ?

L’antenne crée pour une utilisatrice a été supprimée deux fois par l’import EA. Avant la seconde suppression, la structure avait reçu des candidatures, et l’utilisatrice avait reçu des emails de notification, mais la commande a supprimé à la fois la structure et les candidatures associées.

https://plateforme-inclusion.zendesk.com/agent/tickets/14669

## :cake: Comment ? <!-- optionnel -->

Pour éviter que le problème ne se produise :

- empêchons la suppression s’il y a des candidatures.
- étendons la période d’inactivité à 1 an au lieu de 3 mois
