### PR TITLE
UX/UI: Correction d’un petit bug sur la recherche employeur

### DIFF
--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -61,6 +61,10 @@ htmx.onLoad((target) => {
     $('a.btn', this).attr("aria-disabled", $(selector).length !== 0 || null)
   })
 
+  document.querySelectorAll("form.submit-on-change").forEach((form) => {
+    form.addEventListener("change", form.submit);
+  });
+
   /*
    * File selector.
    */

--- a/itou/templates/search/includes/siaes_search_top.html
+++ b/itou/templates/search/includes/siaes_search_top.html
@@ -41,7 +41,11 @@
                         </div>
                     </div>
                     {% if form.company %}
-                        {% bootstrap_field form.company wrapper_class="w-lg-400px" show_label=False %}
+                        <form action="{% url "search:employers_results" %}" class="submit-on-change">
+                            {% bootstrap_field form.company wrapper_class="w-lg-400px" show_label=False %}
+                            <input type="hidden" name="city" value="{{ form.city.value }}">
+                            <input type="hidden" name="distance" value="{{ form.distance.value }}">
+                        </form>
                     {% endif %}
                 {% endif %}
             </div>

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -23,17 +23,17 @@
                     </form>
                     {% include "search/includes/siaes_search_tabs.html" %}
                     <div class="tab-content">
-                        <form hx-get="{% url request.resolver_match.view_name %}"
-                              hx-trigger="change delay:.5s"
-                              hx-include="#id_city"
-                              hx-indicator="#job-search-results"
-                              hx-target="#job-search-results"
-                              hx-swap="outerHTML"
-                              hx-push-url="true">
-                            <div class="row">
-                                <div class="col-12">
-                                    {% include "search/includes/siaes_search_subtitle.html" %}
-                                    <div class="d-block w-100">
+                        <div class="row">
+                            <div class="col-12">
+                                {% include "search/includes/siaes_search_subtitle.html" %}
+                                <div class="d-block w-100">
+                                    <form hx-get="{% url request.resolver_match.view_name %}"
+                                          hx-trigger="change delay:.5s"
+                                          hx-include="#id_city"
+                                          hx-indicator="#job-search-results"
+                                          hx-target="#job-search-results"
+                                          hx-swap="outerHTML"
+                                          hx-push-url="true">
                                         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                                             {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance only %}
                                             {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.kinds only %}
@@ -51,16 +51,16 @@
                                                 </a>
                                             </div>
                                         </div>
-                                    </div>
+                                    </form>
                                 </div>
                             </div>
-                            <div class="row">
-                                <div class="col-12">
-                                    {% include "search/includes/siaes_search_top.html" %}
-                                    {% include "search/includes/siaes_search_results.html" %}
-                                </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-12">
+                                {% include "search/includes/siaes_search_top.html" %}
+                                {% include "search/includes/siaes_search_results.html" %}
                             </div>
-                        </form>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -395,7 +395,10 @@ class SearchCompanyTest(TestCase):
         simulated_page = parse_response_to_soup(response)
 
         def distance_radio(distance):
-            [elt] = simulated_page.find_all("input", attrs={"name": "distance", "value": f"{distance}"})
+            [elt] = simulated_page.find_all(
+                "input",
+                attrs={"type": "radio", "name": "distance", "value": f"{distance}"},
+            )
             return elt
 
         distance_radio(100)["checked"] = ""


### PR DESCRIPTION
## :thinking: Pourquoi ?

Seul un résultat est possible lorsqu’on utilise la recherche entreprise. Enlever le reste des filtres afin qu’ils n’interagissent pas avec l’entreprise des résultats:

1. Filtrer par distance 100 kms
2. Sélectionner une entreprise à plus de 5 kms dans le filtre d’entreprise
3. Filtrer sur une de 5 kms

Sur la prod : il n’y a aucun filtre actif dans l’UI, mais aucun résultat. Ceci est dû à la présence de `company=PK` dans l’URL, qui est un choix maintenant invalide. Le select2 ne peut pas être initialisé avec un choix qui n’est pas dans la liste, et n’indique pas d’erreur.

## :desert_island: Comment tester

https://c1-review-ff-filter-company.cleverapps.io/

1. Filtrer par distance 100 kms
2. Sélectionner une entreprise à plus de 5 kms dans le filtre d’entreprise
3. Filtrer sur une de 5 kms