### PR TITLE
Utiliser le mode async de Huey dans la plupart des environnements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -462,7 +462,8 @@ CACHES = {
 }
 
 HUEY = {
-    "name": "ITOU",
+    # Use value from CleverCloud deployment config, or a value per REVIEW-APP.
+    "name": os.getenv("HUEY_QUEUE_NAME", DATABASES["default"]["NAME"]),
     # Don't store task results (see our Redis Post-Morten in documentation for more information)
     "results": False,
     "url": f"{redis_url}/?db={redis_db}",
@@ -470,7 +471,8 @@ HUEY = {
         "workers": 2,
         "worker_type": "thread",
     },
-    "immediate": ITOU_ENVIRONMENT not in (ItouEnvironment.DEMO, ItouEnvironment.PROD),
+    # Send emails immediately in FAST-MACHINE, there are no queue consumers in that environment.
+    "immediate": ITOU_ENVIRONMENT != ItouEnvironment.FAST_MACHINE,
 }
 
 MAILJET_API_KEY_PRINCIPAL = os.getenv("API_MAILJET_KEY_PRINCIPAL")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -28,6 +28,8 @@ DATABASES["default"]["NAME"] = os.getenv("PGDATABASE", "itou")  # noqa: F405
 DATABASES["default"]["USER"] = os.getenv("PGUSER", "postgres")  # noqa: F405
 DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: F405
 
+HUEY["immediate"] = True  # noqa: F405
+
 MAILJET_API_KEY_PRINCIPAL = "API_MAILJET_KEY_PRINCIPAL"
 MAILJET_SECRET_KEY_PRINCIPAL = "API_MAILJET_SECRET_PRINCIPAL"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les review apps ont accès à Redis, elles peuvent utiliser la même configuration que la prod et la démo.

Les *fast-machines* sont faites pour lancer des scripts, elles ne démarrent pas le *worker* Huey. Elles doivent rester en mode `immediate`.

Les environnements de test et dev restent en mode immédiat, car l’utilisation de Huey est plus facile dans ce cas.

## :cake: Comment ? <!-- optionnel -->

Ajout de `CC_WORKER_COMMAND=django-admin run_huey` au `c1-deployment-config` des *review apps*. Le `HUEY_QUEUE_NAME` permet d’isoler les queues des différentes *review apps*.
