### PR TITLE
UX/UI : Remplacer le bandeau promotionnel « Besoin d’un chiffre » par un bloc d’information

### DIFF
--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -8,35 +8,6 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block messages %}
-    {{ block.super }}
-    {% if export_for == "siae" or can_view_stats_pe %}
-        <div class="alert alert-info mt-3" id="besoin-dun-chiffre">
-            <p>
-                <i class="ri-information-line me-1" aria-hidden="true"></i>
-                <b>Besoin d'un chiffre ?</b>
-            </p>
-            {% if export_for == "siae" %}
-                <p class="mb-0">
-                    Accédez aux <a href="{% url 'stats:stats_siae_hiring' %}"  target="_blank" rel="noopener">données de recrutement de votre structure</a> (non nominatives) compilées, calculées et mises à jour quotidiennement.
-                </p>
-            {% elif export_for == "prescriptions" and can_view_stats_pe %}
-                <p class="mb-0">
-                    Accédez aux données de votre agence (non nominatives) compilées, calculées et mises à jour quotidiennement :
-                </p>
-                <ul class="mb-0">
-                    <li>
-                        <a href="{% url 'stats:stats_pe_state_main' %}"  target="_blank" rel="noopener">Voir les données de l'ensemble de l'état des candidatures orientées</a>
-                    </li>
-                    <li>
-                        <a href="{% url 'stats:stats_pe_conversion_main' %}"  target="_blank" rel="noopener">Voir les données du taux de transformation des candidatures</a>
-                    </li>
-                </ul>
-            {% endif %}
-        </div>
-    {% endif %}
-{% endblock %}
-
 {% block content_title %}
     <h1>
         Exporter les candidatures
@@ -54,6 +25,30 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
+                    {% if export_for == "siae" or can_view_stats_pe %}
+                        <div class="c-info mb-3 mb-md-4" id="besoin-dun-chiffre">
+                            <button class="c-info__summary collapsed" data-bs-toggle="collapse" data-bs-target="#collapseBesoinChiffre" aria-expanded="false" aria-controls="collapseBesoinChiffre">
+                                <span>Besoin d'un chiffre ?</span>
+                            </button>
+                            {% if export_for == "siae" %}
+                                <div id="collapseBesoinChiffre" class="c-info__detail collapse">
+                                    Accédez aux <a href="{% url 'stats:stats_siae_hiring' %}"  target="_blank" rel="noopener">données de recrutement de votre structure</a> (non nominatives) compilées, calculées et mises à jour quotidiennement.
+                                </div>
+                            {% elif export_for == "prescriptions" and can_view_stats_pe %}
+                                <div id="collapseBesoinChiffre" class="c-info__detail collapse">
+                                    Accédez aux données de votre agence (non nominatives) compilées, calculées et mises à jour quotidiennement :
+                                    <ul class="mb-0">
+                                        <li>
+                                            <a href="{% url 'stats:stats_pe_state_main' %}"  target="_blank" rel="noopener">Voir les données de l'ensemble de l'état des candidatures orientées</a>
+                                        </li>
+                                        <li>
+                                            <a href="{% url 'stats:stats_pe_conversion_main' %}"  target="_blank" rel="noopener">Voir les données du taux de transformation des candidatures</a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                     {% if not job_applications_by_month %}
                         <h2 class="h4">Aucune candidature pour le moment.</h2>
                     {% else %}

--- a/tests/www/apply/__snapshots__/test_list_for_prescriber.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_prescriber.ambr
@@ -1,25 +1,24 @@
 # serializer version: 1
 # name: test_list_prescriptions_exports_as_pole_emploi_prescriber
   '''
-  <div class="alert alert-info mt-3" id="besoin-dun-chiffre">
-              <p>
-                  <i aria-hidden="true" class="ri-information-line me-1"></i>
-                  <b>Besoin d'un chiffre ?</b>
-              </p>
-              
-                  <p class="mb-0">
-                      Accédez aux données de votre agence (non nominatives) compilées, calculées et mises à jour quotidiennement :
-                  </p>
-                  <ul class="mb-0">
-                      <li>
-                          <a href="/stats/pe/state/main" rel="noopener" target="_blank">Voir les données de l'ensemble de l'état des candidatures orientées</a>
-                      </li>
-                      <li>
-                          <a href="/stats/pe/conversion/main" rel="noopener" target="_blank">Voir les données du taux de transformation des candidatures</a>
-                      </li>
-                  </ul>
-              
-          </div>
+  <div class="c-info mb-3 mb-md-4" id="besoin-dun-chiffre">
+                              <button aria-controls="collapseBesoinChiffre" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseBesoinChiffre" data-bs-toggle="collapse">
+                                  <span>Besoin d'un chiffre ?</span>
+                              </button>
+                              
+                                  <div class="c-info__detail collapse" id="collapseBesoinChiffre">
+                                      Accédez aux données de votre agence (non nominatives) compilées, calculées et mises à jour quotidiennement :
+                                      <ul class="mb-0">
+                                          <li>
+                                              <a href="/stats/pe/state/main" rel="noopener" target="_blank">Voir les données de l'ensemble de l'état des candidatures orientées</a>
+                                          </li>
+                                          <li>
+                                              <a href="/stats/pe/conversion/main" rel="noopener" target="_blank">Voir les données du taux de transformation des candidatures</a>
+                                          </li>
+                                      </ul>
+                                  </div>
+                              
+                          </div>
   '''
 # ---
 # name: test_list_prescriptions_filters

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -1,17 +1,16 @@
 # serializer version: 1
 # name: test_list_for_siae_exports
   '''
-  <div class="alert alert-info mt-3" id="besoin-dun-chiffre">
-              <p>
-                  <i aria-hidden="true" class="ri-information-line me-1"></i>
-                  <b>Besoin d'un chiffre ?</b>
-              </p>
-              
-                  <p class="mb-0">
-                      Accédez aux <a href="/stats/siae/hiring" rel="noopener" target="_blank">données de recrutement de votre structure</a> (non nominatives) compilées, calculées et mises à jour quotidiennement.
-                  </p>
-              
-          </div>
+  <div class="c-info mb-3 mb-md-4" id="besoin-dun-chiffre">
+                              <button aria-controls="collapseBesoinChiffre" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseBesoinChiffre" data-bs-toggle="collapse">
+                                  <span>Besoin d'un chiffre ?</span>
+                              </button>
+                              
+                                  <div class="c-info__detail collapse" id="collapseBesoinChiffre">
+                                      Accédez aux <a href="/stats/siae/hiring" rel="noopener" target="_blank">données de recrutement de votre structure</a> (non nominatives) compilées, calculées et mises à jour quotidiennement.
+                                  </div>
+                              
+                          </div>
   '''
 # ---
 # name: test_list_for_siae_filter_for_different_kind[geiq]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Diminuer le nombre d’alertes sur le site, pour attirer l’attention lorsqu’il y a une alerte.

## :computer: Captures d'écran <!-- optionnel -->
### État replié par défaut
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/f5990c73-a3eb-47cd-b3a5-49612f0f65b9)
### Employeur
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/ab99bfbd-063a-4429-84e0-48c81cda9a71)
### Prescripteur
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/f9c31f23-a857-47e5-8f14-937407eaf951)

