### PR TITLE
Admin: le statut d'une demande de prolongation est maintenant en lecture seule

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -575,7 +575,7 @@ class ProlongationRequestAdmin(ProlongationCommonAdmin):
         return obj.deny_information.proposed_actions_explanation
 
     def get_readonly_fields(self, request, obj=None):
-        fields = ProlongationCommonAdmin.readonly_fields + ("processed_at", "processed_by", "prolongation")
+        fields = ProlongationCommonAdmin.readonly_fields + ("processed_at", "processed_by", "prolongation", "status")
         if not obj:
             return fields
 


### PR DESCRIPTION

## :thinking: Pourquoi ?

Sinon, on pourrait croire que l'on peut accepter ou refuser la demande dans l'admin alors que cela ne déclenche rien (pas de création de prolongation, etc).

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
