### PR TITLE
logs: ajout de l'identifiant du token dans nos logs Datadog

### DIFF
--- a/itou/api/models.py
+++ b/itou/api/models.py
@@ -20,3 +20,7 @@ class CompanyToken(models.Model):
     class Meta:
         verbose_name = "jeton d'API entreprise"
         verbose_name_plural = "jetons d'API entreprise"
+
+    def datadog_info(self):
+        """Method returning the token representation in our Datadog logs (no secret here!)"""
+        return f"CompanyToken-{self.pk}"

--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -1,4 +1,12 @@
+import logging
+
 from django_datadog_logger.formatters import datadog
+
+
+logger = logging.getLogger(__name__)
+
+
+NO_RECURSIVE_LOG_FLAG = "_no_recursive_log_flag"
 
 
 class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):
@@ -11,6 +19,21 @@ class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):
             if log_key in log_entry_dict:
                 del log_entry_dict[log_key]
         wsgi_request = self.get_wsgi_request()
-        if wsgi_request is not None and (current_org := getattr(wsgi_request, "current_organization", None)):
-            log_entry_dict["usr.organization_id"] = current_org.pk
+        if wsgi_request is not None:
+            if current_org := getattr(wsgi_request, "current_organization", None):
+                log_entry_dict["usr.organization_id"] = current_org.pk
+            if token := getattr(wsgi_request, "auth", None):
+                if hasattr(token, "datadog_info"):
+                    log_entry_dict["token"] = token.datadog_info()
+                else:
+                    try:
+                        user_pk = wsgi_request.user.pk
+                    except AttributeError:
+                        user_pk = None
+                    if user_pk is None and not getattr(wsgi_request, NO_RECURSIVE_LOG_FLAG, False):
+                        # Avoid coming right back here with the following logger.warning
+                        setattr(wsgi_request, NO_RECURSIVE_LOG_FLAG, True)
+                        logger.warning(
+                            "Request using token (%r) without datadog_info() method: please define one", token
+                        )
         return log_entry_dict


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour pouvoir voir qui utilise nos APIs et voir si les tokens sont toujours utilisés.

## :cake: Comment ? <!-- optionnel -->

Via une nouvelle méthode `datadog_info` sur les objets token pour que le mécanisme soit _opt-in_ et ne pas se retrouver par accident avec des tokens dans nos logs.

## :computer: Captures d'écran <!-- optionnel -->

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
