### PR TITLE
Contrôle a posteriori: envoi de la notification aux DDETS au moment du blocage des soumissions [GEN-1860]

### DIFF
--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -1,11 +1,8 @@
-import datetime
-
 from dateutil.relativedelta import relativedelta
 from django.db import transaction
-from django.db.models import Exists, F, Max, OuterRef, Q
+from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 
-from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.emails import CampaignEmailFactory, SIAEEmailFactory
 from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria, EvaluatedSiae, EvaluationCampaign
 from itou.utils.command import BaseCommand
@@ -65,43 +62,14 @@ class Command(BaseCommand):
                     f"Emailed second reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
                 )
 
-        # When SIAE submissions are frozen, notify institutions:
-        # - on the day submissions are frozen, and
-        # - 7 days after submissions have been frozen.
-        siae_subq = EvaluatedSiae.objects.filter(evaluation_campaign_id=OuterRef("pk"))
-        submissions_frozen = ~Exists(siae_subq.filter(submission_freezed_at=None))
-        has_siae_to_control = Exists(
-            siae_subq.filter(
-                Exists(
-                    EvaluatedAdministrativeCriteria.objects.filter(
-                        evaluated_job_application__evaluated_siae=OuterRef("pk"),
-                        review_state=evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING,
-                        submitted_at__isnull=False,
-                    )
-                ),
-            ).filter(
-                Q(reviewed_at=None, evaluation_campaign__calendar__adversarial_stage_start__gt=today)
-                | Q(final_reviewed_at=None, evaluation_campaign__calendar__adversarial_stage_start__lte=today)
-            )
-        )
+        # When a campaign is frozen, a notification is sent to institutions synchronously
+        # Then every 7 days a reminder email is sent if there is still work to do
+        has_siae_to_control = Exists(EvaluatedSiae.objects.to_control_in_campaign(campaign_id=OuterRef("pk")))
         for campaign in campaigns.filter(
-            Q(submission_freeze_notified_at=None)
-            | Q(submission_freeze_notified_at__date__lte=today - relativedelta(days=7)),
-            submissions_frozen,
             has_siae_to_control,
+            submission_freeze_notified_at__date__lte=today - relativedelta(days=7),
         ):
-            action = None
-            if campaign.submission_freeze_notified_at is None:
-                send_email_messages([CampaignEmailFactory(campaign).submission_frozen()])
-                action = "Instructed"
-            else:
-                submission_frozen_at = EvaluatedSiae.objects.filter(evaluation_campaign=campaign).aggregate(
-                    Max("submission_freezed_at")
-                )["submission_freezed_at__max"]
-                if submission_frozen_at - campaign.submission_freeze_notified_at <= datetime.timedelta(days=7):
-                    send_email_messages([CampaignEmailFactory(campaign).submission_frozen_reminder()])
-                    action = "Reminded"
-            if action:
-                self.stdout.write(f"{action} “{campaign.institution}” to control SIAE during the submission freeze.")
-                campaign.submission_freeze_notified_at = timezone.now()
-                campaign.save(update_fields=["submission_freeze_notified_at"])
+            send_email_messages([CampaignEmailFactory(campaign).submission_frozen_reminder()])
+            campaign.submission_freeze_notified_at = timezone.now()
+            campaign.save(update_fields=["submission_freeze_notified_at"])
+            self.stdout.write(f"Reminded “{campaign.institution}” to control SIAE during the submission freeze.")

--- a/tests/siae_evaluations/test_admin.py
+++ b/tests/siae_evaluations/test_admin.py
@@ -209,7 +209,7 @@ class TestEvaluationCampaignAdmin:
             + 1  # Count the filtered results (paginator)
             + 1  # Count the full results
             + 1  # Fetch selected evaluation_campaigns
-            + 2  # Update EvaluatedSiae for each selected campaign
+            + 2 * 2  # For each campaign: update EvaluatedSiae & check if a notification is needed
         ):
             response = client.post(
                 reverse("admin:siae_evaluations_evaluationcampaign_changelist"),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement dès que toutes les SIAES d'un département avaient soumis leur contrôle, la DDETS correspondante recevait la notification (potentiellement donc en avance par rapport au calendrier de la campagne) ce qui les perturbait.

Dorénavant, cette notification est envoyée au moment du blocage des soumissions.

Le rappel quant à lui est envoyé tous les 7 jours tant que la DDETS a des SIAE à contrôler.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

https://c1-review-xfernandez-phase-bis-email.cleverapps.io/
Se connecter en tant qu'admin et tenter les différents scénarios. 

## :computer: Captures d'écran <!-- optionnel -->
