### PR TITLE
Ajouter API_BAN_BASE_URL au CONNECT_SRC de la CSP dans les settings de dev

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -59,6 +59,8 @@ REST_FRAMEWORK["DEFAULT_RENDERER_CLASSES"] += [  # noqa: F405
 # -------------
 
 API_BAN_BASE_URL = os.getenv("API_BAN_BASE_URL", "https://api-adresse.data.gouv.fr")
+if API_BAN_BASE_URL:
+    CSP_CONNECT_SRC.append(API_BAN_BASE_URL)  # noqa: F405
 API_GEO_BASE_URL = os.getenv("API_GEO_BASE_URL", "https://geo.api.gouv.fr")
 MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL", "https://matomo.inclusion.beta.gouv.fr/")
 MATOMO_SITE_ID = 220


### PR DESCRIPTION
## :desert_island: Comment tester

1. Vérifier que vous n’exportez pas `API_BAN_BASE_URL` dans votre environnement.
2. Démarrer un serveur local
3. Créer un compte candidat
4. Remplir l’adresse du compte créer, l’autocomplétion de la BAN devrait fonctionner.