### PR TITLE
Changement du backend de cache en faveur de django-redis

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -450,19 +450,24 @@ STATS_PH_PRESCRIPTION_REGION_WHITELIST = ["Pays de la Loire", "Nouvelle-Aquitain
 SLACK_CRON_WEBHOOK_URL = os.getenv("SLACK_CRON_WEBHOOK_URL")
 
 # Production instances (`PROD`, `DEMO`, `PENTEST`, `FAST-MACHINE`, ...) share the same redis but different DB
-redis_url = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
-redis_db = os.getenv("REDIS_DB")
-redis_django_settings = {
-    "LOCATION": redis_url,
+redis_url = os.environ["REDIS_URL"]
+redis_db = os.environ["REDIS_DB"]
+redis_common_django_settings = {
+    "BACKEND": "itou.utils.cache.UnclearableCache",
+    "LOCATION": f"{redis_url}?db={redis_db}",
     "KEY_PREFIX": "django",
-    "OPTIONS": {
-        "db": redis_db,
-    },
 }
 
 CACHES = {
-    "default": {"BACKEND": "itou.utils.cache.UnclearableCache", **redis_django_settings},
-    "failsafe": {"BACKEND": "itou.utils.cache.FailSafeRedisCache", **redis_django_settings},
+    "default": {
+        **redis_common_django_settings,
+    },
+    "failsafe": {
+        **redis_common_django_settings,
+        "OPTIONS": {
+            "CLIENT_CLASS": "itou.utils.cache.FailSafeRedisCacheClient",
+        },
+    },
 }
 
 HUEY = {

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -6,6 +6,10 @@ from itou.utils.enums import ItouEnvironment
 ITOU_ENVIRONMENT = ItouEnvironment.DEV
 os.environ["ITOU_ENVIRONMENT"] = ITOU_ENVIRONMENT
 
+# Inject default redis settings
+os.environ["REDIS_URL"] = os.getenv("REDIS_URL", "redis://127.0.0.1:6379")
+os.environ["REDIS_DB"] = os.getenv("REDIS_DB", "0")
+
 from .base import *  # noqa: E402,F403
 
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -49,6 +49,9 @@ django-storages  # https://github.com/jschneier/django-storages
 # Datadog logger (who could have guessed?!)
 django-datadog-logger
 
+# django-redis (full featured cache backend)
+django-redis  # https://github.com/jazzband/django-redis
+
 # Front-end
 # ------------------------------------------------------------------------------
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -265,6 +265,7 @@ django==5.0.6 \
     #   django-htmx
     #   django-import-export
     #   django-pgtrigger
+    #   django-redis
     #   django-select2
     #   django-storages
     #   django-xworkflows
@@ -320,6 +321,10 @@ django-import-export==4.1.0 \
 django-pgtrigger==4.11.1 \
     --hash=sha256:39862f229405c6fe49b33451e13910a70578ba569f7e8bea6ea82049058b371f \
     --hash=sha256:9ef664932b3b7fb06e6dc091e4e292d029c221804469ff42968dad272076915f
+    # via -r requirements/base.in
+django-redis==5.4.0 \
+    --hash=sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42 \
+    --hash=sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b
     # via -r requirements/base.in
 django-select2==8.2.0 \
     --hash=sha256:0e173ce49c6ea91efa9fc24c5ca8d1f8a3c545e60db779cf2c623d4e07405360 \
@@ -904,7 +909,9 @@ pyzipper==0.3.6 \
 redis==5.0.7 \
     --hash=sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db \
     --hash=sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   django-redis
 referencing==0.29.1 \
     --hash=sha256:90cb53782d550ba28d2166ef3f55731f38397def8832baac5d45235f1995e35e \
     --hash=sha256:d3c8f323ee1480095da44d55917cfb8278d73d6b4d5f677e3e40eb21314ac67f

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -327,6 +327,7 @@ django==5.0.6 \
     #   django-htmx
     #   django-import-export
     #   django-pgtrigger
+    #   django-redis
     #   django-select2
     #   django-storages
     #   django-xworkflows
@@ -392,6 +393,10 @@ django-import-export==4.1.0 \
 django-pgtrigger==4.11.1 \
     --hash=sha256:39862f229405c6fe49b33451e13910a70578ba569f7e8bea6ea82049058b371f \
     --hash=sha256:9ef664932b3b7fb06e6dc091e4e292d029c221804469ff42968dad272076915f
+    # via -r requirements/test.txt
+django-redis==5.4.0 \
+    --hash=sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42 \
+    --hash=sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b
     # via -r requirements/test.txt
 django-select2==8.2.0 \
     --hash=sha256:0e173ce49c6ea91efa9fc24c5ca8d1f8a3c545e60db779cf2c623d4e07405360 \
@@ -956,6 +961,7 @@ psycopg[binary]==3.1.10 \
     # via
     #   -r requirements/test.txt
     #   django-citext
+    #   psycopg
 psycopg-binary==3.1.10 \
     --hash=sha256:0471869e658d0c6b8c3ed53153794739c18d7dad2dd5b8e6ff023a364c20f7df \
     --hash=sha256:0f062f20256708929a58c41d44f350efced4c00a603323d1413f6dc0b84d95a5 \
@@ -1199,7 +1205,9 @@ pyzipper==0.3.6 \
 redis==5.0.7 \
     --hash=sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db \
     --hash=sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   django-redis
 referencing==0.29.1 \
     --hash=sha256:90cb53782d550ba28d2166ef3f55731f38397def8832baac5d45235f1995e35e \
     --hash=sha256:d3c8f323ee1480095da44d55917cfb8278d73d6b4d5f677e3e40eb21314ac67f

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -300,6 +300,7 @@ django==5.0.6 \
     #   django-htmx
     #   django-import-export
     #   django-pgtrigger
+    #   django-redis
     #   django-select2
     #   django-storages
     #   django-xworkflows
@@ -357,6 +358,10 @@ django-import-export==4.1.0 \
 django-pgtrigger==4.11.1 \
     --hash=sha256:39862f229405c6fe49b33451e13910a70578ba569f7e8bea6ea82049058b371f \
     --hash=sha256:9ef664932b3b7fb06e6dc091e4e292d029c221804469ff42968dad272076915f
+    # via -r requirements/base.txt
+django-redis==5.4.0 \
+    --hash=sha256:6a02abaa34b0fea8bf9b707d2c363ab6adc7409950b2db93602e6cb292818c42 \
+    --hash=sha256:ebc88df7da810732e2af9987f7f426c96204bf89319df4c6da6ca9a2942edd5b
     # via -r requirements/base.txt
 django-select2==8.2.0 \
     --hash=sha256:0e173ce49c6ea91efa9fc24c5ca8d1f8a3c545e60db779cf2c623d4e07405360 \
@@ -850,6 +855,7 @@ psycopg[binary]==3.1.10 \
     # via
     #   -r requirements/base.txt
     #   django-citext
+    #   psycopg
 psycopg-binary==3.1.10 \
     --hash=sha256:0471869e658d0c6b8c3ed53153794739c18d7dad2dd5b8e6ff023a364c20f7df \
     --hash=sha256:0f062f20256708929a58c41d44f350efced4c00a603323d1413f6dc0b84d95a5 \
@@ -1078,7 +1084,9 @@ pyzipper==0.3.6 \
 redis==5.0.7 \
     --hash=sha256:0e479e24da960c690be5d9b96d21f7b918a98c0cf49af3b6fafaa0753f93a0db \
     --hash=sha256:8f611490b93c8109b50adc317b31bfd84fff31def3475b92e7e80bf39f48175b
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   django-redis
 referencing==0.29.1 \
     --hash=sha256:90cb53782d550ba28d2166ef3f55731f38397def8832baac5d45235f1995e35e \
     --hash=sha256:d3c8f323ee1480095da44d55917cfb8278d73d6b4d5f677e3e40eb21314ac67f

--- a/tests/utils/apis/test_pole_emploi_api.py
+++ b/tests/utils/apis/test_pole_emploi_api.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 import respx
 from django.core.cache import caches
+from django_redis import get_redis_connection
 
 from itou.utils.apis.pole_emploi import (
     CACHE_API_TOKEN_KEY,
@@ -37,7 +38,7 @@ class PoleEmploiAPIClientTest(TestCase):
         self.api_client._refresh_token()
         cache = caches["failsafe"]
         assert cache.get(CACHE_API_TOKEN_KEY) == "foo batman"
-        redis_client = cache._cache.get_client()
+        redis_client = get_redis_connection("failsafe")
         expiry = redis_client.expiretime(cache.make_key(CACHE_API_TOKEN_KEY))
         assert start + self.CACHE_EXPIRY - REFRESH_TOKEN_MARGIN_SECONDS <= expiry <= start + self.CACHE_EXPIRY
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

- Pour pouvoir facilement lock les accès au cache dans certains cas de figure (cf. #4356)
- Pour pouvoir facilement surcharger le client Redis sans recourir à un backend dédié
- Pour pouvoir récupérer le client sans passer par des méthodes privées

## :cake: Comment ? <!-- optionnel -->

Utilisation du module [django-redis](https://github.com/jazzband/django-redis/) maintenu par jazzband qui expose davantage de méthodes redis.