### PR TITLE
Demandes de prolongation: Gérer le cas où l'entreprise déclarante n'existe plus

### DIFF
--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -51,7 +51,7 @@
                                             <tr>
                                                 <td class="font-weight-bold">{{ prolongation_request.approval.user.get_full_name }}</td>
                                                 <td>{{ prolongation_request.approval.number|format_approval_number }}</td>
-                                                <td>{{ prolongation_request.declared_by_siae }}</td>
+                                                <td>{{ prolongation_request.declared_by_siae|default:"-" }}</td>
                                                 <td>{{ prolongation_request.created_at|date:"d/m/Y" }}</td>
                                                 <td>{{ prolongation_request.validated_by.get_full_name }}</td>
                                                 <td>{% include "approvals/prolongation_requests/_status_badge.html" with badge_size="badge-xs" %}</td>

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -76,7 +76,9 @@
                     {% include "approvals/prolongation_requests/_status_box.html" %}
                     {# SIAE card #}
                     {% with siae=prolongation_request.declared_by_siae %}
-                        {% include "companies/includes/_company_info.html" with company=siae only %}
+                        {% if siae %}
+                            {% include "companies/includes/_company_info.html" with company=siae only %}
+                        {% endif %}
                     {% endwith %}
                 </div>
             </div>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -819,6 +819,73 @@
                       </div>
   '''
 # ---
+# name: test_list_view_no_siae
+  '''
+  <div class="c-box">
+                          <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between">
+                              <h3 class="h4 mb-3 mb-md-0">1 résultat</h3>
+                              <div class="d-flex align-items-center">
+                                  <strong class="me-2">Filtres :</strong>
+                                  <form action="/approvals/prolongation/requests" hx-boost="true" hx-trigger="change">
+                                      <input id="id_only_pending" name="only_pending" type="checkbox"/>
+                                      <label for="id_only_pending">Voir uniquement les demandes à traiter</label>
+                                  </form>
+                              </div>
+                          </div>
+  
+                          
+                              <div class="table-responsive-lg mt-3 mt-md-4">
+                                  <table class="table">
+                                      <caption class="visually-hidden">Liste des prolongations de PASS IAE</caption>
+                                      <thead>
+                                          <tr>
+                                              <th scope="col">Salarié</th>
+                                              <th scope="col">Numéro de PASS IAE</th>
+                                              <th scope="col">Structure</th>
+                                              <th scope="col">Demandée le</th>
+                                              <th scope="col">
+                                                  Adressée à
+                                                  <i class="ri-information-line text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                                              </th>
+                                              <th scope="col">Statut</th>
+                                              <th scope="col">Action</th>
+                                          </tr>
+                                      </thead>
+                                      <tbody>
+                                          
+                                              <tr>
+                                                  <td class="font-weight-bold">John DOE</td>
+                                                  <td><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></td>
+                                                  <td>-</td>
+                                                  <td>01/01/2000</td>
+                                                  <td>John DOE</td>
+                                                  <td>
+      
+          <span class="badge rounded-pill badge-xs bg-accent-03 text-primary">À traiter</span>
+      
+  
+  </td>
+                                                  <td>
+                                                      <a class="btn btn-outline-primary btn-sm" href="/approvals/prolongation/request/666">
+                                                          
+                                                              Traiter
+                                                          
+                                                      </a>
+                                                  </td>
+                                              </tr>
+                                          
+                                      </tbody>
+                                  </table>
+                              </div>
+                          
+  
+                          
+  
+  
+  
+                      </div>
+  '''
+# ---
 # name: test_show_view
   '''
   <div class="c-box mb-3 mb-lg-5">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce cas de figure peut arriver lorsque le script import siae fait du zèle.
#3150 devrait permettre d'éviter que de nouveaux cas apparaissent.

https://itou.sentry.io/issues/5414626200/?project=6164438&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=3

## :desert_island: Comment 

Voir https://itou-inclusion.slack.com/archives/C01AQKD7MAN/p1716818805256809
