### PR TITLE
GPS : ajout d'un lien vers Tally pour inviter des partenaires

### DIFF
--- a/itou/templates/dashboard/includes/gps_card.html
+++ b/itou/templates/dashboard/includes/gps_card.html
@@ -1,4 +1,5 @@
 {% load matomo %}
+{% load tally %}
 
 <div class="col mb-3 mb-md-5" id="gps-card">
     <div class="c-box p-0 h-100">
@@ -16,6 +17,18 @@
                        {% matomo_event "gps" "clic" "tdb_liste_beneficiaires" %}>
                         <i class="ri-article-line ri-lg font-weight-normal align-self-start"></i>
                         <span>Visualiser les bénéficiaires</span>
+                        <i class="ri-external-link-line font-weight-normal ms-2"></i>
+                    </a>
+                </li>
+                <li class="d-flex justify-content-between align-items-center mb-3">
+                    <a href='{% tally_form_url form_id="w5kLqM" user_public_id=user.public_id user_first_name=user.first_name user_last_name=user.last_name %}&{% if request.current_organization %}&user_organization_uid={{ request.current_organization.uid }}&user_organization_name={{ request.current_organization.display_name }}{% endif %}'
+                       rel="noopener"
+                       target="_blank"
+                       aria-label="Inviter un partenaire."
+                       class="btn-link btn-ico"
+                       {% matomo_event "gps" "clic" "tdb_inviter_partenaire" %}>
+                        <i class="ri-mail-send-line ri-lg font-weight-normal align-self-start"></i>
+                        <span>Inviter un partenaire</span>
                         <i class="ri-external-link-line font-weight-normal ms-2"></i>
                     </a>
                 </li>

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -1,4 +1,6 @@
 {% extends "layout/base.html" %}
+{% load tally %}
+{% load matomo %}
 {% load str_filters %}
 
 
@@ -14,6 +16,33 @@
             <div class="s-box__row row">
                 <div class="col-12">
                     <section aria-labelledby="results" id="follow-up-groups-section">
+                        <div class="alert alert-info alert-dismissible fade show" role="status">
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+                            <div class="row">
+                                <div class="col-auto pe-0">
+                                    <i class="ri-mail-send-line ri-xl text-important" aria-hidden="true"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-2">
+                                        <strong>Inviter un partenaire</strong>
+                                    </p>
+                                    <p class="mb-0">
+                                        Invitez un partenaire à rejoindre l’expérimentation GPS pour suivre ses propres bénéficiaires. Votre partenaire recevra un email de votre part afin de créer son compte.
+                                    </p>
+                                </div>
+                                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                    <a href='{% tally_form_url form_id="w5kLqM" user_public_id=user.public_id user_first_name=user.first_name user_last_name=user.last_name %}&{% if request.current_organization %}&user_organization_uid={{ request.current_organization.uid }}&user_organization_name={{ request.current_organization.display_name }}{% endif %}'
+                                       rel="noopener"
+                                       target="_blank"
+                                       aria-label="Inviter un partenaire."
+                                       class="btn btn-sm btn-primary"
+                                       {% matomo_event "gps" "clic" "liste_benef_inviter_partenaire" %}>
+                                        <span>Inviter un partenaire</span>
+                                        <i class="ri-external-link-line font-weight-normal ms-2"></i>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
 
                         <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
                             <h3 class="h4 mb-0" id="results">

--- a/tests/gps/__snapshots__/tests.ambr
+++ b/tests/gps/__snapshots__/tests.ambr
@@ -15,6 +15,13 @@
                           <i class="ri-external-link-line font-weight-normal ms-2"></i>
                       </a>
                   </li>
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Inviter un partenaire." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_inviter_partenaire" href="https://hello-tally.so/r/w5kLqM?user_public_id=03580247-b036-4578-bf9d-f92c9c2f68cd&amp;user_first_name=Pierre&amp;user_last_name=Dupont&amp;" rel="noopener" target="_blank">
+                          <i class="ri-mail-send-line ri-lg font-weight-normal align-self-start"></i>
+                          <span>Inviter un partenaire</span>
+                          <i class="ri-external-link-line font-weight-normal ms-2"></i>
+                      </a>
+                  </li>
               </ul>
           </div>
       </div>
@@ -164,6 +171,13 @@
                       <a aria-label="Gérer les utilisateurs suivis dans votre groupe." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_liste_beneficiaires" href="/gps/groups" rel="noopener" target="_blank">
                           <i class="ri-article-line ri-lg font-weight-normal align-self-start"></i>
                           <span>Visualiser les bénéficiaires</span>
+                          <i class="ri-external-link-line font-weight-normal ms-2"></i>
+                      </a>
+                  </li>
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Inviter un partenaire." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_inviter_partenaire" href="https://hello-tally.so/r/w5kLqM?user_public_id=03580247-b036-4578-bf9d-f92c9c2f68cd&amp;user_first_name=Pierre&amp;user_last_name=Dupont&amp;" rel="noopener" target="_blank">
+                          <i class="ri-mail-send-line ri-lg font-weight-normal align-self-start"></i>
+                          <span>Inviter un partenaire</span>
                           <i class="ri-external-link-line font-weight-normal ms-2"></i>
                       </a>
                   </li>

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -88,6 +88,7 @@ class PrescriberFactory(UserFactory):
             first_name="Pierre",
             last_name="Dupont",
             email="pierre.dupont@test.local",
+            public_id="03580247-b036-4578-bf9d-f92c9c2f68cd",
         )
 
     @factory.post_generation


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mise en place d'un challenge pendant l'Open Lab de jeudi ! Les utilisateurs de GPS (des professionnels uniquement pour le moment) sont incités à inviter un maximum de partenaire jusqu'au prochain Open Lab.

## :cake: Comment ?

Ajout d'un bouton dirigeant vers un formulaire Tally.

## :computer: Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/d9706fe5-38e2-47eb-9d3a-f4c539f1fe92)
![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/89f31a7e-7aa2-4d1a-be20-b6fd62bf99c0)


## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Se connecter en tant que prescripteur. Aller tout en bas du tableau de bord et dans la page listant les bénéficiaires.
