### PR TITLE
Vie privée: utilisation du ID public en place de PK dans les URLs

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -124,7 +124,7 @@
     {% include "apply/includes/job_application_diagoriente_invite.html" with job_application=job_application %}
 {% endif %}
 
-<a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_pk=job_seeker.pk %}?back_url={{ request.get_full_path|urlencode }}{% if job_application %}&from_application={{ job_application.pk }}{% endif %}{% endif %}"
+<a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}{% if job_application %}&from_application={{ job_application.pk }}{% endif %}{% endif %}"
    class="btn btn-ico btn-secondary{% if not can_edit_personal_information %} disabled{% endif %}"
    {% if with_matomo_event %}{% matomo_event "salaries" "clic" "edit_jobseeker_infos" %}{% endif %}
    aria-label="Modifier les informations personnelles de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}">

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -35,7 +35,7 @@
         <p>
             Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}
             {% if can_view_personal_information and not request.user.is_job_seeker %}
-                <a class="btn btn-link" href="{% url "apply:update_job_seeker_step_1" company_pk=siae.pk job_seeker_pk=job_seeker.pk %}">Vérifier le profil</a>
+                <a class="btn btn-link" href="{% url "apply:update_job_seeker_step_1" company_pk=siae.pk job_seeker_public_id=job_seeker.public_id %}">Vérifier le profil</a>
             {% endif %}
             {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning"></i>{% endif %}
         </p>

--- a/itou/templates/apply/submit/check_job_seeker_info_for_hire.html
+++ b/itou/templates/apply/submit/check_job_seeker_info_for_hire.html
@@ -14,12 +14,12 @@
     <div class="c-box my-4">
         <h1>
             Informations personnelles
-            <a class="btn btn-outline-primary float-end" href="{% url "apply:update_job_seeker_step_1_for_hire" company_pk=siae.pk job_seeker_pk=job_seeker.pk %}">Mettre à jour</a>
+            <a class="btn btn-outline-primary float-end" href="{% url "apply:update_job_seeker_step_1_for_hire" company_pk=siae.pk job_seeker_public_id=job_seeker.public_id %}">Mettre à jour</a>
         </h1>
 
         {% include "apply/includes/profile_infos.html" %}
 
-        {% url 'apply:check_prev_applications_for_hire' company_pk=siae.pk job_seeker_pk=job_seeker.pk as primary_url %}
+        {% url 'apply:check_prev_applications_for_hire' company_pk=siae.pk job_seeker_public_id=job_seeker.public_id as primary_url %}
         {% itou_buttons_form primary_url=primary_url primary_label="Poursuivre l'embauche" secondary_url=back_url show_mandatory_fields_mention=False %}
     </div>
 

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -51,32 +51,32 @@ urlpatterns = [
     ),
     # Submit - common.
     path(
-        "<int:company_pk>/create/<int:job_seeker_pk>/check_job_seeker_info",
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/check_job_seeker_info",
         submit_views.CheckJobSeekerInformations.as_view(),
         name="step_check_job_seeker_info",
     ),
     path(
-        "<int:company_pk>/create/<int:job_seeker_pk>/check_prev_applications",
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/check_prev_applications",
         submit_views.CheckPreviousApplications.as_view(),
         name="step_check_prev_applications",
     ),
     path(
-        "<int:company_pk>/create/<int:job_seeker_pk>/select_jobs",
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/select_jobs",
         submit_views.ApplicationJobsView.as_view(),
         name="application_jobs",
     ),
     path(
-        "<int:company_pk>/create/<int:job_seeker_pk>/eligibility",
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/eligibility",
         submit_views.ApplicationEligibilityView.as_view(),
         name="application_eligibility",
     ),
     path(
-        "<int:company_pk>/create/<int:job_seeker_pk>/geiq_eligibility",
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/geiq_eligibility",
         submit_views.ApplicationGEIQEligibilityView.as_view(),
         name="application_geiq_eligibility",
     ),
     path(
-        "<int:company_pk>/create/<int:job_seeker_pk>/resume",
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/resume",
         submit_views.ApplicationResumeView.as_view(),
         name="application_resume",
     ),
@@ -87,22 +87,22 @@ urlpatterns = [
     ),
     # Job seeker check/updates
     path(
-        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/1",
+        "<int:company_pk>/update_job_seeker/<uuid:job_seeker_public_id>/1",
         submit_views.UpdateJobSeekerStep1View.as_view(),
         name="update_job_seeker_step_1",
     ),
     path(
-        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/2",
+        "<int:company_pk>/update_job_seeker/<uuid:job_seeker_public_id>/2",
         submit_views.UpdateJobSeekerStep2View.as_view(),
         name="update_job_seeker_step_2",
     ),
     path(
-        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/3",
+        "<int:company_pk>/update_job_seeker/<uuid:job_seeker_public_id>/3",
         submit_views.UpdateJobSeekerStep3View.as_view(),
         name="update_job_seeker_step_3",
     ),
     path(
-        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/end",
+        "<int:company_pk>/update_job_seeker/<uuid:job_seeker_public_id>/end",
         submit_views.UpdateJobSeekerStepEndView.as_view(),
         name="update_job_seeker_step_end",
     ),
@@ -144,58 +144,58 @@ urlpatterns = [
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/1",
+        "<int:company_pk>/hire/update-job-seeker/<uuid:job_seeker_public_id>/1",
         submit_views.UpdateJobSeekerStep1View.as_view(),
         name="update_job_seeker_step_1_for_hire",
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/2",
+        "<int:company_pk>/hire/update-job-seeker/<uuid:job_seeker_public_id>/2",
         submit_views.UpdateJobSeekerStep2View.as_view(),
         name="update_job_seeker_step_2_for_hire",
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/3",
+        "<int:company_pk>/hire/update-job-seeker/<uuid:job_seeker_public_id>/3",
         submit_views.UpdateJobSeekerStep3View.as_view(),
         name="update_job_seeker_step_3_for_hire",
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/end",
+        "<int:company_pk>/hire/update-job-seeker/<uuid:job_seeker_public_id>/end",
         submit_views.UpdateJobSeekerStepEndView.as_view(),
         name="update_job_seeker_step_end_for_hire",
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/<int:job_seeker_pk>/check-infos",
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/check-infos",
         submit_views.CheckJobSeekerInformationsForHire.as_view(),
         name="check_job_seeker_info_for_hire",
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/<int:job_seeker_pk>/check-previous-applications",
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/check-previous-applications",
         submit_views.CheckPreviousApplications.as_view(),
         name="check_prev_applications_for_hire",
         kwargs={"hire_process": True},
     ),
     path(
-        "<int:company_pk>/hire/<int:job_seeker_pk>/eligibility",
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/eligibility",
         submit_views.eligibility_for_hire,
         name="eligibility_for_hire",
     ),
     path(
-        "<int:company_pk>/hire/<int:job_seeker_pk>/geiq-eligibility",
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/geiq-eligibility",
         submit_views.geiq_eligibility_for_hire,
         name="geiq_eligibility_for_hire",
     ),
     path(
-        "<int:company_pk>/hire/<int:job_seeker_pk>/geiq-eligibility-criteria",
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/geiq-eligibility-criteria",
         submit_views.geiq_eligibility_criteria_for_hire,
         name="geiq_eligibility_criteria_for_hire",
     ),
     path(
-        "<int:company_pk>/hire/<int:job_seeker_pk>/confirm",
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/confirm",
         submit_views.hire_confirmation,
         name="hire_confirmation",
     ),
@@ -302,5 +302,96 @@ urlpatterns = [
         "<int:company_pk>/accept/reload_job_description_fields",
         process_views.ReloadJobDescriptionFields.as_view(),
         name="reload_job_description_fields",
+    ),
+]
+
+# NOTE: temporary URL patterns to help with migration which will be removed next week
+urlpatterns += [
+    path(
+        "<int:company_pk>/create/<int:job_seeker_pk>/check_job_seeker_info",
+        submit_views.CheckJobSeekerInformations.as_view(),
+    ),
+    path(
+        "<int:company_pk>/create/<int:job_seeker_pk>/check_prev_applications",
+        submit_views.CheckPreviousApplications.as_view(),
+    ),
+    path(
+        "<int:company_pk>/create/<int:job_seeker_pk>/select_jobs",
+        submit_views.ApplicationJobsView.as_view(),
+    ),
+    path(
+        "<int:company_pk>/create/<int:job_seeker_pk>/eligibility",
+        submit_views.ApplicationEligibilityView.as_view(),
+    ),
+    path(
+        "<int:company_pk>/create/<int:job_seeker_pk>/geiq_eligibility",
+        submit_views.ApplicationGEIQEligibilityView.as_view(),
+    ),
+    path(
+        "<int:company_pk>/create/<int:job_seeker_pk>/resume",
+        submit_views.ApplicationResumeView.as_view(),
+    ),
+    path(
+        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/1",
+        submit_views.UpdateJobSeekerStep1View.as_view(),
+    ),
+    path(
+        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/2",
+        submit_views.UpdateJobSeekerStep2View.as_view(),
+    ),
+    path(
+        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/3",
+        submit_views.UpdateJobSeekerStep3View.as_view(),
+    ),
+    path(
+        "<int:company_pk>/update_job_seeker/<int:job_seeker_pk>/end",
+        submit_views.UpdateJobSeekerStepEndView.as_view(),
+    ),
+    path(
+        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/1",
+        submit_views.UpdateJobSeekerStep1View.as_view(),
+        name="update_job_seeker_step_1_for_hire_pk_redirect",
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/2",
+        submit_views.UpdateJobSeekerStep2View.as_view(),
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/3",
+        submit_views.UpdateJobSeekerStep3View.as_view(),
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<int:company_pk>/hire/update-job-seeker/<int:job_seeker_pk>/end",
+        submit_views.UpdateJobSeekerStepEndView.as_view(),
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<int:company_pk>/hire/<int:job_seeker_pk>/check-infos",
+        submit_views.CheckJobSeekerInformationsForHire.as_view(),
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<int:company_pk>/hire/<int:job_seeker_pk>/check-previous-applications",
+        submit_views.CheckPreviousApplications.as_view(),
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<int:company_pk>/hire/<int:job_seeker_pk>/eligibility",
+        submit_views.eligibility_for_hire,
+    ),
+    path(
+        "<int:company_pk>/hire/<int:job_seeker_pk>/geiq-eligibility",
+        submit_views.geiq_eligibility_for_hire,
+    ),
+    path(
+        "<int:company_pk>/hire/<int:job_seeker_pk>/geiq-eligibility-criteria",
+        submit_views.geiq_eligibility_criteria_for_hire,
+    ),
+    path(
+        "<int:company_pk>/hire/<int:job_seeker_pk>/confirm",
+        submit_views.hire_confirmation,
     ),
 ]

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -275,7 +275,7 @@ def _geiq_eligibility_criteria(
         "progress": 66,
         "back_url": reverse(
             "apply:check_job_seeker_info_for_hire",
-            kwargs={"job_seeker_pk": job_seeker.pk, "company_pk": company.pk},
+            kwargs={"job_seeker_public_id": job_seeker.public_id, "company_pk": company.pk},
         ),
     }
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -41,6 +41,7 @@ from itou.www.apply.forms import (
     SubmitJobApplicationForm,
 )
 from itou.www.apply.views import common as common_views, constants as apply_view_constants
+from itou.www.apply.views.utils import get_job_seeker_public_id
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
 from itou.www.geiq_eligibility_views.forms import GEIQAdministrativeCriteriaForm
 
@@ -159,7 +160,15 @@ class ApplicationBaseView(ApplyStepBaseView):
         if not request.user.is_authenticated:
             # Do nothing, LoginRequiredMixin will raise in dispatch()
             return
-        self.job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), pk=kwargs["job_seeker_pk"])
+
+        job_seeker_public_id = (
+            kwargs["job_seeker_public_id"]
+            if "job_seeker_public_id" in kwargs
+            else get_job_seeker_public_id(kwargs["job_seeker_pk"])
+        )
+        self.job_seeker = get_object_or_404(
+            User.objects.filter(kind=UserKind.JOB_SEEKER), public_id=job_seeker_public_id
+        )
         _check_job_seeker_approval(request, self.job_seeker, self.company)
         if self.company.kind == CompanyKind.GEIQ:
             self.geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(
@@ -206,10 +215,10 @@ class ApplyStepForSenderBaseView(ApplyStepBaseView):
             return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
         return super().dispatch(request, *args, **kwargs)
 
-    def redirect_to_check_infos(self, job_seeker_pk):
+    def redirect_to_check_infos(self, job_seeker_public_id):
         view_name = "apply:check_job_seeker_info_for_hire" if self.hire_process else "apply:step_check_job_seeker_info"
         return HttpResponseRedirect(
-            reverse(view_name, kwargs={"company_pk": self.company.pk, "job_seeker_pk": job_seeker_pk})
+            reverse(view_name, kwargs={"company_pk": self.company.pk, "job_seeker_public_id": job_seeker_public_id})
         )
 
 
@@ -282,7 +291,7 @@ class CheckNIRForJobSeekerView(ApplyStepBaseView):
             return HttpResponseRedirect(
                 reverse(
                     "apply:step_check_job_seeker_info",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
                 )
             )
 
@@ -293,7 +302,7 @@ class CheckNIRForJobSeekerView(ApplyStepBaseView):
             return HttpResponseRedirect(
                 reverse(
                     "apply:step_check_job_seeker_info",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
                 )
             )
 
@@ -304,7 +313,7 @@ class CheckNIRForJobSeekerView(ApplyStepBaseView):
             return HttpResponseRedirect(
                 reverse(
                     "apply:step_check_job_seeker_info",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
                 )
             )
 
@@ -360,7 +369,7 @@ class CheckNIRForSenderView(ApplyStepForSenderBaseView):
                     )
                     return HttpResponseRedirect(reverse("gps:my_groups"))
                 else:
-                    return self.redirect_to_check_infos(job_seeker.pk)
+                    return self.redirect_to_check_infos(job_seeker.public_id)
 
             context = {
                 # Ask the sender to confirm the NIR we found is associated to the correct user
@@ -431,7 +440,7 @@ class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, ApplyStepForSend
             # The email we found is correct
             if self.form.data.get("confirm"):
                 if not can_add_nir:
-                    return self.redirect_to_check_infos(job_seeker.pk)
+                    return self.redirect_to_check_infos(job_seeker.public_id)
 
                 try:
                     job_seeker.jobseeker_profile.nir = nir
@@ -454,7 +463,7 @@ class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, ApplyStepForSend
                         )
                         return HttpResponseRedirect(reverse("gps:my_groups"))
                     else:
-                        return self.redirect_to_check_infos(job_seeker.pk)
+                        return self.redirect_to_check_infos(job_seeker.public_id)
 
         return self.render_to_response(
             self.get_context_data(**kwargs)
@@ -682,7 +691,7 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
         )
 
     def get_next_url(self):
-        kwargs = {"company_pk": self.company.pk, "job_seeker_pk": self.profile.user.pk}
+        kwargs = {"company_pk": self.company.pk, "job_seeker_public_id": self.profile.user.public_id}
 
         if self.is_gps:
             kwargs = {}
@@ -759,7 +768,7 @@ class CheckJobSeekerInformations(ApplicationBaseView):
             return HttpResponseRedirect(
                 reverse(
                     "apply:step_check_prev_applications",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
                 )
             )
 
@@ -771,7 +780,7 @@ class CheckJobSeekerInformations(ApplicationBaseView):
             return HttpResponseRedirect(
                 reverse(
                     "apply:step_check_prev_applications",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
                 )
             )
 
@@ -829,7 +838,9 @@ class CheckPreviousApplications(ApplicationBaseView):
             )
         else:
             view_name = "apply:application_jobs"
-        return reverse(view_name, kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk})
+        return reverse(
+            view_name, kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id}
+        )
 
     def get(self, request, *args, **kwargs):
         if not self.previous_applications.exists():
@@ -891,7 +902,8 @@ class ApplicationJobsView(ApplicationBaseView):
             )
             return HttpResponseRedirect(
                 reverse(
-                    "apply:" + path_name, kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
+                    "apply:" + path_name,
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
                 )
             )
 
@@ -944,7 +956,8 @@ class ApplicationEligibilityView(ApplicationBaseView):
 
     def get_next_url(self):
         return reverse(
-            "apply:application_resume", kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
+            "apply:application_resume",
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
 
     def dispatch(self, request, *args, **kwargs):
@@ -996,7 +1009,8 @@ class ApplicationEligibilityView(ApplicationBaseView):
             "progress": 50,
             "job_seeker": self.job_seeker,
             "back_url": reverse(
-                "apply:application_jobs", kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
+                "apply:application_jobs",
+                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
             ),
             "full_content_width": True,
         }
@@ -1028,14 +1042,15 @@ class ApplicationGEIQEligibilityView(ApplicationBaseView):
             ),
             form_url=reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
             ),
             data=request.POST or None,
         )
 
     def get_next_url(self):
         return reverse(
-            "apply:application_resume", kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
+            "apply:application_resume",
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
 
     def dispatch(self, request, *args, **kwargs):
@@ -1049,7 +1064,8 @@ class ApplicationGEIQEligibilityView(ApplicationBaseView):
         geo_criteria_detected = self.job_seeker.address_in_qpv or self.job_seeker.zrr_city_name
         return super().get_context_data(**kwargs) | {
             "back_url": reverse(
-                "apply:application_jobs", kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
+                "apply:application_jobs",
+                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
             ),
             "form": self.form,
             "full_content_width": True,
@@ -1193,7 +1209,7 @@ class ApplicationResumeView(ApplicationBaseView):
 
         return reverse(
             view_name,
-            kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
 
     def get_context_data(self, **kwargs):
@@ -1264,8 +1280,14 @@ class UpdateJobSeekerBaseView(SessionNamespaceRequiredMixin, ApplyStepBaseView):
         return User.objects.filter(kind=UserKind.JOB_SEEKER)
 
     def setup(self, request, *args, **kwargs):
-        self.job_seeker = get_object_or_404(self.get_job_seeker_queryset(), pk=kwargs["job_seeker_pk"])
-        self.job_seeker_session = SessionNamespace(request.session, f"job_seeker-{self.job_seeker.pk}")
+        job_seeker_public_id = (
+            kwargs["job_seeker_public_id"]
+            if "job_seeker_public_id" in kwargs
+            else get_job_seeker_public_id(kwargs["job_seeker_pk"])
+        )
+
+        self.job_seeker = get_object_or_404(self.get_job_seeker_queryset(), public_id=job_seeker_public_id)
+        self.job_seeker_session = SessionNamespace(request.session, f"job_seeker-{self.job_seeker.public_id}")
         if request.user.is_authenticated and (
             request.user.is_job_seeker or not request.user.can_view_personal_information(self.job_seeker)
         ):
@@ -1279,10 +1301,11 @@ class UpdateJobSeekerBaseView(SessionNamespaceRequiredMixin, ApplyStepBaseView):
             "job_seeker": self.job_seeker,
             "step_3_url": reverse(
                 "apply:update_job_seeker_step_3_for_hire" if self.hire_process else "apply:update_job_seeker_step_3",
-                kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
             ),
             "reset_url": reverse(
-                "apply:application_jobs", kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk}
+                "apply:application_jobs",
+                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
             ),
             "readonly_form": False,
         }
@@ -1295,14 +1318,14 @@ class UpdateJobSeekerBaseView(SessionNamespaceRequiredMixin, ApplyStepBaseView):
         view_name = self.previous_hire_url if self.hire_process else self.previous_apply_url
         return reverse(
             view_name,
-            kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
 
     def get_next_url(self):
         view_name = self.next_hire_url if self.hire_process else self.next_apply_url
         return reverse(
             view_name,
-            kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
 
 
@@ -1538,7 +1561,7 @@ class UpdateJobSeekerStepEndView(UpdateJobSeekerBaseView):
             messages.error(request, " ".join(e.messages))
             url = reverse(
                 "apply:update_job_seeker_step_1",
-                kwargs={"company_pk": self.company.pk, "job_seeker_pk": self.job_seeker.pk},
+                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
             )
         else:
             self.profile.save()
@@ -1551,11 +1574,18 @@ class UpdateJobSeekerStepEndView(UpdateJobSeekerBaseView):
 
 
 @login_required
-def eligibility_for_hire(request, company_pk, job_seeker_pk, template_name="apply/submit/eligibility_for_hire.html"):
+def eligibility_for_hire(
+    request, company_pk, job_seeker_public_id, template_name="apply/submit/eligibility_for_hire.html"
+):
+    if isinstance(job_seeker_public_id, int):
+        job_seeker_public_id = get_job_seeker_public_id(job_seeker_public_id)
+
     company = get_object_or_404(Company.objects.member_required(request.user), pk=company_pk)
-    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), pk=job_seeker_pk)
+    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), public_id=job_seeker_public_id)
     _check_job_seeker_approval(request, job_seeker, company)
-    next_url = reverse("apply:hire_confirmation", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk})
+    next_url = reverse(
+        "apply:hire_confirmation", kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id}
+    )
     bypass_eligibility_conditions = [
         # Don't perform an eligibility diagnosis is the SIAE doesn't need it,
         not company.is_subject_to_eligibility_rules,
@@ -1569,7 +1599,8 @@ def eligibility_for_hire(request, company_pk, job_seeker_pk, template_name="appl
         company,
         job_seeker,
         cancel_url=reverse(
-            "apply:check_job_seeker_info_for_hire", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk}
+            "apply:check_job_seeker_info_for_hire",
+            kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         ),
         next_url=next_url,
         template_name=template_name,
@@ -1579,13 +1610,18 @@ def eligibility_for_hire(request, company_pk, job_seeker_pk, template_name="appl
 
 @login_required
 def geiq_eligibility_for_hire(
-    request, company_pk, job_seeker_pk, template_name="apply/submit/geiq_eligibility_for_hire.html"
+    request, company_pk, job_seeker_public_id, template_name="apply/submit/geiq_eligibility_for_hire.html"
 ):
+    if isinstance(job_seeker_public_id, int):
+        job_seeker_public_id = get_job_seeker_public_id(job_seeker_public_id)
+
     company = get_object_or_404(
         Company.objects.member_required(request.user).filter(kind=CompanyKind.GEIQ), pk=company_pk
     )
-    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), pk=job_seeker_pk)
-    next_url = reverse("apply:hire_confirmation", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk})
+    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), public_id=job_seeker_public_id)
+    next_url = reverse(
+        "apply:hire_confirmation", kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id}
+    )
     if GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(job_seeker, company).exists():
         return HttpResponseRedirect(next_url)
     return common_views._geiq_eligibility(
@@ -1593,12 +1629,13 @@ def geiq_eligibility_for_hire(
         company,
         job_seeker,
         back_url=reverse(
-            "apply:check_job_seeker_info_for_hire", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk}
+            "apply:check_job_seeker_info_for_hire",
+            kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         ),
         next_url=next_url,
         geiq_eligibility_criteria_url=reverse(
             "apply:geiq_eligibility_criteria_for_hire",
-            kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk},
+            kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         ),
         template_name=template_name,
         extra_context={
@@ -1609,11 +1646,14 @@ def geiq_eligibility_for_hire(
 
 
 @login_required
-def geiq_eligibility_criteria_for_hire(request, company_pk, job_seeker_pk):
+def geiq_eligibility_criteria_for_hire(request, company_pk, job_seeker_public_id):
+    if isinstance(job_seeker_public_id, int):
+        job_seeker_public_id = get_job_seeker_public_id(job_seeker_public_id)
+
     company = get_object_or_404(
         Company.objects.member_required(request.user).filter(kind=CompanyKind.GEIQ), pk=company_pk
     )
-    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), pk=job_seeker_pk)
+    job_seeker = get_object_or_404(User.objects.filter(kind=UserKind.JOB_SEEKER), public_id=job_seeker_public_id)
     return common_views._geiq_eligibility_criteria(
         request,
         company,
@@ -1622,10 +1662,14 @@ def geiq_eligibility_criteria_for_hire(request, company_pk, job_seeker_pk):
 
 
 @login_required
-def hire_confirmation(request, company_pk, job_seeker_pk, template_name="apply/submit/hire_confirmation.html"):
+def hire_confirmation(request, company_pk, job_seeker_public_id, template_name="apply/submit/hire_confirmation.html"):
+    if isinstance(job_seeker_public_id, int):
+        job_seeker_public_id = get_job_seeker_public_id(job_seeker_public_id)
+
     company = get_object_or_404(Company.objects.member_required(request.user), pk=company_pk)
     job_seeker = get_object_or_404(
-        User.objects.filter(kind=UserKind.JOB_SEEKER).select_related("jobseeker_profile"), pk=job_seeker_pk
+        User.objects.filter(kind=UserKind.JOB_SEEKER).select_related("jobseeker_profile"),
+        public_id=job_seeker_public_id,
     )
     if company.kind == CompanyKind.GEIQ:
         geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(job_seeker, company).first()
@@ -1643,10 +1687,11 @@ def hire_confirmation(request, company_pk, job_seeker_pk, template_name="apply/s
         company,
         job_seeker,
         error_url=reverse(
-            "apply:hire_confirmation", kwargs={"company_pk": company_pk, "job_seeker_pk": job_seeker_pk}
+            "apply:hire_confirmation", kwargs={"company_pk": company_pk, "job_seeker_public_id": job_seeker_public_id}
         ),
         back_url=reverse(
-            "apply:check_job_seeker_info_for_hire", kwargs={"company_pk": company.pk, "job_seeker_pk": job_seeker.pk}
+            "apply:check_job_seeker_info_for_hire",
+            kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         ),
         template_name=template_name,
         extra_context={

--- a/itou/www/apply/views/utils.py
+++ b/itou/www/apply/views/utils.py
@@ -1,0 +1,14 @@
+from django.shortcuts import get_object_or_404
+
+from itou.users.enums import UserKind
+from itou.users.models import User
+
+
+def get_job_seeker_public_id(job_seeker_pk):
+    """
+    Temporary need for the conversion of primary key to public_id on a job_seeker
+    """
+    return get_object_or_404(
+        User.objects.filter(kind=UserKind.JOB_SEEKER),
+        pk=job_seeker_pk,
+    ).public_id

--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -12,11 +12,19 @@ urlpatterns = [
     path("edit_user_email", views.edit_user_email, name="edit_user_email"),
     path("edit_user_info", views.edit_user_info, name="edit_user_info"),
     path("edit_user_notifications", views.edit_user_notifications, name="edit_user_notifications"),
-    path("edit_job_seeker_info/<int:job_seeker_pk>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
+    path("edit_job_seeker_info/<uuid:job_seeker_public_id>", views.edit_job_seeker_info, name="edit_job_seeker_info"),
     path("switch-organization", views.switch_organization, name="switch_organization"),
     path(
         "activate_ic_account",
         views.AccountMigrationView.as_view(),
         name="activate_ic_account",
     ),
+]
+
+# NOTE: temporary URL patterns to help with migration which will be removed next week
+urlpatterns += [
+    path(
+        "edit_job_seeker_info/<int:job_seeker_public_id>",
+        views.edit_job_seeker_info,
+    )
 ]

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -40,6 +40,7 @@ from itou.utils import constants as global_constants
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.urls import add_url_params, get_absolute_url, get_safe_url
+from itou.www.apply.views.utils import get_job_seeker_public_id
 from itou.www.dashboard.forms import (
     EditJobSeekerInfoForm,
     EditUserEmailForm,
@@ -350,9 +351,13 @@ def edit_user_info(request, template_name="dashboard/edit_user_info.html"):
 
 
 @login_required
-def edit_job_seeker_info(request, job_seeker_pk, template_name="dashboard/edit_job_seeker_info.html"):
+def edit_job_seeker_info(request, job_seeker_public_id, template_name="dashboard/edit_job_seeker_info.html"):
+    if isinstance(job_seeker_public_id, int):
+        job_seeker_public_id = get_job_seeker_public_id(job_seeker_public_id)
+
     job_seeker = get_object_or_404(
-        User.objects.filter(kind=UserKind.JOB_SEEKER).select_related("jobseeker_profile"), pk=job_seeker_pk
+        User.objects.filter(kind=UserKind.JOB_SEEKER).select_related("jobseeker_profile"),
+        public_id=job_seeker_public_id,
     )
     from_application_uuid = request.GET.get("from_application")
     tally_form_query = from_application_uuid and f"jobapplication={from_application_uuid}"

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -231,7 +231,7 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.geiq.pk, "job_seeker_pk": self.job_seeker.pk},
+                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": self.job_seeker.public_id},
             )
         )
 
@@ -256,7 +256,7 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.geiq.pk, "job_seeker_pk": self.job_seeker_in_qpv.pk},
+                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": self.job_seeker_in_qpv.public_id},
             )
         )
 
@@ -283,7 +283,7 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
         response = self.client.get(
             reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.geiq.pk, "job_seeker_pk": self.job_seeker_in_zrr.pk},
+                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": self.job_seeker_in_zrr.public_id},
             )
         )
 

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -377,7 +377,7 @@ class TestApprovalDetailView:
 
         user_info_edit_url = reverse(
             "dashboard:edit_job_seeker_info",
-            kwargs={"job_seeker_pk": job_application.job_seeker_id},
+            kwargs={"job_seeker_public_id": job_application.job_seeker.public_id},
         )
         user_info_edit_url = f"{user_info_edit_url}?back_url={url}&from_application={job_application.pk}"
         user_info_not_allowed = "Vous ne pouvez pas modifier ses informations"

--- a/tests/www/dashboard/test_edit_job_seeker_info.py
+++ b/tests/www/dashboard/test_edit_job_seeker_info.py
@@ -76,7 +76,9 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         url = f"{url}?back_url={back_url}&from_application={job_application.pk}"
 
         with self.assertNumQueries(
@@ -150,7 +152,9 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -200,7 +204,9 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -273,7 +279,9 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.save()
 
         self.client.force_login(user)
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         with self.assertNumQueries(
             BASE_NUM_QUERIES
             + 1  # session
@@ -300,7 +308,9 @@ class EditJobSeekerInfo(TestCase):
             user=other_prescriber, organization=job_application.sender_prescriber_organization
         )
         self.client.force_login(other_prescriber)
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         response = self.client.get(url)
         assert response.status_code == 200
 
@@ -310,7 +320,9 @@ class EditJobSeekerInfo(TestCase):
         user = job_application.sender
         self.client.force_login(user)
 
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
 
         response = self.client.get(url)
         assert response.status_code == 403
@@ -322,7 +334,9 @@ class EditJobSeekerInfo(TestCase):
         # Lambda prescriber not member of the sender organization
         prescriber = PrescriberFactory()
         self.client.force_login(prescriber)
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
 
         response = self.client.get(url)
         assert response.status_code == 403
@@ -340,7 +354,9 @@ class EditJobSeekerInfo(TestCase):
 
         self.client.force_login(user)
         response = self.client.post(
-            reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id}),
+            reverse(
+                "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+            ),
             data=post_data,
         )
         self.assertContains(
@@ -386,7 +402,9 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -441,7 +459,9 @@ class EditJobSeekerInfo(TestCase):
         self.client.force_login(user)
 
         back_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.id})
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         url = f"{url}?back_url={back_url}"
 
         response = self.client.get(url)
@@ -489,7 +509,9 @@ class EditJobSeekerInfo(TestCase):
         job_application.job_seeker.save()
 
         self.client.force_login(user)
-        url = reverse("dashboard:edit_job_seeker_info", kwargs={"job_seeker_pk": job_application.job_seeker_id})
+        url = reverse(
+            "dashboard:edit_job_seeker_info", kwargs={"job_seeker_public_id": job_application.job_seeker.public_id}
+        )
         post_data = {
             "title": "M",
             "email": user.email,


### PR DESCRIPTION
## :thinking: Pourquoi ?

En tant qu’employeur, je ne dois pas récupérer les informations personnelles de tous les candidats des emplois

## :cake: Comment ? <!-- optionnel -->

Remplacer l'utilisation des PKs du base de donnée avec les `public_id`s

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
