### PR TITLE
Candidature: Double fermeture de form sur les filtres candidats

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters/offcanvas.html
+++ b/itou/templates/apply/includes/job_applications_filters/offcanvas.html
@@ -5,7 +5,6 @@
       {% if not request.user.is_job_seeker %}hx-include="#id_job_seeker"{% endif %}
       hx-swap="outerHTML"
       hx-push-url="true">
-    >
     {% comment %}
     Do not reload the entire offcanvas with HTMX. Otherwise, STR :
     1. Select a filter from the top bar (one with btn_dropdown_filter=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Erreur de double fermeture de balise `<form>` sur le htmx des filtres candidats
Chevron en trop visible dans le html sur la page https://demo.emplois.inclusion.beta.gouv.fr/apply/siae/list 

## :computer: Captures d'écran
![capture 2024-07-08 à 16 39 29](https://github.com/gip-inclusion/les-emplois/assets/3874024/f2621b14-ad42-4425-971e-b59d8c426aea)

