### PR TITLE
Mettre en cache les fichiers statiques pour la CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
         python-version: "3.11"
         cache: pip
         cache-dependency-path: requirements/test.txt
+    - name: 💾 Restore static files cache
+      uses: actions/cache@v4
+      with:
+        key: staticfiles-${{ hashFiles('itou/utils/staticfiles.py') }}
+        path: |
+          ~/.cache/itou_cached_assets/
     - name: 📥 Install dependencies
       run: |
         make venv


### PR DESCRIPTION
## :thinking: Pourquoi ?

Robustesse de la CI, moins d’appels réseau = moins d’erreurs, moins de charges pour les serveurs de fichiers statiques, plus rapide et mieux pour les castors.
