### PR TITLE
Retirer le fichier .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-if test -f .envrc.local; then
-    . .envrc.local
-fi


### PR DESCRIPTION
## :thinking: Pourquoi ?

Aurait du être retiré avec 57a0776b236021ee8d28daeb65234684e6db37ef.
