### PR TITLE
Candidats : limitation du nom à 70 caractères et correctif et sécurité

### DIFF
--- a/itou/static/js/gps.js
+++ b/itou/static/js/gps.js
@@ -8,10 +8,9 @@ htmx.onLoad((target) => {
     const frTranslations = Translation.loadPath("./i18n/fr");
     searchUserInputField.select2({
         placeholder: 'Jean DUPONT',
-        escapeMarkup: function (markup) { return markup; },
         language: {
             ...frTranslations.dict,
-            noResults: () => `
+            noResults: () => $(`
               <div class="d-inline-flex w-100 mb-2">
                   <span class="text-muted d-block pe-1">Aucun résultat.</span>
                   <a href="${searchUserInputField.data('noResultsUrl')}" class="link" data-matomo-event="true"
@@ -20,7 +19,7 @@ htmx.onLoad((target) => {
                   Enregistrer un nouveau bénéficiaire
                   </a>
               </div>
-          `,
+          `),
         },
     });
     searchUserInputField.on("select2:select", function (e) {

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -748,9 +748,6 @@ class User(AbstractUser, AddressMixin):
     def get_kind_display(self):
         return UserKind(self.kind).label
 
-    def autocomplete_display(self):
-        return self.get_full_name()
-
 
 def get_allauth_account_user_display(user):
     return user.email

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -379,7 +379,7 @@ class User(AbstractUser, AddressMixin):
         Return the first_name plus the last_name, with a space in between.
         """
         full_name = f"{self.first_name.strip().title()} {self.last_name.upper()}"
-        return full_name.strip()
+        return full_name.strip()[:70]
 
     @property
     def is_job_seeker(self):

--- a/itou/www/autocomplete/views.py
+++ b/itou/www/autocomplete/views.py
@@ -171,7 +171,7 @@ def gps_users_autocomplete(request):
     if term:
         users = [
             {
-                "text": user.autocomplete_display(),
+                "text": user.get_full_name(),
                 "id": user.pk,
             }
             for user in User.objects.autocomplete(term, limit=10, current_user=current_user)

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -651,7 +651,6 @@ class ModelTest(TestCase):
         assert len(JobSeekerFactory(first_name=too_long_name, last_name="maréchal").get_full_name()) == 70
 
 
-
 class JobSeekerProfileModelTest(TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -646,6 +646,10 @@ class ModelTest(TestCase):
             JobSeekerFactory(first_name=" marie aurore", last_name="maréchal").get_full_name()
             == "Marie Aurore MARÉCHAL"
         )
+        too_long_name = "a" * 149
+
+        assert len(JobSeekerFactory(first_name=too_long_name, last_name="maréchal").get_full_name()) == 70
+
 
 
 class JobSeekerProfileModelTest(TestCase):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Corrections suite à la campagne de _Bug bounty_.

- Limitation du nom de l'utilisateur à 70 caractères.
- Échappement du nom de l'utilisateur dans les résultats de recherche bénéficiaire.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->


## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

- Se connecter en tant que candidat et modifier son prénom. Par exemple :

```
<form%20action=#%20style="margin:100px">Login:<input%20name=1><br>Password:<input%20name=2><input%20type=submit%20value="go">
```

- Se connecter en tant qu'employeur et ajouter un bénéficiaire. Vérifier que le nom qui s'affiche n'est pas un formulaire et qu'il est plus court que celui entré précédemment. :sunglasses: 

## :computer: Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/2fe1181d-13e6-4f20-86e5-bcc2a73639c4)

