### PR TITLE
Correction d’une typo pour l’activation du mode immédiat de Huey

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -472,7 +472,7 @@ HUEY = {
         "worker_type": "thread",
     },
     # Send emails immediately in FAST-MACHINE, there are no queue consumers in that environment.
-    "immediate": ITOU_ENVIRONMENT != ItouEnvironment.FAST_MACHINE,
+    "immediate": ITOU_ENVIRONMENT == ItouEnvironment.FAST_MACHINE,
 }
 
 MAILJET_API_KEY_PRINCIPAL = os.getenv("API_MAILJET_KEY_PRINCIPAL")


### PR DESCRIPTION
## :thinking: Pourquoi ?

`== "FAST-MACHINE"`…

Refs 8186cb2c1380502962f3f28de4f5285555303cf7
