### PR TITLE
UX/UI : bandeau « chercher un bénéficiaire » sur GPS

### DIFF
--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -21,7 +21,7 @@
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
                             <div class="row">
                                 <div class="col-auto pe-0">
-                                    <i class="ri-user-search-line ri-xl text-important" aria-hidden="true"></i>
+                                    <i class="ri-user-search-line ri-xl text-info" aria-hidden="true"></i>
                                 </div>
                                 <div class="col">
                                     <p class="mb-2">
@@ -39,7 +39,7 @@
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
                             <div class="row">
                                 <div class="col-auto pe-0">
-                                    <i class="ri-mail-send-line ri-xl text-important" aria-hidden="true"></i>
+                                    <i class="ri-mail-send-line ri-xl text-info" aria-hidden="true"></i>
                                 </div>
                                 <div class="col">
                                     <p class="mb-2">

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -21,6 +21,26 @@
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
                             <div class="row">
                                 <div class="col-auto pe-0">
+                                    <i class="ri-user-search-line ri-xl text-important" aria-hidden="true"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-2">
+                                        <strong>Rechercher un bénéficiaire</strong>
+                                    </p>
+                                    <p class="mb-2">
+                                        En attendant que les fonctionalités de filtre et de tri soient déployées, vous pouvez retrouver rapidement votre bénéficiaire en utilisant la recherche de votre navigateur (ctrl&#8209;F sur PC ou ⌘&#8209;F sur macOS).
+                                    </p>
+                                    <p class="mb-0">
+                                        Nous vous remercions de votre patience.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="alert alert-info alert-dismissible fade show" role="status">
+                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+                            <div class="row">
+                                <div class="col-auto pe-0">
                                     <i class="ri-mail-send-line ri-xl text-important" aria-hidden="true"></i>
                                 </div>
                                 <div class="col">

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -17,7 +17,7 @@
             <div class="s-box__row row">
                 <div class="col-12">
                     <section aria-labelledby="results" id="follow-up-groups-section">
-                        <div class="alert alert-info alert-dismissible fade show" role="status">
+                        <div id="gps_search-tip" class="alert alert-info alert-dismissible-once d-none" role="status">
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
                             <div class="row">
                                 <div class="col-auto pe-0">

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -30,9 +30,7 @@
                                     <p class="mb-2">
                                         En attendant que les fonctionalités de filtre et de tri soient déployées, vous pouvez retrouver rapidement votre bénéficiaire en utilisant la recherche de votre navigateur (ctrl&#8209;F sur PC ou ⌘&#8209;F sur macOS).
                                     </p>
-                                    <p class="mb-0">
-                                        Nous vous remercions de votre patience.
-                                    </p>
+                                    <p class="mb-0">Nous vous remercions de votre patience.</p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les utilisateurs GPS demandent une fonction de recherche / filtrage de la liste des bénficiaires. C'est un certain boulot, donc en attendant, devant nos urgences en déploiement / com, on ajoute un bandeau avec des infos basiques.

## :cake: Comment ?

Juste un bandeau en plus du bandeau déjà existant (😓).

## :rotating_light: À vérifier

- [ ] Il faudra le supprimer lors de la publication de la version avec filtres.

## :desert_island: Comment tester

N/A.

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/gip-inclusion/les-emplois/assets/614448/4444e69a-0e96-4af7-9539-fb5ceb0a8e76)
