### PR TITLE
Retirer un doublon de logging.setLevel dans emails.tasks

### DIFF
--- a/itou/emails/tasks.py
+++ b/itou/emails/tasks.py
@@ -15,8 +15,6 @@ from itou.emails.models import Email
 from itou.utils.iterators import chunks
 
 
-# Reduce verbosity of huey logs (INFO by default)
-logging.getLogger("huey").setLevel(logging.WARNING)
 logger = logging.getLogger("itou.emails")
 
 # Mailjet max number of recipients (CC, BCC, TO)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Retirer un effet de bord à l’import du module de tâche.
Centraliser la configuration de `logging`.

## :desert_island: Comment tester

```diff
diff --git a/tests/emails/test_tasks.py b/tests/emails/test_tasks.py
index 8158a9644..f2120c6f7 100644
--- a/tests/emails/test_tasks.py
+++ b/tests/emails/test_tasks.py
@@ -58,6 +58,8 @@ class TestAsyncSendMessage:
         requests_mock.post(f"{anymail_mailjet_settings.ANYMAIL['MAILJET_API_URL']}send", json=success_response)
         _async_send_message(email.pk)
         assert self.EXC_TEXT not in caplog.text
+        # Huey INFO level is very verbose, make sure it doesn’t log.
+        assert caplog.text == ""
         fresh_email = Email.objects.get(pk=email.pk)
         self.assert_fields_unchanged(email, fresh_email)
         assert fresh_email.esp_response == success_response
 ```
Jouer avec la variable d’environnement `HUEY_LOG_LEVEL`.