### PR TITLE
Définir la valeur par défaut de REDIS_URL dans base.py

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -437,7 +437,7 @@ STATS_PH_PRESCRIPTION_REGION_WHITELIST = ["Pays de la Loire", "Nouvelle-Aquitain
 SLACK_CRON_WEBHOOK_URL = os.getenv("SLACK_CRON_WEBHOOK_URL")
 
 # Production instances (`PROD`, `DEMO`, `FAST-MACHINE`, ...) share the same redis but different DB
-redis_url = os.getenv("REDIS_URL")
+redis_url = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
 redis_db = os.getenv("REDIS_DB")
 redis_django_settings = {
     "LOCATION": redis_url,

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -26,8 +26,6 @@ DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "itou")  # noqa: F405
 DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")  # noqa: F405
 DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: F405
 
-REDIS_URL = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
-
 MAILJET_API_KEY_PRINCIPAL = "API_MAILJET_KEY_PRINCIPAL"
 MAILJET_SECRET_KEY_PRINCIPAL = "API_MAILJET_SECRET_PRINCIPAL"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour réparer l’environnement de test sans `.envrc`.
