### PR TITLE
Admin : Limiter les champs des `inline` d’appartenance à une entreprise ou organisation aux champs en lecture seule

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -92,6 +92,7 @@ class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
         "updated_at",
         "updated_by",
     )
+    fields = readonly_fields
     can_delete = True
     show_change_link = True
     fk_name = "user"
@@ -120,6 +121,7 @@ class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
         "updated_at",
         "updated_by",
     )
+    fields = readonly_fields
     can_delete = True
     fk_name = "user"
 
@@ -150,6 +152,7 @@ class InstitutionMembershipInline(ItouTabularInline):
         "updated_at",
         "updated_by",
     )
+    fields = readonly_fields
     can_delete = True
     fk_name = "user"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Autrement, des champs éditables apparaissent lorsqu’on a ajouté un affichage particulier pour le champ (notifications, ID de la structure, etc).

## :desert_island: Comment tester

Voir les inline de membership sur la page de détail d’un prescripteur, d’un employeur et membre d’une institution partenaire dans l’admin.
