### PR TITLE
Stats : Augmentation de la durée de vie de l'iframe de 10 à 30 minutes pour réduire la frustration utilisateur au niveau des filtres qui cessent de fonctionner après ce délai

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -1,7 +1,9 @@
-import time
+import datetime
 
 import jwt
+import pytz
 from django.conf import settings
+from django.utils import timezone
 
 
 ASP_SIAE_FILTER_KEY_FLAVOR1 = "identifiant_de_la_structure"
@@ -281,11 +283,11 @@ def metabase_embedded_url(request=None, dashboard_id=None, params=None, with_tit
         metabase_dashboard = METABASE_DASHBOARDS.get(view_name)
         dashboard_id = metabase_dashboard["dashboard_id"] if metabase_dashboard else None
 
-    token_duration_in_seconds = 30 * 60
+    initial_dt = datetime.datetime(1970, 1, 1, 0, 0, 0, 0, pytz.UTC)
     payload = {
         "resource": {"dashboard": dashboard_id},
         "params": params,
-        "exp": round(time.time()) + token_duration_in_seconds,
+        "exp": int((timezone.now() + datetime.timedelta(minutes=30) - initial_dt).total_seconds()),
     }
     is_titled = "true" if with_title else "false"
     return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload) + f"#titled={is_titled}"


### PR DESCRIPTION
https://www.notion.so/gip-inclusion/Iframe-Metabase-Apporter-une-solution-qui-permette-un-affichage-des-donn-es-m-me-apr-s-plusieurs--f24f043572fe4cbabaebc1bd72a45d1a

## :thinking: Pourquoi ?

Au bout de 10 minutes les filtres cessent de fonctionner, causant frustration de l'utilisateur.

## :cake: Comment ?

On monte ce délai à 30 minutes.

## :computer: Notes techniques.

J'ai pu reproduire le problème au bout de 10 minutes en prod et en local.

Dans la console navigateur on constate bien une "400 Bad Request" avec "Token is expired (1718721060)". Bref je suis assez confiant sur ce fix. En local j'ai bien pu ensuite dépasser 10 minutes.