### PR TITLE
UX/UI : Utiliser un bandeau d’alerte globale pour la refonte

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -6,6 +6,22 @@
 
 {% block title %}Tableau de bord {{ block.super }}{% endblock %}
 
+{% block global_messages %}
+    <div class="alert alert-info alert-dismissible-once d-none" role="status" id="alertDismissiblOnceUiImprovements">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+        <div class="row">
+            <div class="col-auto pe-0">
+                <i class="ri-star-s-line ri-xl"></i>
+            </div>
+            <div class="col pl-0">
+                <p class="mb-0">
+                    <strong>Améliorations en cours sur votre espace</strong> : un nouveau design va arriver de façon progressive lors des prochains mois.
+                </p>
+            </div>
+        </div>
+    </div>
+{% endblock global_messages %}
+
 {% block messages %}
     {{ block.super }}
 
@@ -99,19 +115,6 @@
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
         </div>
     {% endif %}
-
-    <div class="alert alert-info alert-dismissible-once d-none" role="status" id="alertDismissiblOnceUiImprovements">
-        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-        <div class="row">
-            <div class="col-auto pe-0">
-                <i class="ri-star-s-line ri-xl text-info"></i>
-            </div>
-            <div class="col pl-0">
-                <p class="fw-bold mb-0">Améliorations en cours sur votre espace</p>
-                <p class="mb-0">Un nouveau design va arriver de façon progressive lors des prochains mois.</p>
-            </div>
-        </div>
-    </div>
 
     {% if user.is_employer and request.current_organization and not request.current_organization.jobs.exists %}
         <div class="alert alert-warning alert-dismissible show" role="status">

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -58,6 +58,9 @@
                 </li>
             </ul>
         </nav>
+        <div class="global-messages-container">
+            {% block global_messages %}{% endblock %}
+        </div>
 
         {% include "includes/demo_accounts.html" %}
         {% include "layout/_header.html" %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les messages d’alertes sont plutôt liés au contenu d’une page. Pour les messages globaux, un nouveau composant permet de les afficher en bannière et de les retirer du contenu de la page.

Voir le composant dans le thème : https://zeroheight.com/85c89893b/p/0775de-alerts/t/23587a

## Captures d’écran :computer: 

![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/d915da69-2a42-4178-b4ff-e81b58762e39)

