### PR TITLE
Local: ignorer temporairement le .envrc.local pour éviter les erreurs d'inattention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ coverage.xml
 .env
 # direnv
 /.envrc
+# TODO: delete me end of june 2024.
+/.envrc.local
 
 # virtualenv
 .venv*


### PR DESCRIPTION
cf https://github.com/gip-inclusion/les-emplois/commit/57a0776b236021ee8d28daeb65234684e6db37ef