### PR TITLE
Ajouter un espace entre deux mots dans l'encart info bleu du NIR [GEN-1750]

### DIFF
--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -70,7 +70,7 @@
                         </div>
                         <div class="col">
                             <p class="mb-0">
-                                {{ request.user.is_job_seeker|yesno:"Vous n'avez,Le candidat n'a" }}pas de numéro de sécurité sociale ?
+                                {{ request.user.is_job_seeker|yesno:"Vous n'avez,Le candidat n'a" }} pas de numéro de sécurité sociale ?
                                 <br>
                                 <a href="https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale"
                                    aria-label="ameli.fr, article concernant le numéro de sécurité sociale (ouverture dans un nouvel onglet)"


### PR DESCRIPTION
## :thinking: Pourquoi ?

![image](https://github.com/gip-inclusion/les-emplois/assets/7632730/49a13b7b-0138-47ed-8993-e40ec219c6a5)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
