### PR TITLE
GPS : indiquer que le téléphone du membre n'est pas renseigné ou que la date de naissance du bénéficiaire n'est pas renseignée

### DIFF
--- a/itou/templates/includes/copy_to_clipboard.html
+++ b/itou/templates/includes/copy_to_clipboard.html
@@ -1,4 +1,4 @@
 <button class="{{ css_classes|default:"btn btn-ico" }}" {% if matomo_event_attrs %}{{ matomo_event_attrs }}{% endif %} data-it-clipboard-button="copy" data-it-copy-to-clipboard="{{ content }}" data-bs-toggle="tooltip" data-bs-placement="{{ placement|default:"top" }}" data-bs-trigger="manual" data-bs-title="Copié !">
     <i class="ri-file-copy-line ri-lg font-weight-normal" aria-hidden="true"></i>
-    <span>{{ text|default:"Copier" }}</span>
+    {% if not only_icon|default:False %}<span>{{ text|default:"Copier" }}</span>{% endif %}
 </button>

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -43,31 +43,15 @@
                                     <li>
                                         <small>Adresse e-mail</small>
                                         <strong>{{ beneficiary.email }}</strong>
-                                        <button class="btn-link"
-                                                data-bs-toggle="tooltip"
-                                                data-bs-placement="top"
-                                                data-bs-trigger="manual"
-                                                data-bs-title="Copié!"
-                                                data-it-clipboard-button="copy"
-                                                data-it-copy-to-clipboard="{{ beneficiary.email }}"
-                                                {% matomo_event "gps" "clic" "copied_user_email" %}>
-                                            <i class="ri-file-copy-line"></i>
-                                        </button>
+                                        {% matomo_event "gps" "clic" "copied_user_email" as matomo_event_attrs %}
+                                        {% include 'includes/copy_to_clipboard.html' with content=beneficiary.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
                                     </li>
                                     <li>
                                         <small>Téléphone</small>
                                         {% if beneficiary.phone %}
                                             <strong>{{ beneficiary.phone|format_phone }}</strong>
-                                            <button class="btn-link"
-                                                    data-bs-toggle="tooltip"
-                                                    data-bs-placement="top"
-                                                    data-bs-trigger="manual"
-                                                    data-bs-title="Copié!"
-                                                    data-it-clipboard-button="copy"
-                                                    data-it-copy-to-clipboard="{{ beneficiary.phone|cut:" " }}"
-                                                    {% matomo_event "gps" "clic" "copied_user_phone" %}>
-                                                <i class="ri-file-copy-line"></i>
-                                            </button>
+                                            {% matomo_event "gps" "clic" "copied_user_phone" as matomo_event_attrs %}
+                                            {% include 'includes/copy_to_clipboard.html' with content=beneficiary.phone css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
                                         {% else %}
                                             <i class="text-disabled">Non renseigné</i>
                                         {% endif %}
@@ -157,15 +141,8 @@
                                         {% if profile.pole_emploi_id or profile.lack_of_pole_emploi_id_reason %}
                                             {% if profile.pole_emploi_id %}
                                                 <strong>{{ profile.pole_emploi_id }}</strong>
-                                                <button class="btn-link"
-                                                        data-bs-toggle="tooltip"
-                                                        data-bs-placement="top"
-                                                        data-bs-trigger="manual"
-                                                        data-bs-title="Copié!"
-                                                        data-it-clipboard-button="copy"
-                                                        data-it-copy-to-clipboard="{{ profile.pole_emploi_id }}">
-                                                    <i class="ri-file-copy-line"></i>
-                                                </button>
+                                                {% matomo_event "gps" "clic" "copied_user_pe_id" as matomo_event_attrs %}
+                                                {% include 'includes/copy_to_clipboard.html' with content=profile.pole_emploi_id css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
                                             {% else %}
                                                 <strong>{{ profile.get_lack_of_pole_emploi_id_reason_display }}</strong>
                                             {% endif %}

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -44,14 +44,14 @@
                                         <small>Adresse e-mail</small>
                                         <strong>{{ beneficiary.email }}</strong>
                                         {% matomo_event "gps" "clic" "copied_user_email" as matomo_event_attrs %}
-                                        {% include 'includes/copy_to_clipboard.html' with content=beneficiary.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
+                                        {% include 'includes/copy_to_clipboard.html' with content=beneficiary.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
                                     </li>
                                     <li>
                                         <small>Téléphone</small>
                                         {% if beneficiary.phone %}
                                             <strong>{{ beneficiary.phone|format_phone }}</strong>
                                             {% matomo_event "gps" "clic" "copied_user_phone" as matomo_event_attrs %}
-                                            {% include 'includes/copy_to_clipboard.html' with content=beneficiary.phone css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
+                                            {% include 'includes/copy_to_clipboard.html' with content=beneficiary.phone css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
                                         {% else %}
                                             <i class="text-disabled">Non renseigné</i>
                                         {% endif %}
@@ -142,7 +142,7 @@
                                             {% if profile.pole_emploi_id %}
                                                 <strong>{{ profile.pole_emploi_id }}</strong>
                                                 {% matomo_event "gps" "clic" "copied_user_pe_id" as matomo_event_attrs %}
-                                                {% include 'includes/copy_to_clipboard.html' with content=profile.pole_emploi_id css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
+                                                {% include 'includes/copy_to_clipboard.html' with content=profile.pole_emploi_id css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
                                             {% else %}
                                                 <strong>{{ profile.get_lack_of_pole_emploi_id_reason_display }}</strong>
                                             {% endif %}

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -34,7 +34,11 @@
 
                                     <li>
                                         <small>Date de naissance</small>
-                                        <strong>{{ beneficiary.birthdate|date:"d/m/Y" }}</strong>
+                                        {% if beneficiary.birthdate %}
+                                            <strong>{{ beneficiary.birthdate|date:"d/m/Y" }}</strong>
+                                        {% else %}
+                                            <i class="text-disabled">Non renseignée</i>
+                                        {% endif %}
                                     </li>
                                     <li>
                                         <small>Adresse e-mail</small>

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -3,7 +3,7 @@
 {% load str_filters %}
 {% load format_filters %}
 
-{% block title %}Profil salarié - {{ beneficiary.get_full_name }} {{ block.super }}{% endblock %}
+{% block title %}Profil de {{ beneficiary.get_full_name }} {{ block.super }}{% endblock %}
 
 {% block content_title %}<h1>{{ beneficiary.get_full_name }}</h1>{% endblock %}
 

--- a/itou/templates/users/includes/gps_group.html
+++ b/itou/templates/users/includes/gps_group.html
@@ -27,31 +27,15 @@
                             <li class="py-1">
                                 <i class="ri-mail-line font-weight-normal me-1" aria-hidden="true"></i>
                                 <span>{{ membership.member.email }}</span>
-                                <button class="btn-link"
-                                        data-bs-toggle="tooltip"
-                                        data-bs-placement="top"
-                                        data-bs-trigger="manual"
-                                        data-bs-title="Copié!"
-                                        data-it-clipboard-button="copy"
-                                        data-it-copy-to-clipboard="{{ membership.member.email }}"
-                                        {% matomo_event "gps" "clic" "copied_member_email" %}>
-                                    <i class="ri-file-copy-line"></i>
-                                </button>
+                                {% matomo_event "gps" "clic" "copied_member_email" as matomo_event_attrs %}
+                                {% include 'includes/copy_to_clipboard.html' with content=membership.member.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
                             </li>
                             <li class="py-1">
                                 <i class="ri-phone-line font-weight-normal me-1" aria-hidden="true"></i>
                                 {% if membership.member.phone %}
                                     <span>{{ membership.member.phone|format_phone }}</span>
-                                    <button class="btn-link"
-                                            data-bs-toggle="tooltip"
-                                            data-bs-placement="top"
-                                            data-bs-trigger="manual"
-                                            data-bs-title="Copié!"
-                                            data-it-clipboard-button="copy"
-                                            data-it-copy-to-clipboard="{{ membership.member.phone|cut:' ' }}"
-                                            {% matomo_event "gps" "clic" "copied_member_phone" %}>
-                                        <i class="ri-file-copy-line"></i>
-                                    </button>
+                                    {% matomo_event "gps" "clic" "copied_member_phone" as matomo_event_attrs %}
+                                    {% include 'includes/copy_to_clipboard.html' with content=membership.member.phone css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
                                 {% else %}
                                     <span class="text-disabled">Téléphone non renseigné</span>
                                 {% endif %}

--- a/itou/templates/users/includes/gps_group.html
+++ b/itou/templates/users/includes/gps_group.html
@@ -1,60 +1,73 @@
 {% load str_filters %}
 {% load format_filters %}
+{% load matomo %}
 
 <div class="c-box mb-3 mb-lg-5" id="gps_intervenants">
-
-    <h2>Intervenant{{ gps_memberships|length|pluralizefr }}</h2>
-    <hr />
-    <div class="p-0 m-0">
+    <h2 class="border-bottom pb-3">Intervenant{{ gps_memberships|length|pluralizefr }}</h2>
+    <ul class="list-unstyled p-0 m-0">
         {% for membership in gps_memberships %}
+            <li class="c-box--results__header px-0 gps_intervenant">
+                <div class="c-box--results__summary flex-grow-1">
+                    <i class="ri-user-line" aria-hidden="true"></i>
+                    <div>
+                        <h3 class="mb-2">
+                            {{ membership.member.get_full_name }}
+                            <span class="font-weight-normal fs-6 fst-italic">
+                                {% comment %}
+                                DJlint wants to move the if block and the closing parenthesis to the next line,
+                                adding two inelegant spaces.
+                                {% endcomment %}
+                                {# djlint:off #}
+                                ({{ membership.member.get_kind_display }}{% if membership.organization_name %} pour {{ membership.organization_name }}{% endif %})
+                                {# djlint:on #}
+                            </span>
+                        </h3>
 
-            <div class="c-box--results__header px-0 gps_intervenant">
-                <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-
-                    <div class="c-box--results__summary flex-grow-1">
-                        <i class="ri-user-line" aria-hidden="true"></i>
-
-                        <div>
-                            <h3>
-                                {{ membership.member.get_full_name }}
-                                <span class="font-weight-normal fs-6 fst-italic">
-                                    {% comment %}
-                                    DJlint wants to move the if block and the closing parenthesis to the next line,
-                                    adding two inelegant spaces.
-                                    {% endcomment %}
-                                    {# djlint:off #}
-                                    ({{ membership.member.get_kind_display }}{% if membership.organization_name %} pour {{ membership.organization_name }}{% endif %})
-                                    {# djlint:on #}
-                                </span>
-                            </h3>
-
-                            <div class="d-flex flex-column flex-md-column gap-1 gap-md-2">
-                                <span>
-                                    <i class="ri-mail-line font-weight-normal me-1" aria-hidden="true"></i>{{ membership.member.email }}
-                                </span>
-
+                        <ul class="list-unstyled">
+                            <li class="py-1">
+                                <i class="ri-mail-line font-weight-normal me-1" aria-hidden="true"></i>
+                                <span>{{ membership.member.email }}</span>
+                                <button class="btn-link"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        data-bs-trigger="manual"
+                                        data-bs-title="Copié!"
+                                        data-it-clipboard-button="copy"
+                                        data-it-copy-to-clipboard="{{ membership.member.email }}"
+                                        {% matomo_event "gps" "clic" "copied_member_email" %}>
+                                    <i class="ri-file-copy-line"></i>
+                                </button>
+                            </li>
+                            <li class="py-1">
+                                <i class="ri-phone-line font-weight-normal me-1" aria-hidden="true"></i>
                                 {% if membership.member.phone %}
-                                    <span>
-                                        <i class="ri-phone-line font-weight-normal me-1" aria-hidden="true"></i>{{ membership.member.phone|format_phone }}
-                                    </span>
-
-
+                                    <span>{{ membership.member.phone|format_phone }}</span>
+                                    <button class="btn-link"
+                                            data-bs-toggle="tooltip"
+                                            data-bs-placement="top"
+                                            data-bs-trigger="manual"
+                                            data-bs-title="Copié!"
+                                            data-it-clipboard-button="copy"
+                                            data-it-copy-to-clipboard="{{ membership.member.phone|cut:' ' }}"
+                                            {% matomo_event "gps" "clic" "copied_member_phone" %}>
+                                        <i class="ri-file-copy-line"></i>
+                                    </button>
+                                {% else %}
+                                    <span class="text-disabled">Téléphone non renseigné</span>
                                 {% endif %}
-                                <span>
-                                    <i class="ri-calendar-line font-weight-normal me-1" aria-hidden="true"></i>Suivi depuis le <strong>{{ membership.created_at|date:"d/m/Y" }}</strong>
-                                </span>
-                                {% if membership.is_referent %}
-                                    <span>
-                                        <i class="ri-map-pin-user-line font-weight-normal me-1" aria-hidden="true"></i><strong>Référent</strong>
-                                    </span>
-                                {% endif %}
-                            </div>
-                        </div>
+                            </li>
+                            <li class="py-1">
+                                <i class="ri-calendar-line font-weight-normal me-1" aria-hidden="true"></i>Suivi depuis le <strong>{{ membership.created_at|date:"d/m/Y" }}</strong>
+                            </li>
+                            {% if membership.is_referent %}
+                                <li class="py-1">
+                                    <i class="ri-map-pin-user-line font-weight-normal me-1" aria-hidden="true"></i><strong>Référent</strong>
+                                </li>
+                            {% endif %}
+                        </ul>
                     </div>
                 </div>
-            </div>
-
+            </li>
         {% endfor %}
-    </div>
-
+    </ul>
 </div>

--- a/itou/templates/users/includes/gps_group.html
+++ b/itou/templates/users/includes/gps_group.html
@@ -28,14 +28,14 @@
                                 <i class="ri-mail-line font-weight-normal me-1" aria-hidden="true"></i>
                                 <span>{{ membership.member.email }}</span>
                                 {% matomo_event "gps" "clic" "copied_member_email" as matomo_event_attrs %}
-                                {% include 'includes/copy_to_clipboard.html' with content=membership.member.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
+                                {% include 'includes/copy_to_clipboard.html' with content=membership.member.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
                             </li>
                             <li class="py-1">
                                 <i class="ri-phone-line font-weight-normal me-1" aria-hidden="true"></i>
                                 {% if membership.member.phone %}
                                     <span>{{ membership.member.phone|format_phone }}</span>
                                     {% matomo_event "gps" "clic" "copied_member_phone" as matomo_event_attrs %}
-                                    {% include 'includes/copy_to_clipboard.html' with content=membership.member.phone css_classes="btn-link" matomo_event_attrs=matomo_event_attrs text=" " %}
+                                    {% include 'includes/copy_to_clipboard.html' with content=membership.member.phone css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
                                 {% else %}
                                     <span class="text-disabled">Téléphone non renseigné</span>
                                 {% endif %}

--- a/itou/www/users_views/views.py
+++ b/itou/www/users_views/views.py
@@ -25,7 +25,7 @@ class UserDetailsView(LoginRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["gps_memberships"] = (
+        gps_memberships = (
             FollowUpGroupMembership.objects.with_members_organizations_names()
             .filter(follow_up_group=self.object.follow_up_group)
             .filter(is_active=True)
@@ -33,15 +33,18 @@ class UserDetailsView(LoginRequiredMixin, DetailView):
             .select_related("follow_up_group", "member")
         )
 
-        context["profile"] = self.object.jobseeker_profile
-
-        context["can_view_personal_information"] = self.request.user.can_view_personal_information(self.object)
-
-        context["breadcrumbs"] = {
+        breadcrumbs = {
             "Mes bénéficiaires": reverse("gps:my_groups"),
             f"Fiche de {self.object.get_full_name()}": reverse(
                 "users:details", kwargs={"public_id": self.object.public_id}
             ),
+        }
+
+        context = context | {
+            "breadcrumbs": breadcrumbs,
+            "can_view_personal_information": self.request.user.can_view_personal_information(self.object),
+            "gps_memberships": gps_memberships,
+            "profile": self.object.jobseeker_profile,
         }
 
         return context

--- a/itou/www/users_views/views.py
+++ b/itou/www/users_views/views.py
@@ -44,6 +44,7 @@ class UserDetailsView(LoginRequiredMixin, DetailView):
             "breadcrumbs": breadcrumbs,
             "can_view_personal_information": self.request.user.can_view_personal_information(self.object),
             "gps_memberships": gps_memberships,
+            "matomo_custom_title": "Profil GPS",
             "profile": self.object.jobseeker_profile,
         }
 

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -30,7 +30,7 @@
                                           
                                           <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="jane.doe@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_email">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
-      <span> </span>
+      
   </button>
   
                                       </li>
@@ -41,7 +41,7 @@
                                               
                                               <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_phone">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
-      <span> </span>
+      
   </button>
   
                                           
@@ -120,7 +120,7 @@
                                   
                                   <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="pierre.dupont@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_email">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
-      <span> </span>
+      
   </button>
   
                               </li>
@@ -131,7 +131,7 @@
                                       
                                       <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_phone">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
-      <span> </span>
+      
   </button>
   
                                   

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -86,59 +86,56 @@
                       
   
   
+  
   <div class="c-box mb-3 mb-lg-5" id="gps_intervenants">
-  
-      <h2>Intervenant</h2>
-      <hr/>
-      <div class="p-0 m-0">
+      <h2 class="border-bottom pb-3">Intervenant</h2>
+      <ul class="list-unstyled p-0 m-0">
           
-  
-              <div class="c-box--results__header px-0 gps_intervenant">
-                  <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-  
-                      <div class="c-box--results__summary flex-grow-1">
-                          <i aria-hidden="true" class="ri-user-line"></i>
-  
-                          <div>
-                              <h3>
-                                  Pierre DUPONT
-                                  <span class="font-weight-normal fs-6 fst-italic">
-                                      
-                                      
-                                      (prescripteur pour Les Olivades)
-                                      
-                                  </span>
-                              </h3>
-  
-                              <div class="d-flex flex-column flex-md-column gap-1 gap-md-2">
-                                  <span>
-                                      <i aria-hidden="true" class="ri-mail-line font-weight-normal me-1"></i>pierre.dupont@test.local
-                                  </span>
-  
+              <li class="c-box--results__header px-0 gps_intervenant">
+                  <div class="c-box--results__summary flex-grow-1">
+                      <i aria-hidden="true" class="ri-user-line"></i>
+                      <div>
+                          <h3 class="mb-2">
+                              Pierre DUPONT
+                              <span class="font-weight-normal fs-6 fst-italic">
                                   
-                                      <span>
-                                          <i aria-hidden="true" class="ri-phone-line font-weight-normal me-1"></i>06 12 34 56 78
-                                      </span>
+                                  
+                                  (prescripteur pour Les Olivades)
+                                  
+                              </span>
+                          </h3>
   
-  
+                          <ul class="list-unstyled">
+                              <li class="py-1">
+                                  <i aria-hidden="true" class="ri-mail-line font-weight-normal me-1"></i>
+                                  <span>pierre.dupont@test.local</span>
+                                  <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="pierre.dupont@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_email">
+                                      <i class="ri-file-copy-line"></i>
+                                  </button>
+                              </li>
+                              <li class="py-1">
+                                  <i aria-hidden="true" class="ri-phone-line font-weight-normal me-1"></i>
                                   
-                                  <span>
-                                      <i aria-hidden="true" class="ri-calendar-line font-weight-normal me-1"></i>Suivi depuis le <strong>21/06/2024</strong>
-                                  </span>
+                                      <span>06 12 34 56 78</span>
+                                      <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_phone">
+                                          <i class="ri-file-copy-line"></i>
+                                      </button>
                                   
-                                      <span>
-                                          <i aria-hidden="true" class="ri-map-pin-user-line font-weight-normal me-1"></i><strong>Référent</strong>
-                                      </span>
-                                  
-                              </div>
-                          </div>
+                              </li>
+                              <li class="py-1">
+                                  <i aria-hidden="true" class="ri-calendar-line font-weight-normal me-1"></i>Suivi depuis le <strong>21/06/2024</strong>
+                              </li>
+                              
+                                  <li class="py-1">
+                                      <i aria-hidden="true" class="ri-map-pin-user-line font-weight-normal me-1"></i><strong>Référent</strong>
+                                  </li>
+                              
+                          </ul>
                       </div>
                   </div>
-              </div>
-  
+              </li>
           
-      </div>
-  
+      </ul>
   </div>
   
                   </div>

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -20,22 +20,30 @@
   
                                       <li>
                                           <small>Date de naissance</small>
-                                          <strong>01/01/1990</strong>
+                                          
+                                              <strong>01/01/1990</strong>
+                                          
                                       </li>
                                       <li>
                                           <small>Adresse e-mail</small>
                                           <strong>jane.doe@test.local</strong>
-                                          <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="jane.doe@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_email">
-                                              <i class="ri-file-copy-line"></i>
-                                          </button>
+                                          
+                                          <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="jane.doe@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_email">
+      <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
+      <span> </span>
+  </button>
+  
                                       </li>
                                       <li>
                                           <small>Téléphone</small>
                                           
                                               <strong>06 12 34 56 78</strong>
-                                              <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_phone">
-                                                  <i class="ri-file-copy-line"></i>
-                                              </button>
+                                              
+                                              <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_phone">
+      <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
+      <span> </span>
+  </button>
+  
                                           
                                       </li>
                                       <li>
@@ -109,17 +117,23 @@
                               <li class="py-1">
                                   <i aria-hidden="true" class="ri-mail-line font-weight-normal me-1"></i>
                                   <span>pierre.dupont@test.local</span>
-                                  <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="pierre.dupont@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_email">
-                                      <i class="ri-file-copy-line"></i>
-                                  </button>
+                                  
+                                  <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="pierre.dupont@test.local" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_email">
+      <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
+      <span> </span>
+  </button>
+  
                               </li>
                               <li class="py-1">
                                   <i aria-hidden="true" class="ri-phone-line font-weight-normal me-1"></i>
                                   
                                       <span>06 12 34 56 78</span>
-                                      <button class="btn-link" data-bs-placement="top" data-bs-title="Copié!" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_phone">
-                                          <i class="ri-file-copy-line"></i>
-                                      </button>
+                                      
+                                      <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_member_phone">
+      <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
+      <span> </span>
+  </button>
+  
                                   
                               </li>
                               <li class="py-1">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour inciter les membres à renseigner le leur. J'en ai profité pour ajouter un bouton pour copier l'e-mail rapidement.
J'ai aussi réorganisé et nettoyé le HTML et les tests.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Consulter la page d'un bénéficiaire dans GPS qui a plusieurs membres.

## :computer: Captures d'écran

![image](https://github.com/gip-inclusion/les-emplois/assets/6150920/26f62103-07a1-4665-9bef-3f79af8a5c82)
