### PR TITLE
Admin: Amélioration de la page des candidature pour les actions du support

### DIFF
--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -320,6 +320,8 @@ class JobApplicationAdmin(InconsistencyCheckMixin, ItouModelAdmin):
             )
         elif error.args[0] == models.JobApplicationWorkflow.error_missing_hiring_start_at:
             message = "Le champ 'Date de début du contrat' est obligatoire pour accepter une candidature"
+        elif error.args[0] == models.JobApplicationWorkflow.error_wrong_eligibility_diagnosis:
+            message = "Le diagnostic d'eligibilité n'est pas valide pour ce candidat et cette entreprise"
         self.message_user(request, message or error, messages.ERROR)
         return HttpResponseRedirect(request.get_full_path())
 

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -16,6 +16,7 @@ from itou.users.models import User
 from itou.utils.admin import (
     InconsistencyCheckMixin,
     ItouModelAdmin,
+    ItouStackedInline,
     ItouTabularInline,
     UUIDSupportRemarkInline,
     get_admin_view_link,
@@ -66,6 +67,27 @@ class ManualApprovalDeliveryRequiredFilter(admin.SimpleListFilter):
         return queryset
 
 
+class EmployeeRecordInline(ItouStackedInline):
+    model = employee_record_models.EmployeeRecord
+    extra = 0
+    can_delete = False
+    fields = ("link",)
+    readonly_fields = ("link",)
+
+    @admin.display(description="situation fiche salarié")
+    def link(self, obj):
+        return get_admin_view_link(
+            obj,
+            content=mark_safe(f"<b>{obj.get_status_display()} (ID: {obj.pk})</b>"),
+        )
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+
 @admin.register(models.JobApplication)
 class JobApplicationAdmin(InconsistencyCheckMixin, ItouModelAdmin):
     form = JobApplicationAdminForm
@@ -107,7 +129,7 @@ class JobApplicationAdmin(InconsistencyCheckMixin, ItouModelAdmin):
         "origin",
         "state",
     )
-    inlines = (JobsInline, PriorActionInline, TransitionLogInline, UUIDSupportRemarkInline)
+    inlines = (JobsInline, PriorActionInline, TransitionLogInline, UUIDSupportRemarkInline, EmployeeRecordInline)
 
     fieldsets = [
         (

--- a/itou/job_applications/admin_forms.py
+++ b/itou/job_applications/admin_forms.py
@@ -63,4 +63,12 @@ class JobApplicationAdminForm(forms.ModelForm):
         elif sender_prescriber_organization is not None:
             raise ValidationError("Organisation du prescripteur émettrice inattendue.")
 
+        eligibility_diagnosis = self.cleaned_data.get("eligibility_diagnosis") or self.cleaned_data.get(
+            "geiq_eligibility_diagnosis"
+        )
+        if eligibility_diagnosis:
+            job_seeker = self.cleaned_data.get("job_seeker")
+            if job_seeker.pk != eligibility_diagnosis.job_seeker_id:
+                raise ValidationError("Le diagnostic d'eligibilité n'appartient pas au candidat de la candidature.")
+
         return

--- a/itou/templates/admin/job_applications/jobapplication_change_form.html
+++ b/itou/templates/admin/job_applications/jobapplication_change_form.html
@@ -13,8 +13,12 @@
             {% if original.is_in_acceptable_state %}
                 <input type='submit' class="danger js-with-confirm" name="transition_accept" value="Accepter">
             {% endif %}
-            {% if original.state.is_accepted and original.can_be_cancelled %}
-                <input type='submit' class="danger js-with-confirm" name="transition_cancel" value="Annuler">
+            {% if original.state.is_accepted %}
+                <input type='submit'
+                       class="danger js-with-confirm"
+                       name="transition_cancel"
+                       value="Annuler"
+                       {% if not original.can_be_cancelled %} disabled data-bs-toggle="tooltip" data-bs-placement="top" title=" Une fichie salarié doit probablement être supprimée avant de pouvoir annuler cette candidature " {% endif %}>
             {% endif %}
             {% if original.state.is_obsolete %}
                 <input type='submit' class="danger js-with-confirm" name="transition_reset" value="Remettre au statut nouveau">

--- a/itou/templates/admin/job_applications/jobapplication_change_form.html
+++ b/itou/templates/admin/job_applications/jobapplication_change_form.html
@@ -12,6 +12,9 @@
             {% endif %}
             {% if original.is_in_acceptable_state %}
                 <input type='submit' class="danger js-with-confirm" name="transition_accept" value="Accepter">
+                <p>
+                    <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                </p>
             {% endif %}
             {% if original.state.is_accepted %}
                 <input type='submit'

--- a/tests/job_applications/__snapshots__/test_admin.ambr
+++ b/tests/job_applications/__snapshots__/test_admin.ambr
@@ -19,6 +19,9 @@
               
               
                   <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+                  <p>
+                      <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                  </p>
               
               
               
@@ -45,6 +48,9 @@
               
               
                   <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+                  <p>
+                      <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                  </p>
               
               
               
@@ -60,6 +66,9 @@
               
               
                   <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+                  <p>
+                      <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                  </p>
               
               
               
@@ -73,6 +82,9 @@
               
               
                   <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+                  <p>
+                      <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                  </p>
               
               
               
@@ -86,6 +98,9 @@
               
               
                   <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+                  <p>
+                      <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                  </p>
               
               
               
@@ -99,6 +114,9 @@
               
               
                   <input class="danger js-with-confirm" name="transition_accept" type="submit" value="Accepter"/>
+                  <p>
+                      <strong>Vous pouvez choisir un diagnostic d'eligibilité IAE, mais sa date d'expiration ne sera pas vérifiée. Si vous souhaitez que le système choisisse le dernier diagnostic valide, laissez le champ vide.</strong>
+                  </p>
               
               
               

--- a/tests/job_applications/test_admin.py
+++ b/tests/job_applications/test_admin.py
@@ -160,6 +160,10 @@ JOB_APPLICATION_FORMSETS_PAYLOAD = {
     "utils-uuidsupportremark-content_type-object_id-0-id": "",
     "utils-uuidsupportremark-content_type-object_id-__prefix__-remark": "",
     "utils-uuidsupportremark-content_type-object_id-__prefix__-id": "",
+    "employee_record-TOTAL_FORMS": 0,
+    "employee_record-INITIAL_FORMS": 0,
+    "employee_record-MIN_NUM_FORMS": 0,
+    "employee_record-MAX_NUM_FORMS": 0,
 }
 
 

--- a/tests/job_applications/test_admin.py
+++ b/tests/job_applications/test_admin.py
@@ -253,6 +253,65 @@ def test_create_then_accept_job_application(admin_client):
     assert job_application.approval
 
 
+def test_accept_job_application_with_old_eligibility_diagnosis(admin_client):
+    job_application = factories.JobApplicationFactory(
+        sent_by_another_employer=True,
+        eligibility_diagnosis__expires_at=timezone.now() - timezone.timedelta(days=1),
+    )
+    old_diag = job_application.eligibility_diagnosis
+    other_diag = IAEEligibilityDiagnosisFactory(from_employer=True)
+    post_data = {
+        "job_seeker": job_application.job_seeker_id,
+        "to_company": job_application.to_company_id,
+        "sender_kind": "employer",
+        "sender_company": job_application.sender_company_id,
+        "sender": job_application.sender_id,
+        "hiring_start_at": timezone.localdate(),
+        # Formsets to please django admin
+        **JOB_APPLICATION_FORMSETS_PAYLOAD,
+    }
+    url = reverse("admin:job_applications_jobapplication_change", args=(job_application.pk,))
+    response = admin_client.get(url)
+    assertContains(response, 'value="Passer à l\'étude"')
+
+    response = admin_client.post(url, {**post_data, "transition_process": True})
+    assertRedirects(response, url)
+    job_application.refresh_from_db()
+    assert job_application.state == JobApplicationState.PROCESSING
+
+    response = admin_client.get(url)
+    assertContains(response, 'value="Accepter"')
+
+    response = admin_client.post(url, {**post_data, "eligibility_diagnosis": other_diag.pk, "transition_accept": True})
+    assertRedirects(response, url, fetch_redirect_response=False)  # don't flush the messages
+    job_application.refresh_from_db()
+    assert job_application.state == JobApplicationState.PROCESSING
+
+    response = admin_client.get(url)
+    assertMessages(
+        response,
+        [
+            messages.Message(
+                messages.ERROR,
+                "Le diagnostic d'eligibilité n'est pas valide pour ce candidat et cette entreprise",
+            )
+        ],
+    )
+    assertContains(response, 'value="Accepter"')
+
+    # Retry with a correct but too old eligibility diagnosis
+    response = admin_client.post(
+        url,
+        {**post_data, "transition_accept": True, "eligibility_diagnosis": old_diag.pk},
+    )
+    assertRedirects(response, url)
+    job_application.refresh_from_db()
+    assert job_application.state == JobApplicationState.ACCEPTED
+    assert job_application.logs.count() == 2
+    assert job_application.approval
+    assert job_application.eligibility_diagnosis == old_diag
+
+
 def test_accept_job_application_not_subject_to_eligibility(admin_client):
     job_application = factories.JobApplicationFactory(
         to_company__not_subject_to_eligibility=True,

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -2122,11 +2122,20 @@ class JobApplicationAdminFormTest(TestCase):
         assert form.is_valid()
 
     def test_application_on_non_job_seeker(self):
-        job_application = JobApplicationFactory()
+        job_application = JobApplicationFactory(eligibility_diagnosis=None)
         job_application.job_seeker = PrescriberFactory()
         form = JobApplicationAdminForm(model_to_dict(job_application))
         assert not form.is_valid()
         assert ["Impossible de candidater pour cet utilisateur, celui-ci n'est pas un compte candidat"] == form.errors[
+            "__all__"
+        ]
+
+    def test_application_bad_eligibility_diagnosis_job_seeker(self):
+        job_application = JobApplicationFactory()
+        job_application.job_seeker = JobSeekerFactory()
+        form = JobApplicationAdminForm(model_to_dict(job_application))
+        assert not form.is_valid()
+        assert ["Le diagnostic d'eligibilité n'appartient pas au candidat de la candidature."] == form.errors[
             "__all__"
         ]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite aux changement de status, voir : https://itou-inclusion.slack.com/archives/C02J7LWNT6Z/p1720176613306289?thread_ts=1718717668.744509&cid=C02J7LWNT6Z

## :cake: Comment ? <!-- optionnel -->

- Le bouton "Annuler" est à présent toujours visible sur une candidature acceptée, mais grisé quand il y a des fiches salariées qui bloquent l'annulation, avec un tooltip. 
- Les fiches salariées d'une candidature sont visible depuis la page de celle-ci pour les retrouver plus rapidement quand elles doivent être supprimées pour régulation.
- On peut accepter depuis l'admin un candidature avec un vieil agrément (on fait confiance au support)
- On vérifie que le diagnostic appartient au candidat

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

Le bouton accepter avec le commentaire :
![image](https://github.com/gip-inclusion/les-emplois/assets/7632730/6cd2546d-0af2-4ed0-ae5f-199977ce3a34)
