### PR TITLE
Retirer le paramètre city de Matomo

### DIFF
--- a/itou/utils/context_processors.py
+++ b/itou/utils/context_processors.py
@@ -29,8 +29,8 @@ def matomo(request):
     url = request.path
     if request.resolver_match:
         url = request.resolver_match.route
-    # only keep Matomo-related and "city" (for Site Search) GET params for now
-    params = {k: v for k, v in request.GET.lists() if k in ["city"] or k.startswith(("utm_", "mtm_", "piwik_"))}
+    # Only keep Matomo-related params for now.
+    params = {k: v for k, v in request.GET.lists() if k.startswith(("utm_", "mtm_", "piwik_"))}
     if params:
         url = f"{url}?{urlencode(sorted(params.items()), doseq=True)}"
     context["matomo_custom_url"] = url

--- a/tests/utils/__snapshots__/tests.ambr
+++ b/tests/utils/__snapshots__/tests.ambr
@@ -60,7 +60,7 @@
   
                   window._paq.push(['setUserId', '99999']);
   
-                  window._paq.push(['setCustomUrl', new URL('company/&lt;int:siae_id&gt;/card?city=paris&amp;mtm_bar=bidule&amp;mtm_foo=truc', window.location.origin).href]);
+                  window._paq.push(['setCustomUrl', new URL('company/&lt;int:siae_id&gt;/card?mtm_bar=bidule&amp;mtm_foo=truc', window.location.origin).href]);
   
                   
                       window._paq.push(['setDocumentTitle', 'Fiche de la structure d&#x27;insertion']);

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1412,10 +1412,10 @@ def test_matomo_context_processor(client, settings, snapshot):
 
     # canonical case
     url = reverse("companies_views:card", kwargs={"siae_id": company.pk})
-    response = client.get(f"{url}?foo=bar&mtm_foo=truc&mtm_bar=bidule&city=paris")
+    response = client.get(f"{url}?foo=bar&mtm_foo=truc&mtm_bar=bidule")
     assert response.status_code == 200
     assert response.context["siae"] == company
-    assert response.context["matomo_custom_url"] == "company/<int:siae_id>/card?city=paris&mtm_bar=bidule&mtm_foo=truc"
+    assert response.context["matomo_custom_url"] == "company/<int:siae_id>/card?mtm_bar=bidule&mtm_foo=truc"
     assert response.context["matomo_custom_title"] == "Fiche de la structure d'insertion"
     assert response.context["matomo_user_id"] == user.pk
     script_content = parse_response_to_soup(response, selector="#matomo-custom-init")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suivi utilisateur plus exploitable, voir le message de commit pour les détails.
