### PR TITLE
Supprimer le contrôle des auto-prescriptions sélectionnées par erreur

### DIFF
--- a/delete-2023-evaluation-invalid-job-apps
+++ b/delete-2023-evaluation-invalid-job-apps
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import csv
+from collections import defaultdict
+from io import StringIO
+
+import django
+from django.db import transaction
+from django.db.models import Prefetch
+
+from itou.siae_evaluations import enums as evaluation_enums
+from itou.utils.emails import get_email_message, send_email_messages
+
+
+def main():
+    from itou.companies.models import CompanyMembership
+    from itou.siae_evaluations.models import EvaluatedJobApplication, EvaluatedSiae
+
+    with transaction.atomic():
+        evaluated_job_apps = EvaluatedJobApplication.objects.filter(
+            job_application__approval__start_at__lt="2023-01-01",
+            evaluated_siae__evaluation_campaign__calendar_id=2,
+        ).select_related(
+            "job_application__approval",
+            "job_application__job_seeker",
+        )
+        company_job_apps = defaultdict(list)
+        for ja in evaluated_job_apps:
+            company_job_apps[ja.evaluated_siae_id].append(ja)
+
+        deletion_report = evaluated_job_apps.delete()
+        print(f"Deletion report: {deletion_report}")
+        emails = []
+        remaining_evaluated_siae = []
+        headers = ["SIAE ID", "admin emails", "PASS", "candidat"]
+        with StringIO() as remaining_buf, StringIO() as canceled_buf:
+            remaining = csv.writer(remaining_buf)
+            remaining.writerow(headers)
+            canceled = csv.writer(canceled_buf)
+            canceled.writerow(headers)
+            for evaluated_siae in (
+                EvaluatedSiae.objects.filter(pk__in=company_job_apps)
+                .select_related("siae")
+                .prefetch_related(
+                    Prefetch(
+                        "siae__memberships",
+                        queryset=CompanyMembership.objects.filter(is_admin=True, is_active=True).select_related(
+                            "user"
+                        ),
+                        to_attr="admin_memberships",
+                    ),
+                )
+            ):
+                evaluated_job_apps = company_job_apps[evaluated_siae.pk]
+                remaining_job_apps = evaluated_siae.evaluated_job_applications.all()
+                admin_emails = [m.user.email for m in evaluated_siae.siae.admin_memberships]
+                if len(remaining_job_apps) < 2:
+                    # Cancel the evaluation campaign.
+                    evaluated_job_apps.extend(remaining_job_apps)
+                    writer = canceled
+                    emails.append(
+                        get_email_message(
+                            admin_emails,
+                            {"company": evaluated_siae.siae},
+                            "siae_evaluations/email/to_siae_canceled_evaluation_subject.txt",
+                            "siae_evaluations/email/to_siae_canceled_evaluation_body.txt",
+                        )
+                    )
+                else:
+                    writer = remaining
+                    remaining_evaluated_siae.append(evaluated_siae)
+                    emails.append(
+                        get_email_message(
+                            admin_emails,
+                            {"company": evaluated_siae.siae, "evaluated_job_apps": evaluated_job_apps},
+                            "siae_evaluations/email/to_siae_removed_auto_prescriptions_subject.txt",
+                            "siae_evaluations/email/to_siae_removed_auto_prescriptions_body.txt",
+                        )
+                    )
+                for evaluated_job_app in evaluated_job_apps:
+                    writer.writerow(
+                        [
+                            evaluated_siae.pk,
+                            ", ".join(admin_emails),
+                            evaluated_job_app.job_application.approval.number,
+                            evaluated_job_app.job_application.job_seeker,
+                        ]
+                    )
+            print(f"{remaining_buf.getvalue()}\n\n{canceled_buf.getvalue()}")
+
+        for evaluated_siae in remaining_evaluated_siae:
+            # Removing invalid job applications may make the SIAE evaluation accepted.
+            if (
+                evaluated_siae.reviewed_at
+                and not evaluated_siae.final_reviewed_at
+                and evaluated_siae.state_from_applications == evaluation_enums.EvaluatedSiaeState.ACCEPTED
+            ):
+                print(f"Setting the evaluation state to ACCEPTED for {evaluated_siae} ({evaluated_siae.pk}).")
+                evaluated_siae.final_reviewed_at = evaluated_siae.reviewed_at
+                evaluated_siae.save(update_fields=["final_reviewed_at"])
+
+        send_email_messages(emails)
+
+
+if __name__ == "__main__":
+    django.setup()
+    main()

--- a/itou/templates/siae_evaluations/email/to_siae_canceled_evaluation_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_canceled_evaluation_body.txt
@@ -1,0 +1,10 @@
+Bonjour,
+
+Suite à une vérification, nous avons constaté que votre entreprise [{{ company.kind }}] {{ company.display_name }} basée à {{ company.city }} enregistrée avec le numéro de siret {{ company.siret }} n'aurait pas dû être soumise au contrôle a posteriori pour cette année.
+
+Nous avons donc retiré votre entreprise de la liste du contrôle a posteriori sur l’espace professionnel de votre DDETS ainsi que la rubrique contrôle a posteriori qui figurait dans votre tableau de bord.
+
+Veuillez nous excuser pour la gêne occasionnée.
+Cordialement,
+---
+L’équipe des emplois de l’inclusion

--- a/itou/templates/siae_evaluations/email/to_siae_canceled_evaluation_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_canceled_evaluation_subject.txt
@@ -1,0 +1,1 @@
+Annulation du contrôle a posteriori pour votre structure

--- a/itou/templates/siae_evaluations/email/to_siae_removed_auto_prescriptions_body.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_removed_auto_prescriptions_body.txt
@@ -1,0 +1,13 @@
+Bonjour,
+
+Suite à une vérification, nous avons constaté qu{{ evaluated_job_apps|pluralize:"’une,e plusieurs" }} de vos auto-prescriptions réalisées au sein de l’entreprise [{{ company.kind }}] {{ company.display_name }} basée à {{ company.city }} enregistrée avec le numéro de siret {{ company.siret }} n’auraient pas dû être soumises au contrôle a posteriori.
+
+Auto-prescription{{ evaluated_job_apps|pluralize }} concernée{{ evaluated_job_apps|pluralize }}:
+{% for evaluated_job_app in evaluated_job_apps %}
+- {{ evaluated_job_app.job_application.job_seeker.get_full_name }}, PASS N°{{ evaluated_job_app.job_application.approval.number }}{% endfor %}
+
+Nous avons donc retiré ces auto-prescriptions de votre dossier de contrôle.
+
+Veuillez nous excuser pour la gêne occasionnée.
+Cordialement,
+L’équipe des emplois de l’inclusion

--- a/itou/templates/siae_evaluations/email/to_siae_removed_auto_prescriptions_subject.txt
+++ b/itou/templates/siae_evaluations/email/to_siae_removed_auto_prescriptions_subject.txt
@@ -1,0 +1,1 @@
+Annulation du contrôle de certaines auto-prescriptions dans votre structure


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à une anomalie détectée dans le script de sélection des auto-prescriptions à contrôler, nous avons identifié des auto-prescriptions qui n’auraient pas du être contrôlées. Nous avons donc fait le choix de les supprimer.

Suite à cette suppression :
- les SIAE qui se retrouvent avec une seule auto-prescription passent sous le seuil, requis donc on annule leur contrôle
- les SIAE qui ont encore au moins 2 auto-prescriptions sont toujours dans l’obligation de répondre au contrôle pour cette année
