### PR TITLE
Employeur: changer la mention “auto-prescription” par “ma structure” dans l'export de candidatures [GEN-1818]

### DIFF
--- a/itou/job_applications/export.py
+++ b/itou/job_applications/export.py
@@ -75,7 +75,7 @@ def _get_readable_sender_kind(job_application):
     if job_application.sender_kind == SenderKind.EMPLOYER:
         kind = "Employeur"
         if job_application.sender_company == job_application.to_company:
-            kind = "Auto-prescription"
+            kind = "Ma structure"
     elif job_application.sender_kind == SenderKind.PRESCRIBER:
         kind = "Orienteur"
         if job_application.is_sent_by_authorized_prescriber:

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1909,7 +1909,7 @@ class JobApplicationXlsxExportTest(TestCase):
                 "Acme inc.",
                 "EI",
                 "",
-                "Auto-prescription",
+                "Ma structure",
                 "",
                 "",
                 "05/07/2024",

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1883,6 +1883,48 @@ class JobApplicationXlsxExportTest(TestCase):
             ],
         ]
 
+    def test_auto_prescription_xlsx_export(self):
+        job_seeker = JobSeekerFactory(for_snapshot=True)
+        company = CompanyFactory(for_snapshot=True)
+        job_application = JobApplicationFactory(
+            job_seeker=job_seeker,
+            to_company=company,
+            sender_company=company,
+            sender_kind=SenderKind.EMPLOYER,
+        )
+        job_application.sender = company.memberships.first()
+        job_application.save(update_fields={"sender"})
+        response = stream_xlsx_export(JobApplication.objects.all(), "filename")
+        assert get_rows_from_streaming_response(response) == [
+            JOB_APPLICATION_CSV_HEADERS,
+            [
+                "MME",
+                "Doe",
+                "Jane",
+                "jane.doe@test.local",
+                "0612345678",
+                "01/01/1990",
+                "Rennes",
+                "35000",
+                "Acme inc.",
+                "EI",
+                "",
+                "Auto-prescription",
+                "",
+                "",
+                "05/07/2024",
+                "Nouvelle candidature",
+                "05/07/2024",
+                "05/07/2026",
+                "",
+                "oui",
+                "",
+                "",
+                "",
+                "",
+            ],
+        ]
+
     def test_all_gender_cases_in_export(self):
         assert _resolve_title(title="", nir="") == ""
         assert _resolve_title(title=Title.M, nir="") == Title.M

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -10,6 +10,7 @@ from itou.companies.enums import CompanyKind
 from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.eligibility.models import AdministrativeCriteria
 from itou.job_applications.enums import JobApplicationState
+from itou.job_applications.export import JOB_APPLICATION_CSV_HEADERS
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.jobs.models import Appellation
 from itou.utils.urls import add_url_params
@@ -30,7 +31,13 @@ from tests.prescribers.factories import (
 )
 from tests.users.factories import JobSeekerFactory
 from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
-from tests.utils.test import BASE_NUM_QUERIES, TestCase, assert_previous_step, parse_response_to_soup
+from tests.utils.test import (
+    BASE_NUM_QUERIES,
+    TestCase,
+    assert_previous_step,
+    get_rows_from_streaming_response,
+    parse_response_to_soup,
+)
 
 
 @pytest.mark.usefixtures("unittest_compatibility")
@@ -785,6 +792,9 @@ def test_list_for_siae_exports_download(client):
     response = client.get(reverse("apply:list_for_siae_exports_download"))
     assert 200 == response.status_code
     assert "spreadsheetml" in response.get("Content-Type")
+    rows = get_rows_from_streaming_response(response)
+    assert rows[0] == JOB_APPLICATION_CSV_HEADERS
+    assert len(rows) == 2
 
 
 def test_list_for_siae_exports_download_as_prescriber(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Apparemment le wording actuel pose problème.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
