### PR TITLE
Sécurité : Toujours préfixer le sujet des emails par l’environnement depuis lequel ils sont envoyés

### DIFF
--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -7,6 +7,7 @@ from django.template.loader import get_template
 
 from itou.utils import constants as global_constants
 from itou.utils.context_processors import expose_enums
+from itou.utils.enums import ItouEnvironment
 
 
 def remove_extra_line_breaks(text):
@@ -32,7 +33,11 @@ def get_email_text_template(template, context):
 
 
 def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FROM_EMAIL, bcc=None, cc=None):
-    subject_prefix = "[DEMO] " if settings.ITOU_ENVIRONMENT == "DEMO" else ""
+    subject_prefix = (
+        ""
+        if settings.ITOU_ENVIRONMENT in (ItouEnvironment.PROD, ItouEnvironment.FAST_MACHINE)
+        else f"[{settings.ITOU_ENVIRONMENT}] "
+    )
     # Mailjet max subject length is 255
     subject = textwrap.shorten(
         subject_prefix + get_email_text_template(subject, context), width=250, placeholder="..."

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -50,7 +50,7 @@
   '''
 # ---
 # name: test_prolongation_request_created[subject]
-  'Demande de prolongation du PASS IAE de Jane DOE'
+  '[DEV] Demande de prolongation du PASS IAE de Jane DOE'
 # ---
 # name: test_prolongation_request_created_reminder[body]
   '''
@@ -109,7 +109,7 @@
   '''
 # ---
 # name: test_prolongation_request_created_reminder[subject]
-  'Relance - Demande de prolongation du PASS IAE de Jane DOE'
+  '[DEV] Relance - Demande de prolongation du PASS IAE de Jane DOE'
 # ---
 # name: test_prolongation_request_denied_employer[body]
   '''
@@ -144,7 +144,7 @@
   '''
 # ---
 # name: test_prolongation_request_denied_employer[subject]
-  'Prolongation du PASS IAE de Jane DOE refusée'
+  '[DEV] Prolongation du PASS IAE de Jane DOE refusée'
 # ---
 # name: test_prolongation_request_denied_jobseeker[body]
   '''
@@ -177,7 +177,7 @@
   '''
 # ---
 # name: test_prolongation_request_denied_jobseeker[subject]
-  'Prolongation de votre PASS IAE refusée'
+  '[DEV] Prolongation de votre PASS IAE refusée'
 # ---
 # name: test_prolongation_request_granted_employer[body]
   '''
@@ -198,7 +198,7 @@
   '''
 # ---
 # name: test_prolongation_request_granted_employer[subject]
-  'Prolongation du PASS IAE de Jane DOE acceptée'
+  '[DEV] Prolongation du PASS IAE de Jane DOE acceptée'
 # ---
 # name: test_prolongation_request_granted_jobseeker[body]
   '''
@@ -217,5 +217,5 @@
   '''
 # ---
 # name: test_prolongation_request_granted_jobseeker[subject]
-  'Prolongation de votre PASS IAE acceptée'
+  '[DEV] Prolongation de votre PASS IAE acceptée'
 # ---

--- a/tests/common_apps/organizations/tests.py
+++ b/tests/common_apps/organizations/tests.py
@@ -9,7 +9,7 @@ def assert_set_admin_role__creation(user, organization):
 
     # The admin should receive a valid email
     [email] = mail.outbox
-    assert "Votre rôle d’administrateur" == email.subject
+    assert "[DEV] Votre rôle d’administrateur" == email.subject
     assert (
         "Vous avez désormais le statut d’administrateur sur l’espace professionnel de "
         f"votre organisation {organization.name} ({organization.kind})"
@@ -39,6 +39,6 @@ def assert_set_admin_role__removal(user, organization):
 
     # The admin should receive a valid email
     [email] = mail.outbox
-    assert f"[Désactivation] Vous n'êtes plus administrateur de {organization.display_name}" == email.subject
+    assert f"[DEV] [Désactivation] Vous n'êtes plus administrateur de {organization.display_name}" == email.subject
     assert "Un administrateur vous a retiré les droits d'administrateur d'une structure" in email.body
     assert email.to[0] == user.email

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -216,7 +216,7 @@ class ImportSiaeManagementCommandsTest(TestCase):
         assert len(mail.outbox) == 6
         assert reverse("signup:company_select") in mail.outbox[0].body
         assert collections.Counter(mail.subject for mail in mail.outbox) == collections.Counter(
-            f"Activez le compte de votre {kind} {name} sur les emplois de l'inclusion"
+            f"[DEV] Activez le compte de votre {kind} {name} sur les emplois de l'inclusion"
             for (kind, name) in Company.objects.values_list("kind", "name")
         )
 

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -234,7 +234,7 @@ class JobApplicationTransferModelTest(TestCase):
 
         assert len(mail.outbox[0].to) == 1
         assert origin_user.email in mail.outbox[0].to
-        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[0].subject
+        assert f"[DEV] La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[0].subject
         assert "a transféré la candidature de :" in mail.outbox[0].body
 
         assert len(mail.outbox[1].to) == 1
@@ -268,7 +268,7 @@ class JobApplicationTransferModelTest(TestCase):
         # Focusing on prescriber email content
         assert len(mail.outbox[2].to) == 1
         assert job_application.sender.email in mail.outbox[2].to
-        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[2].subject
+        assert f"[DEV] La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[2].subject
         assert "a transféré la candidature de :" in mail.outbox[2].body
 
     def test_transfer_notifications_to_many_employers(self):
@@ -297,8 +297,8 @@ class JobApplicationTransferModelTest(TestCase):
         assert first_mail_to != second_mail_to
         assert first_mail_to in [origin_user_1.email, origin_user_2.email]
         assert second_mail_to in [origin_user_1.email, origin_user_2.email]
-        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[0].subject
-        assert f"La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[1].subject
+        assert f"[DEV] La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[0].subject
+        assert f"[DEV] La candidature de {job_seeker.get_full_name()} a été transférée" == mail.outbox[1].subject
         assert "a transféré la candidature de :" in mail.outbox[0].body
         assert "a transféré la candidature de :" in mail.outbox[1].body
-        assert "Votre candidature a été transférée à une autre structure" == mail.outbox[2].subject
+        assert "[DEV] Votre candidature a été transférée à une autre structure" == mail.outbox[2].subject

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1022,7 +1022,7 @@ class JobApplicationNotificationsTest(TestCase):
         email = job_application.notifications_deliver_approval(job_application.to_company.members.first()).build()
 
         assert (
-            f"PASS IAE pour {job_application.job_seeker.get_full_name()} et avis sur les emplois de l'inclusion"
+            f"[DEV] PASS IAE pour {job_application.job_seeker.get_full_name()} et avis sur les emplois de l'inclusion"
             == email.subject
         )
         assert "PASS IAE" in email.body
@@ -1032,7 +1032,7 @@ class JobApplicationNotificationsTest(TestCase):
 
         email = job_application.notifications_deliver_approval(job_application.to_company.members.first()).build()
 
-        assert "Confirmation de l'embauche" == email.subject
+        assert "[DEV] Confirmation de l'embauche" == email.subject
         assert "PASS IAE" not in email.body
         assert global_constants.ITOU_HELP_CENTER_URL in email.body
 

--- a/tests/siae_evaluations/test_emails.py
+++ b/tests/siae_evaluations/test_emails.py
@@ -39,7 +39,7 @@ class TestInstitutionEmailFactory:
 
         assert email.to == list(u.email for u in evaluated_siae.siae.active_admin_members)
         assert email.subject == (
-            "Contrôle a posteriori sur vos embauches réalisées "
+            "[DEV] Contrôle a posteriori sur vos embauches réalisées "
             + f"du {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_start_at, 'd E Y')} "
             + f"au {dateformat.format(evaluated_siae.evaluation_campaign.evaluated_period_end_at, 'd E Y')}"
         )
@@ -85,10 +85,10 @@ class TestInstitutionEmailFactory:
         [siae_refused_email, institution_email] = mailoutbox
 
         assert sorted(institution_email.to) == sorted(institution.active_members.values_list("email", flat=True))
-        assert institution_email.subject == "[Contrôle a posteriori] Notification des sanctions"
+        assert institution_email.subject == "[DEV] [Contrôle a posteriori] Notification des sanctions"
         assert institution_email.body == self.snapshot(name="sanction notification email")
 
-        assert siae_refused_email.subject == "Résultat du contrôle - EI les petits jardins ID-1000"
+        assert siae_refused_email.subject == "[DEV] Résultat du contrôle - EI les petits jardins ID-1000"
         assert siae_refused_email.body == self.snapshot(name="refused result email")
 
     def test_close_does_not_notify_when_siae_has_been_notified(self, django_capture_on_commit_callbacks, mailoutbox):
@@ -140,7 +140,7 @@ class TestInstitutionEmailFactory:
             campaign.close()
 
         [siae_accepted_email] = mailoutbox
-        assert siae_accepted_email.subject == "Résultat du contrôle - EI les petits jardins ID-1000"
+        assert siae_accepted_email.subject == "[DEV] Résultat du contrôle - EI les petits jardins ID-1000"
         assert siae_accepted_email.body == self.snapshot(name="accepted result email")
 
     def test_close_does_not_notify_when_siae_has_positive_result_in_amicable_phase(

--- a/tests/siae_evaluations/test_management_commands.py
+++ b/tests/siae_evaluations/test_management_commands.py
@@ -87,7 +87,7 @@ class TestManagementCommand:
         # EvaluatedSiae are not ordered.
         [mail1, mail2, mail3] = sorted(mailoutbox, key=lambda mail: (mail.subject, mail.body))
         assert mail1.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
         )
         assert (
@@ -103,7 +103,7 @@ class TestManagementCommand:
             f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_company_1.pk}/" in mail1.body
         )
         assert mail2.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 02"
         )
         assert (
@@ -119,7 +119,7 @@ class TestManagementCommand:
             f"http://localhost:8000/siae_evaluation/siae_job_applications_list/{evaluated_company_2.pk}/" in mail2.body
         )
         assert mail3.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 02"
         )
         assert (
@@ -157,7 +157,7 @@ class TestManagementCommand:
         assert stderr == ""
         [mail] = mailoutbox
         assert mail.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
         )
         assert (
@@ -291,7 +291,7 @@ class TestManagementCommand:
             # EvaluatedSiae are not ordered, email order is not deterministic.
             mail2, mail1 = mail1, mail2
         assert mail1.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
         )
         assert (
@@ -308,7 +308,7 @@ class TestManagementCommand:
             in mail1.body
         )
         assert mail2.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
         )
         assert (
@@ -392,7 +392,7 @@ class TestManagementCommand:
             # EvaluatedSiae are not ordered, email order is not deterministic.
             mail2, mail1 = mail1, mail2
         assert mail1.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
         )
         assert (
@@ -409,7 +409,7 @@ class TestManagementCommand:
             in mail1.body
         )
         assert mail2.subject == (
-            "Contrôle a posteriori des auto-prescriptions : "
+            "[DEV] Contrôle a posteriori des auto-prescriptions : "
             "Plus que quelques jours pour transmettre vos justificatifs à la DDETS 01"
         )
         assert (
@@ -512,7 +512,8 @@ class TestManagementCommand:
         assert stderr == ""
         [email] = mailoutbox
         assert (
-            email.subject == "[Contrôle a posteriori] Contrôle des justificatifs à réaliser avant la clôture de phase"
+            email.subject
+            == "[DEV] [Contrôle a posteriori] Contrôle des justificatifs à réaliser avant la clôture de phase"
         )
 
     @freeze_time("2023-01-18 11:11:11")
@@ -536,7 +537,8 @@ class TestManagementCommand:
         assert stderr == ""
         [email] = mailoutbox
         assert (
-            email.subject == "[Contrôle a posteriori] Contrôle des justificatifs à réaliser avant la clôture de phase"
+            email.subject
+            == "[DEV] [Contrôle a posteriori] Contrôle des justificatifs à réaliser avant la clôture de phase"
         )
 
     @freeze_time("2023-01-18 11:11:11")
@@ -602,7 +604,7 @@ class TestManagementCommand:
         assert stdout == "Reminded “DDETS 01” to control SIAE during the submission freeze.\n"
         assert stderr == ""
         [email] = mailoutbox
-        assert email.subject == "[Contrôle a posteriori] Rappel : Contrôle des justificatifs à finaliser"
+        assert email.subject == "[DEV] [Contrôle a posteriori] Rappel : Contrôle des justificatifs à finaliser"
         assert email.body == snapshot()
 
     @freeze_time("2023-01-18 11:11:11")

--- a/tests/siae_evaluations/test_models.py
+++ b/tests/siae_evaluations/test_models.py
@@ -531,34 +531,36 @@ class EvaluationCampaignManagerTest(TestCase):
             institution_email,
         ] = sorted(mail.outbox, key=lambda mail: mail.subject)
         assert (
-            siae_refused_email.subject == f"Résultat du contrôle - EI Geo refused ID-{evaluated_siae_refused.siae_id}"
+            siae_refused_email.subject
+            == f"[DEV] Résultat du contrôle - EI Geo refused ID-{evaluated_siae_refused.siae_id}"
         )
         assert siae_refused_email.body == self.snapshot(name="refused review email body")
 
         assert (
             siae_accepted_email.subject
-            == f"Résultat du contrôle - EI Geo accepted ID-{evaluated_siae_accepted.siae_id}"
+            == f"[DEV] Résultat du contrôle - EI Geo accepted ID-{evaluated_siae_accepted.siae_id}"
         )
         assert siae_accepted_email.body == self.snapshot(name="accepted review email body")
 
         assert (
             siae_no_response_email.subject
-            == f"Résultat du contrôle - EI Les grands jardins ID-{evaluated_siae_no_response.siae_id}"
+            == f"[DEV] Résultat du contrôle - EI Les grands jardins ID-{evaluated_siae_no_response.siae_id}"
         )
         assert siae_no_response_email.body == self.snapshot(name="no response email body")
 
         assert (
             siae_no_docs_email.subject
-            == f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae_no_docs.siae_id}"
+            == f"[DEV] Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae_no_docs.siae_id}"
         )
         assert siae_no_docs_email.body == self.snapshot(name="no docs email body")
 
         assert (
-            siae_force_accepted.subject == f"Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
+            siae_force_accepted.subject
+            == f"[DEV] Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
         )
         assert siae_force_accepted.body == self.snapshot(name="force accepted email body")
 
-        assert institution_email.subject == "[Contrôle a posteriori] Passage en phase contradictoire"
+        assert institution_email.subject == "[DEV] [Contrôle a posteriori] Passage en phase contradictoire"
         assert institution_email.body == self.snapshot(name="institution summary email body")
 
     @freeze_time("2023-01-02 11:11:11")
@@ -581,11 +583,11 @@ class EvaluationCampaignManagerTest(TestCase):
         [siae_no_response_email, institution_email] = sorted(mail.outbox, key=lambda mail: mail.subject)
         assert (
             siae_no_response_email.subject
-            == f"Résultat du contrôle - EI Les grands jardins ID-{evaluated_siae_no_response.siae_id}"
+            == f"[DEV] Résultat du contrôle - EI Les grands jardins ID-{evaluated_siae_no_response.siae_id}"
         )
         assert siae_no_response_email.body == self.snapshot(name="no response email body")
 
-        assert institution_email.subject == "[Contrôle a posteriori] Passage en phase contradictoire"
+        assert institution_email.subject == "[DEV] [Contrôle a posteriori] Passage en phase contradictoire"
         assert institution_email.body == self.snapshot(name="institution summary email body")
 
     @freeze_time("2023-01-02 11:11:11")
@@ -614,9 +616,9 @@ class EvaluationCampaignManagerTest(TestCase):
         assert evaluated_siae_submitted.state == evaluation_enums.EvaluatedSiaeState.ACCEPTED
 
         [siae_email, institution_email] = mail.outbox
-        assert institution_email.subject == "[Contrôle a posteriori] Passage en phase contradictoire"
+        assert institution_email.subject == "[DEV] [Contrôle a posteriori] Passage en phase contradictoire"
         assert institution_email.body == self.snapshot(name="institution summary email body")
-        assert siae_email.subject == f"Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
+        assert siae_email.subject == f"[DEV] Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
         assert siae_email.body == self.snapshot(name="force accepted email body")
 
     @freeze_time("2023-01-02 11:11:11")
@@ -647,7 +649,7 @@ class EvaluationCampaignManagerTest(TestCase):
         assert evaluated_siae_submitted.state == evaluation_enums.EvaluatedSiaeState.ACCEPTED
 
         [siae_email] = mail.outbox
-        assert siae_email.subject == f"Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
+        assert siae_email.subject == f"[DEV] Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
         assert siae_email.body == self.snapshot(name="positive review email body")
 
     @freeze_time("2023-01-02 11:11:11")
@@ -675,7 +677,7 @@ class EvaluationCampaignManagerTest(TestCase):
         assert evaluated_siae_submitted.state == evaluation_enums.EvaluatedSiaeState.ADVERSARIAL_STAGE
 
         [siae_email] = mail.outbox
-        assert siae_email.subject == f"Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
+        assert siae_email.subject == f"[DEV] Résultat du contrôle - EI Prim’vert ID-{evaluated_siae_submitted.siae_id}"
         assert siae_email.body == self.snapshot(name="negative review email body")
 
     def test_close_no_response(self):
@@ -700,14 +702,14 @@ class EvaluationCampaignManagerTest(TestCase):
         [siae_email, institution_email] = mail.outbox
         assert siae_email.to == list(evaluated_siae.siae.active_admin_members.values_list("email", flat=True))
         assert siae_email.subject == (
-            "[Contrôle a posteriori] "
+            "[DEV] [Contrôle a posteriori] "
             f"Absence de réponse de la structure EI Les petits jardins ID-{evaluated_siae.siae_id}"
         )
         assert siae_email.body == self.snapshot(name="no docs email body")
         assert sorted(institution_email.to) == sorted(
             evaluation_campaign.institution.active_members.values_list("email", flat=True)
         )
-        assert institution_email.subject == "[Contrôle a posteriori] Notification des sanctions"
+        assert institution_email.subject == "[DEV] [Contrôle a posteriori] Notification des sanctions"
         assert institution_email.body == self.snapshot(name="sanction notification email body")
 
         with self.captureOnCommitCallbacks(execute=True):
@@ -749,7 +751,8 @@ class EvaluationCampaignManagerTest(TestCase):
         [accepted_siae_email] = mail.outbox
         assert accepted_siae_email.to == list(evaluated_siae.siae.active_admin_members.values_list("email", flat=True))
         assert (
-            accepted_siae_email.subject == f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}"
+            accepted_siae_email.subject
+            == f"[DEV] Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}"
         )
         assert accepted_siae_email.body == self.snapshot(name="accepted email body")
 
@@ -793,14 +796,15 @@ class EvaluationCampaignManagerTest(TestCase):
         [refused_siae_email, institution_email] = mail.outbox
         assert refused_siae_email.to == list(evaluated_siae.siae.active_admin_members.values_list("email", flat=True))
         assert (
-            refused_siae_email.subject == f"Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}"
+            refused_siae_email.subject
+            == f"[DEV] Résultat du contrôle - EI Les petits jardins ID-{evaluated_siae.siae_id}"
         )
         assert refused_siae_email.body == self.snapshot(name="refused email body")
 
         assert sorted(institution_email.to) == sorted(
             evaluation_campaign.institution.active_members.values_list("email", flat=True)
         )
-        assert institution_email.subject == "[Contrôle a posteriori] Notification des sanctions"
+        assert institution_email.subject == "[DEV] [Contrôle a posteriori] Notification des sanctions"
         assert institution_email.body == self.snapshot(name="sanction notification email body")
 
         with self.captureOnCommitCallbacks(execute=True):

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -356,7 +356,7 @@ class ApprovalProlongationTest(TestCase):
 
         [email] = mail.outbox
         assert email.to == [post_data["email"]]
-        assert email.subject == f"Demande de prolongation du PASS IAE de {self.approval.user.get_full_name()}"
+        assert email.subject == f"[DEV] Demande de prolongation du PASS IAE de {self.approval.user.get_full_name()}"
         assert (
             reverse(
                 "approvals:prolongation_request_report_file",

--- a/tests/www/companies_views/test_views.py
+++ b/tests/www/companies_views/test_views.py
@@ -945,7 +945,7 @@ class UserMembershipDeactivationTest(TestCase):
         # User must have been notified of deactivation (we're human after all)
         assert len(mail.outbox) == 1
         email = mail.outbox[0]
-        assert f"[Désactivation] Vous n'êtes plus membre de {company.display_name}" == email.subject
+        assert f"[DEV] [Désactivation] Vous n'êtes plus membre de {company.display_name}" == email.subject
         assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
         assert email.to[0] == guest.email
 

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -122,7 +122,7 @@ class UserMembershipDeactivationTest(TestCase):
         # User must have been notified of deactivation (we're human after all)
         assert len(mail.outbox) == 1
         email = mail.outbox[0]
-        assert f"[Désactivation] Vous n'êtes plus membre de {organization.display_name}" == email.subject
+        assert f"[DEV] [Désactivation] Vous n'êtes plus membre de {organization.display_name}" == email.subject
         assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
         assert email.to[0] == guest.email
 

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2409,7 +2409,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -2465,7 +2465,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -2799,7 +2799,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -2910,7 +2910,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -3057,7 +3057,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -3118,7 +3118,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -3175,7 +3175,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanction"
+        assert email.subject == "[DEV] Notification de sanction"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "
@@ -3234,7 +3234,7 @@ class InstitutionEvaluatedSiaeNotifyViewStep3Test(InstitutionEvaluatedSiaeNotify
         assert evaluated_siae.notification_text == "A envoyé une photo de son chat."
         [email] = mail.outbox
         assert email.to == ["siae@mailinator.com"]
-        assert email.subject == "Notification de sanctions"
+        assert email.subject == "[DEV] Notification de sanctions"
         assert email.body == (
             "Bonjour,\n\n"
             "Suite aux manquements constatés lors du dernier contrôle a posteriori des auto-prescriptions réalisées "

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -1074,7 +1074,7 @@ class SiaeSubmitProofsViewTest(MessagesTestMixin, TestCase):
         assert len(mail.outbox) == 1
         email = mail.outbox[0]
         assert (
-            f"[Contrôle a posteriori] La structure { evaluated_job_application.evaluated_siae.siae.kind } "
+            f"[DEV] [Contrôle a posteriori] La structure { evaluated_job_application.evaluated_siae.siae.kind } "
             f"{ evaluated_job_application.evaluated_siae.siae.name } a transmis ses pièces justificatives."
         ) == email.subject
         assert (


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de confondre un email envoyé depuis la prod d’un email envoyé depuis un environnement de test.
