### PR TITLE
UX/UI - Wording : Clarification du help text + Ajout d'une majuscule à "Pays"

### DIFF
--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -118,7 +118,10 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
     birth_place = forms.ModelChoiceField(
         queryset=Commune.objects,
         label="Commune de naissance",
-        help_text="La commune de naissance ne doit être saisie que lorsque le salarié est né en France",
+        help_text=(
+            "La commune de naissance est obligatoire lorsque le salarié est né en France. "
+            "Elle ne doit pas être renseignée s’il est né à l'étranger."
+        ),
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
                 "data-ajax--url": reverse_lazy("autocomplete:communes"),
@@ -132,7 +135,7 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
     )
 
     # This is a JobSeekerProfile field
-    birth_country = forms.ModelChoiceField(Country.objects, label="pays de naissance")
+    birth_country = forms.ModelChoiceField(Country.objects, label="Pays de naissance")
 
     class Meta:
         model = User


### PR DESCRIPTION
## :thinking: Pourquoi ?

> Clarification du help text (la formulation était négative) 
> Le terme "Pays" du champs Pays de naissance n'avait pas de majuscule.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> RAS

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> Ces textes sont visible depuis `inclusion.beta.gouv.fr/employee_record/create`

## :computer: Captures d'écran <!-- optionnel -->
