### PR TITLE
Demandeur d’emploi : Mise à jour du label adresse e-mail candidat pour préciser qu’elle doit être personnelle

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -40,7 +40,7 @@ class JobSeekerExistsForm(forms.Form):
         self.user = None
 
     email = forms.EmailField(
-        label="Adresse e-mail du candidat",
+        label="Adresse e-mail personnelle du candidat",
         widget=forms.EmailInput(attrs={"autocomplete": "off", "placeholder": "julie@example.com"}),
     )
 

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -37,7 +37,7 @@ class EditJobSeekerInfoForm(
     PROFILE_FIELDS = ["pole_emploi_id", "lack_of_pole_emploi_id_reason", "nir", "lack_of_nir_reason"]
 
     email = forms.EmailField(
-        label="Adresse électronique",
+        label="Adresse électronique personnelle",
         disabled=True,
         widget=forms.TextInput(attrs={"autocomplete": "off"}),
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter la création de comptes candidats avec l'adresse e-mail de prescripteurs ou employeurs. 

## :cake: Comment ? <!-- optionnel -->

Modifier le label du champ “Adresse e-mail du candidat*” par “E-mail personnel du candidat*”

