### PR TITLE
Utiliser un factory.Iterator() pour les départements des institutions

### DIFF
--- a/tests/institutions/factories.py
+++ b/tests/institutions/factories.py
@@ -14,7 +14,7 @@ class InstitutionFactory(factory.django.DjangoModelFactory):
 
     name = factory.Faker("name", locale="fr_FR")
     kind = InstitutionKind.DDETS_IAE
-    department = factory.fuzzy.FuzzyChoice(DEPARTMENTS.keys())
+    department = factory.Iterator(DEPARTMENTS.keys())
 
 
 class InstitutionMembershipFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter les tests flaky (et le temps nécessaire à leur correction).

Refs b12ea30d6aa091c1d2a44219c79b8d1d49134295, b69f96354751ae70f560606c382b9fc504391571, e20e192b5d20642b89c8761a90d170c02f8f97c0, c39130da689382df4b7a34aaede38728b806b6e9, e04beb373ef71d1478b277e4d062ec261696e553, 83b1b9a52dc44fabf364e2ba8f2778ce4304044f et d’autres à découvrir.

Dernier échec en date :
```
FAILED tests/www/siae_evaluations_views/test_views.py::TestViewProof::test_access_other_institution - django.db.utils.IntegrityError: duplicate key value violates unique constraint "unique_ddets_per_department"
DETAIL:  Key (kind, department)=(DDETS IAE, 14) already exists.
```
