### PR TITLE
Tableau de bord: Retrait d'un section vide pour les institutions [GEN-1714]

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -346,15 +346,13 @@
                                     {% include "dashboard/includes/labor_inspector_evaluation_campains_card.html" %}
                                 {% endif %}
                             </div>
-                            {% if can_view_stats_dashboard_widget or user.is_employer or user.is_prescriber %}
+                            {% if user.is_employer or user.is_prescriber %}
                                 <h2>Services partenaires</h2>
                                 <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4">
-                                    {% if user.is_employer or user.is_prescriber %}
-                                        {% include "dashboard/includes/dora_card.html" with siret=request.current_organization.siret|default:"" tracker="mtm_campaign=LesEmplois&mtm_kwd=Dashboard" %}
-                                        {% include "dashboard/includes/diagoriente_card.html" with user=user only %}
-                                        {% if GPS_ENABLED %}
-                                            {% include "dashboard/includes/gps_card.html" %}
-                                        {% endif %}
+                                    {% include "dashboard/includes/dora_card.html" with siret=request.current_organization.siret|default:"" tracker="mtm_campaign=LesEmplois&mtm_kwd=Dashboard" %}
+                                    {% include "dashboard/includes/diagoriente_card.html" with user=user only %}
+                                    {% if GPS_ENABLED %}
+                                        {% include "dashboard/includes/gps_card.html" %}
                                     {% endif %}
                                 </div>
                             {% endif %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter d'afficher une section vide :
![image](https://github.com/gip-inclusion/les-emplois/assets/7632730/e11279b9-ce68-4046-8659-6101aa127d90)



## :desert_island: Comment tester

Se connecter en tant qu'institution partenaire

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
