### PR TITLE
Corriger l’avertissement de docker-compose sur la version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   minio:
     image: bitnami/minio


### PR DESCRIPTION
## :thinking: Pourquoi ?

> Compose prefers the most recent schema when it's implemented.

https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete
