### PR TITLE
PASS IAE: suppression du bouton retour et correction de l'URL du bouton annuler dans le formulaire de demande de prolongation [GEN-1633]

### DIFF
--- a/itou/templates/approvals/includes/prolongation_declaration_form.html
+++ b/itou/templates/approvals/includes/prolongation_declaration_form.html
@@ -39,5 +39,5 @@
 
     {% include "approvals/includes/declaration_upload_panel.html" %}
 
-    {% itou_buttons_form primary_label="Valider la déclaration" secondary_url=back_url primary_name="preview" primary_value="1" %}
+    {% itou_buttons_form primary_label="Valider la déclaration" reset_url=back_url primary_name="preview" primary_value="1" %}
 </form>

--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -28,6 +28,7 @@ from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.constants import MB
 from itou.utils.db import or_queries
+from itou.utils.urls import add_url_params
 from itou.utils.validators import MaxDateValidator, MinDateValidator
 from itou.utils.widgets import DuetDatePickerWidget, RadioSelectWithDisabledChoices
 
@@ -146,8 +147,9 @@ class CreateProlongationForm(forms.ModelForm):
             "end_at",
         ]
 
-    def __init__(self, *args, approval, siae, **kwargs):
+    def __init__(self, *args, approval, siae, back_url, **kwargs):
         super().__init__(*args, **kwargs)
+        self.back_url = back_url
 
         # Used to display an explanation if the max duration is not possible
         self.max_end_limit = None
@@ -181,9 +183,12 @@ class CreateProlongationForm(forms.ModelForm):
         self.fields["reason"].widget.attrs.update(
             {
                 "hx-trigger": "change",
-                "hx-post": reverse(
-                    "approvals:prolongation_form_for_reason",
-                    kwargs={"approval_id": self.instance.approval_id},
+                "hx-post": add_url_params(
+                    reverse(
+                        "approvals:prolongation_form_for_reason",
+                        kwargs={"approval_id": self.instance.approval_id},
+                    ),
+                    {"back_url": self.back_url},
                 ),
                 "hx-params": "not end_at",  # Clear "end_at" when switching reason
                 "hx-swap": "outerHTML",

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -261,6 +261,7 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
         siae=siae,
         data=request.POST or None,
         files=request.FILES or None,
+        back_url=back_url,
     )
 
     # The file was saved before the preview step, and its reference is stored in the session.
@@ -349,6 +350,7 @@ class DeclareProlongationHTMXFragmentView(TemplateView):
             siae=self.siae,
             data=request.POST or None,
             files=request.FILES or None,
+            back_url=prolongation_back_url(request),
         )
 
     def get_context_data(self, **kwargs):

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -50,6 +50,14 @@
           </div>
   '''
 # ---
+# name: ApprovalProlongationTest.test_htmx_on_reason_with_back_url[reset button with correct back_url]
+  '''
+  <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/somewhere/over/the/rainbow">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </a>
+  '''
+# ---
 # name: ApprovalProlongationTest.test_prolong_approval_view_no_end_at
   '''
   <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_end_at">Du 23/10/2023 au</label><duet-date-picker aria-describedby="id_end_at_helptext" aria-invalid="true" class="is-invalid" identifier="id_end_at" max="2024-10-22" min="2023-10-23" name="end_at" placeholder="Du 23/10/2023 au" required=""></duet-date-picker>
@@ -67,7 +75,7 @@
 # ---
 # name: ApprovalProlongationTest.test_prolongation_approval_view_with_disabled_values[RQTH & SENIOR disabled]
   '''
-  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
       
           
           
@@ -106,7 +114,7 @@
 # ---
 # name: ApprovalProlongationTest.test_prolongation_approval_view_with_disabled_values[RQTH disabled]
   '''
-  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
       
           
           


### PR DESCRIPTION
## :thinking: Pourquoi ?

- Bouton "Retour" en doublon du bouton "Annuler"
- et clairement quand on annule la demande on s'attend à revenir sur la page du PASS et non celle du tableau de bord.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
