### PR TITLE
templates: suppression de l'indirection `approvals/includes/card.html`

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -29,7 +29,13 @@
                             {% if not job_application.state.is_accepted and not job_application.state.is_cancelled %}
                                 {# Employers need to know the expiration date of an approval #}
                                 {# to decide whether they may accept a job application or not. #}
-                                {% include "approvals/includes/card.html" with common_approval=job_application.job_seeker.latest_common_approval job_application=job_application hiring_pending=job_application.is_pending %}
+                                {% with common_approval=job_application.job_seeker.latest_common_approval %}
+                                    {% if common_approval %}
+                                        <div class="c-box mb-4">
+                                            {% include "approvals/includes/status.html" with common_approval=common_approval job_application=job_application hiring_pending=job_application.is_pending %}
+                                        </div>
+                                    {% endif %}
+                                {% endwith %}
                             {% endif %}
                         {% elif request.user.is_prescriber %}
                             <div class="c-box mb-4">

--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -12,7 +12,11 @@
             <div class="row">
                 <div class="col-12 col-lg-8">
                     {% if is_subject_to_eligibility_rules %}
-                        {% include "approvals/includes/card.html" with common_approval=job_seeker.latest_common_approval %}
+                        {% with common_approval=job_seeker.latest_common_approval %}
+                            {% if common_approval %}
+                                <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=common_approval %}</div>
+                            {% endif %}
+                        {% endwith %}
                     {% endif %}
 
                     {% block content_extend %}{% endblock %}

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -19,7 +19,7 @@
                 <div class="col-12 col-lg-8">
                     {% if not preview %}
                         {# Edit mode. #}
-                        {% include "approvals/includes/card.html" with common_approval=approval %}
+                        <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=approval %}</div>
                         <div class="c-box my-4">{% include "approvals/includes/prolongation_declaration_form.html" %}</div>
                     {% else %}
                         {# Preview mode: ask for confirmation before committing to DB. #}

--- a/itou/templates/approvals/includes/card.html
+++ b/itou/templates/approvals/includes/card.html
@@ -1,3 +1,0 @@
-{% if common_approval %}
-    <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=common_approval %}</div>
-{% endif %}

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -20,7 +20,7 @@
                     {% if not preview %}
                         {# Edit mode. #}
 
-                        {% include "approvals/includes/card.html" with common_approval=approval %}
+                        <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=approval %}</div>
                         <div class="c-form">
                             <form method="post" class="js-prevent-multiple-submit">
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2415,7 +2415,7 @@ class DirectHireFullProcessTest(TestCase):
         # ----------------------------------------------------------------------
 
         response = self.client.get(next_url)
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
 
         criterion1 = AdministrativeCriteria.objects.level1().get(pk=1)
         criterion2 = AdministrativeCriteria.objects.level2().get(pk=5)
@@ -2440,7 +2440,7 @@ class DirectHireFullProcessTest(TestCase):
         # Hire confirmation
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
-        self.assertTemplateUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         self.assertContains(response, "Valider l’embauche")
 
         hiring_start_at = timezone.localdate()
@@ -2488,6 +2488,7 @@ class DirectHireFullProcessTest(TestCase):
         # Get application detail
         # ----------------------------------------------------------------------
         response = self.client.get(next_url)
+        self.assertTemplateUsed(response, "approvals/includes/status.html")
         assert response.status_code == 200
 
     def test_hire_as_geiq(self):
@@ -2515,7 +2516,7 @@ class DirectHireFullProcessTest(TestCase):
         # ----------------------------------------------------------------------
 
         response = self.client.get(check_infos_url)
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
 
         prev_applicaitons_url = reverse(
             "apply:check_prev_applications_for_hire", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk}
@@ -2527,7 +2528,7 @@ class DirectHireFullProcessTest(TestCase):
         # ----------------------------------------------------------------------
 
         response = self.client.get(prev_applicaitons_url)
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         geiq_eligibility_url = reverse(
             "apply:geiq_eligibility_for_hire", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk}
         )
@@ -2544,7 +2545,7 @@ class DirectHireFullProcessTest(TestCase):
         )
 
         response = self.client.get(geiq_eligibility_url)
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         response = self.client.post(
             geiq_eligibility_url,
             data={"choice": "True"},
@@ -2571,7 +2572,7 @@ class DirectHireFullProcessTest(TestCase):
         # Hire confirmation
         # ----------------------------------------------------------------------
         response = self.client.get(confirmation_url)
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         self.assertContains(response, "Valider l’embauche")
 
         hiring_start_at = timezone.localdate()
@@ -4248,7 +4249,7 @@ class CheckJobSeekerInformationsForHireTestCase(TestCase):
             '<h1>Informations personnelles de <span class="text-muted">Son Prénom Son Nom De Famille</span></h1>',
             html=True,
         )
-        self.assertTemplateUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         self.assertContains(response, "Éligibilité IAE à valider")
         self.assertContains(
             response,
@@ -4291,7 +4292,7 @@ class CheckJobSeekerInformationsForHireTestCase(TestCase):
             '<h1>Informations personnelles de <span class="text-muted">Son Prénom Son Nom De Famille</span></h1>',
             html=True,
         )
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         self.assertContains(
             response,
             reverse(
@@ -4331,7 +4332,7 @@ class CheckPreviousApplicationsForHireViewTestCase(TestCase):
         self.client.force_login(self.company.members.first())
 
         response = self.client.get(self._reverse("apply:check_prev_applications_for_hire"))
-        self.assertTemplateUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         self.assertContains(response, "Le candidat a déjà postulé chez cet employeur le")
         response = self.client.post(
             self._reverse("apply:check_prev_applications_for_hire"), data={"force_new_application": "force"}
@@ -4352,7 +4353,7 @@ class CheckPreviousApplicationsForHireViewTestCase(TestCase):
 
         response = self.client.get(self._reverse("apply:check_prev_applications_for_hire"))
         self.assertContains(response, "Le candidat a déjà postulé chez cet employeur le")
-        self.assertTemplateNotUsed(response, "approvals/includes/card.html")
+        self.assertTemplateNotUsed(response, "approvals/includes/status.html")
         response = self.client.post(
             self._reverse("apply:check_prev_applications_for_hire"), data={"force_new_application": "force"}
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Beaucoup de vues utilisent `approvals/includes/status.html` et le fait d'avoir une indirection avec une faible valeur ajoutée n'aide pas.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
