### PR TITLE
move_company_data: arrêt du transfert des champs `coords` & `geocoding_score`

### DIFF
--- a/itou/companies/management/commands/move_company_data.py
+++ b/itou/companies/management/commands/move_company_data.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
             "--preserve-to-company-data",
             action=argparse.BooleanOptionalAction,
             default=False,
-            help="Do not override <TO> company brand, description, phone and coords with <FROM> data.",
+            help="Do not override <TO> company brand, description and phone with <FROM> data.",
         )
         parser.add_argument(
             "--only-job-applications",
@@ -175,10 +175,6 @@ class Command(BaseCommand):
                 f"| Description \n{to_company.description}\nwill be updated with\n{from_company.description}\n"
             )
             self.stdout.write(f"| Phone '{to_company.phone}' will be updated with '{from_company.phone}'\n")
-            self.stdout.write(f"| Coords '{to_company.coords}' will be updated with '{from_company.coords}'\n")
-            self.stdout.write(
-                f"| Geoscore '{to_company.geocoding_score}' will be updated with '{from_company.geocoding_score}'\n"
-            )
 
         if not wet_run:
             self.stdout.write("Nothing to do in dry run mode.\n")
@@ -231,8 +227,6 @@ class Command(BaseCommand):
                         brand=from_company.display_name,
                         description=from_company.description,
                         phone=from_company.phone,
-                        coords=from_company.coords,
-                        geocoding_score=from_company.geocoding_score,
                     )
                 from_company_qs.update(
                     block_job_applications=True,

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -70,6 +70,11 @@ class TestMoveCompanyData:
         company_2.refresh_from_db()
         for field in ["brand", "description", "phone"]:
             assert predicate(getattr(company_2, field), getattr(company_1, field))
+        # In move_all_data, the from_company should not appear in search results anymore
+        # and its coords are erased
+        company_1.refresh_from_db()
+        assert company_1.coords is None
+        assert company_1.geocoding_score is None
 
 
 def test_update_companies_job_app_score():

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -68,7 +68,7 @@ class TestMoveCompanyData:
             wet_run=True,
         )
         company_2.refresh_from_db()
-        for field in ["brand", "description", "phone", "coords", "geocoding_score"]:
+        for field in ["brand", "description", "phone"]:
             assert predicate(getattr(company_2, field), getattr(company_1, field))
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ces deux champs devraient être calculés à partir de l'adresse postale de la structure, or cette adresse n'est pas transférée.
https://itou-inclusion.slack.com/archives/C01AQKD7MAN/p1720702597222509?thread_ts=1720701183.511899&cid=C01AQKD7MAN
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
