### PR TITLE
GPS : correctif pour les prescripteurs sans organisation

### DIFF
--- a/itou/www/gps/forms.py
+++ b/itou/www/gps/forms.py
@@ -2,6 +2,8 @@ from django import forms
 from django.urls import reverse_lazy
 from django.utils.text import format_lazy
 
+from itou.companies import enums as companies_enums
+from itou.companies.models import Company
 from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.widgets import RemoteAutocompleteSelect2Widget
@@ -29,8 +31,9 @@ class GpsUserSearchForm(forms.Form):
 
     is_referent = forms.BooleanField(label="Se rattacher comme référent", required=False)
 
-    def __init__(self, company, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        singleton = Company.unfiltered_objects.get(siret=companies_enums.POLE_EMPLOI_SIRET)
         self.fields["user"].widget.attrs["data-no-results-url"] = (
-            reverse_lazy("apply:start", kwargs={"company_pk": company.pk}) + "?gps=true"
+            reverse_lazy("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
         )

--- a/itou/www/gps/views.py
+++ b/itou/www/gps/views.py
@@ -45,7 +45,7 @@ def my_groups(request, template_name="gps/my_groups.html"):
     redirect_field_name=None,
 )
 def join_group(request, template_name="gps/join_group.html"):
-    form = GpsUserSearchForm(request.current_organization, data=request.POST or None)
+    form = GpsUserSearchForm(data=request.POST or None)
 
     my_groups_url = reverse("gps:my_groups")
     back_url = get_safe_url(request, "back_url", my_groups_url)

--- a/tests/gps/tests.py
+++ b/tests/gps/tests.py
@@ -74,21 +74,6 @@ def test_join_group_of_a_job_seeker(is_referent, client, snapshot):
 
     response = client.get(url)
 
-    company = response.context["request"].current_organization
-
-    assert (
-        str(
-            parse_response_to_soup(
-                response,
-                "#join_group",
-                replace_in_attr=[
-                    ("data-no-results-url", f"/apply/{company.pk}/start", "/apply/[PK of Company]/start"),
-                ],
-            )
-        )
-        == snapshot
-    )
-
     post_data = {
         "user": job_seeker.id,
         "is_referent": is_referent,


### PR DESCRIPTION
Nous avons utilisé le parcours de candidature pour la création de bénéficiaires dans GPS. L'objectif était d'aller plus vite en réutilisant l'existant.
Le parcours de candidature a besoin (assez logiquement) d'une `Company.pk`. Celle qui était passée était la `request.current_organization` mais cela a posé deux soucis :
- dans [`ApplyBaseView`](https://github.com/gip-inclusion/les-emplois/blob/master/itou/www/apply/views/submit_views.py#L78),  la Company cherchée l'était parfois avec la PK d'une PrescriberOrganization,
- les prescripteurs sans organisation ont eu des 500.

[Après en avoir discuté en équipe](https://itou-inclusion.slack.com/archives/C0412CTV63D/p1718807642049759), nous proposons d'utiliser le Singleton Pôle emploi uniquement dans ce cas là et en attendant que GPS devienne pérenne. Il sera alors possible de créer un parcours de création dédié.
