### PR TITLE
Admin: Robustifier le changement d'état des candidatures 

### DIFF
--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -1,8 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 
-from itou.eligibility.models import EligibilityDiagnosis
-from itou.job_applications.enums import JobApplicationState, SenderKind
+from itou.job_applications.enums import SenderKind
 from itou.job_applications.models import JobApplication
 
 
@@ -24,31 +23,6 @@ class JobApplicationAdminForm(forms.ModelForm):
         self._job_application_to_accept = False
 
     def clean(self):
-        target_state = self.cleaned_data.get("state")
-        if target_state == JobApplicationState.ACCEPTED and target_state != self._initial_job_application_state:
-            self._job_application_to_accept = True
-            self.cleaned_data["state"] = self._initial_job_application_state or JobApplicationState.NEW
-
-        if self._job_application_to_accept and not self.cleaned_data.get("hiring_start_at"):
-            self.add_error("hiring_start_at", "Ce champ est obligatoire pour les candidatures acceptées.")
-
-        if (
-            self._job_application_to_accept
-            and (to_company := self.cleaned_data.get("to_company"))
-            and to_company.is_subject_to_eligibility_rules
-            and self.cleaned_data.get("hiring_without_approval") is not True
-            and (job_seeker := self.cleaned_data.get("job_seeker"))
-            and not job_seeker.has_valid_common_approval
-            and not EligibilityDiagnosis.objects.last_considered_valid(job_seeker, for_siae=to_company)
-        ):
-            self.add_error(
-                None,
-                (
-                    "Un diagnostic d'éligibilité valide pour ce candidat "
-                    "et cette SIAE est obligatoire pour pouvoir créer un PASS IAE."
-                ),
-            )
-
         sender = self.cleaned_data["sender"]
         sender_kind = self.cleaned_data["sender_kind"]
         sender_company = self.cleaned_data.get("sender_company")

--- a/itou/templates/admin/job_applications/change_form.html
+++ b/itou/templates/admin/job_applications/change_form.html
@@ -1,0 +1,33 @@
+{% extends 'admin/change_form.html' %}
+
+{% block submit_buttons_top %}
+
+    {{ block.super }}
+
+    <div class="submit-row" id="job-app-transitions">
+        <p>Changer l'état de la candidature :</p>
+        {% if original.state.is_new %}
+            <input type='submit' class="danger js-with-confirm" name="transition_process" value="Passer à l'étude">
+        {% endif %}
+        {% if original.is_in_acceptable_state %}
+            <input type='submit' class="danger js-with-confirm" name="transition_accept" value="Accepter">
+        {% endif %}
+        {% if original.state.is_accepted and original.can_be_cancelled %}
+            <input type='submit' class="danger js-with-confirm" name="transition_cancel" value="Annuler">
+        {% endif %}
+        {% if original.state.is_obsolete %}
+            <input type='submit' class="danger js-with-confirm" name="transition_reset" value="Remettre au statut nouveau">
+        {% endif %}
+    </div>
+
+    <script nonce="{{ CSP_NONCE }}">
+        var buttons = document.getElementsByClassName("js-with-confirm");
+        Array.prototype.forEach.call(buttons, function(button) {
+            button.addEventListener("click", function(event) {
+                if (!confirm('Êtes vous certain de vouloir **' + event.target.value.toUpperCase() + '** la candidature ?')) {
+                    event.preventDefault();
+                }
+            });
+        });
+    </script>
+{% endblock %}

--- a/tests/job_applications/__snapshots__/test_admin.ambr
+++ b/tests/job_applications/__snapshots__/test_admin.ambr
@@ -1,0 +1,107 @@
+# serializer version: 1
+# name: test_available_transitions[accepted]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+          
+              <input class="danger js-with-confirm" name="transition_cancel" type="submit" value="Annuler"/>
+          
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[cancelled]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+              <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+          
+          
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[new]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+              <input class="danger js-with-confirm" name="transition_process" type="submit" value="Passer à l'étude"/>
+          
+          
+          
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[obsolete]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+              <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+          
+          
+          
+              <input class="danger js-with-confirm" name="transition_reset" type="submit" value="Remettre au statut nouveau"/>
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[postponed]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+              <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+          
+          
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[prior_to_hire]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+              <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+          
+          
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[processing]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+              <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+          
+          
+          
+      </div>
+  '''
+# ---
+# name: test_available_transitions[refused]
+  '''
+  <div class="submit-row" id="job-app-transitions">
+          <p>Changer l'état de la candidature :</p>
+          
+          
+              <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+          
+          
+          
+      </div>
+  '''
+# ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Force le fait de passer par les transitions d'état et l'envoi des emails correspondants.

Impact pour le support :
- les nouvelles candidatures ne peuvent être qu'au statut accepté
- les vérifications de transition sont les mêmes que précédement

## TODO:
- [ ] Ajouter des tests (attendre le retour du support et des devs pour valider la proposition)

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
