### PR TITLE
UI : Correction du texte du placeholder de recherche salarié dans la liste des salariés

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -48,7 +48,7 @@ class ApprovalForm(forms.Form):
         label="Nom",
         widget=Select2MultipleWidget(
             attrs={
-                "data-placeholder": "Nom du candidat",
+                "data-placeholder": "Nom du salarié",
             }
         ),
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Clarifier l’interface.

## :computer: Captures d'écran <!-- optionnel -->

### avant
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/c039d9d0-bddb-48d6-946b-867368e8f8da)

### après
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/540e2348-dc2f-41e0-a4c7-910e741a333a)
