### PR TITLE
Flaky TestViewProof.test_access_other_institution

### DIFF
--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -497,9 +497,9 @@ class TestViewProof:
         assert httpx.get(response.url).content == pdf_file.read()
 
     def test_access_other_institution(self, client):
-        job_app = EvaluatedJobApplicationFactory()
+        job_app = EvaluatedJobApplicationFactory(evaluated_siae__evaluation_campaign__institution__department="01")
         crit = EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=job_app)
-        membership = InstitutionMembershipFactory()
+        membership = InstitutionMembershipFactory(institution__department="02")
         EvaluationCampaignFactory(institution=membership.institution)
         url = reverse("siae_evaluations_views:view_proof", kwargs={"evaluated_administrative_criteria_id": crit.pk})
         client.force_login(membership.user)


### PR DESCRIPTION
```python
_____________________________________________________________________________________ TestViewProof.test_access_other_institution _____________________________________________________________________________________
[gw2] linux -- Python 3.11.9 /home/freitafr/dev/itou3/.venv/bin/python3.11

self = <django.db.backends.utils.CursorWrapper object at 0x673eb347b750>
sql = 'INSERT INTO "institutions_institution" ("address_line_1", "address_line_2", "post_code", "city", "department", "coord...nd") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "institutions_institution"."id"'
params = ('', '', '', '', '14', None, ...)
ignored_wrapper_args = (False, {'connection': <DatabaseWrapper vendor='postgresql' alias='default'>, 'cursor': <django.db.backends.utils.CursorWrapper object at 0x673eb347b750>})

    def _execute(self, sql, params, *ignored_wrapper_args):
        # Raise a warning during app initialization (stored_app_configs is only
        # ever set during testing).
        if not apps.ready and not apps.stored_app_configs:
            warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                # params default might be backend specific.
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)

.venv/lib/python3.11/site-packages/django/db/backends/utils.py:105:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.postgresql.base.Cursor [closed] [INERROR] (host=localhost user=postgres database=test_itou3_gw2) at 0x673eb3334410>
query = 'INSERT INTO "institutions_institution" ("address_line_1", "address_line_2", "post_code", "city", "department", "coord...nd") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "institutions_institution"."id"'
params = ('', '', '', '', '14', None, ...)

    def execute(
        self: _Self,
        query: Query,
        params: Optional[Params] = None,
        *,
        prepare: Optional[bool] = None,
        binary: Optional[bool] = None,
    ) -> _Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "unique_ddets_per_department"
E           DETAIL:  Key (kind, department)=(DDETS IAE, 14) already exists.

.venv/lib/python3.11/site-packages/psycopg/cursor.py:737: UniqueViolation

The above exception was the direct cause of the following exception:

self = <tests.www.siae_evaluations_views.test_views.TestViewProof object at 0x673eb6933dd0>, client = <tests.utils.test.ItouClient object at 0x673eb34acb10>

    def test_access_other_institution(self, client):
        job_app = EvaluatedJobApplicationFactory()
        crit = EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=job_app)
>       membership = InstitutionMembershipFactory()

tests/www/siae_evaluations_views/test_views.py:502:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.11/site-packages/factory/base.py:40: in __call__
    return cls.create(**kwargs)
.venv/lib/python3.11/site-packages/factory/base.py:528: in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
.venv/lib/python3.11/site-packages/factory/django.py:121: in _generate
    return super()._generate(strategy, params)
.venv/lib/python3.11/site-packages/factory/base.py:465: in _generate
    return step.build()
.venv/lib/python3.11/site-packages/factory/builder.py:270: in build
    step.resolve(pre)
.venv/lib/python3.11/site-packages/factory/builder.py:211: in resolve
    self.attributes[field_name] = getattr(self.stub, field_name)
.venv/lib/python3.11/site-packages/factory/builder.py:356: in __getattr__
    value = value.evaluate_pre(
.venv/lib/python3.11/site-packages/factory/declarations.py:67: in evaluate_pre
    return self.evaluate(instance, step, context)
.venv/lib/python3.11/site-packages/factory/declarations.py:457: in evaluate
    return step.recurse(subfactory, extra, force_sequence=force_sequence)
.venv/lib/python3.11/site-packages/factory/builder.py:228: in recurse
    return builder.build(parent_step=self, force_sequence=force_sequence)
.venv/lib/python3.11/site-packages/factory/builder.py:274: in build
    instance = self.factory_meta.instantiate(
.venv/lib/python3.11/site-packages/factory/base.py:317: in instantiate
    return self.factory._create(model, *args, **kwargs)
.venv/lib/python3.11/site-packages/factory/django.py:174: in _create
    return manager.create(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:679: in create
    obj.save(force_insert=True, using=self.db)
.venv/lib/python3.11/site-packages/django/db/models/base.py:822: in save
    self.save_base(
.venv/lib/python3.11/site-packages/django/db/models/base.py:909: in save_base
    updated = self._save_table(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1071: in _save_table
    results = self._do_insert(
.venv/lib/python3.11/site-packages/django/db/models/base.py:1112: in _do_insert
    return manager._insert(
.venv/lib/python3.11/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.11/site-packages/django/db/models/query.py:1847: in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
.venv/lib/python3.11/site-packages/django/db/models/sql/compiler.py:1823: in execute_sql
    cursor.execute(sql, params)
.venv/lib/python3.11/site-packages/sentry_sdk/utils.py:1713: in runner
    return sentry_patched_function(*args, **kwargs)
.venv/lib/python3.11/site-packages/sentry_sdk/integrations/django/__init__.py:650: in execute
    result = real_execute(self, sql, params)
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:79: in execute
    return self._execute_with_wrappers(
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:92: in _execute_with_wrappers
    return executor(sql, params, many, context)
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:100: in _execute
    with self.db.wrap_database_errors:
.venv/lib/python3.11/site-packages/django/db/utils.py:91: in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
.venv/lib/python3.11/site-packages/django/db/backends/utils.py:105: in _execute
    return self.cursor.execute(sql, params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.postgresql.base.Cursor [closed] [INERROR] (host=localhost user=postgres database=test_itou3_gw2) at 0x673eb3334410>
query = 'INSERT INTO "institutions_institution" ("address_line_1", "address_line_2", "post_code", "city", "department", "coord...nd") VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "institutions_institution"."id"'
params = ('', '', '', '', '14', None, ...)

    def execute(
        self: _Self,
        query: Query,
        params: Optional[Params] = None,
        *,
        prepare: Optional[bool] = None,
        binary: Optional[bool] = None,
    ) -> _Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           django.db.utils.IntegrityError: duplicate key value violates unique constraint "unique_ddets_per_department"
E           DETAIL:  Key (kind, department)=(DDETS IAE, 14) already exists.
```