### PR TITLE
Fiche salarié: ajout d'un préfixe à la session d'ajout d'une fiche salarié [GEN-1550]

### DIFF
--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -103,6 +103,13 @@ class AddView(LoginRequiredMixin, NamedUrlSessionWizardView):
             }
         return {}
 
+    def get_prefix(self, request, *args, **kwargs):
+        """
+        Ensure that each add session is bound to a company.
+        Avoid session conflicts when using multiple tabs.
+        """
+        return f"company_{self.company.pk}_add_employee_record"
+
     def done(self, form_list, *args, **kwargs):
         approval = Approval.objects.get(
             pk=self.get_all_cleaned_data()["approval"], user=self.get_all_cleaned_data()["employee"]

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -17,7 +17,7 @@
                       <div class="c-form mb-3 mb-lg-5">
                           <form method="post">
                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                              <input id="id_add_view-current_step" name="add_view-current_step" type="hidden" value="choose-approval"/>
+                              <input id="id_company_[PK of Company]_add_employee_record-current_step" name="company_[PK of Company]_add_employee_record-current_step" type="hidden" value="choose-approval"/>
   
                               <div class="form-group form-group-required"><label class="form-label" for="id_choose-approval-approval">PASS IAE de Jane DOE</label><select aria-describedby="id_choose-approval-approval_helptext" class="form-select" id="id_choose-approval-approval" name="choose-approval-approval">
     <option value="[PK of Approval]">999999999999 — Du 01/01/2000 au 01/01/3000</option>

--- a/tests/www/employee_record_views/test_add.py
+++ b/tests/www/employee_record_views/test_add.py
@@ -36,7 +36,10 @@ def test_wizard(snapshot, client):
     # )
     response = client.post(
         choose_employee_url,
-        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+        {
+            "choose-employee-employee": job_application.job_seeker.pk,
+            f"company_{company.pk}_add_employee_record-current_step": "choose-employee",
+        },
     )
     assertRedirects(response, choose_approval_url)
 
@@ -44,12 +47,15 @@ def test_wizard(snapshot, client):
     soup = parse_response_to_soup(client.get(choose_approval_url), selector="#main .s-section")
     assert soup.find(id="id_choose-approval-approval").option["value"] == str(approval.pk)
     soup.find(id="id_choose-approval-approval").option["value"] = "[PK of Approval]"
+    [input] = soup.select(selector=f"#id_company_{company.pk}_add_employee_record-current_step")
+    input["name"] = input["name"].replace(str(company.pk), "[PK of Company]")
+    input["id"] = input["id"].replace(str(company.pk), "[PK of Company]")
     assert str(soup) == snapshot(name="choose-approval")
     response = client.post(
         choose_approval_url,
         {
             "choose-approval-approval": job_application.approval.pk,
-            "add_view-current_step": "choose-approval",
+            f"company_{company.pk}_add_employee_record-current_step": "choose-approval",
         },
     )
 
@@ -70,13 +76,16 @@ def test_done_step_when_the_employee_record_need_to_be_created(client):
 
     client.post(
         choose_employee_url,
-        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+        {
+            "choose-employee-employee": job_application.job_seeker.pk,
+            f"company_{company.pk}_add_employee_record-current_step": "choose-employee",
+        },
     )
     response = client.post(
         choose_approval_url,
         {
             "choose-approval-approval": job_application.approval.pk,
-            "add_view-current_step": "choose-approval",
+            f"company_{company.pk}_add_employee_record-current_step": "choose-approval",
         },
         follow=True,  # Don't stop to the `done` step
     )
@@ -105,14 +114,17 @@ def test_done_step_when_a_new_employee_record_already_exists(client):
 
     client.post(
         choose_employee_url,
-        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+        {
+            "choose-employee-employee": job_application.job_seeker.pk,
+            f"company_{company.pk}_add_employee_record-current_step": "choose-employee",
+        },
     )
 
     response = client.post(
         choose_approval_url,
         {
             "choose-approval-approval": job_application.approval.pk,
-            "add_view-current_step": "choose-approval",
+            f"company_{company.pk}_add_employee_record-current_step": "choose-approval",
         },
         follow=True,  # Don't stop to the `done` step
     )
@@ -140,14 +152,17 @@ def test_done_step_when_a_other_than_new_employee_record_already_exists(client):
 
     client.post(
         choose_employee_url,
-        {"choose-employee-employee": job_application.job_seeker.pk, "add_view-current_step": "choose-employee"},
+        {
+            "choose-employee-employee": job_application.job_seeker.pk,
+            f"company_{company.pk}_add_employee_record-current_step": "choose-employee",
+        },
     )
 
     response = client.post(
         choose_approval_url,
         {
             "choose-approval-approval": job_application.approval.pk,
-            "add_view-current_step": "choose-approval",
+            f"company_{company.pk}_add_employee_record-current_step": "choose-approval",
         },
         follow=True,  # Don't stop to the `done` step
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour limiter _un tout petit peu_ le conflit de session.

En vrai, vu qu'on stocke également l'entreprise courante en session, ça ne protège que le cas où:
- en tant qu'entreprise A, on commence à ajouter une fiche salarié
- on ouvre un autre onglet
- on bascule en entreprise B
- on commence à ajouter une fiche salarié sur l'entreprise B
- on continue son travail et on rebascule sur l'entreprise A
- on revient sur l'onglet du début et on continue le wizard qui ne plante pas

Cela aurait déjà plus de sens si le wizard d'ajout de fiche salarié mettait l'entreprise dans l'URL plutôt que d'utiliser la `request.current_organization`.

Tout cela pour dire que je suis 0+ pour merger ce fix mais qu'on pourrait aussi passer le ticket Notion en wontfix.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
