### PR TITLE
Corriger le REDIS_URL dans l’environnement docker

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -26,7 +26,7 @@ DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "itou")  # noqa: F405
 DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")  # noqa: F405
 DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: F405
 
-REDIS_URL = "redis://127.0.0.1:6379"
+REDIS_URL = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
 
 MAILJET_API_KEY_PRINCIPAL = "API_MAILJET_KEY_PRINCIPAL"
 MAILJET_SECRET_KEY_PRINCIPAL = "API_MAILJET_SECRET_PRINCIPAL"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce qu’autrement, le lien vers le Redis ne se fait pas, les tests et certaines fonctionnalités sont indisponibles.

## :desert_island: Comment tester

1. `docker-compose --profile django up`
2. `make shell_on_django_container`
3. `make test`

La commande doit s’exécuter avec succès.
