### PR TITLE
Stats : Ouverture des stats CD à 4 nouveaux départements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -436,7 +436,7 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User pks or Company asp_ids in clear in the code.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 STATS_SIAE_HIRING_REPORT_REGION_WHITELIST = ["Occitanie"]
-STATS_CD_DEPARTMENT_WHITELIST = ["13", "18", "31", "37", "38", "41", "45", "49", "93"]
+STATS_CD_DEPARTMENT_WHITELIST = ["13", "16", "18", "31", "37", "38", "41", "45", "48", "49", "55", "63", "93"]
 STATS_ACI_DEPARTMENT_WHITELIST = ["31", "84"]
 STATS_PH_PRESCRIPTION_REGION_WHITELIST = ["Pays de la Loire", "Nouvelle-Aquitaine", "Île-de-France"]
 


### PR DESCRIPTION
https://www.notion.so/gip-inclusion/Liste-blanche-CD-Donner-acc-s-plusieurs-CD-l-acc-s-2-TB-priv-s-ff2e91592d334639b21e5ffcde8b49cd?pvs=23

## :thinking: Pourquoi ?

On arrête pas le progrès... des stats CD !

## :cake: Comment ?

Grâce à la liste blanche.


