### PR TITLE
UX/UI : Limiter la sélection rapide à un candidat dans la liste des candidatures [GEN-1687]

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters/job_seekers.html
+++ b/itou/templates/apply/includes/job_applications_filters/job_seekers.html
@@ -1,15 +1,13 @@
 {% load django_bootstrap5 %}
 
-{% if filters_form.job_seekers %}
+{% if filters_form.job_seeker %}
     <hr>
     <fieldset>
         <legend>
-            <button class="btn has-collapse-caret collapsed" data-bs-toggle="collapse" data-bs-target="#collapseJobSeekers" type="button" aria-expanded="false" aria-controls="collapseJobSeekers">
-                {{ filters_form.job_seekers.label | capfirst }}
+            <button class="btn has-collapse-caret collapsed" data-bs-toggle="collapse" data-bs-target="#collapseJobSeekers" type="button" aria-expanded="false" aria-controls="collapseJobSeeker">
+                {{ filters_form.job_seeker.label | capfirst }}
             </button>
         </legend>
-        <div class="mt-3 collapse" id="collapseJobSeekers">
-            {% bootstrap_field filters_form.job_seekers show_label=False %}
-        </div>
+        <div class="mt-3 collapse" id="collapseJobSeeker">{% bootstrap_field filters_form.job_seeker show_label=False %}</div>
     </fieldset>
 {% endif %}

--- a/itou/templates/apply/includes/job_applications_filters/offcanvas.html
+++ b/itou/templates/apply/includes/job_applications_filters/offcanvas.html
@@ -1,8 +1,8 @@
 <form hx-get="{{ request.path }}"
-      hx-trigger="change delay:.5s, duetChange delay:.5s{% if not request.user.is_job_seeker %}, change from:#id_job_seekers{% endif %}"
+      hx-trigger="change delay:.5s, duetChange delay:.5s{% if not request.user.is_job_seeker %}, change from:#id_job_seeker{% endif %}"
       hx-indicator="#job-applications-section"
       hx-target="#job-applications-section"
-      {% if not request.user.is_job_seeker %}hx-include="#id_job_seekers"{% endif %}
+      {% if not request.user.is_job_seeker %}hx-include="#id_job_seeker"{% endif %}
       hx-swap="outerHTML"
       hx-push-url="true">
     >

--- a/itou/templates/apply/includes/job_applications_filters/offcanvas_body.html
+++ b/itou/templates/apply/includes/job_applications_filters/offcanvas_body.html
@@ -22,9 +22,9 @@
           field present twice on the page (in the top bar and side bar) is
           challenging.
         {% endcomment %}
-        {% for job_seeker_id in filters_form.job_seekers.value %}
-            <input type="hidden" name="{{ filters_form.job_seekers.name }}" value="{{ job_seeker_id }}">
-        {% endfor %}
+        {% if filters_form.job_seeker.value %}
+            <input type="hidden" name="{{ filters_form.job_seeker.name }}" value="{{ filters_form.job_seeker.value }}">
+        {% endif %}
     {% endif %}
     {% include "apply/includes/job_applications_filters/dates.html" %}
 </div>

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -66,7 +66,7 @@
                     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
                         {% include "apply/includes/list_counter.html" %}
                         <div class="flex-column flex-md-row mt-3 mt-md-0">
-                            {% bootstrap_field filters_form.job_seekers wrapper_class="w-lg-400px" show_label=False %}
+                            {% bootstrap_field filters_form.job_seeker wrapper_class="w-lg-400px" show_label=False %}
                         </div>
                     </div>
                     {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request pending_states_job_applications_count=pending_states_job_applications_count list_exports_url=list_exports_url SenderKind=SenderKind job_applications_list_kind=job_applications_list_kind JobApplicationsListKind=JobApplicationsListKind JobApplicationOrigin=JobApplicationOrigin only %}

--- a/itou/templates/apply/list_prescriptions.html
+++ b/itou/templates/apply/list_prescriptions.html
@@ -60,7 +60,7 @@
                     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
                         {% include "apply/includes/list_counter.html" %}
                         <div class="flex-column flex-md-row mt-3 mt-md-0">
-                            {% bootstrap_field filters_form.job_seekers wrapper_class="w-lg-400px" show_label=False %}
+                            {% bootstrap_field filters_form.job_seeker wrapper_class="w-lg-400px" show_label=False %}
                         </div>
                     </div>
                     {% include "apply/includes/list_job_applications.html" with job_applications_page=job_applications_page filters_counter=filters_counter request=request list_exports_url=list_exports_url SenderKind=SenderKind job_applications_list_kind=job_applications_list_kind JobApplicationsListKind=JobApplicationsListKind JobApplicationOrigin=JobApplicationOrigin only %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -10,7 +10,7 @@ from django.db.models.fields import BLANK_CHOICE_DASH
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
-from django_select2.forms import Select2MultipleWidget
+from django_select2.forms import Select2MultipleWidget, Select2Widget
 
 from itou.approvals.models import Approval
 from itou.asp import models as asp_models
@@ -939,10 +939,10 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
     """
 
     senders = forms.MultipleChoiceField(required=False, label="Nom de la personne", widget=Select2MultipleWidget)
-    job_seekers = forms.MultipleChoiceField(
+    job_seeker = forms.ChoiceField(
         required=False,
         label="Nom du candidat",
-        widget=Select2MultipleWidget(
+        widget=Select2Widget(
             attrs={"data-placeholder": "Nom du candidat"},
         ),
     )
@@ -969,7 +969,7 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
         senders = self.job_applications_qs.get_unique_fk_objects("sender")
         self.fields["senders"].choices += self._get_choices_for(senders)
         job_seekers = self.job_applications_qs.get_unique_fk_objects("job_seeker")
-        self.fields["job_seekers"].choices = self._get_choices_for(job_seekers)
+        self.fields["job_seeker"].choices = self._get_choices_for(job_seekers)
         self.fields["criteria"].choices = self._get_choices_for_administrativecriteria()
         self.fields["departments"].choices = self._get_choices_for_departments(job_seekers)
         self.fields["selected_jobs"].choices = self._get_choices_for_jobs()
@@ -1005,8 +1005,8 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
         if senders := self.cleaned_data.get("senders"):
             queryset = queryset.filter(sender__id__in=senders)
 
-        if job_seekers := self.cleaned_data.get("job_seekers"):
-            queryset = queryset.filter(job_seeker__id__in=job_seekers)
+        if job_seeker := self.cleaned_data.get("job_seeker"):
+            queryset = queryset.filter(job_seeker__id=job_seeker)
         return queryset
 
 

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -275,7 +275,7 @@ class ProcessListSiaeTest(TestCase):
 
         self.client.force_login(self.eddie_hit_pit)
         # Only show maggie's applications
-        params = {"job_seekers": [self.maggie.id]}
+        params = {"job_seeker": self.maggie.id}
         response = self.client.get(reverse("apply:list_for_siae"), params)
 
         # 4 criteria: all are shown
@@ -328,7 +328,7 @@ class ProcessListSiaeTest(TestCase):
                 self.hit_pit.kind = kind
                 self.hit_pit.save(update_fields=("kind",))
                 # Only show maggie's applications
-                response = self.client.get(reverse("apply:list_for_siae"), {"job_seekers": [self.maggie.id]})
+                response = self.client.get(reverse("apply:list_for_siae"), {"job_seeker": self.maggie.id})
                 if expect_to_see_criteria[kind]:
                     assertContains(response, TITLE, html=True)
                     assertContains(response, CRITERION, html=True)
@@ -457,13 +457,12 @@ class ProcessListSiaeTest(TestCase):
         Eddie wants to see Maggie's job applications.
         """
         self.client.force_login(self.eddie_hit_pit)
-        job_seekers_ids = [self.maggie.id]
-        response = self.client.get(reverse("apply:list_for_siae"), {"job_seekers": job_seekers_ids})
+        response = self.client.get(reverse("apply:list_for_siae"), {"job_seeker": self.maggie.pk})
 
         applications = response.context["job_applications_page"].object_list
 
         assert len(applications) == 2
-        assert applications[0].job_seeker.id in job_seekers_ids
+        assert applications[0].job_seeker_id == self.maggie.pk
 
     def test_list_for_siae_filtered_by_many_organization_names(self):
         """

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -131,7 +131,7 @@ def test_list_prescriptions_filtered_by_job_seeker(client):
     JobApplicationFactory.create_batch(2, sender=prescriber)
     client.force_login(prescriber)
 
-    response = client.get(reverse("apply:list_prescriptions"), {"job_seekers": [job_seeker.pk]})
+    response = client.get(reverse("apply:list_prescriptions"), {"job_seeker": job_seeker.pk})
     applications = response.context["job_applications_page"].object_list
     assert len(applications) == 1
     assert applications[0].job_seeker.pk == job_seeker.pk


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le thème casse partiellement le `MultipleChoiceField`, utilisons plutôt le composant de sélection d’un seul élément.
Dans tous les cas, les utilisateurs utilisent le widget pour accéder rapidement à un candidat, et non pour limiter les éléments présents dans la liste à un ensemble de candidats.

## :desert_island: Comment tester

1. Utiliser le filtre candidat sur la page de gestion des candidatures employeur et prescripteur.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/43681e09-7509-4365-b3d0-a62aa31400a1)

