### PR TITLE
UX/UI : Limiter la sélection rapide à un candidat dans la liste des PASS IAE et salariés [GEN-1687]

### DIFF
--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -16,12 +16,12 @@
             <div class="s-section__row row">
                 <div class="col-12">
                     <form hx-get="{% url 'approvals:list' %}"
-                          hx-trigger="change delay:.5s, change from:#id_users"
+                          hx-trigger="change delay:.5s, change from:#id_job_seeker"
                           hx-indicator="#approvals-list"
                           hx-target="#approvals-list"
                           hx-swap="outerHTML"
                           hx-push-url="true"
-                          hx-include="#id_users">
+                          hx-include="#id_job_seeker">
                         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
                             {% include "approvals/includes/approvals_filters/status.html" %}
                             {% include "includes/btn_dropdown_filter/radio.html" with field=filters_form.expiry only %}
@@ -34,7 +34,7 @@
                 <div class="col-12">
                     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
                         {% include "approvals/includes/list_counter.html" %}
-                        <div class="flex-column flex-md-row mt-3 mt-md-0">{% bootstrap_field filters_form.users layout="inline" %}</div>
+                        <div class="flex-column flex-md-row mt-3 mt-md-0">{% bootstrap_field filters_form.job_seeker layout="inline" %}</div>
                     </div>
                     {% include "approvals/includes/list_results.html" %}
                 </div>

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -7,7 +7,7 @@ from django.db.models import Exists, OuterRef, Q, TextChoices
 from django.shortcuts import reverse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from django_select2.forms import Select2MultipleWidget
+from django_select2.forms import Select2Widget
 
 from itou.approvals.constants import PROLONGATION_REPORT_FILE_REASONS
 from itou.approvals.enums import (
@@ -42,10 +42,10 @@ class ApprovalExpiry(TextChoices):
 
 
 class ApprovalForm(forms.Form):
-    users = forms.MultipleChoiceField(
+    job_seeker = forms.ChoiceField(
         required=False,
         label="Nom",
-        widget=Select2MultipleWidget(
+        widget=Select2Widget(
             attrs={
                 "data-placeholder": "Nom du salarié",
             }
@@ -67,7 +67,7 @@ class ApprovalForm(forms.Form):
     def __init__(self, siae_pk, data, *args, **kwargs):
         self.siae_pk = siae_pk
         super().__init__(data, *args, **kwargs)
-        self.fields["users"].choices = self._get_choices_for_job_seekers()
+        self.fields["job_seeker"].choices = self._get_choices_for_job_seekers()
 
     def get_approvals_qs_filter(self):
         return Exists(
@@ -94,8 +94,8 @@ class ApprovalForm(forms.Form):
         qs_filters_list = []
         data = self.cleaned_data
 
-        if users := data.get("users"):
-            qs_filters_list.append(Q(user_id__in=users))
+        if job_seeker_id := data.get("job_seeker"):
+            qs_filters_list.append(Q(user_id=job_seeker_id))
 
         status_filters_list = []
         now = timezone.localdate()

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -74,7 +74,7 @@ class TestApprovalsListView:
 
         assertContains(response, "1 résultat")
 
-    def test_users_filters(self, client):
+    def test_job_seeker_filters(self, client):
         approval = ApprovalFactory(
             with_jobapplication=True,
             user__first_name="Jean",
@@ -111,23 +111,16 @@ class TestApprovalsListView:
         assertNotContains(response, reverse("approvals:detail", kwargs={"pk": approval_other_company.pk}))
 
         form = response.context["filters_form"]
-        assert form.fields["users"].choices == [
+        assert form.fields["job_seeker"].choices == [
             (approval.user_id, "Jean VIER"),
             (approval_same_company.user_id, "Seb TAMBRE"),
         ]
 
-        url = f"{reverse('approvals:list')}?users={approval.user_id}&expiry="
+        url = f"{reverse('approvals:list')}?job_seeker={approval.user_id}&expiry="
         response = client.get(url)
         assertContains(response, "1 résultat")
         assertContains(response, reverse("approvals:detail", kwargs={"pk": approval.pk}))
         assertNotContains(response, reverse("approvals:detail", kwargs={"pk": approval_same_company.pk}))
-        assertNotContains(response, reverse("approvals:detail", kwargs={"pk": approval_other_company.pk}))
-
-        url = f"{reverse('approvals:list')}?users={approval.user_id}&users={approval_same_company.user_id}&expiry="
-        response = client.get(url)
-        assertContains(response, "2 résultats")
-        assertContains(response, reverse("approvals:detail", kwargs={"pk": approval.pk}))
-        assertContains(response, reverse("approvals:detail", kwargs={"pk": approval_same_company.pk}))
         assertNotContains(response, reverse("approvals:detail", kwargs={"pk": approval_other_company.pk}))
 
     def test_approval_state_filters(self, client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le thème casse partiellement le MultipleChoiceField, utilisons plutôt le composant de sélection d’un seul élément.
Dans tous les cas, les utilisateurs utilisent le widget pour accéder rapidement à un candidat, et non pour limiter les éléments présents dans la liste à un ensemble de candidats.

## :desert_island: Comment tester

1. Se connecter en tant que l’EI
2. http://localhost:8000/approvals/list
3. Utiliser le filtre de salarié

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/6d22aab7-9e61-4bea-b952-f38459e856ad)

