### PR TITLE
PASS IAE: modification des règles d'affichage de l'encart

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -32,7 +32,7 @@
                                 {% with common_approval=job_application.job_seeker.latest_common_approval %}
                                     {% if common_approval %}
                                         <div class="c-box mb-4">
-                                            {% include "approvals/includes/status.html" with common_approval=common_approval job_application=job_application hiring_pending=job_application.is_pending %}
+                                            {% include "approvals/includes/status.html" with common_approval=common_approval hiring_pending=job_application.is_pending %}
                                         </div>
                                     {% endif %}
                                 {% endwith %}

--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -14,7 +14,9 @@
                     {% if is_subject_to_eligibility_rules %}
                         {% with common_approval=job_seeker.latest_common_approval %}
                             {% if common_approval %}
-                                <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=common_approval %}</div>
+                                <div class="c-box mb-4">
+                                    {% include "approvals/includes/status.html" with common_approval=common_approval hiring_pending=True %}
+                                </div>
                             {% endif %}
                         {% endwith %}
                     {% endif %}

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -19,7 +19,9 @@
                 <div class="col-12 col-lg-8">
                     {% if not preview %}
                         {# Edit mode. #}
-                        <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=approval %}</div>
+                        <div class="c-box mb-4">
+                            {% include "approvals/includes/status.html" with common_approval=approval hiring_pending=False %}
+                        </div>
                         <div class="c-box my-4">{% include "approvals/includes/prolongation_declaration_form.html" %}</div>
                     {% else %}
                         {# Preview mode: ask for confirmation before committing to DB. #}

--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -16,7 +16,7 @@
                 <div class="col-12 col-lg-8">
                     <div class="c-box mb-3 mb-lg-5">
                         {# Approval status. #}
-                        <div>{% include "approvals/includes/status.html" with common_approval=approval hiring_pending=hiring_pending %}</div>
+                        <div>{% include "approvals/includes/status.html" with common_approval=approval hiring_pending=False %}</div>
 
                         {# Approval actions. #}
                         {% if approval and request.user.is_employer %}

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -9,7 +9,6 @@ Arguments:
     user
     common_approval  (which may be an Approval or PE Approval)
     hiring_pending
-    job_application
 
 {% endcomment %}
 
@@ -46,7 +45,7 @@ Arguments:
         {% endif %}
     </p>
 
-    {% if job_application.origin == JobApplicationOrigin.PE_APPROVAL %}
+    {% if common_approval.origin == ApprovalOrigin.PE_APPROVAL %}
         <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
     {% endif %}
 

--- a/itou/templates/approvals/includes/status.html
+++ b/itou/templates/approvals/includes/status.html
@@ -6,9 +6,9 @@
 
 Arguments:
 
-    user
     common_approval  (which may be an Approval or PE Approval)
     hiring_pending
+    request
 
 {% endcomment %}
 
@@ -34,7 +34,7 @@ Arguments:
         {% else %}
             Numéro d'agrément :
         {% endif %}
-        {% if user.is_employer and common_approval.is_in_waiting_period and common_approval.user.has_valid_diagnosis %}
+        {% if request.user.is_employer and common_approval.is_in_waiting_period and common_approval.user.has_valid_diagnosis %}
             {% comment %}
             If the PASS IAE number is displayed at this time, some employers think that there is
             no need to validate the application because a number is already assigned.
@@ -59,7 +59,7 @@ Arguments:
                    title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
             </li>
 
-            {% if hiring_pending and user.is_employer %}
+            {% if hiring_pending and request.user.is_employer %}
                 <li>
                     PASS IAE valide jusqu’au {{ common_approval.remainder_as_date|date:"d/m/Y" }}, si le contrat démarre aujourd’hui.
                 </li>
@@ -73,7 +73,7 @@ Arguments:
             {% endif %}
         </ul>
     {% elif common_approval.is_in_waiting_period %}
-        {% if user.is_employer and common_approval.user.has_valid_diagnosis %}
+        {% if request.user.is_employer and common_approval.user.has_valid_diagnosis %}
             {% comment %}
             When an authorized prescriber bypasses the waiting period and sends a candidate
             with an "expired" approval, the employer receives the application with the mention

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -22,7 +22,9 @@
                 <div class="col-12 col-lg-8">
                     <div class="c-box mb-3 mb-lg-5">
                         {# Approval status. #}
-                        <div>{% include "approvals/includes/status.html" with common_approval=prolongation_request.approval %}</div>
+                        <div>
+                            {% include "approvals/includes/status.html" with common_approval=prolongation_request.approval hiring_pending=False %}
+                        </div>
                     </div>
 
                     <div class="c-box mb-3 mb-lg-5">

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -20,7 +20,9 @@
                     {% if not preview %}
                         {# Edit mode. #}
 
-                        <div class="c-box mb-4">{% include "approvals/includes/status.html" with common_approval=approval %}</div>
+                        <div class="c-box mb-4">
+                            {% include "approvals/includes/status.html" with common_approval=approval hiring_pending=False %}
+                        </div>
                         <div class="c-form">
                             <form method="post" class="js-prevent-multiple-submit">
 

--- a/itou/templates/dashboard/includes/job_seeker_approval_card.html
+++ b/itou/templates/dashboard/includes/job_seeker_approval_card.html
@@ -12,7 +12,7 @@
         <div class="px-3 px-lg-4">
             <ul class="list-unstyled mb-lg-5">
                 <li class="mb-2">
-                    {% include "approvals/includes/status.html" with common_approval=user.latest_common_approval hiring_pending=False job_application=None %}
+                    {% include "approvals/includes/status.html" with common_approval=user.latest_common_approval hiring_pending=False %}
                 </li>
                 {% if user.has_common_approval_in_waiting_period %}
                     <li class="mb-2">

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -797,7 +797,6 @@ class CheckJobSeekerInformationsForHire(ApplicationBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "profile": self.job_seeker.jobseeker_profile,
-            "hiring_pending": True,
             "back_url": reverse("apply:check_nir_for_hire", kwargs={"company_pk": self.company.pk}),
         }
 

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -121,7 +121,6 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
         context["approval_can_be_suspended_by_siae"] = approval.can_be_suspended_by_siae(self.siae)
         context["approval_can_be_prolonged"] = approval.can_be_prolonged
         context["job_application"] = job_application
-        context["hiring_pending"] = job_application and job_application.is_pending
         context["matomo_custom_title"] = "Profil salarié"
         context["eligibility_diagnosis"] = job_application and job_application.get_eligibility_diagnosis()
         context["approval_deletion_form_url"] = None

--- a/tests/www/approvals_views/__snapshots__/test_includes.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_includes.ambr
@@ -27,6 +27,8 @@
       </p>
   
       
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
   
       
           
@@ -70,6 +72,8 @@
       </p>
   
       
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
   
       
           
@@ -110,6 +114,8 @@
           
       </p>
   
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
       
   
       
@@ -152,6 +158,8 @@
       </p>
   
       
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
   
       
           
@@ -192,6 +200,74 @@
           
       </p>
   
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
+      
+  
+      
+          <p class="mb-1">Date de début : 01/01/2000</p>
+          <ul class="list-unstyled">
+              <li class="h4 mt-4 mb-2">
+                  Nombre de jours restants sur le PASS IAE : 357199 jours
+                  <i class="ri-information-line ri-xl text-info"
+                     data-bs-toggle="tooltip"
+                     title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+              </li>
+  
+              
+  
+              
+                  <li class="pb-2">
+                      Date de fin prévisionnelle : 01/01/3000
+                      <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="Cette date de fin est susceptible d'évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i>
+                  </li>
+              
+          </ul>
+      
+  </div>
+  
+  
+      
+      
+          
+      
+  
+      
+      
+          
+      
+  
+  
+  '''
+# ---
+# name: TestStatusInclude.test_valid_approval_for_employer_not_from_pe_approval[valid_approval_for_employer]
+  '''
+  
+  
+  
+  
+  
+  
+  
+      <div class="text-center mb-3">
+          
+              <img src="/static/img/pass_iae/logo_pass_iae.svg" width="180" alt="Logo du PASS IAE">
+          
+      </div>
+  
+  
+  <div class="ps-3 border-start approval-left-border">
+      <p class="mb-1">
+          
+              Numéro de PASS IAE :
+          
+          
+              <b><span>99999</span><span class="ms-1">99</span><span class="ms-1">99999</span></b>
+          
+      </p>
+  
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
       
   
       
@@ -256,6 +332,8 @@
           
       </p>
   
+      
+          <p class="mb-1">Ce PASS IAE a été importé depuis un agrément Pôle emploi.</p>
       
   
       

--- a/tests/www/approvals_views/test_includes.py
+++ b/tests/www/approvals_views/test_includes.py
@@ -4,7 +4,7 @@ import pytest  # noqa
 from django.template import Context, Template
 from freezegun import freeze_time
 
-import itou.job_applications.enums as job_applications_enums
+import itou.approvals.enums as approvals_enums
 from tests.approvals.factories import ApprovalFactory
 from tests.eligibility.factories import IAEEligibilityDiagnosisFactory
 from tests.users.factories import EmployerFactory, PrescriberFactory
@@ -20,7 +20,7 @@ class TestStatusInclude:
                 "user": EmployerFactory(),
                 "hiring_pending": False,
                 "job_application": None,
-                "JobApplicationOrigin": job_applications_enums.Origin,
+                "ApprovalOrigin": approvals_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -33,7 +33,7 @@ class TestStatusInclude:
                 "user": PrescriberFactory(),
                 "hiring_pending": False,
                 "job_application": None,
-                "JobApplicationOrigin": job_applications_enums.Origin,
+                "ApprovalOrigin": approvals_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -46,7 +46,7 @@ class TestStatusInclude:
                 "user": EmployerFactory(),
                 "hiring_pending": False,
                 "job_application": None,
-                "JobApplicationOrigin": job_applications_enums.Origin,
+                "ApprovalOrigin": approvals_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -63,7 +63,7 @@ class TestStatusInclude:
                 "user": EmployerFactory(),
                 "hiring_pending": False,
                 "job_application": None,
-                "JobApplicationOrigin": job_applications_enums.Origin,
+                "ApprovalOrigin": approvals_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -80,7 +80,7 @@ class TestStatusInclude:
                 "user": PrescriberFactory(),
                 "hiring_pending": False,
                 "job_application": None,
-                "JobApplicationOrigin": job_applications_enums.Origin,
+                "ApprovalOrigin": approvals_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
@@ -97,10 +97,29 @@ class TestStatusInclude:
                 "user": approval.user,
                 "hiring_pending": False,
                 "job_application": None,
-                "JobApplicationOrigin": job_applications_enums.Origin,
+                "ApprovalOrigin": approvals_enums.Origin,
             }
         )
         rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
         assert remove_static_hash(rendered_template) == snapshot(
             name="expired_approval_with_eligibility_diagnosis_for_jobseeker"
         )
+
+    def test_valid_approval_for_employer_not_from_pe_approval(self, snapshot, db):
+        context = Context(
+            {
+                "common_approval": ApprovalFactory(
+                    number="999999999999",
+                    user__for_snapshot=True,
+                    start_at=datetime.date(2000, 1, 1),
+                    end_at=datetime.date(3000, 1, 1),
+                    origin_ai_stock=True,
+                ),
+                "user": EmployerFactory(),
+                "hiring_pending": False,
+                "job_application": None,
+                "ApprovalOrigin": approvals_enums.Origin,
+            }
+        )
+        rendered_template = Template('{% include "approvals/includes/status.html" %}').render(context)
+        assert remove_static_hash(rendered_template) == snapshot(name="valid_approval_for_employer")

--- a/tests/www/approvals_views/test_includes.py
+++ b/tests/www/approvals_views/test_includes.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest  # noqa
 from django.template import Context, Template
+from django.test import RequestFactory
 from freezegun import freeze_time
 
 import itou.approvals.enums as approvals_enums
@@ -14,10 +15,12 @@ from tests.utils.test import remove_static_hash
 @freeze_time("2022-01-10")
 class TestStatusInclude:
     def test_valid_approval_for_employer(self, snapshot, db):
+        request = RequestFactory()
+        request.user = EmployerFactory()
         context = Context(
             {
                 "common_approval": ApprovalFactory(for_snapshot=True),
-                "user": EmployerFactory(),
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,
@@ -27,10 +30,12 @@ class TestStatusInclude:
         assert remove_static_hash(rendered_template) == snapshot(name="valid_approval_for_employer")
 
     def test_valid_approval_for_prescriber(self, snapshot, db):
+        request = RequestFactory()
+        request.user = PrescriberFactory()
         context = Context(
             {
                 "common_approval": ApprovalFactory(for_snapshot=True),
-                "user": PrescriberFactory(),
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,
@@ -40,10 +45,12 @@ class TestStatusInclude:
         assert remove_static_hash(rendered_template) == snapshot(name="valid_approval_for_prescriber")
 
     def test_expired_approval_without_eligibility_diagnosis_for_employer(self, snapshot, db):
+        request = RequestFactory()
+        request.user = EmployerFactory()
         context = Context(
             {
                 "common_approval": ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1)),
-                "user": EmployerFactory(),
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,
@@ -55,12 +62,14 @@ class TestStatusInclude:
         )
 
     def test_expired_approval_with_eligibility_diagnosis_for_employer(self, snapshot, db):
+        request = RequestFactory()
+        request.user = EmployerFactory()
         approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
         approval.eligibility_diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=approval.user)
         context = Context(
             {
                 "common_approval": approval,
-                "user": EmployerFactory(),
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,
@@ -72,12 +81,14 @@ class TestStatusInclude:
         )
 
     def test_expired_approval_with_eligibility_diagnosis_for_prescriber(self, snapshot, db):
+        request = RequestFactory()
+        request.user = PrescriberFactory()
         approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
         approval.eligibility_diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=approval.user)
         context = Context(
             {
                 "common_approval": approval,
-                "user": PrescriberFactory(),
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,
@@ -91,10 +102,12 @@ class TestStatusInclude:
     def test_expired_approval_with_eligibility_diagnosis_for_jobseeker(self, snapshot, db):
         approval = ApprovalFactory(for_snapshot=True, end_at=datetime.date(2022, 1, 1))
         approval.eligibility_diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=approval.user)
+        request = RequestFactory()
+        request.user = approval.user
         context = Context(
             {
                 "common_approval": approval,
-                "user": approval.user,
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,
@@ -106,6 +119,8 @@ class TestStatusInclude:
         )
 
     def test_valid_approval_for_employer_not_from_pe_approval(self, snapshot, db):
+        request = RequestFactory()
+        request.user = EmployerFactory()
         context = Context(
             {
                 "common_approval": ApprovalFactory(
@@ -115,7 +130,7 @@ class TestStatusInclude:
                     end_at=datetime.date(3000, 1, 1),
                     origin_ai_stock=True,
                 ),
-                "user": EmployerFactory(),
+                "request": request,
                 "hiring_pending": False,
                 "job_application": None,
                 "ApprovalOrigin": approvals_enums.Origin,

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -21,7 +21,7 @@ from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
 from tests.utils.test import TestCase, parse_response_to_soup
 
 
-@pytest.mark.ignore_unknown_variable_template_error("job_application", "hiring_pending")
+@pytest.mark.ignore_unknown_variable_template_error("hiring_pending")
 @pytest.mark.usefixtures("unittest_compatibility")
 @freeze_time("2023-08-23")
 class ApprovalProlongationTest(TestCase):

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -21,7 +21,6 @@ from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
 from tests.utils.test import TestCase, parse_response_to_soup
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending")
 @pytest.mark.usefixtures("unittest_compatibility")
 @freeze_time("2023-08-23")
 class ApprovalProlongationTest(TestCase):

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -105,7 +105,6 @@ def test_list_view_only_pending_filter(client):
     assert list(response.context["pager"].object_list) == [pending_prolongation_request]
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending")
 def test_show_view_access(client):
     prolongation_request, other_prolongation_request = approvals_factories.ProlongationRequestFactory.create_batch(2)
 
@@ -133,7 +132,7 @@ def test_show_view_access(client):
     assert response.status_code == 404
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "matomo_event_attrs")
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 def test_show_view(snapshot, client):
     prolongation_request = approvals_factories.ProlongationRequestFactory(for_snapshot=True)
     client.force_login(prolongation_request.validated_by)
@@ -146,7 +145,7 @@ def test_show_view(snapshot, client):
     assert_previous_step(response, reverse("approvals:prolongation_requests_list") + "?only_pending=on")
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "matomo_event_attrs")
+@pytest.mark.ignore_unknown_variable_template_error("matomo_event_attrs")
 def test_show_view_no_siae(client):
     prolongation_request = approvals_factories.ProlongationRequestFactory()
     prolongation_request.declared_by_siae.delete()

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -105,7 +105,7 @@ def test_list_view_only_pending_filter(client):
     assert list(response.context["pager"].object_list) == [pending_prolongation_request]
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application")
+@pytest.mark.ignore_unknown_variable_template_error("hiring_pending")
 def test_show_view_access(client):
     prolongation_request, other_prolongation_request = approvals_factories.ProlongationRequestFactory.create_batch(2)
 
@@ -133,7 +133,7 @@ def test_show_view_access(client):
     assert response.status_code == 404
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application", "matomo_event_attrs")
+@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "matomo_event_attrs")
 def test_show_view(snapshot, client):
     prolongation_request = approvals_factories.ProlongationRequestFactory(for_snapshot=True)
     client.force_login(prolongation_request.validated_by)
@@ -146,7 +146,7 @@ def test_show_view(snapshot, client):
     assert_previous_step(response, reverse("approvals:prolongation_requests_list") + "?only_pending=on")
 
 
-@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application", "matomo_event_attrs")
+@pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "matomo_event_attrs")
 def test_show_view_no_siae(client):
     prolongation_request = approvals_factories.ProlongationRequestFactory()
     prolongation_request.declared_by_siae.delete()

--- a/tests/www/approvals_views/test_suspend.py
+++ b/tests/www/approvals_views/test_suspend.py
@@ -20,7 +20,6 @@ from tests.utils.test import BASE_NUM_QUERIES, TestCase, parse_response_to_soup
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class ApprovalSuspendViewTest(TestCase):
-    @pytest.mark.ignore_unknown_variable_template_error("hiring_pending")
     def test_suspend_approval(self):
         """
         Test the creation of a suspension.

--- a/tests/www/approvals_views/test_suspend.py
+++ b/tests/www/approvals_views/test_suspend.py
@@ -20,7 +20,7 @@ from tests.utils.test import BASE_NUM_QUERIES, TestCase, parse_response_to_soup
 
 @pytest.mark.usefixtures("unittest_compatibility")
 class ApprovalSuspendViewTest(TestCase):
-    @pytest.mark.ignore_unknown_variable_template_error("hiring_pending", "job_application")
+    @pytest.mark.ignore_unknown_variable_template_error("hiring_pending")
     def test_suspend_approval(self):
         """
         Test the creation of a suspension.


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela semble plus logique (et plus simple).

- On utilise désormais l'origine du PASS et non celle de la candidature pour afficher le texte `Ce PASS IAE a été importé depuis un agrément Pôle emploi.`
- Affichage systématique de la date de fin prévisionnelle, sauf:
  * pour le parcours de candidature/d'embauche
  * l'acceptation d'une candidature

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
