### PR TITLE
Prescripteur : Ignorer les diagnostics d’éligibilité des auto-prescriptions [GEN-1657]

### DIFF
--- a/itou/templates/apply/includes/list_card_body_company.html
+++ b/itou/templates/apply/includes/list_card_body_company.html
@@ -1,3 +1,4 @@
+{% load call_method %}
 {% load str_filters %}
 
 <div class="c-box--results__header">
@@ -22,7 +23,8 @@
                                 PASS IAE {{ approval.get_state_display|lower }}
                             </span>
                         {% else %}
-                            {% if job_application.iae_eligibility_diagnosis_required %}
+                            {% call_method job_application "eligibility_diagnosis_by_siae_required" request.user as eligibility_diagnosis_required %}
+                            {% if eligibility_diagnosis_required %}
                                 <span class="badge badge-xs rounded-pill bg-accent-02-lighter text-primary">
                                     <i class="ri-error-warning-line" aria-hidden="true"></i>
                                     Éligibilité IAE à valider

--- a/itou/templates/apply/includes/siae_hiring_actions.html
+++ b/itou/templates/apply/includes/siae_hiring_actions.html
@@ -1,3 +1,4 @@
+{% load call_method %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load matomo %}
@@ -20,7 +21,8 @@
 
         {# Possible next steps when the state is processing / prior_to_hire ------------------------------------- #}
         {% if job_application.state.is_processing or job_application.state.is_prior_to_hire %}
-            {% if eligibility_diagnosis_by_siae_required %}
+            {% call_method job_application "eligibility_diagnosis_by_siae_required" request.user as eligibility_diagnosis_required %}
+            {% if eligibility_diagnosis_required %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/new_diagnosis.html" %}</div>
             {% else %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/accept.html" %}</div>
@@ -31,7 +33,8 @@
 
         {# Possible next steps when the state is postponed ------------------------------------------------------ #}
         {% if job_application.state.is_postponed %}
-            {% if eligibility_diagnosis_by_siae_required %}
+            {% call_method job_application "eligibility_diagnosis_by_siae_required" request.user as eligibility_diagnosis_required %}
+            {% if eligibility_diagnosis_required %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/new_diagnosis.html" %}</div>
             {% else %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/accept.html" %}</div>
@@ -41,7 +44,8 @@
 
         {# Possible next steps when the state is obsolete, refused or cancelled --------------------------------- #}
         {% if job_application.state.is_obsolete or job_application.state.is_refused or job_application.state.is_cancelled %}
-            {% if eligibility_diagnosis_by_siae_required %}
+            {% call_method job_application "eligibility_diagnosis_by_siae_required" request.user as eligibility_diagnosis_required %}
+            {% if eligibility_diagnosis_required %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/new_diagnosis.html" %}</div>
             {% else %}
                 <div class="form-group col col-lg-auto">{% include "apply/includes/buttons/accept.html" %}</div>

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -35,7 +35,11 @@ Arguments:
         {% else %}
             Numéro d'agrément :
         {% endif %}
-        {% if user.is_employer and common_approval.is_in_waiting_period and common_approval.user.has_valid_diagnosis %}
+        {% if user.is_employer and common_approval.is_in_waiting_period %}
+            {# Lazily call this expensive method. #}
+            {% call_method common_approval.user "has_valid_diagnosis" request.user as has_valid_diagnosis %}
+        {% endif %}
+        {% if user.is_employer and common_approval.is_in_waiting_period and has_valid_diagnosis %}
             {% comment %}
             If the PASS IAE number is displayed at this time, some employers think that there is
             no need to validate the application because a number is already assigned.
@@ -74,7 +78,8 @@ Arguments:
             {% endif %}
         </ul>
     {% elif common_approval.is_in_waiting_period %}
-        {% if user.is_employer and common_approval.user.has_valid_diagnosis %}
+        {% call_method common_approval.user "has_valid_diagnosis" request.user as has_valid_diagnosis %}
+        {% if user.is_employer and has_valid_diagnosis %}
             {% comment %}
             When an authorized prescriber bypasses the waiting period and sends a candidate
             with an "expired" approval, the employer receives the application with the mention

--- a/itou/templates/dashboard/includes/job_seeker_approval_card.html
+++ b/itou/templates/dashboard/includes/job_seeker_approval_card.html
@@ -1,3 +1,5 @@
+{% load call_method %}
+
 <div class="col-md-8 mb-3 mb-md-5">
     <div class="c-box p-0 h-100">
         <div class="d-flex p-3 p-lg-4">
@@ -14,7 +16,8 @@
                 <li class="mb-2">{% include "approvals/includes/status.html" with common_approval=user.latest_common_approval %}</li>
                 {% if user.has_common_approval_in_waiting_period %}
                     <li class="mb-2">
-                        {% if user.has_valid_diagnosis %}
+                        {% call_method user "has_valid_diagnosis" request.user as has_valid_diagnosis %}
+                        {% if has_valid_diagnosis %}
                             <p class="mb-0">
                                 Un prescripteur habilité a réalisé un diagnostic d'éligibilité. <b>Vous pouvez commencer un nouveau parcours.</b>
                             </p>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -533,7 +533,7 @@ class User(AbstractUser, AddressMixin):
     def has_no_common_approval(self):
         return not self.latest_approval and not self.latest_pe_approval
 
-    def new_approval_blocked_by_waiting_period(self, siae, sender_prescriber_organization):
+    def new_approval_blocked_by_waiting_period(self, viewing_user, siae, sender_prescriber_organization):
         """
         Don’t create approvals for users whose approval recently ended,
         unless an authorized prescriber asks for it, or the structure isn’t an SIAE.
@@ -543,7 +543,7 @@ class User(AbstractUser, AddressMixin):
         )
 
         # Only diagnoses made by authorized prescribers are taken into account.
-        has_valid_diagnosis = self.has_valid_diagnosis()
+        has_valid_diagnosis = self.has_valid_diagnosis(viewing_user)
         return (
             self.has_common_approval_in_waiting_period
             and siae.is_subject_to_eligibility_rules
@@ -597,8 +597,8 @@ class User(AbstractUser, AddressMixin):
     def has_jobseeker_profile(self):
         return self.is_job_seeker and hasattr(self, "jobseeker_profile")
 
-    def has_valid_diagnosis(self, for_siae=None):
-        return self.eligibility_diagnoses.has_considered_valid(job_seeker=self, for_siae=for_siae)
+    def has_valid_diagnosis(self, viewing_user, for_siae=None):
+        return self.eligibility_diagnoses.has_considered_valid(viewing_user, self, for_siae=for_siae)
 
     def joined_recently(self):
         time_since_date_joined = timezone.now() - self.date_joined

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -963,7 +963,8 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
     )
 
     @sentry_sdk.trace
-    def __init__(self, job_applications_qs, *args, **kwargs):
+    def __init__(self, user, job_applications_qs, *args, **kwargs):
+        self.user = user
         self.job_applications_qs = job_applications_qs
         super().__init__(*args, **kwargs)
         senders = self.job_applications_qs.get_unique_fk_objects("sender")
@@ -1000,7 +1001,7 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
     def filter(self, queryset):
         queryset = super().filter(queryset)
         if self.cleaned_data.get("eligibility_validated"):
-            queryset = queryset.eligibility_validated()
+            queryset = queryset.eligibility_validated(self.user)
 
         if senders := self.cleaned_data.get("senders"):
             queryset = queryset.filter(sender__id__in=senders)
@@ -1027,8 +1028,8 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
         widget=Select2MultipleWidget,
     )
 
-    def __init__(self, job_applications_qs, company, *args, **kwargs):
-        super().__init__(job_applications_qs, *args, **kwargs)
+    def __init__(self, user, job_applications_qs, company, *args, **kwargs):
+        super().__init__(user, job_applications_qs, *args, **kwargs)
         self.fields["sender_prescriber_organizations"].choices += self.get_sender_prescriber_organization_choices()
         self.fields["sender_companies"].choices += self.get_sender_companies_choices()
 
@@ -1073,8 +1074,8 @@ class PrescriberFilterJobApplicationsForm(CompanyPrescriberFilterJobApplications
 
     to_companies = forms.MultipleChoiceField(required=False, label="Structure", widget=Select2MultipleWidget)
 
-    def __init__(self, job_applications_qs, *args, **kwargs):
-        super().__init__(job_applications_qs, *args, **kwargs)
+    def __init__(self, user, job_applications_qs, *args, **kwargs):
+        super().__init__(user, job_applications_qs, *args, **kwargs)
         self.fields["to_companies"].choices += self.get_to_companies_choices()
 
     def filter(self, queryset):

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -123,7 +123,9 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
         context["job_application"] = job_application
         context["hiring_pending"] = job_application and job_application.is_pending
         context["matomo_custom_title"] = "Profil salarié"
-        context["eligibility_diagnosis"] = job_application and job_application.get_eligibility_diagnosis()
+        context["eligibility_diagnosis"] = job_application and job_application.get_eligibility_diagnosis(
+            self.request.user
+        )
         context["approval_deletion_form_url"] = None
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
 

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -166,6 +166,8 @@ class EligibilityDiagnosisManagerTest(TestCase):
     def test_itou_diagnosis_both_siae_and_prescriber(self):
         company = CompanyFactory(with_membership=True)
         prescriber_diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=self.job_seeker)
+        # More recent than the prescriber diagnosis.
+        IAEEligibilityDiagnosisFactory(from_employer=True, author_siae=company, job_seeker=self.job_seeker)
         # From `siae` perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
             job_seeker=self.job_seeker, for_siae=company

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -13,7 +13,7 @@ from tests.eligibility.factories import (
 )
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from tests.users.factories import JobSeekerFactory
+from tests.users.factories import EmployerFactory, JobSeekerFactory
 from tests.utils.test import TestCase
 
 
@@ -41,20 +41,25 @@ class EligibilityDiagnosisManagerTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.job_seeker = JobSeekerFactory(with_pole_emploi_id=True)
+        cls.employer = EmployerFactory()
 
     def test_no_diagnosis(self):
-        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self.job_seeker)
-        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=self.job_seeker)
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker)
+        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
+            self.employer, job_seeker=self.job_seeker
+        )
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(self.employer, self.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=self.job_seeker)
         assert last_considered_valid is None
         assert last_expired is None
         assert not has_considered_valid
 
     def test_itou_diagnosis(self):
         diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=self.job_seeker)
-        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=diagnosis.job_seeker)
-        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=diagnosis.job_seeker)
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=diagnosis.job_seeker)
+        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
+            self.employer, job_seeker=diagnosis.job_seeker
+        )
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(self.employer, diagnosis.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=diagnosis.job_seeker)
         assert last_considered_valid == diagnosis
         assert last_expired is None
         assert has_considered_valid
@@ -63,9 +68,13 @@ class EligibilityDiagnosisManagerTest(TestCase):
         PoleEmploiApprovalFactory(
             pole_emploi_id=self.job_seeker.jobseeker_profile.pole_emploi_id, birthdate=self.job_seeker.birthdate
         )
-        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self.job_seeker)
-        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=self.job_seeker)
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker)
+        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
+            self.employer, job_seeker=self.job_seeker
+        )
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
+            self.employer, job_seeker=self.job_seeker
+        )
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=self.job_seeker)
         assert has_considered_valid
         assert last_considered_valid is None
         assert last_expired is None
@@ -79,9 +88,13 @@ class EligibilityDiagnosisManagerTest(TestCase):
             start_at=start_at,
             end_at=end_at,
         )
-        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(job_seeker=self.job_seeker)
-        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=self.job_seeker)
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker)
+        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
+            self.employer, job_seeker=self.job_seeker
+        )
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
+            self.employer, job_seeker=self.job_seeker
+        )
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=self.job_seeker)
         assert not has_considered_valid
         assert last_considered_valid is None
         assert last_expired is None
@@ -91,12 +104,14 @@ class EligibilityDiagnosisManagerTest(TestCase):
             from_prescriber=True, job_seeker=self.job_seeker, expired=True
         )
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
-            job_seeker=expired_diagnosis.job_seeker
+            self.employer, job_seeker=expired_diagnosis.job_seeker
         )
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=expired_diagnosis.job_seeker
+            self.employer, job_seeker=expired_diagnosis.job_seeker
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=expired_diagnosis.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            self.employer, job_seeker=expired_diagnosis.job_seeker
+        )
         assert not has_considered_valid
         assert last_considered_valid is None
         assert last_expired is not None
@@ -107,57 +122,66 @@ class EligibilityDiagnosisManagerTest(TestCase):
         )
         ApprovalFactory(user=expired_diagnosis.job_seeker, eligibility_diagnosis=expired_diagnosis)
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
-            job_seeker=expired_diagnosis.job_seeker
+            self.employer, job_seeker=expired_diagnosis.job_seeker
         )
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=expired_diagnosis.job_seeker
+            self.employer, job_seeker=expired_diagnosis.job_seeker
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=expired_diagnosis.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            self.employer, job_seeker=expired_diagnosis.job_seeker
+        )
         assert has_considered_valid
         assert last_considered_valid == expired_diagnosis
         assert last_expired is None
 
     def test_itou_diagnosis_by_siae(self):
         company_1 = CompanyFactory(with_membership=True)
+        employer_1 = company_1.members.get()
         company_2 = CompanyFactory(with_membership=True)
+        employer_2 = company_2.members.get()
         diagnosis = IAEEligibilityDiagnosisFactory(
             from_employer=True, author_siae=company_1, job_seeker=self.job_seeker
         )
         # From `company_1` perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
-            job_seeker=diagnosis.job_seeker, for_siae=company_1
+            employer_1, job_seeker=diagnosis.job_seeker, for_siae=company_1
         )
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=diagnosis.job_seeker, for_siae=company_1
+            employer_1, job_seeker=diagnosis.job_seeker, for_siae=company_1
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=diagnosis.job_seeker, for_siae=company_1)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            employer_1, job_seeker=diagnosis.job_seeker, for_siae=company_1
+        )
         assert has_considered_valid
         assert last_considered_valid == diagnosis
         assert last_expired is None
         # From `company_2` perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
-            job_seeker=diagnosis.job_seeker, for_siae=company_2
+            employer_2, job_seeker=diagnosis.job_seeker, for_siae=company_2
         )
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=diagnosis.job_seeker, for_siae=company_2
+            employer_2, job_seeker=diagnosis.job_seeker, for_siae=company_2
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=diagnosis.job_seeker, for_siae=company_2)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            employer_2, job_seeker=diagnosis.job_seeker, for_siae=company_2
+        )
         assert not has_considered_valid
         assert last_considered_valid is None
         assert last_expired is None
 
     def test_itou_diagnosis_by_prescriber(self):
         company = CompanyFactory(with_membership=True)
+        employer = company.members.get()
         prescriber_diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=self.job_seeker)
         # From siae perspective.
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
-            job_seeker=prescriber_diagnosis.job_seeker, for_siae=company
+            employer, job_seeker=prescriber_diagnosis.job_seeker, for_siae=company
         )
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=prescriber_diagnosis.job_seeker, for_siae=company
+            employer, job_seeker=prescriber_diagnosis.job_seeker, for_siae=company
         )
         last_expired = EligibilityDiagnosis.objects.last_expired(
-            job_seeker=prescriber_diagnosis.job_seeker, for_siae=company
+            employer, job_seeker=prescriber_diagnosis.job_seeker, for_siae=company
         )
         assert has_considered_valid
         assert last_considered_valid == prescriber_diagnosis
@@ -169,13 +193,32 @@ class EligibilityDiagnosisManagerTest(TestCase):
         # More recent than the prescriber diagnosis.
         IAEEligibilityDiagnosisFactory(from_employer=True, author_siae=company, job_seeker=self.job_seeker)
         # From `siae` perspective.
+        employer = company.members.get()
         has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
-            job_seeker=self.job_seeker, for_siae=company
+            employer, job_seeker=self.job_seeker, for_siae=company
         )
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=self.job_seeker, for_siae=company
+            employer, job_seeker=self.job_seeker, for_siae=company
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker, for_siae=company)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            employer, job_seeker=self.job_seeker, for_siae=company
+        )
+        assert has_considered_valid
+        # A diagnosis made by a prescriber takes precedence.
+        assert last_considered_valid == prescriber_diagnosis
+        assert last_expired is None
+
+        # From `prescriber` perspective.
+        prescriber = prescriber_diagnosis.author
+        has_considered_valid = EligibilityDiagnosis.objects.has_considered_valid(
+            prescriber, job_seeker=self.job_seeker, for_siae=company
+        )
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
+            prescriber, job_seeker=self.job_seeker, for_siae=company
+        )
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            prescriber, job_seeker=self.job_seeker, for_siae=company
+        )
         assert has_considered_valid
         # A diagnosis made by a prescriber takes precedence.
         assert last_considered_valid == prescriber_diagnosis
@@ -183,7 +226,9 @@ class EligibilityDiagnosisManagerTest(TestCase):
 
     def test_expired_itou_diagnosis_by_another_siae(self):
         company_1 = CompanyFactory(with_membership=True)
+        employer_1 = company_1.members.get()
         company_2 = CompanyFactory(with_membership=True)
+        employer_2 = company_2.members.get()
         expired_diagnosis = IAEEligibilityDiagnosisFactory(
             job_seeker=self.job_seeker,
             from_employer=True,
@@ -191,18 +236,23 @@ class EligibilityDiagnosisManagerTest(TestCase):
             expired=True,
         )
         # From `siae` perspective.
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker, for_siae=company_1)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            employer_1, job_seeker=self.job_seeker, for_siae=company_1
+        )
         assert last_expired == expired_diagnosis
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker, for_siae=company_2)
+        last_expired = EligibilityDiagnosis.objects.last_expired(
+            employer_2, job_seeker=self.job_seeker, for_siae=company_2
+        )
         assert last_expired is None
 
     def test_itou_diagnosis_one_valid_other_expired(self):
         IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=self.job_seeker, expired=True)
-        IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=self.job_seeker)
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker)
-        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=self.job_seeker)
-        # When has a valid diagnosis, `last_expired` return None
-        assert last_considered_valid is not None
+        diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=self.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=self.job_seeker)
+        last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
+            self.employer, job_seeker=self.job_seeker
+        )
+        assert last_considered_valid == diagnosis
         assert last_expired is None
 
     def test_itou_diagnosis_one_valid_other_expired_same_siae(self):
@@ -221,7 +271,7 @@ class EligibilityDiagnosisManagerTest(TestCase):
         # An approval causes the system to ignore expires_at.
         ApprovalFactory(user=self.job_seeker, eligibility_diagnosis=new_diag)
         last_considered_valid = EligibilityDiagnosis.objects.last_considered_valid(
-            job_seeker=self.job_seeker, for_siae=company
+            company.members.get(), job_seeker=self.job_seeker, for_siae=company
         )
         assert last_considered_valid == new_diag
 
@@ -233,12 +283,12 @@ class EligibilityDiagnosisManagerTest(TestCase):
         expired_diagnosis_old = IAEEligibilityDiagnosisFactory(
             from_prescriber=True, job_seeker=self.job_seeker, created_at=date_12m
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=self.job_seeker)
         assert last_expired == expired_diagnosis_old
         expired_diagnosis_last = IAEEligibilityDiagnosisFactory(
             from_prescriber=True, job_seeker=self.job_seeker, created_at=date_6m
         )
-        last_expired = EligibilityDiagnosis.objects.last_expired(job_seeker=self.job_seeker)
+        last_expired = EligibilityDiagnosis.objects.last_expired(self.employer, job_seeker=self.job_seeker)
         assert last_expired == expired_diagnosis_last
 
 

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -224,6 +224,25 @@ class EligibilityDiagnosisManagerTest(TestCase):
         assert last_considered_valid == prescriber_diagnosis
         assert last_expired is None
 
+    def test_prescribers_do_not_see_company_diag(self):
+        eligibility_diagnosis = IAEEligibilityDiagnosisFactory(from_employer=True, job_seeker=self.job_seeker)
+        company = eligibility_diagnosis.author_siae
+        prescriber_org = PrescriberOrganizationWithMembershipFactory()
+        prescriber = prescriber_org.members.get()
+        assert (
+            EligibilityDiagnosis.objects.has_considered_valid(prescriber, job_seeker=self.job_seeker, for_siae=company)
+            is False
+        )
+        assert (
+            EligibilityDiagnosis.objects.last_considered_valid(
+                prescriber, job_seeker=self.job_seeker, for_siae=company
+            )
+            is None
+        )
+        assert (
+            EligibilityDiagnosis.objects.last_expired(prescriber, job_seeker=self.job_seeker, for_siae=company) is None
+        )
+
     def test_expired_itou_diagnosis_by_another_siae(self):
         company_1 = CompanyFactory(with_membership=True)
         employer_1 = company_1.members.get()

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1013,38 +1013,46 @@ class LatestApprovalTestCase(TestCase):
 
         # Waiting period cannot be bypassed for SIAE if no prescriber
         # and there is no valid eligibility diagnosis this in period
+        etti = CompanyFactory(kind=CompanyKind.ETTI, with_membership=True)
+        etti_employer = etti.members.get()
         assert user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.ETTI), sender_prescriber_organization=None
+            etti_employer, siae=etti, sender_prescriber_organization=None
         )
 
         # Waiting period cannot be bypassed for SIAE if unauthorized prescriber
         # and there is no valid eligibility diagnosis this in period
         assert user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.ETTI),
+            etti_employer,
+            siae=etti,
             sender_prescriber_organization=PrescriberOrganizationFactory(),
         )
 
         # Waiting period is bypassed for SIAE if authorized prescriber.
         assert not user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.ETTI),
+            etti_employer,
+            siae=etti,
             sender_prescriber_organization=PrescriberOrganizationFactory(authorized=True),
         )
 
         # Waiting period is bypassed for GEIQ even if no prescriber.
+        geiq = CompanyFactory(kind=CompanyKind.GEIQ, with_membership=True)
+        geiq_employer = geiq.members.get()
         assert not user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.GEIQ), sender_prescriber_organization=None
+            geiq_employer, siae=geiq, sender_prescriber_organization=None
         )
 
         # Waiting period is bypassed for GEIQ even if unauthorized prescriber.
         assert not user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.GEIQ),
+            geiq_employer,
+            siae=geiq,
             sender_prescriber_organization=PrescriberOrganizationFactory(),
         )
 
         # Waiting period is bypassed if a valid diagnosis made by an authorized prescriber exists.
         diag = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=user)
         assert not user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.ETTI),
+            etti_employer,
+            siae=etti,
             sender_prescriber_organization=None,
         )
         diag.delete()
@@ -1053,7 +1061,8 @@ class LatestApprovalTestCase(TestCase):
         # but was not made by an authorized prescriber.
         diag = IAEEligibilityDiagnosisFactory(job_seeker=user, from_employer=True)
         assert user.new_approval_blocked_by_waiting_period(
-            siae=CompanyFactory(kind=CompanyKind.ETTI),
+            etti_employer,
+            siae=etti,
             sender_prescriber_organization=None,
         )
 

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -214,6 +214,7 @@
                   
                       
   
+  
   <div class="c-box--results__header">
       
   
@@ -243,6 +244,7 @@
                   
                       
                           
+                              
                               
                                   <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                                       <i aria-hidden="true" class="ri-check-line"></i>
@@ -290,6 +292,7 @@
                   
                       
   
+  
   <div class="c-box--results__header">
       
   
@@ -319,6 +322,7 @@
                   
                       
                           
+                              
                               
                                   <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                                       <i aria-hidden="true" class="ri-check-line"></i>
@@ -371,6 +375,7 @@
                   
                       
   
+  
   <div class="c-box--results__header">
       
   
@@ -400,6 +405,7 @@
                   
                       
                           
+                              
                               
                                   <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                                       <i aria-hidden="true" class="ri-check-line"></i>
@@ -465,6 +471,7 @@
                   
                       
   
+  
   <div class="c-box--results__header">
       
   
@@ -493,6 +500,7 @@
                   
                       
                           
+                              
                               
                                   <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                                       <i aria-hidden="true" class="ri-check-line"></i>
@@ -538,6 +546,7 @@
                   
                       
   
+  
   <div class="c-box--results__header">
       
   
@@ -566,6 +575,7 @@
                   
                       
                           
+                              
                               
                                   <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                                       <i aria-hidden="true" class="ri-check-line"></i>
@@ -616,6 +626,7 @@
                   
                       
   
+  
   <div class="c-box--results__header">
       
   
@@ -644,6 +655,7 @@
                   
                       
                           
+                              
                               
                                   <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                                       <i aria-hidden="true" class="ri-check-line"></i>

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1802,7 +1802,7 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         self.client.force_login(employer)
 
         has_considered_valid_diagnoses = EligibilityDiagnosis.objects.has_considered_valid(
-            job_application.job_seeker, for_siae=job_application.to_company
+            employer, job_application.job_seeker, for_siae=job_application.to_company
         )
         assert not has_considered_valid_diagnoses
 
@@ -1835,12 +1835,12 @@ class ProcessViewsTest(MessagesTestMixin, TestCase):
         self.assertRedirects(response, next_url)
 
         has_considered_valid_diagnoses = EligibilityDiagnosis.objects.has_considered_valid(
-            job_application.job_seeker, for_siae=job_application.to_company
+            employer, job_application.job_seeker, for_siae=job_application.to_company
         )
         assert has_considered_valid_diagnoses
 
         # Check diagnosis.
-        eligibility_diagnosis = job_application.get_eligibility_diagnosis()
+        eligibility_diagnosis = job_application.get_eligibility_diagnosis(employer)
         assert eligibility_diagnosis.author == employer
         assert eligibility_diagnosis.author_kind == AuthorKind.EMPLOYER
         assert eligibility_diagnosis.author_siae == job_application.to_company

--- a/tests/www/approvals_views/__snapshots__/test_includes.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_includes.ambr
@@ -22,6 +22,10 @@
           
           
               
+              
+          
+          
+              
               <b>pour obtenir son numéro, vous devez valider l'embauche et demander l'obtention d'un PASS IAE.</b>
           
       </p>
@@ -29,6 +33,7 @@
       
   
       
+          
           
               
   
@@ -65,6 +70,7 @@
               Numéro de PASS IAE :
           
           
+          
               <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
           
       </p>
@@ -72,6 +78,7 @@
       
   
       
+          
           
               <p class="text-danger">
                   <b>Expiré</b> le 01/01/2022 (depuis 1 semaine, 2 jours)
@@ -106,6 +113,7 @@
               Numéro de PASS IAE :
           
           
+          
               <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
           
       </p>
@@ -113,6 +121,7 @@
       
   
       
+          
           
               <p class="text-danger">
                   <b>Expiré</b> le 01/01/2022 (depuis 1 semaine, 2 jours)
@@ -147,6 +156,10 @@
               Numéro de PASS IAE :
           
           
+              
+              
+          
+          
               <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
           
       </p>
@@ -154,6 +167,7 @@
       
   
       
+          
           
               <p class="text-danger">
                   <b>Expiré</b> le 01/01/2022 (depuis 1 semaine, 2 jours)
@@ -186,6 +200,7 @@
       <p class="mb-1">
           
               Numéro de PASS IAE :
+          
           
           
               <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
@@ -250,6 +265,7 @@
       <p class="mb-1">
           
               Numéro de PASS IAE :
+          
           
           
               <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les prescripteurs voient les diagnostics d’éligibilité établis par les SIAE pour leurs auto-prescriptions. Ceci conduit les prescripteurs à considérer que le candidat bénéficie déjà d’un diagnostic d’éligibilité et à ne pas le refaire. Au final, les candidats sont mis en difficulté, car un diagnostic établi par un prescripteur habilité est valide pour toutes les SIAE, alors que celui établi par une SIAE n’est valide que pour cet employeur.

## :desert_island: Comment tester

1. Se connecter en tant que SIAE (EI)
2. Déclarer une candidature
3. Créer un compte candidat (e.g. NIR 111111111111120)
4. Étudier la candidature
5. Accepter la candidature
6. Établir un diagnostic d’éligibilité
7. Arrêter le parcours à l’étape de détail du contrat
8. Se connecter en tant que prescripteur habilité
9. Faire une candidature pour le candidat (NIR 111111111111120) auprès de l’employeur

Le prescripteur est obligé de remplir le diagnostic d’éligibilité pour le candidat
