### PR TITLE
Tableau de bord : suppression de Diagoriente, déplacement de GPS et ajout d'un message informatif

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -329,9 +329,8 @@
                             {% if user.is_employer or user.is_prescriber %}
                                 <h2>Services partenaires</h2>
                                 <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4">
-                                    {% include "dashboard/includes/dora_card.html" with siret=request.current_organization.siret|default:"" tracker="mtm_campaign=LesEmplois&mtm_kwd=Dashboard" %}
-                                    {% include "dashboard/includes/diagoriente_card.html" with user=user only %}
                                     {% include "dashboard/includes/gps_card.html" %}
+                                    {% include "dashboard/includes/dora_card.html" with siret=request.current_organization.siret|default:"" tracker="mtm_campaign=LesEmplois&mtm_kwd=Dashboard" %}
                                 </div>
                             {% endif %}
                         </div>

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -179,6 +179,15 @@
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
         </div>
     {% endif %}
+
+    {% if user.is_prescriber or user.is_employer %}
+        <div class="alert alert-info alert-dismissible-once fade show d-none" role="status" id="GPS_banner">
+            <p class="mb-0">
+                Une nouvelle entrée dans votre tableau de bord vous permet de visualiser l’ensemble des intervenants auprès des personnes pour lesquelles vous avez réalisé une action. Il s’agit de l’encart GPS (Guide de Partage et de Suivi).
+            </p>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block content_title %}

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -81,10 +81,10 @@
                                     <div>
                                         {% with membership.nb_members|add:"-1" as counter %}
                                             <div>
-                                                {# Don't let djlint add a newline before the . or it will add a space after référent and . #}
                                                 {% if not membership.is_from_bulk_creation %}
                                                     <div>
                                                         {# djlint:off #}
+                                                        {# Don't let djlint add a newline before the . or it will add a space after référent and . #}
                                                         Vous avez ajouté ce bénéficiaire le <strong>{{ membership.created_at|date:"d/m/Y" }}</strong>{% if membership.is_referent %} et êtes <strong>référent</strong>{% endif %}.{# djlint:on #}
                                                     </div>
                                                 {% elif membership.is_referent %}

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -199,8 +199,8 @@
                                           
                                               <div>
                                                   
-                                                  
                                                       <div>
+                                                          
                                                           
                                                           Vous avez ajouté ce bénéficiaire le <strong>21/06/2024</strong>.
                                                       </div>

--- a/tests/www/dashboard/tests.py
+++ b/tests/www/dashboard/tests.py
@@ -616,25 +616,25 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
             "https://diagoriente.beta.gouv.fr/services/plateforme?utm_source=emploi-inclusion-candidat",
         )
 
-    def test_diagoriente_card_is_not_shown_for_job_seeker(self):
+    def test_gps_card_is_not_shown_for_job_seeker(self):
         user = JobSeekerFactory()
         self.client.force_login(user)
 
-        with self.assertTemplateNotUsed("dashboard/includes/diagoriente_card.html"):
+        with self.assertTemplateNotUsed("dashboard/includes/gps_card.html"):
             self.client.get(reverse("dashboard:index"))
 
-    def test_diagoriente_card_is_shown_for_employer(self):
+    def test_gps_card_is_shown_for_employer(self):
         company = CompanyFactory(with_membership=True)
         self.client.force_login(company.members.first())
 
-        with self.assertTemplateUsed("dashboard/includes/diagoriente_card.html"):
+        with self.assertTemplateUsed("dashboard/includes/gps_card.html"):
             self.client.get(reverse("dashboard:index"))
 
-    def test_diagoriente_card_is_shown_for_prescriber(self):
+    def test_gps_card_is_shown_for_prescriber(self):
         prescriber_organization = prescribers_factories.PrescriberOrganizationWithMembershipFactory()
         self.client.force_login(prescriber_organization.members.first())
 
-        with self.assertTemplateUsed("dashboard/includes/diagoriente_card.html"):
+        with self.assertTemplateUsed("dashboard/includes/gps_card.html"):
             self.client.get(reverse("dashboard:index"))
 
     def test_dashboard_prescriber_without_organization_message(self):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour rendre GPS plus visible.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ?

- En supprimant la carte Diagoriente et en déplaçant GPS vers le haut. Diagoriente étant intégré au processus de candidature, il n'est plus nécessaire de continuer de l'afficher sur le tableau de bord.
- Et en ajoutant un encart informatif.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Se connecter en tant que prescripteur ou employeur.

## :computer: Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/61c1db81-ee9e-40d7-a07a-8c51291b9649)
