### PR TITLE
GPS : dans la liste des membres d'un groupe, affichage du type de membre 

### DIFF
--- a/itou/templates/users/includes/gps_group.html
+++ b/itou/templates/users/includes/gps_group.html
@@ -15,13 +15,17 @@
                         <i class="ri-user-line" aria-hidden="true"></i>
 
                         <div>
-
                             <h3>
                                 {{ membership.member.get_full_name }}
-
-                                {% if membership.member.organizations %}
-                                    <span class="font-weight-normal fs-6 fst-italic">({{ membership.member.organizations.0 }})</span>
-                                {% endif %}
+                                <span class="font-weight-normal fs-6 fst-italic">
+                                    {% comment %}
+                                    DJlint wants to move the if block and the closing parenthesis to the next line,
+                                    adding two inelegant spaces.
+                                    {% endcomment %}
+                                    {# djlint:off #}
+                                    ({{ membership.member.get_kind_display }}{% if membership.organization_name %} pour {{ membership.organization_name }}{% endif %})
+                                    {# djlint:on #}
+                                </span>
                             </h3>
 
                             <div class="d-flex flex-column flex-md-column gap-1 gap-md-2">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -32,9 +32,6 @@ from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.address.format import compute_hexa_address
 from itou.common_apps.address.models import AddressMixin
 from itou.companies.enums import CompanyKind
-from itou.companies.models import Company
-from itou.institutions.models import Institution
-from itou.prescribers.models import PrescriberOrganization
 from itou.utils.models import UniqueConstraintWithErrorCode
 from itou.utils.validators import validate_birthdate, validate_nir, validate_pole_emploi_id
 
@@ -753,29 +750,6 @@ class User(AbstractUser, AddressMixin):
 
     def autocomplete_display(self):
         return self.get_full_name()
-
-    @property
-    def organizations(self):
-        """
-        Get organizations depending on the type of the user. Orgs we are admins are sorted first.
-        """
-
-        if self.is_employer:
-            org_model = Company
-
-        elif self.is_prescriber:
-            org_model = PrescriberOrganization
-
-        elif self.is_labor_inspector:
-            org_model = Institution
-
-        membership_name = org_model.members.through.user.field.remote_field.name
-        qs_filters = {f"{membership_name}__user": self, f"{membership_name}__is_active": True}
-        organizations = org_model.objects.filter(**qs_filters).order_by(
-            f"-{membership_name}__is_admin", f"{membership_name}__created_at"
-        )
-
-        return organizations
 
 
 def get_allauth_account_user_display(user):

--- a/itou/www/users_views/views.py
+++ b/itou/www/users_views/views.py
@@ -19,7 +19,8 @@ class UserDetailsView(LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["gps_memberships"] = (
-            FollowUpGroupMembership.objects.filter(follow_up_group=self.object.follow_up_group)
+            FollowUpGroupMembership.objects.with_members_organizations_names()
+            .filter(follow_up_group=self.object.follow_up_group)
             .filter(is_active=True)
             .order_by("-is_referent")
             .select_related("follow_up_group", "member")

--- a/tests/gps/__snapshots__/tests.ambr
+++ b/tests/gps/__snapshots__/tests.ambr
@@ -100,13 +100,14 @@
                           <i aria-hidden="true" class="ri-user-line"></i>
   
                           <div>
-  
                               <h3>
                                   Pierre DUPONT
-  
-                                  
-                                      <span class="font-weight-normal fs-6 fst-italic">(Les Olivades)</span>
-                                  
+                                  <span class="font-weight-normal fs-6 fst-italic">
+                                      
+                                      
+                                      (prescripteur pour Les Olivades)
+                                      
+                                  </span>
                               </h3>
   
                               <div class="d-flex flex-column flex-md-column gap-1 gap-md-2">

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -23,9 +23,8 @@ from itou.users.enums import IdentityProvider, LackOfNIRReason, LackOfPoleEmploi
 from itou.users.models import JobSeekerProfile, User
 from itou.utils.mocks.address_format import BAN_GEOCODING_API_RESULTS_MOCK, mock_get_geocoding_data
 from tests.approvals.factories import ApprovalFactory, PoleEmploiApprovalFactory
-from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
+from tests.companies.factories import CompanyFactory
 from tests.eligibility.factories import EligibilityDiagnosisFactory, EligibilityDiagnosisMadeBySiaeFactory
-from tests.institutions.factories import InstitutionMembershipFactory
 from tests.prescribers.factories import (
     PrescriberMembershipFactory,
     PrescriberOrganizationFactory,
@@ -1265,37 +1264,6 @@ def test_is_prescriber_with_authorized_org(user_active, membership_active, organ
     assert prescriber.is_prescriber_with_authorized_org is all(
         [user_active, membership_active, organization_authorized]
     )
-
-
-@pytest.mark.parametrize(
-    "UserFactory,MembershipFactory,relation_name, factories_extra",
-    [
-        (EmployerFactory, CompanyMembershipFactory, "company", [{}] * 3),
-        (
-            LaborInspectorFactory,
-            InstitutionMembershipFactory,
-            "institution",
-            [
-                {"institution__department": "01"},
-                {"institution__department": "02"},
-                {"institution__department": "03"},
-            ],
-        ),
-        (PrescriberFactory, PrescriberMembershipFactory, "organization", [{}] * 3),
-    ],
-)
-def test_employer_organizations(UserFactory, MembershipFactory, relation_name, factories_extra):
-    user = UserFactory()
-    first_membership = MembershipFactory(is_active=True, is_admin=False, user=user, **factories_extra[0])
-    admin_membership = MembershipFactory(is_active=True, is_admin=True, user=user, **factories_extra[1])
-    MembershipFactory(is_active=True, is_admin=False, user=user, **factories_extra[2])
-
-    assert len(user.organizations) == 3
-
-    # The organization we are admin of should come first
-    assert user.organizations[0] == getattr(admin_membership, relation_name)
-    # Then it's ordered by membership creation date.
-    assert user.organizations[1] == getattr(first_membership, relation_name)
 
 
 def test_user_first_login(client):


### PR DESCRIPTION
RAF : 
- [x] corriger erreur 500 : https://github.com/gip-inclusion/les-emplois/pull/4265
- [x] corriger nom utilisateur dans liste déroulante : https://github.com/gip-inclusion/les-emplois/pull/4263

## :thinking: Pourquoi ?

Pour que les utilisateurs distinguent mieux les prescripteurs des employeurs.

## :computer: Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/3283e68a-5481-4c17-b547-c605b2dda218)


## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Aller dans la liste des membres d'un bénéficiaire suivi. 
