### PR TITLE
UX/UI : Limiter la sélection rapide à un candidat dans la liste des fiches salarié [GEN-1687]

### DIFF
--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -59,12 +59,12 @@
             <div class="row">
                 <div class="col-12">
                     <form hx-get="{% url 'employee_record_views:list' %}"
-                          hx-trigger="change delay:.5s, change from:#id_job_seekers"
+                          hx-trigger="change delay:.5s, change from:#id_job_seeker"
                           hx-indicator="#employee-records-container"
                           hx-target="#employee-records-container"
                           hx-swap="outerHTML"
                           hx-push-url="true"
-                          hx-include="#id_job_seekers">
+                          hx-include="#id_job_seeker">
                         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                             <div class="dropdown">
                                 <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
@@ -86,7 +86,7 @@
                         {% include "employee_record/includes/list_counter.html" %}
                         {% include "employee_record/includes/list_order.html" %}
                         <div class="flex-column flex-md-row mt-3 mt-md-0 ms-md-3">
-                            {% bootstrap_field filters_form.job_seekers layout="inline" %}
+                            {% bootstrap_field filters_form.job_seeker layout="inline" %}
                         </div>
                     </div>
                     {% include "employee_record/includes/list_results.html" %}

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -4,7 +4,7 @@ from django.core.validators import MinLengthValidator, RegexValidator
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.text import format_lazy
-from django_select2.forms import Select2MultipleWidget, Select2Widget
+from django_select2.forms import Select2Widget
 
 from itou.asp.models import Commune, Country, RSAAllocation
 from itou.companies.models import SiaeFinancialAnnex
@@ -80,10 +80,11 @@ class SelectEmployeeRecordStatusForm(forms.Form):
 
 
 class EmployeeRecordFilterForm(forms.Form):
-    job_seekers = forms.MultipleChoiceField(
+    job_seeker = forms.TypedChoiceField(
+        coerce=int,
         required=False,
         label="Nom du salarié",
-        widget=Select2MultipleWidget(
+        widget=Select2Widget(
             attrs={
                 "data-placeholder": "Nom du salarié",
             }
@@ -93,7 +94,7 @@ class EmployeeRecordFilterForm(forms.Form):
     def __init__(self, job_seekers, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["job_seekers"].choices = sorted(
+        self.fields["job_seeker"].choices = sorted(
             [(user.id, user.get_full_name().title()) for user in job_seekers if user.get_full_name()],
             key=lambda u: u[1],
         )

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -211,9 +211,9 @@ def list_employee_records(request, template_name="employee_record/list.html"):
     if status == Status.NEW:
         # Browse to get only the linked employee record in "new" state
         data = eligible_job_applications
-        if job_seekers := filters_form.cleaned_data.get("job_seekers"):
+        if job_seeker_id := filters_form.cleaned_data.get("job_seeker"):
             # The queryset was already evaluated for badges, so it's faster to iterate because of the non-trivial query
-            data = [ja for ja in data if str(ja.job_seeker_id) in job_seekers]
+            data = [ja for ja in data if ja.job_seeker_id == job_seeker_id]
 
         for item in data:
             item.date_were_not_transmitted = item.has_suspension or item.has_prolongation
@@ -238,8 +238,8 @@ def list_employee_records(request, template_name="employee_record/list.html"):
             .filter(status=status)
             .order_by(*employee_record_order_by)
         )
-        if job_seekers := filters_form.cleaned_data.get("job_seekers"):
-            data = data.filter(job_application__job_seeker__in=job_seekers)
+        if job_seeker_id := filters_form.cleaned_data.get("job_seeker"):
+            data = data.filter(job_application__job_seeker=job_seeker_id)
 
     context = {
         "form": form,

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -114,11 +114,11 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         self.assertContains(response, approval_number_formatted)
         self.assertContains(response, other_approval_number_formatted)
 
-        response = self.client.get(self.URL + f"?job_seekers={self.job_seeker.pk}")
+        response = self.client.get(self.URL + f"?job_seeker={self.job_seeker.pk}")
         self.assertContains(response, approval_number_formatted)
         self.assertNotContains(response, other_approval_number_formatted)
 
-        response = self.client.get(self.URL + "?job_seekers=0")
+        response = self.client.get(self.URL + "?job_seeker=0")
         self.assertContains(response, "Sélectionnez un choix valide. 0 n’en fait pas partie.")
         self.assertContains(response, approval_number_formatted)
         self.assertContains(response, other_approval_number_formatted)
@@ -545,7 +545,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         # form to no longer pick up change events from the select2.
         # Given that options aren’t added frequently to that dropdown, wait
         # until the next full page load to get new job seekers.
-        [new_jobseeker_opt] = fresh_page.select(f'#id_job_seekers > option[value="{new_job_app.job_seeker_id}"]')
+        [new_jobseeker_opt] = fresh_page.select(f'#id_job_seeker > option[value="{new_job_app.job_seeker_id}"]')
         new_jobseeker_opt.decompose()
         assertSoupEqual(simulated_page, fresh_page)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le thème casse partiellement le MultipleChoiceField, utilisons plutôt le composant de sélection d’un seul élément.
Dans tous les cas, les utilisateurs utilisent le widget pour accéder rapidement à un candidat, et non pour limiter les éléments présents dans la liste à un ensemble de candidats.

## :desert_island: Comment tester

1. Se connecter en tant qu’employeur EI
2. Dans la liste des fiches salarié, utiliser le champ « Candidat » : http://localhost:8000/employee_record/list?status=SENT

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/303b0c5c-8cc0-48b5-8db2-501ec77c47dc)

