### PR TITLE
Analytics : Suivi des champs prénom et nom pour les candidats

### DIFF
--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_base.html
@@ -72,7 +72,7 @@
                         {% endif %}
                         <hr class="mt-5">
                         {% bootstrap_form_errors form type="all" %}
-                        <form method="post" class="js-collapsable-subfields js-format-nir">
+                        <form method="post" class="js-collapsable-subfields js-format-nir"{% if matomo_form_name|default:"" %} data-matomo-name="{{ matomo_form_name }}"{% endif %}>
                             {% csrf_token %}
 
                             {% block form_content %}{% endblock %}

--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -8,7 +8,7 @@
 {% load django_bootstrap5 %}
 {% load buttons_form %}
 
-<form method="post" class="js-prevent-multiple-submit js-format-nir">
+<form method="post" class="js-prevent-multiple-submit js-format-nir" data-matomo-name="dashboard-edit-job-seeker-identity">
     {% csrf_token %}
 
     {% if form.nir_error %}{{ form.nir_error|safe }}{% endif %}

--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -5,7 +5,7 @@
 <div class="row">
     <div class="col-12 col-lg-8">
         <div class="c-form">
-            <form method="post" class="js-prevent-multiple-submit">
+            <form method="post" class="js-prevent-multiple-submit" data-matomo-name="employee-record-identity">
                 {% csrf_token %}
                 <fieldset>
                     <legend>Etat civil du salarié</legend>

--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -43,7 +43,7 @@
                             <b>Ou utilisez votre adresse e-mail</b>
                         </div>
 
-                        <form method="post" action="{% url 'signup:job_seeker' %}" role="form" class="js-prevent-multiple-submit">
+                        <form method="post" action="{% url 'signup:job_seeker' %}" role="form" class="js-prevent-multiple-submit" data-matomo-name="signup-job-seeker-identity">
 
                             {% csrf_token %}
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -563,6 +563,7 @@ class CreateJobSeekerStep1ForSenderView(CreateJobSeekerForSenderBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "form": self.form,
+            "matomo_form_name": "apply-create-job-seeker-identity",
             "progress": "20",
         }
 
@@ -1367,6 +1368,7 @@ class UpdateJobSeekerStep1View(UpdateJobSeekerBaseView):
         return super().get_context_data(**kwargs) | {
             "confirmation_needed": False,
             "form": self.form,
+            "matomo_form_name": "apply-update-job-seeker-identity",
             "readonly_form": not self.request.user.can_edit_personal_information(self.job_seeker),
             "progress": "20",
         }

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: JobSeekerSignupTest.test_job_seeker_signup[job_seeker_signup_form]
   '''
-  <form action="/signup/job_seeker" class="js-prevent-multiple-submit" method="post" role="form">
+  <form action="/signup/job_seeker" class="js-prevent-multiple-submit" data-matomo-name="signup-job-seeker-identity" method="post" role="form">
   
                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avoir une mesure d’impact avant la mise en place d’API certifiant l’identité des utilisateurs.

## :cake: Comment ? <!-- optionnel -->

Configuration côté Matomo, bien vérifier le site de recette et la prod.
https://matomo.inclusion.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=220&period=day&date=yesterday&showaddsite=false#?idSite=220&period=week&date=2024-07-04&category=FormAnalytics_Forms&subcategory=FormAnalytics_ManageForms
https://matomo.inclusion.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=117&period=day&date=yesterday&showaddsite=false#?idSite=117&period=week&date=2024-07-04&category=FormAnalytics_Forms&subcategory=FormAnalytics_ManageForms

## :desert_island: Comment tester

Se mettre dans un navigateur envoyant les analytics (pas de bloqueur), et aller sur un des formulaires concernés. Changer les prénoms et nom d’un candidat. Côté Matomo, la visite doit être présent dans le “Show visitor log of form starters”. Après plusieurs heures, je suppose que les métriques agrégées seront disponibles.
