### PR TITLE
Admin : Échanger les labels pour le filtre “Envoyé au fournisseur d’e-mail”

### DIFF
--- a/itou/emails/admin.py
+++ b/itou/emails/admin.py
@@ -20,8 +20,8 @@ class EmailStatusFilter(admin.SimpleListFilter):
 
     def lookups(self, request, model_admin):
         return [
-            ("0", "Oui"),
-            ("1", "Non"),
+            ("0", "Non"),
+            ("1", "Oui"),
         ]
 
     def queryset(self, request, queryset):


### PR DESCRIPTION
## :thinking: Pourquoi ?

0 correspond à une erreur, 1 correspond à un réussite. Je vois déjà Xavier rire suite à https://github.com/gip-inclusion/les-emplois/pull/4180#discussion_r1633214062