### PR TITLE
UX/UI : Retirer le bandeau d’information pour le passage aux fiches salarié des EITI

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -9,36 +9,6 @@
 {% block messages %}
     {{ block.super }}
 
-    {% if show_eiti_webinar_banner %}
-        <div class="alert alert-important alert-dismissible-once d-none" role="status" id="alertDismissibleOnceEITIWebinar">
-            <p class="mb-0">
-                Sur décision de la DGEFP et en accord avec l’ASP, <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/23342362389265--14-03-24-Webinaire-d%C3%A9di%C3%A9-aux-EITI"
-    target="_blank"
-    rel="noopener"
-    aria-label="Revoir le webinaire (ouverture dans un nouvel onglet)">vous devez déclarer vos fiches salarié à partir du 26/03/2024</a> dans votre tableau de bord des emplois de l’inclusion via l’onglet « gérer les fiches salarié (ASP) ».
-            </p>
-            <div class="row g-0">
-                <p class="my-2">
-                    Consultez le <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/23342362389265--14-03-24-Webinaire-d%C3%A9di%C3%A9-aux-EITI"
-    target="_blank"
-    rel="noopener"
-    aria-label="Revoir le webinaire (ouverture dans un nouvel onglet)">
-                    replay, les supports de présentation ASP/EMPLOI ainsi que les modes d'emploi</a>.
-                </p>
-                <div class="col-12 col-md-auto mt-2">
-                    <a class="btn btn-primary btn-block btn-ico"
-                       href="{{ ITOU_HELP_CENTER_URL }}/sections/15257055244817-Fiches-salari%C3%A9-pour-les-SIAE"
-                       target="_blank"
-                       rel="noopener"
-                       aria-label="Mode d'emploi pour déclarer les fiches salariés">
-                        <span>Découvrir le mode d'emploi</span>
-                        <i class="ri-external-link-line ri-lg"></i>
-                    </a>
-                </div>
-            </div>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-        </div>
-    {% endif %}
     {% if show_mobilemploi_banner %}
         <div class="alert alert-info alert-dismissible-once fade show d-none" role="status" id="showMobilEmploiBanner">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -20,7 +20,6 @@ from rest_framework.authtoken.models import Token
 from itou.api.token_auth.views import TOKEN_ID_STR
 from itou.approvals.enums import ProlongationRequestStatus
 from itou.approvals.models import ProlongationRequest
-from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
@@ -79,8 +78,6 @@ def _employer_dashboard_context(request):
         category["counter"] = len([ja for ja in job_applications if ja["state"] in category["states"]])
         category["url"] = f"{reverse('apply:list_for_siae')}?{'&'.join([f'states={c}' for c in category['states']])}"
 
-    show_eiti_webinar_banner = current_org.kind == CompanyKind.EITI
-
     return {
         "active_campaigns": (
             EvaluatedSiae.objects.for_company(current_org)
@@ -104,7 +101,6 @@ def _employer_dashboard_context(request):
         "num_rejected_employee_records": (
             EmployeeRecord.objects.for_company(current_org).filter(status=Status.REJECTED).count()
         ),
-        "show_eiti_webinar_banner": show_eiti_webinar_banner,
         "siae_suspension_text_with_dates": (
             current_org.get_active_suspension_text_with_dates()
             # Otherwise they cannot be suspended
@@ -148,7 +144,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "num_rejected_employee_records": 0,
         "pending_prolongation_requests": None,
         "evaluated_siae_notifications": EvaluatedSiae.objects.none(),
-        "show_eiti_webinar_banner": False,
         "show_mobilemploi_banner": False,
         "show_mobilemploi_prescriber_banner": False,
         "siae_suspension_text_with_dates": None,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Après 3 mois et une campagne de communication, les EITI sont informées.
