### PR TITLE
Pilotage : Encart de promotion du webinaire pour les ML / Cap emploi & les acteurs AHI pour 3 régions spécifiques

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -362,6 +362,28 @@
                                 <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
                                     <img src="{% static_theme_images 'logo-pilotage-inclusion.svg' %}" height="80" alt="Le pilotage de l'inclusion">
                                 </div>
+
+                                {% if pilotage_webinar_banner_url %}
+                                    <div class="alert alert-important alert-dismissible fade show" role="status">
+                                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+                                        <div class="row">
+                                            <div class="col-auto pe-0">
+                                                <i class="ri-information-line ri-xl text-important" aria-hidden="true"></i>
+                                            </div>
+                                            <div class="col">
+                                                <p class="mb-2">
+                                                    <strong>Inscrivez-vous à un webinaire pour découvrir votre tout nouveau tableau de bord !</strong>
+                                                </p>
+                                                <p class="mb-0">
+                                                    En juin, deux sessions vous sont proposées pour vous familiariser avec votre nouvel outil de suivi et d'analyse des résultats de vos prescriptions.
+                                                </p>
+                                            </div>
+                                            <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                                <a class="btn btn-sm btn-primary btn-block" href="{{ pilotage_webinar_banner_url }}">Je m’inscris</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                {% endif %}
                                 <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4">
                                     {% if can_view_stats_dashboard_widget %}
                                         {% include "dashboard/includes/stats.html" %}

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -153,12 +153,27 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "show_mobilemploi_prescriber_banner": False,
         "siae_suspension_text_with_dates": None,
         "siae_search_form": SiaeSearchForm(),
+        "pilotage_webinar_banner_url": "",
     }
 
     if request.user.is_employer:
         context.update(_employer_dashboard_context(request))
     elif request.user.is_prescriber:
         if current_org := request.current_organization:
+            if stats_utils.can_view_stats_ph(request):
+                if current_org.kind in [PrescriberOrganizationKind.ML, PrescriberOrganizationKind.CAP_EMPLOI]:
+                    context["pilotage_webinar_banner_url"] = (
+                        "https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-missions-locales-et-cap-emploi-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed"
+                    )
+                elif current_org.kind in [
+                    PrescriberOrganizationKind.CHRS,
+                    PrescriberOrganizationKind.CHU,
+                    PrescriberOrganizationKind.OIL,
+                    PrescriberOrganizationKind.RS_FJT,
+                ]:
+                    context["pilotage_webinar_banner_url"] = (
+                        "https://app.livestorm.co/itou/le-pilotage-de-linclusion-prescripteurs-de-laccueil-de-lhebergement-et-de-linsertion-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed"
+                    )
             if current_org.is_authorized:
                 context["pending_prolongation_requests"] = ProlongationRequest.objects.filter(
                     prescriber_organization=current_org,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ticket nochon : https://www.notion.so/gip-inclusion/Mettre-un-encart-pour-promouvoir-webinaire-sur-les-emplois-dans-la-page-stats-du-pilotage-pour-les-M-107032dff4664c298fdbc25cf40d1f16?pvs=4

Encart supprimé dans ~2 semaines.

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/f41a37de-7c5d-4bd8-bc5c-cfdd3286330d)

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
