### PR TITLE
Contrôle a posteriori: Ajout d'un lien contacter le support si un prescripteur souhaite retirer des justificatifs attendus lors du contrôle [GEN-8]

### DIFF
--- a/itou/templates/siae_evaluations/evaluated_job_application.html
+++ b/itou/templates/siae_evaluations/evaluated_job_application.html
@@ -34,6 +34,11 @@
                         </div>
                         <hr class="m-0">
                         <div class="c-box--results__body">
+                            {% if request.user.is_labor_inspector %}
+                                <p>
+                                    Si vous estimez que certains critères ne sont pas nécessaires pour valider cette auto-prescription, <a href="{{ ITOU_HELP_CENTER_URL }}/requests/new" rel="noopener" target="_blank" aria-label="Contacter le support (ouverture dans un nouvel onglet)">veuillez contacter notre support technique.</a>
+                                </p>
+                            {% endif %}
                             {% if evaluated_job_application.evaluated_siae.reviewed_at %}
                                 {% if not evaluated_job_application.hide_state_from_siae %}
                                     {% with jobapp_state=evaluated_job_application.compute_state %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour simplifier le support j'imagine :)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
