### PR TITLE
Pilotage: Donner accès au CD-31 de la Haute-Garonne l’accès à 2 TB privés

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -429,7 +429,7 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User pks or Company asp_ids in clear in the code.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 STATS_SIAE_HIRING_REPORT_REGION_WHITELIST = ["Occitanie"]
-STATS_CD_DEPARTMENT_WHITELIST = ["13", "18", "37", "38", "41", "45", "49", "93"]
+STATS_CD_DEPARTMENT_WHITELIST = ["13", "18", "31", "37", "38", "41", "45", "49", "93"]
 STATS_ACI_DEPARTMENT_WHITELIST = ["31", "84"]
 STATS_PH_PRESCRIPTION_REGION_WHITELIST = ["Pays de la Loire", "Nouvelle-Aquitaine", "Île-de-France"]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Donner-acc-s-au-CD-31-de-la-Haute-Garonne-l-acc-s-2-TB-priv-s-2c720d311b7a4e25aac38f9b1afd17ea?pvs=4
