### PR TITLE
Ajout de GDAL dans le README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ L’adaptateur Python pour PostgreSQL, [psycopg](https://www.psycopg.org/), a
 quelques pré-requis auxquels votre système doit répondre.
 https://www.psycopg.org/docs/install.html#runtime-requirements
 
+Par ailleurs, le projet utilise [GDAL](https://gdal.org/index.html), et nécessite
+son installation préalable.
+
+Sur MacOS :
+
+```sh
+$ brew install gdal
+```
+
+Sur Ubuntu :
+
+```sh
+$ apt-get install gdal-bin
+```
+
 #### Virtualenv
 
 La commande `make` suivante crée un


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter l’installation du projet.
