### PR TITLE
GPS: envoi d'événements à Matomo

### DIFF
--- a/itou/static/js/gps.js
+++ b/itou/static/js/gps.js
@@ -10,11 +10,15 @@ htmx.onLoad((target) => {
         placeholder: 'Jean DUPONT',
         escapeMarkup: function (markup) { return markup; },
         language: {
-          ...frTranslations.dict,
-          noResults: () => `
+            ...frTranslations.dict,
+            noResults: () => `
               <div class="d-inline-flex w-100 mb-2">
                   <span class="text-muted d-block pe-1">Aucun résultat.</span>
-                  <a href="${searchUserInputField.data('noResultsUrl')}" class="link">Enregistrer un nouveau bénéficiaire</a>
+                  <a href="${searchUserInputField.data('noResultsUrl')}" class="link" data-matomo-event="true"
+                  data-matomo-category="GPS_formulaire_recherche" data-matomo-action="clic"
+                  data-matomo-option="creation_beneficiaire">
+                  Enregistrer un nouveau bénéficiaire
+                  </a>
               </div>
           `,
         },

--- a/itou/templates/gps/join_group.html
+++ b/itou/templates/gps/join_group.html
@@ -20,7 +20,7 @@
                     {% bootstrap_form_errors form type="all" %}
                     {% bootstrap_field form.user %}
                     {% bootstrap_field form.is_referent %}
-                    {% itou_buttons_form primary_label="Ajouter le bénéficiaire" reset_url=reset_url primary_disabled=True %}
+                    {% itou_buttons_form primary_label="Ajouter le bénéficiaire" reset_url=reset_url primary_disabled=True matomo_category="GPS_formulaire_recherche" matomo_action="clic" matomo_name="ajout_groupe" %}
                 </form>
             </div>
         </div>

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -2,6 +2,7 @@
 {% load tally %}
 {% load matomo %}
 {% load str_filters %}
+{% load matomo %}
 
 
 {% block content_title %}<h1>Mes bénéficiaires</h1>{% endblock %}
@@ -52,7 +53,7 @@
                             </h3>
                             <div class="flex-column flex-md-row btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les groupes de suivi">
 
-                                <a href="{% url 'gps:join_group' %}" class="btn btn-ico btn-primary mt-3 mt-md-0" aria-label="Rejoindre un group de suivi">
+                                <a href="{% url 'gps:join_group' %}" class="btn btn-ico btn-primary mt-3 mt-md-0" aria-label="Rejoindre un group de suivi" {% matomo_event "GPS_liste_groupes" "clic" "ajout_groupe" %}>
                                     <i class="ri-user-add-line" aria-hidden="true"></i>
                                     <span>Ajouter un bénéficiaire</span>
                                 </a>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour mesurer notre impact.

## :cake: Comment ?

- page de recherche de bénéficiaire (gps/join_group):
  - matomo_category="GPS_formulaire_recherche" matomo_action="clic" matomo_name="ajout_groupe" sur le bouton « Ajouter le bénéficiaire »
  - matomo-category="GPS_formulaire_recherche" matomo-action="clic"    matomo-option="creation_beneficiaire" sur le lien « Enregistrer un nouveau bénéficiaire » qui apparaît dans le menu déroulant du champ de recherche lorsqu'aucun résultat n'est trouvé.
- page qui liste les groupes (gps/my_groups) : matomo-category="GPS_liste_groupes" matomo-action="clic" amtomo-name="ajout_groupe"
