### PR TITLE
Correction d'une 500 sur la page de migration IC

### DIFF
--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -452,6 +452,11 @@ def api_token(request, template_name="dashboard/api_token.html"):
 class AccountMigrationView(LoginRequiredMixin, TemplateView):
     template_name = "account/activate_inclusion_connect_account.html"
 
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.kind not in MATOMO_ACCOUNT_TYPE:
+            return HttpResponseRedirect(reverse("dashboard:index"))
+        return super().dispatch(request, *args, **kwargs)
+
     def _get_inclusion_connect_base_params(self):
         params = {
             "user_kind": self.request.user.kind,

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -2497,6 +2497,25 @@ def test_employer_using_django_has_to_activate_ic_account(client):
 
 
 @pytest.mark.parametrize(
+    "user_factory,is_redirected",
+    [
+        (ItouStaffFactory, True),
+        (JobSeekerFactory, True),
+        (PrescriberFactory, False),
+        (partial(EmployerFactory, with_company=True), False),
+        (partial(LaborInspectorFactory, membership=True), True),
+    ],
+)
+def test_activate_ic_account_permissions(client, user_factory, is_redirected):
+    client.force_login(user_factory())
+    response = client.get(reverse("dashboard:activate_ic_account"))
+    if is_redirected:
+        assertRedirects(response, reverse("dashboard:index"), fetch_redirect_response=False)
+    else:
+        assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
     "factory,expected",
     [
         pytest.param(JobSeekerWithAddressFactory, assertNotContains, id="JobSeeker"),


### PR DESCRIPTION
## :thinking: Pourquoi ?

On a régulièrement des membres de l"équipe qui se retrouvent dessus par erreur (sans doute suite à un détournement + libération de l'utilisateur + retour arrière dans le navigateur).

cf https://itou.sentry.io/issues/4703990078/events/88b25d3585bb4907b66eb4b9f926deed/activity/?notification_uuid=bc1343fd-ad48-4912-bd4a-3422fcbaf67f&project=6164438&referrer=previous-event

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
