### PR TITLE
GEIQ: ajout d'une notification aux DDETS/DREETS lors de la transmission d'un bilan d'exécution [GEN-1739]

### DIFF
--- a/itou/communications/__init__.py
+++ b/itou/communications/__init__.py
@@ -9,6 +9,7 @@ class NotificationCategory(StrEnum):
     IAE_PASS = "PASS IAE"
     MEMBERS_MANAGEMENT = "Gestion des collaborateurs"
     JOB_APPLICATION = "Candidature"
+    GEIQ_IMPLEMENTATION_ASSESSMENT = "Bilan d’exécution GEIQ"
 
 
 class NotificationRegistry:

--- a/itou/geiq/notifications.py
+++ b/itou/geiq/notifications.py
@@ -1,0 +1,42 @@
+from django.urls import reverse
+
+from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, REGIONS
+from itou.common_apps.notifications.base_class import BaseNotification
+from itou.communications import NotificationCategory
+from itou.institutions.enums import InstitutionKind
+from itou.institutions.models import InstitutionMembership
+from itou.utils.emails import get_email_message
+from itou.utils.urls import get_absolute_url
+
+
+class GEIQImplementationAssessmentSubmittedNotification(BaseNotification):
+    NAME = "geiq_implementation_assessment_submitted"
+    category = NotificationCategory.GEIQ_IMPLEMENTATION_ASSESSMENT
+
+    subject_template = "geiq/email/to_institution_assessment_submitted_subject.txt"
+    body_template = "geiq/email/to_institution_assessment_submitted_body.txt"
+
+    def __init__(self, assessment):
+        self.assessment = assessment
+
+    @property
+    def email(self):
+        relevant_ddets_emails = InstitutionMembership.objects.filter(
+            institution__department=self.assessment.company.department,
+            institution__kind=InstitutionKind.DDETS_GEIQ,
+            is_active=True,
+        ).values_list("user__email", flat=True)
+        relevant_dreets_emails = InstitutionMembership.objects.filter(
+            institution__department__in=REGIONS[DEPARTMENT_TO_REGION[self.assessment.company.department]],
+            institution__kind=InstitutionKind.DREETS_GEIQ,
+            is_active=True,
+        ).values_list("user__email", flat=True)
+
+        to = sorted(set(relevant_ddets_emails) | set(relevant_dreets_emails))
+        context = {
+            "assessment": self.assessment,
+            "assessment_absolute_url": get_absolute_url(
+                reverse("geiq:assessment_info", kwargs={"assessment_pk": self.assessment.pk})
+            ),
+        }
+        return get_email_message(to, context, self.subject_template, self.body_template)

--- a/itou/templates/geiq/email/to_institution_assessment_submitted_body.txt
+++ b/itou/templates/geiq/email/to_institution_assessment_submitted_body.txt
@@ -1,0 +1,17 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Un GEIQ a transmis son bilan d’exécution sur les emplois de l’inclusion:
+
+Nom: {{ assessment.company.display_name }}
+Département: {{ assessment.company.department }}
+
+Pour accéder directement à ce bilan d’exécution, cliquez sur le lien suivant : {{ assessment_absolute_url }}
+
+Cette notification e-mail est transmise par défaut à la DDETS et la DREETS, la gestion du bilan d’exécution est réalisée par l’institution compétente selon l’organisation mise en place sur votre territoire.
+
+Pour consulter et traiter les bilans d’exécution, connectez-vous sur votre espace "Institution partenaire" sur le site des emplois de l’inclusion: {{ itou_protocol }}://{{ itou_fqdn }}.
+
+Cordialement,
+{% endblock %}

--- a/itou/templates/geiq/email/to_institution_assessment_submitted_subject.txt
+++ b/itou/templates/geiq/email/to_institution_assessment_submitted_subject.txt
@@ -1,0 +1,1 @@
+{{ assessment.company.display_name }} a transmis son bilan d’exécution

--- a/itou/www/geiq_views/views.py
+++ b/itou/www/geiq_views/views.py
@@ -22,6 +22,7 @@ from itou.geiq.models import (
     ImplementationAssessment,
     ReviewState,
 )
+from itou.geiq.notifications import GEIQImplementationAssessmentSubmittedNotification
 from itou.geiq.sync import sync_employee_and_contracts
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
@@ -98,6 +99,7 @@ def _assessment_info_for_employer(request, assessment_pk, template_name="geiq/as
             assessment.submitted_at = timezone.now()
             assessment.submitted_by = request.user
             assessment.save(update_fields={"activity_report_file", "submitted_at", "submitted_by"})
+            GEIQImplementationAssessmentSubmittedNotification(assessment).send()
 
     if assessment.submitted_at:
         submission_form.fields["up_to_date_information"].widget.attrs.update(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour que les membres des DDETS/DREETS soient au courant.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
