### PR TITLE
UX/UI : Afficher le nom du candidat en majuscule dans le filtre des PASS IAE et salariés

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -82,7 +82,7 @@ class ApprovalForm(forms.Form):
         approvals_qs = Approval.objects.filter(self.get_approvals_qs_filter())
         users_qs = User.objects.filter(kind=UserKind.JOB_SEEKER, approvals__in=approvals_qs)
         return [
-            (user.pk, user.get_full_name().title())
+            (user.pk, user.get_full_name())
             for user in users_qs.order_by("first_name", "last_name")
             if user.get_full_name()
         ]

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -55,7 +55,7 @@ class TestApprovalsListView:
         response = client.get(url)
 
         assertContains(response, "2 résultats")
-        assertContains(response, approval.user.get_full_name(), count=2)
+        assertContains(response, f"<h3>{approval.user.get_full_name()}</h3>", html=True, count=1)
         assertContains(response, reverse("approvals:detail", kwargs={"pk": approval.pk}))
         assertContains(response, reverse("approvals:detail", kwargs={"pk": another_approval.pk}))
 
@@ -112,8 +112,8 @@ class TestApprovalsListView:
 
         form = response.context["filters_form"]
         assert form.fields["users"].choices == [
-            (approval.user_id, "Jean Vier"),
-            (approval_same_company.user_id, "Seb Tambre"),
+            (approval.user_id, "Jean VIER"),
+            (approval_same_company.user_id, "Seb TAMBRE"),
         ]
 
         url = f"{reverse('approvals:list')}?users={approval.user_id}&expiry="


### PR DESCRIPTION
## :thinking: Pourquoi ?

050d7d2d63b582e4fb445a0a948336ae93a97235


## :desert_island: Comment tester

1. Se connecter en tant que l’EI
2. http://localhost:8000/approvals/list

Utiliser le filtre nom salarié.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/gip-inclusion/les-emplois/assets/2758243/c64dd38c-e636-44cb-a294-ba36e8414ba2)

