### PR TITLE
Empêcher les déploiements concurrent de recettes jetables

### DIFF
--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [ labeled, synchronize ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
+
 env:
   CLEVER_TOOLS_DOWNLOAD_URL: https://clever-tools.clever-cloud.com/releases/latest/clever-tools-latest_linux.tar.gz
   CLEVER_TAR_FILE: clever-tools-latest_linux.tar.gz


### PR DESCRIPTION
## :thinking: Pourquoi ?

Essayer de limiter les erreurs au déploiement sur Clever.
