### PR TITLE
PASS IAE: Mise en conformité des règles de  prolongations [GEN-270]

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1309,30 +1309,12 @@ class CommonProlongation(models.Model):
     MAX_DURATION = datetime.timedelta(days=10 * 365)
 
     MAX_CUMULATIVE_DURATION = {
-        enums.ProlongationReason.SENIOR_CDI: {
-            "duration": MAX_DURATION,
-            "label": "10 ans (3650 jours)",
-        },
-        enums.ProlongationReason.COMPLETE_TRAINING: {
-            "duration": datetime.timedelta(days=2 * 365),
-            "label": "2 ans (730 jours)",
-        },
-        enums.ProlongationReason.RQTH: {
-            "duration": datetime.timedelta(days=3 * 365),
-            "label": "3 ans (1095 jours)",
-        },
-        enums.ProlongationReason.SENIOR: {
-            "duration": datetime.timedelta(days=5 * 365),
-            "label": "5 ans (1825 jours)",
-        },
-        enums.ProlongationReason.PARTICULAR_DIFFICULTIES: {
-            "duration": datetime.timedelta(days=3 * 365),
-            "label": "3 ans (1095 jours)",
-        },
-        enums.ProlongationReason.HEALTH_CONTEXT: {
-            "duration": datetime.timedelta(days=365),
-            "label": "12 mois (365 jours)",
-        },
+        enums.ProlongationReason.SENIOR_CDI: MAX_DURATION,
+        enums.ProlongationReason.COMPLETE_TRAINING: datetime.timedelta(days=2 * 365),
+        enums.ProlongationReason.RQTH: datetime.timedelta(days=3 * 365),
+        enums.ProlongationReason.SENIOR: datetime.timedelta(days=5 * 365),
+        enums.ProlongationReason.PARTICULAR_DIFFICULTIES: datetime.timedelta(days=3 * 365),
+        enums.ProlongationReason.HEALTH_CONTEXT: datetime.timedelta(days=365),
     }
 
     REASONS_NOT_NEED_PRESCRIBER_OPINION = (
@@ -1513,7 +1495,7 @@ class CommonProlongation(models.Model):
             max_end = start_at + Prolongation.MAX_DURATION
         else:
             used = Prolongation.objects.get_cumulative_duration_for(approval_id, reason, ignore=ignore)
-            remaining_days = max_cumulative_duration["duration"] - used
+            remaining_days = max_cumulative_duration - used
             max_end = start_at + remaining_days
         return max_end
 

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1320,7 +1320,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.COMPLETE_TRAINING: {
             "max_duration": datetime.timedelta(days=365),
-            "max_cumulative_duration": datetime.timedelta(days=2 * 365),
+            "max_cumulative_duration": MAX_DURATION,
             "help_text": mark_safe(
                 "12 mois (365 jours) maximum pour chaque demande.<br> "
                 "Renouvellements possibles jusqu’à la fin de l’action de formation."
@@ -1537,7 +1537,7 @@ class CommonProlongation(models.Model):
         except KeyError:
             max_end = start_at + Prolongation.MAX_DURATION
         else:
-            used = Prolongation.objects.get_cumulative_duration_for(approval_id, reason, ignore=ignore)
+            used = Prolongation.objects.get_cumulative_duration_for(approval_id, ignore=ignore)
             remaining_days = max_cumulative_duration - used
             max_end = start_at + remaining_days
         return max_end
@@ -1678,12 +1678,9 @@ class ProlongationQuerySet(models.QuerySet):
 
 
 class ProlongationManager(models.Manager):
-    def get_cumulative_duration_for(self, approval_id, reason, ignore=None):
-        """
-        Returns the total duration of all prolongations for the given approval and the given reason.
-        """
+    def get_cumulative_duration_for(self, approval_id, ignore=None):
         duration = datetime.timedelta(0)
-        for prolongation in self.filter(approval_id=approval_id, reason=reason).exclude(pk__in=ignore or []):
+        for prolongation in self.filter(approval_id=approval_id).exclude(pk__in=ignore or []):
             duration += prolongation.duration
         return duration
 

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1312,6 +1312,7 @@ class CommonProlongation(models.Model):
     PROLONGATION_RULES = {
         enums.ProlongationReason.SENIOR_CDI: {
             "max_duration": MAX_DURATION,
+            "max_duration_label": "10 ans",
             "max_cumulative_duration": None,
             "help_text": (
                 "Pour le CDI Inclusion, jusqu’à la retraite "
@@ -1320,6 +1321,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.COMPLETE_TRAINING: {
             "max_duration": datetime.timedelta(days=365),
+            "max_duration_label": "12 mois",
             "max_cumulative_duration": None,
             "help_text": mark_safe(
                 "12 mois (365 jours) maximum pour chaque demande.<br> "
@@ -1328,6 +1330,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.RQTH: {
             "max_duration": datetime.timedelta(days=365),
+            "max_duration_label": "12 mois",
             "max_cumulative_duration": datetime.timedelta(days=3 * 365),
             "help_text": mark_safe(
                 "12 mois (365 jours) maximum pour chaque demande.<br> "
@@ -1337,6 +1340,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.SENIOR: {
             "max_duration": datetime.timedelta(days=365),
+            "max_duration_label": "12 mois",
             "max_cumulative_duration": datetime.timedelta(days=5 * 365),
             "help_text": mark_safe(
                 "12 mois (365 jours) maximum pour chaque demande.<br> "
@@ -1346,6 +1350,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.PARTICULAR_DIFFICULTIES: {
             "max_duration": datetime.timedelta(days=365),
+            "max_duration_label": "12 mois",
             "max_cumulative_duration": datetime.timedelta(days=3 * 365),
             "help_text": mark_safe(
                 "12 mois (365 jours) maximum pour chaque demande.<br> "
@@ -1355,6 +1360,7 @@ class CommonProlongation(models.Model):
         },
         enums.ProlongationReason.HEALTH_CONTEXT: {
             "max_duration": datetime.timedelta(days=365),
+            "max_duration_label": "12 mois",
             "max_cumulative_duration": datetime.timedelta(days=365),
             "help_text": "NE PAS UTILISER",  # This value shouldn't appear anywhere but just in case
         },

--- a/itou/templates/approvals/includes/prolongation_declaration_form.html
+++ b/itou/templates/approvals/includes/prolongation_declaration_form.html
@@ -9,6 +9,34 @@
     {% bootstrap_field form.reason %}
     {% bootstrap_field form.end_at %}
 
+    {% if form.max_end_limit %}
+        <div class="c-info mb-3">
+            <button type="button" class="c-info__summary collapsed" data-bs-toggle="collapse" data-bs-target="#maxEndAtCollapseInfo" aria-expanded="false" aria-controls="maxEndAtCollapseInfo">
+                <span>IMPORTANT: La date de fin maximale autorisée pour ce motif est le {{ form.max_end_limit.max_date }} afin de respecter la durée légale autorisée</span>
+            </button>
+            <div class="c-info__detail collapse" id="maxEndAtCollapseInfo">
+                <p>
+                    Il n’est pas possible de sélectionner {{ form.max_end_limit.max_duration }} pour cette demande car ce PASS IAE aura atteint la limite des renouvellements possibles.
+                    Retrouvez le détail des conditions dans <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14738994643217--Prolonger-un-PASS-IAE" rel="noopener" target="_blank">notre documentation</a>.
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
+    {% if form.reason.field.widget.disabled_values %}
+        <div class="c-info mb-3">
+            <button type="button" class="c-info__summary collapsed" data-bs-toggle="collapse" data-bs-target="#disabledChoicesCollapseInfo" aria-expanded="false" aria-controls="disabledChoicesCollapseInfo">
+                <span>Pourquoi n’est-il pas possible de sélectionner certains éléments ?</span>
+            </button>
+            <div class="c-info__detail collapse" id="disabledChoicesCollapseInfo">
+                <p>
+                    Les prolongations de PASS IAE doivent respecter certaines conditions réglementaires pour être délivrées.
+                    Retrouvez le détail des conditions dans <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14738994643217--Prolonger-un-PASS-IAE" rel="noopener" target="_blank">notre documentation</a>.
+                </p>
+            </div>
+        </div>
+    {% endif %}
+
     {% include "approvals/includes/declaration_upload_panel.html" %}
 
     {% itou_buttons_form primary_label="Valider la déclaration" secondary_url=back_url primary_name="preview" primary_value="1" %}

--- a/itou/templates/django_bootstrap5/widgets/radio_select.html
+++ b/itou/templates/django_bootstrap5/widgets/radio_select.html
@@ -1,0 +1,22 @@
+{# https://github.com/zostera/django-bootstrap5/pull/632 #}
+{# djlint:off #}
+{% load django_bootstrap5 %}
+{% bootstrap_server_side_validation_class widget as server_side_validation_class %}
+<div{% include "django/forms/widgets/attrs.html" %}>
+    {% for group, options, index in widget.optgroups %}
+        {% if group %}
+            <div>{{ group }}</div>{% endif %}
+        {% for option in options %}
+            <div class="form-check">
+                <input class="{% bootstrap_classes 'form-check-input' server_side_validation_class %}"
+                       type="{{ option.type }}"
+                       name="{{ option.name }}"
+                       id="{{ option.attrs.id }}"
+                        {% if option.value != None %} value="{{ option.value|stringformat:'s' }}"
+                            {% if option.attrs.checked %} checked="checked"{% endif %}{% endif %}
+                        {% if widget.attrs.disabled or option.attrs.disabled %} disabled{% endif %}>
+                <label class="form-check-label" for="{{ option.attrs.id }}">{{ option.label }}</label>
+            </div>
+        {% endfor %}
+    {% endfor %}
+</div>

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -181,3 +181,15 @@ class JobSeekerAddressAutocompleteWidget(AddressAutocompleteWidget):
 
     class Media:
         js = ["js/address_autocomplete_fields.js"]
+
+
+class RadioSelectWithDisabledChoices(forms.RadioSelect):
+    def __init__(self, attrs=None, choices=(), *, disabled_values=()):
+        super().__init__(attrs=attrs, choices=choices)
+        self.disabled_values = set(disabled_values)
+
+    def create_option(self, name, value, *args, **kwargs):
+        option = super().create_option(name, value, *args, **kwargs)
+        if value in self.disabled_values:
+            option["attrs"]["disabled"] = True
+        return option

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -1,5 +1,3 @@
-from datetime import timedelta
-
 from dateutil.relativedelta import relativedelta
 from django import forms
 from django.core.exceptions import ValidationError
@@ -141,47 +139,6 @@ class CreateProlongationForm(forms.ModelForm):
     )
     end_at = forms.DateField(widget=DuetDatePickerWidget())
 
-    PROLONGATION_RULES = {
-        ProlongationReason.SENIOR_CDI: {
-            "max_duration": Prolongation.MAX_DURATION,
-            "help_text": (
-                "Pour le CDI Inclusion, jusqu’à la retraite "
-                "(pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut)."
-            ),
-        },
-        ProlongationReason.COMPLETE_TRAINING: {
-            "max_duration": timedelta(days=365),
-            "help_text": mark_safe(
-                "12 mois (365 jours) maximum pour chaque demande.<br> "
-                "Renouvellements possibles jusqu’à la fin de l’action de formation."
-            ),
-        },
-        ProlongationReason.RQTH: {
-            "max_duration": timedelta(days=365),
-            "help_text": mark_safe(
-                "12 mois (365 jours) maximum pour chaque demande.<br> "
-                "Renouvellements possibles dans la limite de 5 ans de parcours IAE "
-                "(2 ans de parcours initial + 3 ans (1095 jours))."
-            ),
-        },
-        ProlongationReason.SENIOR: {
-            "max_duration": timedelta(days=365),
-            "help_text": mark_safe(
-                "12 mois (365 jours) maximum pour chaque demande.<br> "
-                "Renouvellements possibles dans la limite de 7 ans de parcours IAE "
-                "(2 ans de parcours initial + 5 ans (1825 jours))."
-            ),
-        },
-        ProlongationReason.PARTICULAR_DIFFICULTIES: {
-            "max_duration": timedelta(days=365),
-            "help_text": mark_safe(
-                "12 mois (365 jours) maximum pour chaque demande.<br> "
-                "Renouvellements possibles dans la limite de 5 ans de parcours IAE "
-                "(2 ans de parcours initial + 3 ans (1095 jours))."
-            ),
-        },
-    }
-
     class Meta:
         model = Prolongation
         fields = [
@@ -220,7 +177,7 @@ class CreateProlongationForm(forms.ModelForm):
         end_at.label = f"Du {self.instance.start_at:%d/%m/%Y} au"
         reason_not_validated = self.data.get("reason")
         try:
-            rule_details = self.PROLONGATION_RULES[reason_not_validated]
+            rule_details = Prolongation.PROLONGATION_RULES[reason_not_validated]
         except KeyError:
             end_at.disabled = True
         else:

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1573,7 +1573,9 @@ class ProlongationModelTest(TestCase):
                 prolongation = ProlongationFactory(
                     reason=reason,
                     end_at=factory.LazyAttribute(
-                        lambda obj: obj.start_at + info["max_cumulative_duration"] + datetime.timedelta(days=1)
+                        lambda obj: obj.start_at
+                        + (info["max_cumulative_duration"] or info["max_duration"])
+                        + datetime.timedelta(days=1)
                     ),
                     declared_by_siae__kind=CompanyKind.AI,
                 )
@@ -1642,7 +1644,7 @@ class ProlongationModelTest(TestCase):
         approval = ApprovalFactory()
         for reason, expected_max_end_at in [
             (ProlongationReason.SENIOR_CDI, datetime.date(2031, 1, 30)),  # 3650 days (~10 years).
-            (ProlongationReason.COMPLETE_TRAINING, datetime.date(2031, 1, 30)),  # 3650 days (~10 years).
+            (ProlongationReason.COMPLETE_TRAINING, datetime.date(2022, 2, 1)),  # 365 days.
             (ProlongationReason.RQTH, datetime.date(2024, 2, 1)),  # 1095 days (3 years).
             (ProlongationReason.SENIOR, datetime.date(2026, 1, 31)),  # 1825 days (~5 years).
             (ProlongationReason.PARTICULAR_DIFFICULTIES, datetime.date(2024, 2, 1)),  # 1095 days (3 years).

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1570,11 +1570,13 @@ class ProlongationModelTest(TestCase):
         prolongation.clean()
 
     def test_clean_too_long_reason_duration_error(self):
-        for reason, duration in Prolongation.MAX_CUMULATIVE_DURATION.items():
+        for reason, info in Prolongation.PROLONGATION_RULES.items():
             with self.subTest(reason=reason):
                 prolongation = ProlongationFactory(
                     reason=reason,
-                    end_at=factory.LazyAttribute(lambda obj: obj.start_at + duration + datetime.timedelta(days=1)),
+                    end_at=factory.LazyAttribute(
+                        lambda obj: obj.start_at + info["max_cumulative_duration"] + datetime.timedelta(days=1)
+                    ),
                     declared_by_siae__kind=CompanyKind.AI,
                 )
                 with pytest.raises(ValidationError) as error:
@@ -1582,7 +1584,7 @@ class ProlongationModelTest(TestCase):
                 assert error.match("La durée totale est trop longue pour le motif")
 
     def test_clean_end_at_do_not_block_edition(self):
-        max_cumulative_duration = Prolongation.MAX_CUMULATIVE_DURATION[ProlongationReason.SENIOR]
+        max_cumulative_duration = Prolongation.PROLONGATION_RULES[ProlongationReason.SENIOR]["max_cumulative_duration"]
         first_prolongation = ProlongationFactory(
             reason=ProlongationReason.SENIOR,
         )

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1411,10 +1411,8 @@ class ProlongationManagerTest(TestCase):
             reason=ProlongationReason.RQTH.value,
         )
 
-        expected_duration = datetime.timedelta(days=prolongation2_days + prolongation3_days)
-        assert expected_duration == Prolongation.objects.get_cumulative_duration_for(
-            approval, ProlongationReason.RQTH.value
-        )
+        expected_duration = datetime.timedelta(days=prolongation1_days + prolongation2_days + prolongation3_days)
+        assert expected_duration == Prolongation.objects.get_cumulative_duration_for(approval)
 
 
 class ProlongationModelTestTrigger(TestCase):
@@ -1644,7 +1642,7 @@ class ProlongationModelTest(TestCase):
         approval = ApprovalFactory()
         for reason, expected_max_end_at in [
             (ProlongationReason.SENIOR_CDI, datetime.date(2031, 1, 30)),  # 3650 days (~10 years).
-            (ProlongationReason.COMPLETE_TRAINING, datetime.date(2023, 2, 1)),  # 730 days (2 years).
+            (ProlongationReason.COMPLETE_TRAINING, datetime.date(2031, 1, 30)),  # 3650 days (~10 years).
             (ProlongationReason.RQTH, datetime.date(2024, 2, 1)),  # 1095 days (3 years).
             (ProlongationReason.SENIOR, datetime.date(2026, 1, 31)),  # 1825 days (~5 years).
             (ProlongationReason.PARTICULAR_DIFFICULTIES, datetime.date(2024, 2, 1)),  # 1095 days (3 years).

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1570,13 +1570,11 @@ class ProlongationModelTest(TestCase):
         prolongation.clean()
 
     def test_clean_too_long_reason_duration_error(self):
-        for reason, info in Prolongation.MAX_CUMULATIVE_DURATION.items():
+        for reason, duration in Prolongation.MAX_CUMULATIVE_DURATION.items():
             with self.subTest(reason=reason):
                 prolongation = ProlongationFactory(
                     reason=reason,
-                    end_at=factory.LazyAttribute(
-                        lambda obj: obj.start_at + info["duration"] + datetime.timedelta(days=1)
-                    ),
+                    end_at=factory.LazyAttribute(lambda obj: obj.start_at + duration + datetime.timedelta(days=1)),
                     declared_by_siae__kind=CompanyKind.AI,
                 )
                 with pytest.raises(ValidationError) as error:
@@ -1584,7 +1582,7 @@ class ProlongationModelTest(TestCase):
                 assert error.match("La durée totale est trop longue pour le motif")
 
     def test_clean_end_at_do_not_block_edition(self):
-        max_cumulative_duration = Prolongation.MAX_CUMULATIVE_DURATION[ProlongationReason.SENIOR]["duration"]
+        max_cumulative_duration = Prolongation.MAX_CUMULATIVE_DURATION[ProlongationReason.SENIOR]
         first_prolongation = ProlongationFactory(
             reason=ProlongationReason.SENIOR,
         )

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -35,6 +35,21 @@
   </div>
   '''
 # ---
+# name: ApprovalProlongationTest.test_end_at_with_existing_prolongation[max_limit_info]
+  '''
+  <div class="c-info mb-3">
+              <button aria-controls="maxEndAtCollapseInfo" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#maxEndAtCollapseInfo" data-bs-toggle="collapse" type="button">
+                  <span>IMPORTANT: La date de fin maximale autorisée pour ce motif est le 22 octobre 2026 afin de respecter la durée légale autorisée</span>
+              </button>
+              <div class="c-info__detail collapse" id="maxEndAtCollapseInfo">
+                  <p>
+                      Il n’est pas possible de sélectionner 12 mois (365 jours) pour cette demande car ce PASS IAE aura atteint la limite des renouvellements possibles.
+                      Retrouvez le détail des conditions dans <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738994643217--Prolonger-un-PASS-IAE" rel="noopener" target="_blank">notre documentation</a>.
+                  </p>
+              </div>
+          </div>
+  '''
+# ---
 # name: ApprovalProlongationTest.test_prolong_approval_view_no_end_at
   '''
   <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_end_at">Du 23/10/2023 au</label><duet-date-picker aria-describedby="id_end_at_helptext" aria-invalid="true" class="is-invalid" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required=""></duet-date-picker>
@@ -48,5 +63,98 @@
   '''
   <div class="form-group form-group-required"><label class="form-label" for="id_end_at">Du 23/10/2023 au</label><duet-date-picker aria-describedby="id_end_at_helptext" class="" identifier="id_end_at" max="2033-10-20" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required="" value="2033-10-20"></duet-date-picker><div class="form-text">Pour le CDI Inclusion, jusqu’à la retraite (pour des raisons techniques, une durée de 10 ans (3650 jours) est appliquée par défaut).</div>
   </div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_prolongation_approval_view_with_disabled_values[RQTH & SENIOR disabled]
+  '''
+  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" id="id_reason_0" name="reason" type="radio" value="SENIOR_CDI"/>
+                  <label class="form-check-label" for="id_reason_0">CDI conclu avec une personne de plus de 57 ans</label>
+              </div>
+          
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" id="id_reason_1" name="reason" type="radio" value="COMPLETE_TRAINING"/>
+                  <label class="form-check-label" for="id_reason_1">Fin d'une formation</label>
+              </div>
+          
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" disabled="" id="id_reason_2" name="reason" type="radio" value="RQTH"/>
+                  <label class="form-check-label" for="id_reason_2">RQTH - Reconnaissance de la qualité de travailleur handicapé</label>
+              </div>
+          
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" disabled="" id="id_reason_3" name="reason" type="radio" value="SENIOR"/>
+                  <label class="form-check-label" for="id_reason_3">50 ans et plus</label>
+              </div>
+          
+      
+  </div></div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_prolongation_approval_view_with_disabled_values[RQTH disabled]
+  '''
+  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" id="id_reason_0" name="reason" type="radio" value="SENIOR_CDI"/>
+                  <label class="form-check-label" for="id_reason_0">CDI conclu avec une personne de plus de 57 ans</label>
+              </div>
+          
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" id="id_reason_1" name="reason" type="radio" value="COMPLETE_TRAINING"/>
+                  <label class="form-check-label" for="id_reason_1">Fin d'une formation</label>
+              </div>
+          
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" disabled="" id="id_reason_2" name="reason" type="radio" value="RQTH"/>
+                  <label class="form-check-label" for="id_reason_2">RQTH - Reconnaissance de la qualité de travailleur handicapé</label>
+              </div>
+          
+      
+          
+          
+              <div class="form-check">
+                  <input class="form-check-input" id="id_reason_3" name="reason" type="radio" value="SENIOR"/>
+                  <label class="form-check-label" for="id_reason_3">50 ans et plus</label>
+              </div>
+          
+      
+  </div></div>
+  '''
+# ---
+# name: ApprovalProlongationTest.test_prolongation_approval_view_with_disabled_values[missing_reason_info]
+  '''
+  <div class="c-info mb-3">
+              <button aria-controls="disabledChoicesCollapseInfo" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#disabledChoicesCollapseInfo" data-bs-toggle="collapse" type="button">
+                  <span>Pourquoi n’est-il pas possible de sélectionner certains éléments ?</span>
+              </button>
+              <div class="c-info__detail collapse" id="disabledChoicesCollapseInfo">
+                  <p>
+                      Les prolongations de PASS IAE doivent respecter certaines conditions réglementaires pour être délivrées.
+                      Retrouvez le détail des conditions dans <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14738994643217--Prolonger-un-PASS-IAE" rel="noopener" target="_blank">notre documentation</a>.
+                  </p>
+              </div>
+          </div>
   '''
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Empêcher de saisir certains motifs de prolongations s'il y a déjà un certain nombre de prolongations.
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->


## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Créer des PASS avec suffisamment de prolongations dans le passé et essayer de les prolonger.
J'essaierai de générer des PASS intéressant demain.

## :computer: Captures d'écran <!-- optionnel -->
