### PR TITLE
UX/UI : Partager le template de btn-dropdown-filter pour les checkboxes

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters/departments.html
+++ b/itou/templates/apply/includes/job_applications_filters/departments.html
@@ -2,21 +2,7 @@
 
 {% if filters_form.departments and filters_form.fields.departments.choices %}
     {% if btn_dropdown_filter|default:False %}
-        <div class="dropdown">
-            <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                {{ filters_form.departments.label | capfirst }}
-            </button>
-            <ul class="dropdown-menu">
-                {% for choice in filters_form.departments %}
-                    <li class="dropdown-item">
-                        <div class="form-check">
-                            <input id="{{ choice.id_for_label }}-top" class="form-check-input" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}"{% if choice.data.selected %} checked{% endif %}>
-                            <label for="{{ choice.id_for_label }}-top" class="form-check-label">{{ choice.choice_label }}</label>
-                        </div>
-                    </li>
-                {% endfor %}
-            </ul>
-        </div>
+        {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.departments id_suffix="-top" only %}
     {% else %}
         <hr>
         <fieldset>

--- a/itou/templates/apply/includes/job_applications_filters/selected_jobs.html
+++ b/itou/templates/apply/includes/job_applications_filters/selected_jobs.html
@@ -1,20 +1,6 @@
 {% if filters_form.selected_jobs and filters_form.selected_jobs.field.choices %}
     {% if btn_dropdown_filter|default:False %}
-        <div class="dropdown">
-            <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                {{ filters_form.selected_jobs.label | capfirst }}
-            </button>
-            <ul class="dropdown-menu">
-                {% for choice in filters_form.selected_jobs %}
-                    <li class="dropdown-item">
-                        <div class="form-check">
-                            <input id="{{ choice.id_for_label }}-top" class="form-check-input" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}"{% if choice.data.selected %} checked{% endif %}>
-                            <label for="{{ choice.id_for_label }}-top" class="form-check-label">{{ choice.choice_label }}</label>
-                        </div>
-                    </li>
-                {% endfor %}
-            </ul>
-        </div>
+        {% include "includes/btn_dropdown_filter/checkboxes.html" with field=filters_form.selected_jobs id_suffix="-top" only %}
     {% else %}
         <hr>
         <fieldset>

--- a/itou/templates/apply/includes/job_applications_filters/status.html
+++ b/itou/templates/apply/includes/job_applications_filters/status.html
@@ -1,19 +1,5 @@
 {% if btn_dropdown_filter|default:False %}
-    <div class="dropdown">
-        <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-            Statut
-        </button>
-        <ul class="dropdown-menu">
-            {% for choice in filters_form.states %}
-                <li class="dropdown-item">
-                    <div class="form-check">
-                        <input id="{{ choice.id_for_label }}-top" class="form-check-input" name="{{ choice.data.name }}" type="checkbox" value="{{ choice.data.value }}"{% if choice.data.selected %} checked{% endif %}>
-                        <label for="{{ choice.id_for_label }}-top" class="form-check-label">{{ choice.choice_label }}</label>
-                    </div>
-                </li>
-            {% endfor %}
-        </ul>
-    </div>
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with label="Status" field=filters_form.states id_suffix="-top" only %}
 {% else %}
     <fieldset>
         <legend>

--- a/itou/templates/includes/btn_dropdown_filter/checkboxes.html
+++ b/itou/templates/includes/btn_dropdown_filter/checkboxes.html
@@ -1,0 +1,29 @@
+{% comment %}
+Arguments:
+- field
+- label: (defaults to the field label)
+- id_suffix: When the field is present multiple times on the page, use the
+    suffix to make its input id unique.
+{% endcomment %}
+<div class="dropdown">
+    <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+        {{ label|default:field.label }}
+    </button>
+    <ul class="dropdown-menu">
+        {% for choice in field %}
+            <li class="dropdown-item">
+                <div class="form-check">
+                    <input id="{{ choice.id_for_label }}{{ id_suffix|default:'' }}"
+                           class="form-check-input"
+                           name="{{ choice.data.name }}"
+                           type="checkbox"
+                           value="{{ choice.data.value }}"
+                           {% if choice.data.selected %}checked{% endif %}>
+                    <label for="{{ choice.id_for_label }}{{ id_suffix|default:'' }}" class="form-check-label">
+                        {{ choice.choice_label }}
+                    </label>
+                </div>
+            </li>
+        {% endfor %}
+    </ul>
+</div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

DRY, faciliter le réusinage dans le futur.