### PR TITLE
GPS: correction de deux erreurs d'affichage (nom du candidat et nom de l'utilisateur connecté)

### DIFF
--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -15,7 +15,7 @@
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="col-12" id="beneficiary_details_container">
                     {# Job seeker info ------------------------------------------------------------------------- #}
                     <div class="c-box mb-3 mb-lg-5">
                         <h2>Données administratives</h2>

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -25,11 +25,11 @@
                                 <ul class="list-data mb-3">
                                     <li>
                                         <small>Prénom</small>
-                                        <strong>{{ beneficiary.first_name|mask_unless:can_view_personal_information }}</strong>
+                                        <strong>{{ beneficiary.first_name }}</strong>
                                     </li>
                                     <li>
                                         <small>Nom</small>
-                                        <strong>{{ beneficiary.last_name|mask_unless:can_view_personal_information }}</strong>
+                                        <strong>{{ beneficiary.last_name }}</strong>
                                     </li>
 
                                     <li>

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -3,9 +3,9 @@
 {% load str_filters %}
 {% load format_filters %}
 
-{% block title %}Profil salarié - {{ user.get_full_name }} {{ block.super }}{% endblock %}
+{% block title %}Profil salarié - {{ beneficiary.get_full_name }} {{ block.super }}{% endblock %}
 
-{% block content_title %}<h1>{{ user.get_full_name }}</h1>{% endblock %}
+{% block content_title %}<h1>{{ beneficiary.get_full_name }}</h1>{% endblock %}
 
 {% block breadcrumbs %}
     {% include "layout/breadcrumbs_from_dashboard.html" %}
@@ -25,42 +25,42 @@
                                 <ul class="list-data mb-3">
                                     <li>
                                         <small>Prénom</small>
-                                        <strong>{{ user.first_name|mask_unless:can_view_personal_information }}</strong>
+                                        <strong>{{ beneficiary.first_name|mask_unless:can_view_personal_information }}</strong>
                                     </li>
                                     <li>
                                         <small>Nom</small>
-                                        <strong>{{ user.last_name|mask_unless:can_view_personal_information }}</strong>
+                                        <strong>{{ beneficiary.last_name|mask_unless:can_view_personal_information }}</strong>
                                     </li>
 
                                     <li>
                                         <small>Date de naissance</small>
-                                        <strong>{{ user.birthdate|date:"d/m/Y" }}</strong>
+                                        <strong>{{ beneficiary.birthdate|date:"d/m/Y" }}</strong>
                                     </li>
                                     <li>
                                         <small>Adresse e-mail</small>
-                                        <strong>{{ user.email }}</strong>
+                                        <strong>{{ beneficiary.email }}</strong>
                                         <button class="btn-link"
                                                 data-bs-toggle="tooltip"
                                                 data-bs-placement="top"
                                                 data-bs-trigger="manual"
                                                 data-bs-title="Copié!"
                                                 data-it-clipboard-button="copy"
-                                                data-it-copy-to-clipboard="{{ user.email }}"
+                                                data-it-copy-to-clipboard="{{ beneficiary.email }}"
                                                 {% matomo_event "gps" "clic" "copied_user_email" %}>
                                             <i class="ri-file-copy-line"></i>
                                         </button>
                                     </li>
                                     <li>
                                         <small>Téléphone</small>
-                                        {% if user.phone %}
-                                            <strong>{{ user.phone|format_phone }}</strong>
+                                        {% if beneficiary.phone %}
+                                            <strong>{{ beneficiary.phone|format_phone }}</strong>
                                             <button class="btn-link"
                                                     data-bs-toggle="tooltip"
                                                     data-bs-placement="top"
                                                     data-bs-trigger="manual"
                                                     data-bs-title="Copié!"
                                                     data-it-clipboard-button="copy"
-                                                    data-it-copy-to-clipboard="{{ user.phone|cut:" " }}"
+                                                    data-it-copy-to-clipboard="{{ beneficiary.phone|cut:" " }}"
                                                     {% matomo_event "gps" "clic" "copied_user_phone" %}>
                                                 <i class="ri-file-copy-line"></i>
                                             </button>
@@ -70,8 +70,8 @@
                                     </li>
                                     <li>
                                         <small>Adresse</small>
-                                        {% if user.address_on_one_line %}
-                                            <address>{{ user.address_on_one_line }}</address>
+                                        {% if beneficiary.address_on_one_line %}
+                                            <address>{{ beneficiary.address_on_one_line }}</address>
                                         {% else %}
                                             <i class="text-disabled">Non renseignée</i>
                                         {% endif %}

--- a/itou/www/users_views/views.py
+++ b/itou/www/users_views/views.py
@@ -14,7 +14,7 @@ class UserDetailsView(LoginRequiredMixin, DetailView):
     template_name = "users/details.html"
     slug_field = "public_id"
     slug_url_kwarg = "public_id"
-    context_object_name = "user"
+    context_object_name = "beneficiary"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/gps/__snapshots__/tests.ambr
+++ b/tests/gps/__snapshots__/tests.ambr
@@ -1,4 +1,148 @@
 # serializer version: 1
+# name: test_beneficiary_details
+  '''
+  <div class="col-12" id="beneficiary_details_container">
+                      
+                      <div class="c-box mb-3 mb-lg-5">
+                          <h2>Données administratives</h2>
+                          <hr/>
+                          <div class="row">
+                              <div class="col-6">
+                                  <ul class="list-data mb-3">
+                                      <li>
+                                          <small>Prénom</small>
+                                          <strong>J…</strong>
+                                      </li>
+                                      <li>
+                                          <small>Nom</small>
+                                          <strong>D…</strong>
+                                      </li>
+  
+                                      <li>
+                                          <small>Date de naissance</small>
+                                          <strong>01/01/1990</strong>
+                                      </li>
+                                      <li>
+                                          <small>Adresse e-mail</small>
+                                          <strong>jane.doe@test.local</strong>
+                                          <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="jane.doe@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_email">
+                                              <i class="ri-file-copy-line"></i>
+                                          </button>
+                                      </li>
+                                      <li>
+                                          <small>Téléphone</small>
+                                          
+                                              <strong>06 12 34 56 78</strong>
+                                              <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_phone">
+                                                  <i class="ri-file-copy-line"></i>
+                                              </button>
+                                          
+                                      </li>
+                                      <li>
+                                          <small>Adresse</small>
+                                          
+                                              <address>12 rue Georges Bizet, 35000 Rennes</address>
+                                          
+                                      </li>
+  
+                                      <li>
+                                          <small>Numéro de sécurité sociale</small>
+                                          
+                                              <strong>290010101010125</strong>
+                                          
+                                      </li>
+                                  </ul>
+  
+                              </div>
+                              <div class="col-6">
+                                  <ul class="list-data mb-3">
+                                      <li>
+                                          <small>Niveau de formation</small>
+                                          
+                                              <strong>Formation de niveau BAC</strong>
+                                          
+                                      </li>
+                                      
+                                      
+                                      
+                                      
+                                      
+                                      
+                                      
+                                      
+                                      <li>
+                                          <small>Identifiant France Travail (ex Pôle emploi)</small>
+  
+                                          
+                                              <i class="text-disabled">Non renseigné</i>
+                                          
+                                      </li>
+  
+                                  </ul>
+                              </div>
+                          </div>
+                      </div>
+  
+                      
+  
+  
+  <div class="c-box mb-3 mb-lg-5" id="gps_intervenants">
+  
+      <h2>Intervenant</h2>
+      <hr/>
+      <div class="p-0 m-0">
+          
+  
+              <div class="c-box--results__header px-0 gps_intervenant">
+                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+  
+                      <div class="c-box--results__summary flex-grow-1">
+                          <i aria-hidden="true" class="ri-user-line"></i>
+  
+                          <div>
+  
+                              <h3>
+                                  Pierre DUPONT
+  
+                                  
+                                      <span class="font-weight-normal fs-6 fst-italic">(Les Olivades)</span>
+                                  
+                              </h3>
+  
+                              <div class="d-flex flex-column flex-md-column gap-1 gap-md-2">
+                                  <span>
+                                      <i aria-hidden="true" class="ri-mail-line font-weight-normal me-1"></i>pierre.dupont@test.local
+                                  </span>
+  
+                                  
+                                      <span>
+                                          <i aria-hidden="true" class="ri-phone-line font-weight-normal me-1"></i>06 12 34 56 78
+                                      </span>
+  
+  
+                                  
+                                  <span>
+                                      <i aria-hidden="true" class="ri-calendar-line font-weight-normal me-1"></i>Suivi depuis le <strong>21/06/2024</strong>
+                                  </span>
+                                  
+                                      <span>
+                                          <i aria-hidden="true" class="ri-map-pin-user-line font-weight-normal me-1"></i><strong>Référent</strong>
+                                      </span>
+                                  
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  
+          
+      </div>
+  
+  </div>
+  
+                  </div>
+  '''
+# ---
 # name: test_join_group_of_a_job_seeker[False]
   '''
   <section class="s-box" id="join_group">

--- a/tests/gps/__snapshots__/tests.ambr
+++ b/tests/gps/__snapshots__/tests.ambr
@@ -11,11 +11,11 @@
                                   <ul class="list-data mb-3">
                                       <li>
                                           <small>Prénom</small>
-                                          <strong>J…</strong>
+                                          <strong>Jane</strong>
                                       </li>
                                       <li>
                                           <small>Nom</small>
-                                          <strong>D…</strong>
+                                          <strong>Doe</strong>
                                       </li>
   
                                       <li>
@@ -141,136 +141,6 @@
   </div>
   
                   </div>
-  '''
-# ---
-# name: test_join_group_of_a_job_seeker[False]
-  '''
-  <section class="s-box" id="join_group">
-          <div class="s-box__container container">
-              <div class="c-form">
-                  <form class="js-prevent-multiple-submit" id="join_group_form" method="post">
-                      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                      
-                      <div class="form-group form-group-required"><label class="form-label" for="js-search-user-input">Nom et prénom du bénéficiaire</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/gps_users?select2=" data-allow-clear="false" data-minimum-input-length="2" data-no-results-url="/apply/[PK of Company]/start?gps=true" data-theme="bootstrap-5" id="js-search-user-input" lang="" name="user" required="">
-  </select></div>
-                      <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_is_referent" name="is_referent" type="checkbox"/><label class="form-check-label" for="id_is_referent">Se rattacher comme référent</label></div></div>
-                      
-  
-  <div class="row">
-      <div class="col-12">
-          <hr class="mb-3"/>
-          <small class="d-inline-block mb-3">* champs obligatoires</small>
-          <div class="form-row align-items-center justify-content-end gx-3">
-              <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  
-                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/gps/groups">
-                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
-                          <span>Annuler</span>
-                      </a>
-                  
-              </div>
-              
-              <div class="form-group col col-lg-auto order-2 order-lg-3">
-                  
-                      <button class="btn btn-block btn-primary disabled" type="button">
-                          <span>Ajouter le bénéficiaire</span>
-                      </button>
-                  
-              </div>
-          </div>
-      </div>
-  </div>
-  
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/gps/groups">Confirmer l'annulation</a>
-                  </div>
-              
-          </div>
-      </div>
-  </div>
-  
-                  </form>
-              </div>
-          </div>
-      </section>
-  '''
-# ---
-# name: test_join_group_of_a_job_seeker[True]
-  '''
-  <section class="s-box" id="join_group">
-          <div class="s-box__container container">
-              <div class="c-form">
-                  <form class="js-prevent-multiple-submit" id="join_group_form" method="post">
-                      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                      
-                      <div class="form-group form-group-required"><label class="form-label" for="js-search-user-input">Nom et prénom du bénéficiaire</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/gps_users?select2=" data-allow-clear="false" data-minimum-input-length="2" data-no-results-url="/apply/[PK of Company]/start?gps=true" data-theme="bootstrap-5" id="js-search-user-input" lang="" name="user" required="">
-  </select></div>
-                      <div class="form-group"><div class="form-check"><input class="form-check-input" id="id_is_referent" name="is_referent" type="checkbox"/><label class="form-check-label" for="id_is_referent">Se rattacher comme référent</label></div></div>
-                      
-  
-  <div class="row">
-      <div class="col-12">
-          <hr class="mb-3"/>
-          <small class="d-inline-block mb-3">* champs obligatoires</small>
-          <div class="form-row align-items-center justify-content-end gx-3">
-              <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  
-                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/gps/groups">
-                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
-                          <span>Annuler</span>
-                      </a>
-                  
-              </div>
-              
-              <div class="form-group col col-lg-auto order-2 order-lg-3">
-                  
-                      <button class="btn btn-block btn-primary disabled" type="button">
-                          <span>Ajouter le bénéficiaire</span>
-                      </button>
-                  
-              </div>
-          </div>
-      </div>
-  </div>
-  
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/gps/groups">Confirmer l'annulation</a>
-                  </div>
-              
-          </div>
-      </div>
-  </div>
-  
-                  </form>
-              </div>
-          </div>
-      </section>
   '''
 # ---
 # name: test_navigation

--- a/tests/gps/tests.py
+++ b/tests/gps/tests.py
@@ -234,6 +234,21 @@ def test_referent_group(client):
     assert not membership.is_referent
 
 
+def test_beneficiary_details(client):
+    prescriber = PrescriberFactory(membership=True)
+    beneficiary = JobSeekerFactory()
+    FollowUpGroupFactory(beneficiary=beneficiary, memberships=4, memberships__member=prescriber)
+
+    client.force_login(prescriber)
+
+    user_details_url = reverse("users:details", kwargs={"public_id": beneficiary.public_id})
+    response = client.get(user_details_url)
+    soup = BeautifulSoup(response.content, "html5lib", from_encoding=response.charset or "utf-8")
+    user_dropdown_menu = str(soup.select("div#dashboardUserDropdown")[0])
+    assert prescriber.email in user_dropdown_menu
+    assert beneficiary.email not in user_dropdown_menu
+
+
 def test_remove_members_from_group(client):
     prescriber = PrescriberFactory(membership=True)
 

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -89,6 +89,7 @@ class PrescriberFactory(UserFactory):
             last_name="Dupont",
             email="pierre.dupont@test.local",
             public_id="03580247-b036-4578-bf9d-f92c9c2f68cd",
+            phone="0612345678",
         )
 
     @factory.post_generation


### PR DESCRIPTION
## :thinking: Pourquoi ?

- Dans la page de détails d'un bénéficiaire, dans le menu déroulant de l'utilisateur connecté, le nom n'était plus celui de l'utilisateur connecté mais celui du bénéficiaire.
- Les membres d'un groupe de suivi voyaient uniquement les initiales du bénéficiaire.

## :cake: Comment ?

Distinction des variables.
