### PR TITLE
API: ajout des filtres `departement` et `departement_postes` sur la route `/api/v1/siaes/`

### DIFF
--- a/tests/api/siae_api/tests.py
+++ b/tests/api/siae_api/tests.py
@@ -45,9 +45,11 @@ class SiaeAPIFetchListTest(APITestCase):
         """
         response = self.client.get(ENDPOINT_URL, format="json")
 
-        self.assertContains(
-            response, "Les paramètres `code_insee` et `distance_max_km` sont obligatoires.", status_code=400
-        )
+        assert response.status_code == 400
+        assert response.json() == {
+            "code_insee": ["Ce champ est obligatoire."],
+            "distance_max_km": ["Ce champ est obligatoire."],
+        }
 
     def test_fetch_siae_list_with_too_high_distance(self):
         """
@@ -56,9 +58,8 @@ class SiaeAPIFetchListTest(APITestCase):
         query_params = {"code_insee": 44056, "distance_max_km": 200}
         response = self.client.get(ENDPOINT_URL, query_params, format="json")
 
-        self.assertContains(
-            response, "Le paramètre `distance_max_km` doit être compris entre 0 et 100", status_code=400
-        )
+        assert response.status_code == 400
+        assert response.json() == {"distance_max_km": ["Assurez-vous que cette valeur est inférieure ou égale à 100."]}
 
     def test_fetch_siae_list_with_negative_distance(self):
         """
@@ -67,9 +68,8 @@ class SiaeAPIFetchListTest(APITestCase):
         query_params = {"code_insee": 44056, "distance_max_km": -10}
         response = self.client.get(ENDPOINT_URL, query_params, format="json")
 
-        self.assertContains(
-            response, "Le paramètre `distance_max_km` doit être compris entre 0 et 100", status_code=400
-        )
+        assert response.status_code == 400
+        assert response.json() == {"distance_max_km": ["Assurez-vous que cette valeur est supérieure ou égale à 0."]}
 
     def test_fetch_siae_list_with_invalid_code_insee(self):
         """


### PR DESCRIPTION
## :thinking: Pourquoi ?

Certains départements souhaitent pouvoir facilement récupérer la liste des entreprises opérant sur leur territoire.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
