### PR TITLE
tests: correction d'un test instable 

### DIFF
--- a/tests/institutions/tests.py
+++ b/tests/institutions/tests.py
@@ -23,9 +23,9 @@ class InstitutionModelTest(TestCase):
         Test that if a user is admin of org1 and regular user
         of org2 he is not considered as admin of org2.
         """
-        institution1 = InstitutionWithMembershipFactory()
+        institution1 = InstitutionWithMembershipFactory(department="01")
         institution1_admin_user = institution1.members.first()
-        institution2 = InstitutionWithMembershipFactory()
+        institution2 = InstitutionWithMembershipFactory(department="02")
         institution2.members.add(institution1_admin_user)
 
         assert institution1_admin_user in institution1.active_admin_members

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -402,10 +402,10 @@ class TestItouCurrentOrganizationMiddleware:
     def test_labor_inspector_member_of_2_institutions(self, mocked_get_response_for_middlewaremixin):
         factory = RequestFactory()
         request = factory.get("/")
-        institution1 = InstitutionWithMembershipFactory(name="1")
+        institution1 = InstitutionWithMembershipFactory(name="1", department="01")
         request.user = institution1.members.first()
         institution2 = InstitutionMembershipFactory(
-            is_admin=False, user=request.user, institution__name="2"
+            is_admin=False, user=request.user, institution__name="2", institution__department="02"
         ).institution
         SessionMiddleware(get_response_for_middlewaremixin).process_request(request)
         request.session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = institution2.pk
@@ -469,9 +469,9 @@ def test_logout_as_siae_multiple_memberships(client):
 
 
 def test_logout_as_labor_inspector_multiple_institutions(client):
-    institution1 = InstitutionWithMembershipFactory(name="1st institution")
+    institution1 = InstitutionWithMembershipFactory(name="1st institution", department="01")
     user = institution1.members.first()
-    institution2 = InstitutionFactory(name="2nd institution")
+    institution2 = InstitutionFactory(name="2nd institution", department="02")
     institution2.members.add(user)
 
     client.force_login(user)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avec `--randomly-seed=824007989` ou `--randomly-seed=1838683268` la contrainte `unique_ddets_per_department` 💥

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
