### PR TITLE
Candidature: ajout d'une notification au candidat et au prescripteur/orienteur éventuel lors d'une mise en attente [GEN-1759]

### DIFF
--- a/itou/job_applications/notifications.py
+++ b/itou/job_applications/notifications.py
@@ -63,6 +63,28 @@ class JobApplicationNewForEmployerNotification(EmployerNotification, EmailNotifi
 
 
 @notifications_registry.register
+class JobApplicationPostponedForJobSeekerNotification(JobSeekerNotification, EmailNotification):
+    """Notification sent to job seeker when postponed"""
+
+    name = "Mise en attente de candidature"
+    category = NotificationCategory.JOB_APPLICATION
+    can_be_disabled = False
+    subject_template = "apply/email/postpone_for_job_seeker_subject.txt"
+    body_template = "apply/email/postpone_for_job_seeker_body.txt"
+
+
+@notifications_registry.register
+class JobApplicationPostponedForProxyNotification(PrescriberOrEmployerNotification, EmailNotification):
+    """Notification sent to proxy (prescriber or employer/orienter) when postponed"""
+
+    name = "Mise en attente d’une candidature envoyée"
+    category = NotificationCategory.JOB_APPLICATION
+    can_be_disabled = False
+    subject_template = "apply/email/postpone_for_proxy_subject.txt"
+    body_template = "apply/email/postpone_for_proxy_body.txt"
+
+
+@notifications_registry.register
 class JobApplicationAcceptedForJobSeekerNotification(JobSeekerNotification, EmailNotification):
     """Notification sent to job seeker when accepted"""
 

--- a/itou/templates/apply/email/postpone_for_job_seeker_body.txt
+++ b/itou/templates/apply/email/postpone_for_job_seeker_body.txt
@@ -1,0 +1,12 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+Suite à votre candidature au sein de la structure {{ job_application.to_company.kind }} {{ job_application.to_company.display_name }}, l’employeur a mis votre candidature en attente.
+
+{% if job_application.answer %}
+Commentaire de l’employeur:
+
+{{ job_application.answer }}
+{% endif %}
+{% endblock body %}

--- a/itou/templates/apply/email/postpone_for_job_seeker_subject.txt
+++ b/itou/templates/apply/email/postpone_for_job_seeker_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Votre candidature mise en attente par {{ job_application.to_company.kind }} {{ job_application.to_company.display_name }}
+{% endblock %}

--- a/itou/templates/apply/email/postpone_for_proxy_body.txt
+++ b/itou/templates/apply/email/postpone_for_proxy_body.txt
@@ -1,0 +1,12 @@
+{% extends "layout/base_email_text_body.txt" %}
+{% block body %}
+Bonjour,
+
+La candidature de {{ job_application.job_seeker.get_full_name }} au sein de la structure {{ job_application.to_company.kind }} {{ job_application.to_company.display_name }} a été mise en attente par l’employeur.
+
+{% if job_application.answer %}
+Commentaire de l’employeur:
+
+{{ job_application.answer }}
+{% endif %}
+{% endblock body %}

--- a/itou/templates/apply/email/postpone_for_proxy_subject.txt
+++ b/itou/templates/apply/email/postpone_for_proxy_subject.txt
@@ -1,0 +1,4 @@
+{% extends "layout/base_email_text_subject.txt" %}
+{% block subject %}
+Candidature de {{ job_application.job_seeker.get_full_name }} mise en attente par {{ job_application.to_company.kind }} {{ job_application.to_company.display_name }}
+{% endblock %}

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -110,6 +110,93 @@
   </ul>
   '''
 # ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_body]
+  '''
+  Bonjour,
+  
+  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_subject]
+  '[DEV] Votre candidature mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_proxy_body]
+  '''
+  Bonjour,
+  
+  La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_proxy_subject]
+  '[DEV] Candidature de Jane DOE mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_job_seeker[postpone_email_to_job_seeker_body]
+  '''
+  Bonjour,
+  
+  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
+  
+  Commentaire de l’employeur:
+  
+  On vous rappellera.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_job_seeker[postpone_email_to_job_seeker_subject]
+  '[DEV] Votre candidature mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_job_seeker_body]
+  '''
+  Bonjour,
+  
+  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_job_seeker_subject]
+  '[DEV] Votre candidature mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_proxy_body]
+  '''
+  Bonjour,
+  
+  La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_proxy_subject]
+  '[DEV] Candidature de Jane DOE mise en attente par EI Acme inc.'
+# ---
 # name: test_add_prior_action_processing
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour tenter de réduire le nombre de candidature restant bloquée pour cause de candidat injoignable ou ne se présentant pas à l'entretien.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

https://c1-review-xfernandez-postponed-notification.cleverapps.io/

Mettre des candidatures en attente et aller voir dans l'admin les mails générés.

## :computer: Captures d'écran <!-- optionnel -->
