### PR TITLE
tests: correction d'un autre test instable

### DIFF
--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -288,7 +288,8 @@ class EvaluationCampaignManagerTest(TestCase):
                 assert len(mail.outbox) == 0
 
         # institution DDETS IAE
-        InstitutionWith2MembershipFactory.create_batch(2, kind=InstitutionKind.DDETS_IAE)
+        InstitutionWith2MembershipFactory(kind=InstitutionKind.DDETS_IAE, department="O1")
+        InstitutionWith2MembershipFactory(kind=InstitutionKind.DDETS_IAE, department="1O")
         with self.captureOnCommitCallbacks(execute=True):
             assert 2 == create_campaigns_and_calendar(
                 evaluated_period_start_at, evaluated_period_end_at, adversarial_stage_start


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce que c'est pénible.

`FAILED tests/siae_evaluations/test_models.py::EvaluationCampaignManagerTest::test_create_campaigns_and_calendar - django.db.utils.IntegrityError: duplicate key value violates unique constraint "unique_ddets_per_department"`

Cf https://github.com/gip-inclusion/les-emplois/actions/runs/9566541131/job/26372076377

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
