### PR TITLE
API: utilisation de clefs plus longues pour nos tokens

### DIFF
--- a/itou/api/migrations/0001_initial.py
+++ b/itou/api/migrations/0001_initial.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 (
                     "key",
                     models.UUIDField(
-                        default=itou.api.models._generate_random_token_uuid,
+                        default=itou.api.models._generate_key,
                         editable=False,
                         primary_key=True,
                         serialize=False,

--- a/itou/api/migrations/0002_alter_companyapitoken_companies_companytoken.py
+++ b/itou/api/migrations/0002_alter_companyapitoken_companies_companytoken.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                 ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
                 (
                     "key",
-                    models.CharField(default=itou.api.models._generate_random_token_uuid, editable=False, unique=True),
+                    models.CharField(default=itou.api.models._generate_key, editable=False, unique=True),
                 ),
                 (
                     "label",

--- a/itou/api/models.py
+++ b/itou/api/models.py
@@ -1,5 +1,4 @@
 import secrets
-import uuid
 
 from django.db import models
 from django.utils import timezone
@@ -7,12 +6,12 @@ from django.utils import timezone
 from itou.companies.models import Company
 
 
-def _generate_random_token_uuid():
-    return uuid.UUID(bytes=secrets.token_bytes(16))
+def _generate_key():
+    return secrets.token_urlsafe()
 
 
 class CompanyToken(models.Model):
-    key = models.CharField(default=_generate_random_token_uuid, unique=True, editable=False)
+    key = models.CharField(default=_generate_key, unique=True, editable=False)
     label = models.CharField(verbose_name="mémo permettant d'identifier l'usage du jeton", max_length=60, unique=True)
     created_at = models.DateTimeField(default=timezone.now)
     companies = models.ManyToManyField(Company, related_name="api_tokens")


### PR DESCRIPTION
## :thinking: Pourquoi ?

En Python 3.11.9, les tokens ont 32 octets d'entropie par défaut:
https://github.com/python/cpython/blob/v3.11.9/Lib/secrets.py#L32

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
