### PR TITLE
En tant qu’employeur je peux postuler pour des candidats vers d’autres employeurs (Employeur Orienteur) [GEN-240]

### DIFF
--- a/itou/approvals/migrations/0001_initial.py
+++ b/itou/approvals/migrations/0001_initial.py
@@ -269,7 +269,7 @@ class Migration(migrations.Migration):
                         choices=[
                             ("job_seeker", "Demandeur d'emploi"),
                             ("prescriber", "Prescripteur"),
-                            ("employer", "Employeur (SIAE)"),
+                            ("employer", "Employeur"),
                         ],
                         null=True,
                         verbose_name="origine de la candidature à l'origine du PASS IAE",
@@ -1350,7 +1350,7 @@ class Migration(migrations.Migration):
                         choices=[
                             ("job_seeker", "Demandeur d'emploi"),
                             ("prescriber", "Prescripteur"),
-                            ("employer", "Employeur (SIAE)"),
+                            ("employer", "Employeur"),
                         ],
                         verbose_name="origine de la candidature",
                     ),

--- a/itou/eligibility/enums.py
+++ b/itou/eligibility/enums.py
@@ -22,5 +22,5 @@ class AdministrativeCriteriaLevelPrefix(models.TextChoices):
 
 class AuthorKind(models.TextChoices):
     PRESCRIBER = KIND_PRESCRIBER, "Prescripteur"
-    EMPLOYER = KIND_EMPLOYER, "Employeur (SIAE)"
+    EMPLOYER = KIND_EMPLOYER, "Employeur"
     GEIQ = "geiq", "GEIQ"

--- a/itou/eligibility/migrations/0001_initial.py
+++ b/itou/eligibility/migrations/0001_initial.py
@@ -71,7 +71,7 @@ class Migration(migrations.Migration):
                 (
                     "author_kind",
                     models.CharField(
-                        choices=[("prescriber", "Prescripteur"), ("employer", "Employeur (SIAE)"), ("geiq", "GEIQ")],
+                        choices=[("prescriber", "Prescripteur"), ("employer", "Employeur"), ("geiq", "GEIQ")],
                         default="prescriber",
                         max_length=10,
                         verbose_name="type de l'auteur",
@@ -251,7 +251,7 @@ class Migration(migrations.Migration):
                 (
                     "author_kind",
                     models.CharField(
-                        choices=[("prescriber", "Prescripteur"), ("employer", "Employeur (SIAE)"), ("geiq", "GEIQ")],
+                        choices=[("prescriber", "Prescripteur"), ("employer", "Employeur"), ("geiq", "GEIQ")],
                         default="prescriber",
                         max_length=10,
                         verbose_name="type de l'auteur",

--- a/itou/job_applications/enums.py
+++ b/itou/job_applications/enums.py
@@ -18,7 +18,7 @@ class JobApplicationState(models.TextChoices):
 class SenderKind(models.TextChoices):
     JOB_SEEKER = users_enums.KIND_JOB_SEEKER, "Demandeur d'emploi"
     PRESCRIBER = users_enums.KIND_PRESCRIBER, "Prescripteur"
-    EMPLOYER = users_enums.KIND_EMPLOYER, "Employeur (SIAE)"
+    EMPLOYER = users_enums.KIND_EMPLOYER, "Employeur"
 
 
 def sender_kind_to_pe_origine_candidature(sender_kind):

--- a/itou/job_applications/export.py
+++ b/itou/job_applications/export.py
@@ -73,7 +73,9 @@ def _get_readable_sender_kind(job_application):
     """
     kind = "Candidature spontanée"
     if job_application.sender_kind == SenderKind.EMPLOYER:
-        kind = "Auto-prescription"
+        kind = "Employeur"
+        if job_application.sender_company == job_application.to_company:
+            kind = "Auto-prescription"
     elif job_application.sender_kind == SenderKind.PRESCRIBER:
         kind = "Orienteur"
         if job_application.is_sent_by_authorized_prescriber:

--- a/itou/job_applications/migrations/0001_initial.py
+++ b/itou/job_applications/migrations/0001_initial.py
@@ -88,7 +88,7 @@ class Migration(migrations.Migration):
                         choices=[
                             ("job_seeker", "Demandeur d'emploi"),
                             ("prescriber", "Prescripteur"),
-                            ("employer", "Employeur (SIAE)"),
+                            ("employer", "Employeur"),
                         ],
                         default="prescriber",
                         max_length=10,

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -286,6 +286,7 @@ class JobApplicationQuerySet(models.QuerySet):
         ).prefetch_related(
             "selected_jobs__appellation",
             "selected_jobs__location",
+            "selected_jobs__company",
             Prefetch("job_seeker__approvals", queryset=Approval.objects.order_by("-start_at")),
         )
 
@@ -454,6 +455,8 @@ class JobApplicationQuerySet(models.QuerySet):
                 )
             else:
                 return self.filter(sender=user)
+        elif user.is_employer and organization:
+            return self.filter(sender_company=organization).exclude(to_company=organization)
         return self.none()
 
 

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -24,7 +24,7 @@ from collections import OrderedDict
 
 import tenacity
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.db.models import Count, Max, Min, Prefetch, Q
+from django.db.models import Count, F, Max, Min, Prefetch, Q
 from django.utils import timezone
 from sentry_sdk.crons import monitor
 
@@ -161,7 +161,7 @@ class Command(BaseCommand):
                 ),
                 total_auto_prescriptions=Count(
                     "job_applications_received",
-                    filter=Q(job_applications_received__sender_kind=SenderKind.EMPLOYER),
+                    filter=Q(job_applications_received__sender_company=F("job_applications_received__to_company")),
                     distinct=True,
                 ),
                 total_candidatures_autonomes=Count(
@@ -172,6 +172,14 @@ class Command(BaseCommand):
                 total_candidatures_prescripteur=Count(
                     "job_applications_received",
                     filter=Q(job_applications_received__sender_kind=SenderKind.PRESCRIBER),
+                    distinct=True,
+                ),
+                total_candidatures_employeur=Count(
+                    "job_applications_received",
+                    filter=Q(
+                        ~Q(job_applications_received__sender_company=F("job_applications_received__to_company")),
+                        job_applications_received__sender_kind=SenderKind.EMPLOYER,
+                    ),
                     distinct=True,
                 ),
                 total_candidatures_non_traitees=Count(

--- a/itou/templates/apply/includes/_submit_title.html
+++ b/itou/templates/apply/includes/_submit_title.html
@@ -1,23 +1,19 @@
 {% load str_filters %}
 
-{% if request.user.is_employer %}
-    {% if hire_process %}
-        {% if job_seeker %}
-            Déclarer l’embauche de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}
-        {% else %}
-            Déclarer une embauche
-        {% endif %}
+{% if is_gps|default:False %}
+    Enregistrer un nouveau bénéficiaire
+{% elif hire_process %}
+    {% if job_seeker %}
+        Déclarer l’embauche de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}
     {% else %}
-        {% if is_gps %}
-            Enregistrer un nouveau bénéficaire
-        {% else %}
-            Enregistrer une candidature
-            {% if job_seeker %}pour {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}{% endif %}
-        {% endif %}
+        Déclarer une embauche
     {% endif %}
-{% elif request.user.is_prescriber %}
+{% elif auto_prescription_process %}
+    Enregistrer une candidature
+    {% if job_seeker %}pour {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}{% endif %}
+{% elif prescription_process %}
     Postuler
     {% if job_seeker %}pour {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}{% endif %}
-{% elif request.user.is_job_seeker %}
+{% else %}
     Postuler
 {% endif %}

--- a/itou/templates/apply/includes/job_application_info.html
+++ b/itou/templates/apply/includes/job_application_info.html
@@ -1,14 +1,5 @@
 {% load str_filters %}
 
-<ul class="list-data list-data__two-column-md mb-3">
-    {% if request.user.is_prescriber or request.user.is_job_seeker %}
-        <li>
-            <small>Employeur</small>
-            <strong>{{ job_application.to_company.display_name }}</strong>
-        </li>
-    {% endif %}
-</ul>
-
 {% if job_application.message %}
     <ul class="list-data mb-3">
         <li>
@@ -16,6 +7,16 @@
             <blockquote class="blockquote mt-2 mb-0">
                 {{ job_application.message|linebreaks }}
             </blockquote>
+        </li>
+    </ul>
+{% endif %}
+
+{% if job_application.to_company != request.current_organization %}
+    <hr class="my-4">
+    <ul class="list-data list-data__two-column-md mb-3">
+        <li>
+            <small>Employeur destinataire</small>
+            <strong>{{ job_application.to_company.display_name }}</strong>
         </li>
     </ul>
 {% endif %}

--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -41,7 +41,7 @@
 
     {% if job_application.sender_company %}
         <li>
-            <small>Employeur inclusif</small>
+            <small>Structure</small>
             <strong>{{ job_application.sender_company.display_name }}</strong>
         </li>
     {% endif %}

--- a/itou/templates/apply/includes/job_applications_filters/sender.html
+++ b/itou/templates/apply/includes/job_applications_filters/sender.html
@@ -1,17 +1,20 @@
 {% load django_bootstrap5 %}
 
-{% if filters_form.senders or filters_form.sender_organizations %}
+{% if filters_form.senders or filters_form.sender_prescriber_organizations or filters_form.sender_companies %}
     <hr>
     <fieldset>
         <legend>Émetteur</legend>
-    {% endif %}
 
-    {% if filters_form.senders %}
-        {% bootstrap_field filters_form.senders %}
-    {% endif %}
+        {% if filters_form.senders %}
+            {% bootstrap_field filters_form.senders %}
+        {% endif %}
 
-    {% if filters_form.sender_organizations %}
-        {% bootstrap_field filters_form.sender_organizations %}
-    {% endif %}
+        {% if filters_form.sender_prescriber_organizations %}
+            {% bootstrap_field filters_form.sender_prescriber_organizations %}
+        {% endif %}
 
-    {% if filters_form.senders or filters_form.sender_organizations %}</fieldset>{% endif %}
+        {% if filters_form.sender_companies %}
+            {% bootstrap_field filters_form.sender_companies %}
+        {% endif %}
+    </fieldset>
+{% endif %}

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -120,7 +120,7 @@
     {% endif %}
 </ul>
 {# Diagoriente invite #}
-{% if request.user.is_employer and job_application and not job_application.resume_link %}
+{% if request.user.is_employer and job_application and not job_application.resume_link and job_application.sender_kind == SenderKind.PRESCRIBER %}
     {% include "apply/includes/job_application_diagoriente_invite.html" with job_application=job_application %}
 {% endif %}
 

--- a/itou/templates/apply/includes/list_job_applications.html
+++ b/itou/templates/apply/includes/list_job_applications.html
@@ -11,8 +11,14 @@
         </h3>
         <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action">
             {% if filters_counter > 0 %}
-                <a href="{% if request.user.is_prescriber %}{% url 'apply:list_prescriptions' %}{% elif request.user.is_employer %}{% url 'apply:list_for_siae' %}{% else %}{% url 'apply:list_for_job_seeker' %}{% endif %}"
-                   class="btn btn-secondary btn-ico mt-3 mt-md-0">
+                {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
+                    {% url 'apply:list_prescriptions' as reset_url %}
+                {% elif job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
+                    {% url 'apply:list_for_siae' as reset_url %}
+                {% elif job_applications_list_kind is JobApplicationsListKind.SENT_FOR_ME %}
+                    {% url 'apply:list_for_job_seeker' as reset_url %}
+                {% endif %}
+                <a href="{{ reset_url }}" class="btn btn-secondary btn-ico mt-3 mt-md-0">
                     <i class="ri-arrow-go-back-line" aria-hidden="true"></i>
                     <span>Réinitialiser les filtres ({{ filters_counter }})</span>
                 </a>
@@ -24,45 +30,45 @@
             <img class="img-fluid" src="{% static 'img/illustration-siae-card-no-result.svg' %}" alt="" loading="lazy">
             <p class="mb-1 mt-3">
                 <strong>
-                    {% if request.user.is_prescriber or request.user.is_job_seeker %}
-                        Aucune candidature pour le moment
-                    {% elif request.user.is_employer %}
+                    {% if job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
                         {% if pending_states_job_applications_count == 0 %}
                             Aucune candidature pour le moment
                         {% else %}
                             Aucune candidature ne correspond aux filtres sélectionnés
                         {% endif %}
+                    {% else %}
+                        Aucune candidature pour le moment
                     {% endif %}
                 </strong>
             </p>
             <p>
                 <i>
-                    {% if request.user.is_prescriber %}
+                    {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
                         Vous trouverez ici les candidatures émises par votre organisation
                         <br class="d-none d-lg-inline">
                         pour les candidats.
-                    {% elif request.user.is_employer %}
+                    {% elif job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
                         Pour recevoir des candidatures, vérifiez que les postes ouverts
                         <br class="d-none d-lg-inline">
                         dans votre structure sont bien à jour.
-                    {% elif request.user.is_job_seeker %}
+                    {% elif job_applications_list_kind is JobApplicationsListKind.SENT_FOR_ME %}
                         Vous trouverez ici vos candidatures, émises par un prescripteur
                         <br class="d-none d-lg-inline">
                         ou par vous même.
                     {% endif %}
                 </i>
             </p>
-            {% if request.user.is_prescriber %}
+            {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
                 <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
                     <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
                     <span>Postuler pour un candidat</span>
                 </a>
-            {% elif request.user.is_employer %}
+            {% elif job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
                 <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
                     <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
                     <span>Gérer les métiers et recrutements</span>
                 </a>
-            {% elif request.user.is_job_seeker %}
+            {% elif job_applications_list_kind is JobApplicationsListKind.SENT_FOR_ME %}
                 <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
                     <i class="ri-briefcase-line ri-lg font-weight-normal"></i>
                     <span>Rechercher un emploi inclusif</span>
@@ -85,19 +91,19 @@
                                 En attente de réponse depuis {{ job_application.pending_for_weeks }} semaines.
                             </p>
                         {% endif %}
-                        {% if request.user.is_prescriber %}
+                        {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
                             <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
                                href="{% url 'apply:details_for_prescriber' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
                                {% matomo_event "candidature" "clic" "voir_candidature_prescripteur" %}>
                                 Voir sa candidature
                             </a>
-                        {% elif request.user.is_employer %}
+                        {% elif job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
                             <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
                                href="{% url 'apply:details_for_company' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}"
                                aria-label="Gérer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}"
                                {% matomo_event "candidature" "clic" "voir-candidature-employeur" %}>Voir sa candidature</a>
-                        {% elif request.user.is_job_seeker %}
+                        {% elif job_applications_list_kind is JobApplicationsListKind.SENT_FOR_ME %}
                             <a class="btn btn-outline-primary{% if job_application.pending_for_weeks >= job_application.WEEKS_BEFORE_CONSIDERED_OLD %} btn-block w-100 w-md-auto{% endif %}"
                                href="{% url 'apply:details_for_jobseeker' job_application_id=job_application.id %}?back_url={{ request.get_full_path|urlencode }}">
                                 Voir ma candidature

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -62,7 +62,7 @@
                     </aside>
                 </div>
                 <div class="col-12 col-md-8">
-                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request pending_states_job_applications_count=pending_states_job_applications_count list_exports_url=list_exports_url SenderKind=SenderKind only %}
+                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page job_applications_list_kind=job_applications_list_kind JobApplicationsListKind=JobApplicationsListKind filters_counter=filters_counter request=request pending_states_job_applications_count=pending_states_job_applications_count list_exports_url=list_exports_url SenderKind=SenderKind only %}
                 </div>
             </div>
         </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -11,7 +11,7 @@
 
 {% block content_title %}
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <h1 class="m-0">Candidatures</h1>
+        <h1 class="m-0">Candidatures reçues</h1>
         <div class="d-flex flex-column flex-md-row gap-3" role="group" aria-label="Actions sur les candidatures">
             {% include "apply/includes/job_applications_export_button.html" %}
             <a href="{% url 'apply:start' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "enregistrer-candidature" %}>

--- a/itou/templates/apply/list_prescriptions.html
+++ b/itou/templates/apply/list_prescriptions.html
@@ -57,7 +57,7 @@
                     </aside>
                 </div>
                 <div class="col-12 col-md-8">
-                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request list_exports_url=list_exports_url SenderKind=SenderKind only %}
+                    {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page job_applications_list_kind=job_applications_list_kind JobApplicationsListKind=JobApplicationsListKind filters_counter=filters_counter request=request list_exports_url=list_exports_url SenderKind=SenderKind only %}
                 </div>
             </div>
         </div>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -10,7 +10,7 @@
     {# Job seeker info ------------------------------------------------------------------------- #}
     <div class="c-box mb-4">
         <h3>Informations personnelles</h3>
-        {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token only %}
+        {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token SenderKind=SenderKind only %}
         {% if job_application.to_company.kind == CompanyKind.GEIQ and geiq_eligibility_diagnosis %}
             {# GEIQ eligibility details #}
             {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis %}

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -15,7 +15,7 @@
     {# Job seeker info ------------------------------------------------------------------------- #}
     <div class="c-box mb-4">
         <h3>Informations personnelles</h3>
-        {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request with_matomo_event=True csrf_token=csrf_token only %}
+        {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request with_matomo_event=True csrf_token=csrf_token SenderKind=SenderKind only %}
         {% if job_application.to_company.kind == CompanyKind.GEIQ %}
             {# GEIQ eligibility details #}
             {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis %}

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -54,7 +54,7 @@
                         </div>
                         <span>
                             {% block progress_title %}
-                                {% if request.user.is_employer %}
+                                {% if auto_prescription_process %}
                                     Auto-prescription
                                 {% else %}
                                     Postuler

--- a/itou/templates/apply/submit/application/eligibility.html
+++ b/itou/templates/apply/submit/application/eligibility.html
@@ -38,7 +38,7 @@
 
 {% block form_content %}
     <div class="d-flex flex-column flex-lg-row">
-        {% if is_subject_to_eligibility_rules and request.user.is_prescriber %}
+        {% if is_subject_to_eligibility_rules and prescription_process %}
             <div class="order-0 order-lg-1">
                 <div class="alert alert-primary bg-white py-0" role="status">
                     <div class="row">

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -7,7 +7,7 @@
 {% block title %}Création du compte candidat {{ block.super }}{% endblock %}
 
 {% block content_title %}
-    <h1>{{ request.user.is_employer|yesno:"Auto-prescription enregistrée !,Candidature envoyée !" }}</h1>
+    <h1>{{ auto_prescription_process|yesno:"Auto-prescription enregistrée !,Candidature envoyée !" }}</h1>
     <p>
         {% if request.user.is_job_seeker %}
             Votre candidature

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -203,7 +203,7 @@
                         <p class="font-weight-bold fs-sm mb-1">Vous n’avez pas de CV ?</p>
                         <p class="fs-sm mb-2">Créez-en un grâce à notre partenaire Diagoriente.</p>
                     {% endif %}
-                    <a href="https://diagoriente.beta.gouv.fr/services/plateforme?utm_source=emploi-inclusion-{{ request.user.is_prescriber|yesno:"prescripteur,candidat" }}"
+                    <a href="https://diagoriente.beta.gouv.fr/services/plateforme?utm_source=emploi-inclusion-{{ request.user.is_job_seeker|yesno:"candidat,prescripteur" }}"
                        rel="noopener"
                        target="_blank"
                        aria-label="Créer un CV avec Diagoriente (ouverture dans un nouvel onglet)"

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -15,7 +15,7 @@
             </div>
         {% endif %}
         {# Nothing is displayed to SIAE members when the job seeker is not eligible to the IAE #}
-        {% if not request.user.is_employer or job_seeker.has_valid_common_approval or eligibility_diagnosis %}
+        {% if not auto_prescription_process or job_seeker.has_valid_common_approval or eligibility_diagnosis %}
             <div class="alert alert-info mb-5">
                 <div class="row">
                     <div class="col-auto pe-0">
@@ -27,9 +27,9 @@
                                 <strong>Date de fin de validité du pass IAE : {{ job_seeker.latest_common_approval.end_at|date:"d/m/Y" }}</strong>
                             </p>
                             <p class="mb-0">
-                                {% if request.user.is_prescriber_with_authorized_org or request.user.is_employer %}
+                                {% if request.user.is_prescriber_with_authorized_org or auto_prescription_process %}
                                     Tant que le Pass IAE est valide, vous n’avez pas à valider la situation administrative du candidat.
-                                {% elif request.user.is_prescriber %}
+                                {% elif prescription_process %}
                                     Tant que le pass IAE est valide, l’employeur n’aura pas à vérifier l’éligibilité IAE du candidat.
                                 {% elif request.user.is_job_seeker %}
                                     Tant que le pass IAE est valide, l’employeur n’aura pas à vérifier votre éligibilité à l’IAE.
@@ -40,16 +40,16 @@
                                 <strong>Date de fin de validité du diagnostic : {{ eligibility_diagnosis.expires_at|date:"d/m/Y" }}</strong>
                             </p>
                             <p class="mb-0">
-                                {% if request.user.is_prescriber %}
+                                {% if prescription_process %}
                                     Tant que l’éligibilité IAE est valide, l’employeur n’aura pas à vérifier les critères administratifs du candidat.
-                                {% elif request.user.is_employer %}
+                                {% elif auto_prescription_process %}
                                     Tant que l’éligibilité IAE est valide, vous n’aurez pas à vérifier les critères administratifs du candidat.
                                 {% elif request.user.is_job_seeker %}
                                     Tant que votre éligibilité IAE est valide, l’employeur n’aura pas à vérifier vos critères administratifs.
                                 {% endif %}
                             </p>
                         {% else %}
-                            {% if request.user.is_prescriber %}
+                            {% if prescription_process %}
                                 <p class="mb-2">
                                     <strong>Information</strong>
                                 </p>
@@ -73,7 +73,7 @@
             </div>
         {% endif %}
         {# Nothing is displayed to GEIQ members when the job seeker is not eligible #}
-        {% if not request.user.is_employer or geiq_eligibility_diagnosis %}
+        {% if not auto_prescription_process or geiq_eligibility_diagnosis %}
             <div class="alert alert-info mb-5">
                 <div class="row">
                     <div class="col-auto pe-0">
@@ -85,16 +85,16 @@
                                 <strong>Date de fin de validité du diagnostic : {{ geiq_eligibility_diagnosis.expires_at|date:"d/m/Y" }}</strong>
                             </p>
                             <p class="mb-0">
-                                {% if request.user.is_prescriber %}
+                                {% if prescription_process %}
                                     Tant que l’éligibilité GEIQ est valide, l’employeur n’aura pas à valider les critères administratifs du candidat.
-                                {% elif request.user.is_employer %}
+                                {% elif auto_prescription_process %}
                                     Tant que l’éligibilité GEIQ est valide, vous n’aurez pas à valider les critères administratifs du candidat.
                                 {% elif request.user.is_job_seeker %}
                                     Tant que votre éligibilité GEIQ est valide, l’employeur n’aura pas à valider votre éligibilité à un accompagnement par le GEIQ.
                                 {% endif %}
                             </p>
                         {% else %}
-                            {% if request.user.is_prescriber %}
+                            {% if prescription_process %}
                                 <p class="mb-2">
                                     <strong>Information</strong>
                                 </p>
@@ -125,7 +125,7 @@
                     <p class="mb-0">
                         <i class="ri-lightbulb-line ri-lg me-1"></i><strong>Bon à savoir</strong>
                     </p>
-                    {% if request.user.is_employer %}
+                    {% if auto_prescription_process %}
                         <p class="mb-0">Précisez dans le message :</p>
                         <ul class="mb-0">
                             <li>les motivations du candidat,</li>
@@ -194,9 +194,9 @@
     <div class="row">
         <div class="col-12 col-lg-8">
             {% bootstrap_field form.resume %}
-            {% if request.user.is_prescriber or request.user.is_job_seeker %}
+            {% if prescription_process or request.user.is_job_seeker %}
                 <div class="c-info p-3 mb-4">
-                    {% if request.user.is_prescriber %}
+                    {% if prescription_process %}
                         <p class="font-weight-bold fs-sm mb-1">Ce candidat n’a pas encore de CV ?</p>
                         <p class="fs-sm mb-2">Accompagnez-le dans la création de son CV grâce à notre partenaire Diagoriente.</p>
                     {% else %}
@@ -233,7 +233,7 @@
 {% endblock %}
 
 {% block form_submit_button %}
-    {% if request.user.is_employer %}
+    {% if auto_prescription_process %}
         {% itou_buttons_form primary_label="Enregistrer" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_employer" %}
     {% else %}
         {% itou_buttons_form primary_label="Envoyer la candidature" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_"|add:request.user.get_kind_display %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -8,7 +8,7 @@
 
 {% block content_title %}
     {{ block.super }}
-    {% if request.user.is_employer %}
+    {% if auto_prescription_process or hire_process %}
         {% if siae.is_subject_to_eligibility_rules or siae.kind == CompanyKind.GEIQ %}
             <p>
                 {% if hire_process %}

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -78,7 +78,7 @@
                         <h2>Informations du salarié</h2>
                         <hr>
                         <h3>Informations personnelles</h3>
-                        {% include "apply/includes/job_seeker_info.html" with job_seeker=approval.user job_application=job_application with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token only %}
+                        {% include "apply/includes/job_seeker_info.html" with job_seeker=approval.user job_application=job_application with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token SenderKind=SenderKind only %}
                         {# Eligibility ------------------------------------------------------------------------- #}
                         {% if eligibility_diagnosis %}
                             {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company %}

--- a/itou/templates/approvals/includes/job_description_creation.html
+++ b/itou/templates/approvals/includes/job_description_creation.html
@@ -12,8 +12,10 @@
             {% if request.user.is_employer %}
                 {% if job_application.origin == JobApplicationOrigin.PE_APPROVAL %}
                     <i class="ri-community-line me-1" aria-hidden="true"></i>Employeur (Import agrément Pôle emploi)
-                {% else %}
+                {% elif job_application.sender_company == job_application.to_company %}
                     <i class="ri-community-line me-1" aria-hidden="true"></i>Employeur (Auto-prescription)
+                {% else %}
+                    <i class="ri-community-line me-1" aria-hidden="true"></i>Employeur (Orientation)
                 {% endif %}
             {% elif request.user.is_job_seeker %}
                 <i class="ri-community-line me-1" aria-hidden="true"></i>Employeur
@@ -30,7 +32,7 @@
                 <i class="ri-home-smile-2-line me-1" aria-hidden="true"></i>Orienteur
             {% endif %}
         {% endif %}
-        {% if request.user.is_prescriber %}
+        {% if not request.user.is_job_seeker and job_application.to_company != request.current_organization %}
             chez
             <a href="{% url 'companies_views:card' siae_id=job_application.to_company.id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-ico btn-link">
                 <i class="ri-community-line font-weight-medium ri-sm me-1" aria-hidden="true"></i>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -304,6 +304,7 @@
                                         {% include "dashboard/includes/employer_employees_card.html" %}
                                     {% endif %}
                                     {% include "dashboard/includes/employer_company_card.html" %}
+                                    {% include "dashboard/includes/employer_prescription_card.html" %}
                                     {% if last_geiq_execution_assessment %}
                                         {% include "dashboard/includes/employer_geiq_card.html" %}
                                     {% endif %}

--- a/itou/templates/dashboard/includes/employer_prescription_card.html
+++ b/itou/templates/dashboard/includes/employer_prescription_card.html
@@ -1,0 +1,24 @@
+{% load matomo %}
+
+<div class="col mb-3 mb-md-5">
+    <div class="c-box p-0 h-100">
+        <div class="p-3 p-lg-4">
+            <span class="h4 mb-0">Orientation</span>
+            <span class="badge badge-sm rounded-pill bg-accent-02 text-primary">Nouveau</span>
+        </div>
+        <div class="px-3 px-lg-4">
+            <a href="{% url "search:employers_home" %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
+                <i class="ri-draft-line ri-lg font-weight-normal"></i>
+                <span>Postuler pour un candidat</span>
+            </a>
+            <ul class="list-unstyled mb-lg-5">
+                <li class="d-flex justify-content-between align-items-center mb-3">
+                    <a href="{% url "apply:list_prescriptions" %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-liste-candidatures-envoyées" %}>
+                        <i class="ri-folder-shared-line ri-lg font-weight-normal"></i>
+                        <span>Candidatures envoyées</span>
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -347,7 +347,7 @@ class SubmitJobApplicationForm(forms.Form):
         max_upload_size=5 * global_constants.MB,
     )
 
-    def __init__(self, company, user, *args, **kwargs):
+    def __init__(self, company, user, auto_prescription_process, *args, **kwargs):
         self.company = company
         super().__init__(*args, **kwargs)
         self.fields.update(forms.fields_for_model(JobApplication, fields=["selected_jobs", "message"]))
@@ -357,12 +357,12 @@ class SubmitJobApplicationForm(forms.Form):
         selected_jobs.label = "Métiers recherchés"
 
         message = self.fields["message"]
-        message.required = not user.is_employer
+        message.required = not auto_prescription_process
         message.widget.attrs["placeholder"] = ""
         if user.is_job_seeker:
             message.label = "Message à l’employeur"
             help_text = "Message obligatoire à destination de l’employeur et non modifiable après l’envoi."
-        elif user.is_employer:
+        elif auto_prescription_process:
             message.label = "Message d’information"
             help_text = "Ce message ne sera plus modifiable après l’envoi et une copie sera transmise au candidat."
         else:

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -199,11 +199,6 @@ urlpatterns = [
         submit_views.hire_confirmation,
         name="hire_confirmation",
     ),
-    # List - Compatibility. TODO(rsebille): Remove them at a later date
-    path("prescriber/list", list_views.list_prescriptions),
-    path("prescriber/list/exports", list_views.list_prescriptions_exports),
-    path("prescriber/list/exports/download", list_views.list_prescriptions_exports_download),
-    path("prescriber/list/exports/download/<str:month_identifier>", list_views.list_prescriptions_exports_download),
     # List.
     path("job_seeker/list", list_views.list_for_job_seeker, name="list_for_job_seeker"),
     path("prescriptions/list", list_views.list_prescriptions, name="list_prescriptions"),

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -115,7 +115,11 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
 
 
 @login_required
-@user_passes_test(lambda u: u.is_prescriber, login_url=reverse_lazy("search:employers_home"), redirect_field_name=None)
+@user_passes_test(
+    lambda u: u.is_prescriber or u.is_employer,
+    login_url=reverse_lazy("search:employers_home"),
+    redirect_field_name=None,
+)
 def list_prescriptions(request, template_name="apply/list_prescriptions.html"):
     """
     List of applications for a prescriber.
@@ -154,7 +158,11 @@ def list_prescriptions(request, template_name="apply/list_prescriptions.html"):
 
 
 @login_required
-@user_passes_test(lambda u: u.is_prescriber, login_url=reverse_lazy("search:employers_home"), redirect_field_name=None)
+@user_passes_test(
+    lambda u: u.is_prescriber or u.is_employer,
+    login_url=reverse_lazy("search:employers_home"),
+    redirect_field_name=None,
+)
 def list_prescriptions_exports(request, template_name="apply/list_of_available_exports.html"):
     """
     List of applications for a prescriber, sorted by month, displaying the count of applications per month
@@ -175,7 +183,11 @@ def list_prescriptions_exports(request, template_name="apply/list_of_available_e
 
 
 @login_required
-@user_passes_test(lambda u: u.is_prescriber, login_url=reverse_lazy("search:employers_home"), redirect_field_name=None)
+@user_passes_test(
+    lambda u: u.is_prescriber or u.is_employer,
+    login_url=reverse_lazy("search:employers_home"),
+    redirect_field_name=None,
+)
 def list_prescriptions_exports_download(request, month_identifier=None):
     """
     List of applications for a prescriber for a given month identifier (YYYY-mm),

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -1,3 +1,4 @@
+import enum
 from collections import defaultdict
 
 from django.contrib.auth.decorators import login_required, user_passes_test
@@ -19,6 +20,18 @@ from itou.www.apply.forms import (
     PrescriberFilterJobApplicationsForm,
 )
 from itou.www.stats.utils import can_view_stats_pe
+
+
+class JobApplicationsListKind(enum.Enum):
+    RECEIVED = enum.auto()
+    SENT = enum.auto()
+    SENT_FOR_ME = enum.auto()
+
+    # Make the Enum work in Django's templates
+    # See :
+    # - https://docs.djangoproject.com/en/dev/ref/templates/api/#variables-and-lookups
+    # - https://github.com/django/django/pull/12304
+    do_not_call_in_templates = enum.nonmember(True)
 
 
 def _add_user_can_view_personal_information(job_applications, can_view):
@@ -88,6 +101,8 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
 
     context = {
         "job_applications_page": job_applications_page,
+        "job_applications_list_kind": JobApplicationsListKind.SENT_FOR_ME,
+        "JobApplicationsListKind": JobApplicationsListKind,
         "filters_form": filters_form,
         "filters_counter": filters_counter,
         "list_exports_url": None,
@@ -124,6 +139,8 @@ def list_prescriptions(request, template_name="apply/list_prescriptions.html"):
 
     context = {
         "job_applications_page": job_applications_page,
+        "job_applications_list_kind": JobApplicationsListKind.SENT,
+        "JobApplicationsListKind": JobApplicationsListKind,
         "filters_form": filters_form,
         "filters_counter": filters_counter,
         "list_exports_url": reverse("apply:list_prescriptions_exports"),
@@ -211,6 +228,8 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
     context = {
         "siae": company,
         "job_applications_page": job_applications_page,
+        "job_applications_list_kind": JobApplicationsListKind.RECEIVED,
+        "JobApplicationsListKind": JobApplicationsListKind,
         "filters_form": filters_form,
         "filters_counter": filters_counter,
         "pending_states_job_applications_count": pending_states_job_applications_count,

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -166,7 +166,11 @@ def details_for_company(request, job_application_id, template_name="apply/proces
 
 
 @login_required
-@user_passes_test(lambda u: u.is_prescriber, login_url=reverse_lazy("search:employers_home"), redirect_field_name=None)
+@user_passes_test(
+    lambda u: u.is_prescriber or u.is_employer,
+    login_url=reverse_lazy("search:employers_home"),
+    redirect_field_name=None,
+)
 def details_for_prescriber(request, job_application_id, template_name="apply/process_details.html"):
     """
     Detail of an application for an SIAE with the ability:

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -162,7 +162,7 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
                 job_seeker=approval.user,
                 to_company=self.siae,
             )
-            .select_related("sender")
+            .select_related("sender", "to_company")
             .prefetch_related("selected_jobs")
         )
         return context

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -82,6 +82,11 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             sender=factory.LazyAttribute(lambda obj: obj.sender_prescriber_organization.members.first()),
             sender_kind=SenderKind.PRESCRIBER,
         )
+        sent_by_another_employer = factory.Trait(
+            sender_kind=SenderKind.EMPLOYER,
+            sender_company=factory.SubFactory(CompanyFactory, with_membership=True),
+            sender=factory.LazyAttribute(lambda obj: obj.sender_company.members.first()),
+        )
         was_hired = factory.Trait(
             state="accepted",
             to_company__with_jobs=True,

--- a/tests/www/apply/__snapshots__/test_list_for_prescriber.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_prescriber.ambr
@@ -117,16 +117,17 @@
       <hr/>
       <fieldset>
           <legend>Émetteur</legend>
-      
   
-      
-          <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
+          
+              <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
   </select></div>
-      
+          
   
-      
+          
   
+          
       </fieldset>
+  
   
                                       
   

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -182,19 +182,23 @@
       <hr/>
       <fieldset>
           <legend>Émetteur</legend>
-      
   
-      
-          <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
+          
+              <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
   </select></div>
-      
+          
   
-      
-          <div class="form-group"><label class="form-label" for="id_sender_organizations">Nom de l'organisme prescripteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_organizations" lang="fr" multiple="" name="sender_organizations">
+          
+              <div class="form-group"><label class="form-label" for="id_sender_prescriber_organizations">Nom de l'organisme prescripteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_prescriber_organizations" lang="fr" multiple="" name="sender_prescriber_organizations">
   </select></div>
-      
+          
   
+          
+              <div class="form-group"><label class="form-label" for="id_sender_companies">Nom de l’employeur orienteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_companies" lang="fr" multiple="" name="sender_companies">
+  </select></div>
+          
       </fieldset>
+  
   
                                   </div>
                               </form>
@@ -376,19 +380,23 @@
       <hr/>
       <fieldset>
           <legend>Émetteur</legend>
-      
   
-      
-          <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
+          
+              <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
   </select></div>
-      
+          
   
-      
-          <div class="form-group"><label class="form-label" for="id_sender_organizations">Nom de l'organisme prescripteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_organizations" lang="fr" multiple="" name="sender_organizations">
+          
+              <div class="form-group"><label class="form-label" for="id_sender_prescriber_organizations">Nom de l'organisme prescripteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_prescriber_organizations" lang="fr" multiple="" name="sender_prescriber_organizations">
   </select></div>
-      
+          
   
+          
+              <div class="form-group"><label class="form-label" for="id_sender_companies">Nom de l’employeur orienteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_companies" lang="fr" multiple="" name="sender_companies">
+  </select></div>
+          
       </fieldset>
+  
   
                                   </div>
                               </form>
@@ -557,19 +565,23 @@
       <hr/>
       <fieldset>
           <legend>Émetteur</legend>
-      
   
-      
-          <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
+          
+              <div class="form-group"><label class="form-label" for="id_senders">Nom de la personne</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_senders" lang="fr" multiple="" name="senders">
   </select></div>
-      
+          
   
-      
-          <div class="form-group"><label class="form-label" for="id_sender_organizations">Nom de l'organisme prescripteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_organizations" lang="fr" multiple="" name="sender_organizations">
+          
+              <div class="form-group"><label class="form-label" for="id_sender_prescriber_organizations">Nom de l'organisme prescripteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_prescriber_organizations" lang="fr" multiple="" name="sender_prescriber_organizations">
   </select></div>
-      
+          
   
+          
+              <div class="form-group"><label class="form-label" for="id_sender_companies">Nom de l’employeur orienteur</label><select class="form-select django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="" data-theme="bootstrap-5" id="id_sender_companies" lang="fr" multiple="" name="sender_companies">
+  </select></div>
+          
       </fieldset>
+  
   
                                   </div>
                               </form>

--- a/tests/www/apply/test_list_for_prescriber.py
+++ b/tests/www/apply/test_list_for_prescriber.py
@@ -222,7 +222,7 @@ def test_list_prescriptions_exports_as_employer(client):
     client.force_login(job_application.to_company.members.get())
 
     response = client.get(reverse("apply:list_prescriptions_exports"))
-    assert 302 == response.status_code
+    assertNotContains(response, BESOIN_DUN_CHIFFRE)
 
 
 def test_list_prescriptions_exports_back_to_list(client):
@@ -249,7 +249,8 @@ def test_list_prescriptions_exports_download_as_employer(client):
     client.force_login(job_application.to_company.members.get())
 
     response = client.get(reverse("apply:list_prescriptions_exports_download"))
-    assert 302 == response.status_code
+    assert 200 == response.status_code
+    assert "spreadsheetml" in response.get("Content-Type")
 
 
 def test_list_prescriptions_exports_download_by_month(client):

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -149,6 +149,7 @@ class ProcessListSiaeTest(TestCase):
             + 1  # prefetch selected jobs
             + 1  # prefetch jobs appellation
             + 1  # select distinct sender_prescriber_organization
+            + 1  # select distinct sender_company
             #
             # Paginate the job applications queryset:
             + 1  # has_suspended_approval subquery
@@ -156,6 +157,7 @@ class ProcessListSiaeTest(TestCase):
             + 1  # prefetch selected jobs
             + 1  # prefetch jobs appellation
             + 1  # prefetch jobs location
+            + 1  # prefetch jobs company
             + 1  # prefetch approvals
             + 1  # manually prefetch administrative_criteria
             #
@@ -163,31 +165,31 @@ class ProcessListSiaeTest(TestCase):
             # 9 job applications (1 per state in JobApplicationWorkflow + 1 sent by prescriber)
             # 22 requests, maggie has a diagnosis made by a prescriber in this test
             + 1  # jobapp1: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp1: select last valid diagnosis made by prescriber or SIAE (prescriber)
+            + 1  # jobapp1: select last valid diagnosis made by prescriber or SIAE
             # 24 requests
             + 1  # jobapp2: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp2: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp2: select last valid diagnosis made by prescriber or SIAE
             # 26 requests
             + 1  # jobapp3: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp3: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp3: select last valid diagnosis made by prescriber or SIAE
             # 28 requests
             + 1  # jobapp4: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp4: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp4: select last valid diagnosis made by prescriber or SIAE
             # 30 requests
             + 1  # jobapp5: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp5: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp5: select last valid diagnosis made by prescriber or SIAE
             # 32 requests
             + 1  # jobapp6: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp6: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp6: select last valid diagnosis made by prescriber or SIAE
             # 34 requests
             + 1  # jobapp7: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp7: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp7: select last valid diagnosis made by prescriber or SIAE
             # 36 requests
             + 1  # jobapp8: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp8: select last valid diagnosis made by prescriber or SIAE (SIAE)
+            + 1  # jobapp8: select last valid diagnosis made by prescriber or SIAE
             # 38 requests, maggie has a diagnosis made by a prescriber in this test
             + 1  # jobapp9: no approval (prefetched ⇒ no query), check PE approval (⇒ no PE approval)
-            + 1  # jobapp8: select last valid diagnosis made by prescriber or SIAE (prescriber)
+            + 1  # jobapp8: select last valid diagnosis made by prescriber or SIAE
             + 3  # update session
         ):
             response = self.client.get(reverse("apply:list_for_siae"))
@@ -385,7 +387,9 @@ class ProcessListSiaeTest(TestCase):
         """
         self.client.force_login(self.eddie_hit_pit)
         sender_organization = self.pole_emploi
-        response = self.client.get(reverse("apply:list_for_siae"), {"sender_organizations": [sender_organization.id]})
+        response = self.client.get(
+            reverse("apply:list_for_siae"), {"sender_prescriber_organizations": [sender_organization.id]}
+        )
 
         applications = response.context["job_applications_page"].object_list
 
@@ -425,7 +429,8 @@ class ProcessListSiaeTest(TestCase):
         self.client.force_login(self.eddie_hit_pit)
         senders_ids = [self.pole_emploi.id, self.l_envol.id]
         response = self.client.get(
-            reverse("apply:list_for_siae"), {"sender_organizations": [self.thibault_pe.id, self.audrey_envol.id]}
+            reverse("apply:list_for_siae"),
+            {"sender_prescriber_organizations": [self.thibault_pe.id, self.audrey_envol.id]},
         )
 
         applications = response.context["job_applications_page"].object_list

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -17,8 +17,8 @@ def load_template(path):
     return Template((Path("itou/templates") / path).read_text())
 
 
-def get_request():
-    request = RequestFactory()
+def get_request(path="/"):
+    request = RequestFactory().get(path)
     request.user = EmployerFactory()
     return request
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Voir la carte associée.

## :cake: Comment ? <!-- optionnel -->

Les deux premiers commits sont là pour convertir les divers tests lié au `User.kind` en drapeaux métier afin de n'avoir que ceux-ci à actionner dans le commit ouvrant le parcours aux employeurs et les faisant ainsi passer pour des prescripteurs.

Le commit suivant contient le changement attendu, il manque certainement des endroits utilisant encore la logique `.is_employer` mais je commence à ne plus avoir le recul donc on verra avec la relecture et les tests utilisateurs ce qui en ressort. Dans la même veine, il manque sûrement quelques tests mais vu qu'on reprend des parcours déjà bien utilisé je me dit qu'on va plutôt attendre de tomber sur un os.

Le dernier commit nettoie les URL de la PR préparatoire #4120.

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/gip-inclusion/les-emplois/assets/20045330/e1650a93-2c5b-4782-996d-44ad00a95d55)

## :desert_island: Comment tester

- Se connecter avec un employeur
- Cliquer sur "Postuler pour un candidat" du nouveau bloc; suivre le tunnel, il est normalement identique à celui des prescripteurs
- Une fois la candidature envoyée, cliquer sur "Candidatures envoyées" du nouveau bloc

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
