### PR TITLE
Modification de la colonne motif_de_refus : recuperer la clé au lieu du label

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -37,7 +37,7 @@ from itou.companies.models import Company, CompanyMembership, JobDescription
 from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.institutions.models import Institution, InstitutionMembership
-from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
+from itou.job_applications.enums import JobApplicationState, Origin, RefusalReason, SenderKind
 from itou.job_applications.models import JobApplication
 from itou.jobs.models import Rome
 from itou.metabase.dataframes import get_df_from_rows, store_df
@@ -477,6 +477,7 @@ class Command(BaseCommand):
             Origin: "c1_ref_origine_candidature",
             ContractType: "c1_ref_type_contrat",
             PrescriberOrganizationKind: "c1_ref_type_prescripteur",
+            RefusalReason: "c1_ref_motif_de_refus",
         }
         for enum, table_name in enum_to_table.items():
             self.stdout.write(f"Preparing content for {table_name} table...")

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -181,7 +181,7 @@ TABLE.add_columns(
             "name": "motif_de_refus",
             "type": "varchar",
             "comment": "Motif de refus de la candidature",
-            "fn": lambda o: o.get_refusal_reason_display() if o.refusal_reason != "" else None,
+            "fn": lambda o: str(o.refusal_reason) if o.refusal_reason != "" else None,
         },
         {
             "name": "id_candidat",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -967,7 +967,7 @@ def test_populate_enums():
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
     num_queries += 1  # COMMIT (rename_table_atomically RENAME TABLE)
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
-    num_queries *= 3  # We inject thus many enums so far.
+    num_queries *= 4  # We inject thus many enums so far.
     with assertNumQueries(num_queries):
         management.call_command("populate_metabase_emplois", mode="enums")
 
@@ -990,6 +990,11 @@ def test_populate_enums():
         cursor.execute("SELECT * FROM c1_ref_type_prescripteur ORDER BY code")
         rows = cursor.fetchall()
         assert rows[0] == ("AFPA", "AFPA - Agence nationale pour la formation professionnelle des adultes")
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT * FROM c1_ref_motif_de_refus ORDER BY code")
+        rows = cursor.fetchall()
+        assert rows[0] == ("approval_expiration_too_close", "La date de fin du PASS IAE / agrément est trop proche")
 
 
 def test_data_inconsistencies(capsys):

--- a/tests/metabase/test_job_applications.py
+++ b/tests/metabase/test_job_applications.py
@@ -13,12 +13,12 @@ class MetabaseJobApplicationTest(TestCase):
     def test_refusal_reason_old_value(self):
         ja = JobApplicationFactory(refusal_reason=RefusalReason.ELIGIBILITY_DOUBT.value)
         assert ja.refusal_reason in RefusalReason.hidden()
-        assert TABLE.get(column_name="motif_de_refus", input=ja) == ja.get_refusal_reason_display()
+        assert TABLE.get(column_name="motif_de_refus", input=ja) == str(ja.refusal_reason)
 
     def test_refusal_reason_current_value(self):
         ja = JobApplicationFactory(refusal_reason=RefusalReason.DID_NOT_COME.value)
         assert ja.refusal_reason not in RefusalReason.hidden()
-        assert TABLE.get(column_name="motif_de_refus", input=ja) == ja.get_refusal_reason_display()
+        assert TABLE.get(column_name="motif_de_refus", input=ja) == str(ja.refusal_reason)
 
     def test_refusal_reason_empty_value(self):
         ja = JobApplicationFactory(refusal_reason="")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Simplifier l'affichage les labels des motifs de refus sur metabase. 

## :cake: Comment ? <!-- optionnel -->

On réalise une seed côté pilotage pour afficher le nom comme on le souhaite. Donc pour faire ça proprement et ne pas être embêté aux changements de labels côté emplois, on récupère la clé plutôt que la valeur affichée.

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
