### PR TITLE
Pilotage : Mettre un encart pour promouvoir un webinaire pour les SIAE

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -332,7 +332,7 @@
                                     <img src="{% static_theme_images 'logo-pilotage-inclusion.svg' %}" height="80" alt="Le pilotage de l'inclusion">
                                 </div>
 
-                                {% if pilotage_webinar_banner_url %}
+                                {% for banner in pilotage_webinar_banners %}
                                     <div class="alert alert-important alert-dismissible fade show" role="status">
                                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
                                         <div class="row">
@@ -341,18 +341,16 @@
                                             </div>
                                             <div class="col">
                                                 <p class="mb-2">
-                                                    <strong>Inscrivez-vous à un webinaire pour découvrir votre tout nouveau tableau de bord !</strong>
+                                                    <strong>{{ banner.title }}</strong>
                                                 </p>
-                                                <p class="mb-0">
-                                                    En juin, deux sessions vous sont proposées pour vous familiariser avec votre nouvel outil de suivi et d'analyse des résultats de vos prescriptions.
-                                                </p>
+                                                <p class="mb-0">{{ banner.description }}</p>
                                             </div>
                                             <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                                                <a class="btn btn-sm btn-primary btn-block" href="{{ pilotage_webinar_banner_url }}">Je m’inscris</a>
+                                                <a class="btn btn-sm btn-primary btn-block" href="{{ banner.url }}">Je m’inscris</a>
                                             </div>
                                         </div>
                                     </div>
-                                {% endif %}
+                                {% endfor %}
                                 <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4">
                                     {% if can_view_stats_dashboard_widget %}
                                         {% include "dashboard/includes/stats.html" %}

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -148,7 +148,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "show_mobilemploi_prescriber_banner": False,
         "siae_suspension_text_with_dates": None,
         "siae_search_form": SiaeSearchForm(),
-        "pilotage_webinar_banner_url": "",
+        "pilotage_webinar_banners": [],
     }
 
     if request.user.is_employer:
@@ -157,8 +157,12 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         if current_org := request.current_organization:
             if stats_utils.can_view_stats_ph(request):
                 if current_org.kind in [PrescriberOrganizationKind.ML, PrescriberOrganizationKind.CAP_EMPLOI]:
-                    context["pilotage_webinar_banner_url"] = (
-                        "https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-missions-locales-et-cap-emploi-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed"
+                    context["pilotage_webinar_banners"].append(
+                        {
+                            "title": "Inscrivez-vous à un webinaire pour découvrir votre tout nouveau tableau de bord !",  # noqa: E501
+                            "description": "En juin, deux sessions vous sont proposées pour vous familiariser avec votre nouvel outil de suivi et d'analyse des résultats de vos prescriptions.",  # noqa: E501
+                            "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-missions-locales-et-cap-emploi-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed",  # noqa: E501
+                        }
                     )
                 elif current_org.kind in [
                     PrescriberOrganizationKind.CHRS,
@@ -166,8 +170,12 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                     PrescriberOrganizationKind.OIL,
                     PrescriberOrganizationKind.RS_FJT,
                 ]:
-                    context["pilotage_webinar_banner_url"] = (
-                        "https://app.livestorm.co/itou/le-pilotage-de-linclusion-prescripteurs-de-laccueil-de-lhebergement-et-de-linsertion-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed"
+                    context["pilotage_webinar_banners"].append(
+                        {
+                            "title": "Inscrivez-vous à un webinaire pour découvrir votre tout nouveau tableau de bord !",  # noqa: E501
+                            "description": "En juin, deux sessions vous sont proposées pour vous familiariser avec votre nouvel outil de suivi et d'analyse des résultats de vos prescriptions.",  # noqa: E501
+                            "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-prescripteurs-de-laccueil-de-lhebergement-et-de-linsertion-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed",  # noqa: E501
+                        }
                     )
             if current_org.is_authorized:
                 context["pending_prolongation_requests"] = ProlongationRequest.objects.filter(

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -155,6 +155,18 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
 
     if request.user.is_employer:
         context.update(_employer_dashboard_context(request))
+        if current_org := request.current_organization:
+            if current_org.is_subject_to_eligibility_rules:
+                context["pilotage_webinar_banners"].append(
+                    {
+                        "title": "Inscrivez-vous à un webinaire pour faire le point à mi-année sur vos candidatures & prescriptions",  # noqa: E501
+                        "description": "Des difficultés de recrutement ? Le mardi 9 juillet à 14h, le Pilotage de l’inclusion organise un webinaire pour vous aider à vous saisir des données utiles à la réalisation d’un bilan avec vos prescripteurs.",  # noqa: E501
+                        "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-siae-difficultes-de-recrutement-faites-le-point-a-mi-annee-sur-vos-candidatures-and-prescriptions",  # noqa: E501
+                        "is_displayable": lambda: (
+                            datetime.date(2024, 6, 17) <= timezone.localdate() <= datetime.date(2024, 7, 9)
+                        ),
+                    }
+                )
     elif request.user.is_prescriber:
         if current_org := request.current_organization:
             if stats_utils.can_view_stats_ph(request):

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from allauth.account.views import PasswordChangeView
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -162,6 +164,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                             "title": "Inscrivez-vous à un webinaire pour découvrir votre tout nouveau tableau de bord !",  # noqa: E501
                             "description": "En juin, deux sessions vous sont proposées pour vous familiariser avec votre nouvel outil de suivi et d'analyse des résultats de vos prescriptions.",  # noqa: E501
                             "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-missions-locales-et-cap-emploi-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed",  # noqa: E501
+                            "is_displayable": lambda: timezone.localdate() <= datetime.date(2024, 6, 11),
                         }
                     )
                 elif current_org.kind in [
@@ -175,6 +178,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                             "title": "Inscrivez-vous à un webinaire pour découvrir votre tout nouveau tableau de bord !",  # noqa: E501
                             "description": "En juin, deux sessions vous sont proposées pour vous familiariser avec votre nouvel outil de suivi et d'analyse des résultats de vos prescriptions.",  # noqa: E501
                             "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-prescripteurs-de-laccueil-de-lhebergement-et-de-linsertion-decouvrez-votre-nouveau-tableau-de-bord-personnalise-et-faites-le-point-sur-vos-prescriptions?type=detailed",  # noqa: E501
+                            "is_displayable": lambda: timezone.localdate() <= datetime.date(2024, 6, 13),
                         }
                     )
             if current_org.is_authorized:
@@ -237,6 +241,10 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
             .exclude(state__in=[JobApplicationState.ACCEPTED, JobApplicationState.OBSOLETE])
             .exists()
         )
+
+    context["pilotage_webinar_banners"] = [
+        banner for banner in context["pilotage_webinar_banners"] if banner["is_displayable"]()
+    ]
 
     return render(request, template_name, context)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Mettre-un-encart-pour-promouvoir-webinaire-sur-les-emplois-dans-la-page-stats-du-pilotage-pour-les-S-800a904071904de1bd68711b312b320e?pvs=4

## :cake: Comment ? <!-- optionnel -->

Léger réusinage au passage afin de gérer les dates d'affichage sans avoir besoin de :calendar: et de :brain: les jours J.
Je nettoyais les deux (bientôt) expirés la semaine prochaine ;).