### PR TITLE
Réordonner pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,20 +2,6 @@
 
 > _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._
 
-## :cake: Comment ? <!-- optionnel -->
-
-> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._
-
-## :computer: Captures d'écran <!-- optionnel -->
-
-## :rotating_light: À vérifier
-
-- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
-
-## :desert_island: Comment tester
-
-> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._
-
 <!--
 # Catégories changelog
 
@@ -38,3 +24,17 @@
  +--------------------------|--------------------------+
 
 -->
+
+## :cake: Comment ? <!-- optionnel -->
+
+> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._
+
+## :rotating_light: À vérifier
+
+- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
+
+## :desert_island: Comment tester
+
+> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._
+
+## :computer: Captures d'écran <!-- optionnel -->


### PR DESCRIPTION
## :thinking: Pourquoi ?

Remonter les catégories de changelog, car elles sont utiles pour remplir le titre.

Descendre les captures d’écran, pour qu’on voit mieux la section « comment tester ».
