### PR TITLE
Support: simplification de move_company_data

### DIFF
--- a/itou/companies/management/commands/move_company_data.py
+++ b/itou/companies/management/commands/move_company_data.py
@@ -1,7 +1,6 @@
 import argparse
 
 from django.db import transaction
-from django.db.models import Exists, OuterRef, Subquery
 from django.utils import timezone
 
 from itou.approvals import models as approvals_models
@@ -114,16 +113,7 @@ class Command(BaseCommand):
         self.stdout.write(f"| Employee records created: {employee_records_created_count}")
 
         if move_all_data:
-            # Move Job Description not already present in company destination, Job Applications
-            # related will be attached to Job Description present in company destination
-            appellation_subquery = Subquery(
-                companies_models.JobDescription.objects.filter(
-                    company_id=to_id, appellation_id=OuterRef("appellation_id")
-                )
-            )
-            job_descriptions = companies_models.JobDescription.objects.filter(company_id=from_id).exclude(
-                Exists(appellation_subquery)
-            )
+            job_descriptions = companies_models.JobDescription.objects.filter(company_id=from_id)
             self.stdout.write(f"| Job descriptions: {job_descriptions.count()}\n")
 
             # Move users not already present in company destination
@@ -193,34 +183,11 @@ class Command(BaseCommand):
                 for job_application in job_applications_received:
                     job_application.selected_jobs.clear()
 
-            # If we move job_description, we have to take care of existant job_description linked
-            # to company B (destination), because we can't have 2 job_applications with the same Appellation
-            # for one company. Job applications linked to these kind of job_description have to be
-            # unlinked to be transfered. Job_description can be different enough to be irrelevant.
-            if move_all_data:
-                # find Appellation linked to job_description company B
-                to_company_appellation_id = companies_models.JobDescription.objects.filter(
-                    company_id=to_id
-                ).values_list("appellation_id", flat=True)
-
-                # find job_applications in company A, linked with job_description which Appellation is found in siae B
-                job_applications_to_clear = job_applications_models.JobApplication.objects.filter(
-                    to_company_id=from_id,
-                    selected_jobs__in=companies_models.JobDescription.objects.filter(
-                        company_id=from_id, appellation_id__in=to_company_appellation_id
-                    ),
-                )
-
-                # clean job_applications to let them be transfered in company B
-                for job_application in job_applications_to_clear:
-                    job_application.selected_jobs.clear()
-
             job_applications_sent.update(sender_company_id=to_id)
             job_applications_received.update(to_company_id=to_id)
 
             if move_all_data:
-                # do not move duplicated job_descriptions
-                job_descriptions.exclude(appellation_id__in=to_company_appellation_id).update(company_id=to_id)
+                job_descriptions.update(company_id=to_id)
                 members.update(company_id=to_id)
                 diagnoses.update(author_siae_id=to_id)
                 prolongations.update(declared_by_siae_id=to_id)


### PR DESCRIPTION
Depuis e0c0139c83f68ef2c9e7f3b444427fd7523f85ea, une entreprise peut avoir plusieurs fiches de poste avec la même appelation.

On peut donc bouger toutes les fiches de poste si demandé.

## :thinking: Pourquoi ?

> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
