### PR TITLE
UX/UI : Remplacer l’alerte de la liste des organisations accréditées par le conseil départemental par un bloc d’information

### DIFF
--- a/itou/templates/prescribers/list_accredited_organizations.html
+++ b/itou/templates/prescribers/list_accredited_organizations.html
@@ -7,13 +7,6 @@
     <h2>{{ prescriber_org.display_name }}</h2>
 {% endblock %}
 
-{% block messages %}
-    {{ block.super }}
-    <div class="alert alert-info">
-        <p class="mb-0">Seuls les administrateurs peuvent voir cette liste.</p>
-    </div>
-{% endblock %}
-
 {% block breadcrumbs %}
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
@@ -23,6 +16,9 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
+                    <div class="c-info mb-3 mb-md-4">
+                        <span class="c-info__summary">Seuls les administrateurs peuvent voir cette liste.</span>
+                    </div>
                     {% if not accredited_orgs %}
                         <div class="alert alert-emploi" role="status">
                             <p class="mb-0">Aucun résultat.</p>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Diminuer le nombre d’alertes sur le site, pour attirer l’attention lorsqu’il y a une alerte.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/f0ae39b2-deaa-4784-bf6d-6dc13d2e9d53)

