### PR TITLE
Employeur: Ajout de marqueurs Matomo sur certains onglets

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -240,14 +240,21 @@
 {% block content_title_after_alerts %}
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" role="tablist" data-it-sliding-tabs="true">
         <li class="nav-item" role="presentation">
-            <a class="nav-link active" id="ensemble-tab" data-bs-toggle="tab" href="#ensemble" role="tab" aria-controls="ensemble" aria-selected="true">Vue d’ensemble</a>
+            <a class="nav-link active" id="ensemble-tab" data-bs-toggle="tab" href="#ensemble" role="tab" aria-controls="ensemble" aria-selected="true" {% matomo_event "dashboard" "clic-onglet" "vue-d-ensemble" %}>Vue d’ensemble</a>
         </li>
         <li class="nav-item" role="presentation">
-            <a class="nav-link" id="statistiques-tab" data-bs-toggle="tab" href="#statistiques" role="tab" aria-controls="statistiques" aria-selected="false">Statistiques</a>
+            <a class="nav-link"
+               id="statistiques-tab"
+               data-bs-toggle="tab"
+               href="#statistiques"
+               role="tab"
+               aria-controls="statistiques"
+               aria-selected="false"
+               {% matomo_event "dashboard" "clic-onglet" "statistiques" %}>Statistiques</a>
         </li>
         {% if user.is_employer or user.is_prescriber %}
             <li class="nav-item" role="presentation">
-                <a class="nav-link" id="evenements-tab" data-bs-toggle="tab" href="#evenements" role="tab" aria-controls="evenements" aria-selected="false">Événements à venir</a>
+                <a class="nav-link" id="evenements-tab" data-bs-toggle="tab" href="#evenements" role="tab" aria-controls="evenements" aria-selected="false" {% matomo_event "dashboard" "clic-onglet" "evenements" %}>Événements à venir</a>
             </li>
         {% endif %}
     </ul>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -9,16 +9,9 @@
 {% block global_messages %}
     <div class="alert alert-info alert-dismissible-once d-none" role="status" id="alertDismissiblOnceUiImprovements">
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-        <div class="row">
-            <div class="col-auto pe-0">
-                <i class="ri-star-s-line ri-xl"></i>
-            </div>
-            <div class="col pl-0">
-                <p class="mb-0">
-                    <strong>Améliorations en cours sur votre espace</strong> : un nouveau design va arriver de façon progressive lors des prochains mois.
-                </p>
-            </div>
-        </div>
+        <p class="mb-0">
+            <strong>Améliorations en cours sur votre espace</strong> : un nouveau design va arriver de façon progressive lors des prochains mois.
+        </p>
     </div>
 {% endblock global_messages %}
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Tracker le nombre de clic sur chaque onglet indépendamment 

## :cake: Comment ? <!-- optionnel -->

Ajout du tags Matomo sur les onglets du "Tabelau de bord" 


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
