### PR TITLE
UX/UI : Corriger une typo sur le filtre par statut de la liste des candidatures

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters/status.html
+++ b/itou/templates/apply/includes/job_applications_filters/status.html
@@ -1,5 +1,5 @@
 {% if btn_dropdown_filter|default:False %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with label="Status" field=filters_form.states id_suffix="-top" only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with label="Statut" field=filters_form.states id_suffix="-top" only %}
 {% else %}
     <fieldset>
         <legend>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Corriger une erreur introduite avec 19389b8c8659f9d3e4583bdfa50abcd642d0b19c.
