### PR TITLE
[Demandeur d’emploi] Reprise de stock des critères certifiés

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -17,6 +17,7 @@
   "0 */6 * * * $ROOT/clevercloud/run_management_command.sh sync_s3_files",
 
   "1 0 * * * $ROOT/clevercloud/run_management_command.sh update_prescriber_organization_with_api_entreprise --verbosity 2",
+  "15 0 * * * $ROOT/clevercloud/run_management_command.sh certify_selected_administrative_criteria --wet-run",
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "45 0 * * * $ROOT/clevercloud/run_management_command.sh import_advisor_information shared_bucket/imports-gps/export_gps.xlsx --wet-run",
   "30 1 * * * $ROOT/clevercloud/run_management_command.sh new_users_to_brevo --wet-run",

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -85,4 +85,5 @@ CSP_IMG_SRC.append(f"{AWS_S3_ENDPOINT_URL}{AWS_STORAGE_BUCKET_NAME}/news-images/
 # Don't use json formatter in dev
 del LOGGING["handlers"]["console"]["formatter"]  # noqa: F405
 
-API_PARTICULIER_BASE_URL = "https://staging.particulier.api.gouv.fr/api/"
+API_PARTICULIER_BASE_URL = os.getenv("API_PARTICULIER_BASE_URL", "https://staging.particulier.api.gouv.fr/api/")
+API_PARTICULIER_TOKEN = os.getenv("API_PARTICULIER_TOKEN")

--- a/itou/users/management/commands/certify_selected_administrative_criteria.py
+++ b/itou/users/management/commands/certify_selected_administrative_criteria.py
@@ -1,0 +1,142 @@
+import datetime
+import logging
+from math import ceil
+
+from django.db.models import Exists, OuterRef, Q
+from django.utils.timezone import make_aware
+
+from itou.eligibility.models.geiq import GEIQAdministrativeCriteria, GEIQSelectedAdministrativeCriteria
+from itou.eligibility.models.iae import AdministrativeCriteria, SelectedAdministrativeCriteria
+from itou.users.models import User
+from itou.utils.apis import api_particulier
+from itou.utils.command import BaseCommand
+from itou.utils.iterators import chunks
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Certify selected administrative criteria from eligiility diagnosis made during the last 6 months
+    by calling the Particulier API.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument("--limit", dest="limit", action="store", type=int)
+        parser.add_argument("--verbose", dest="verbose", action="store_true")
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+
+    def call_api_and_store_result(
+        self,
+        SelectedAdministrativeCriteriaModel,
+        AdministrativeCriteriaModel,
+        limit=None,
+        verbose=False,
+        wet_run=False,
+    ):
+        if not verbose:
+            # Don't log HTTP requests detail.
+            logging.getLogger("httpx").setLevel(logging.WARNING)
+            logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+        total_criteria_with_certification = 0
+        found_beneficiaries = set()
+        found_not_beneficiaries = set()
+        not_found_users = set()  # 404
+        server_errors = 0  # 429, 503, 504
+
+        criteria = AdministrativeCriteriaModel.objects.certifiable()
+        period = (make_aware(datetime.datetime(2024, 1, 1)), make_aware(datetime.datetime(2024, 10, 1)))
+        criteria_pks = (
+            SelectedAdministrativeCriteriaModel.objects.filter(
+                administrative_criteria__in=criteria,
+                eligibility_diagnosis__created_at__range=period,
+                eligibility_diagnosis__job_seeker__jobseeker_profile__birth_country__isnull=False,
+                eligibility_diagnosis__job_seeker__jobseeker_profile__birthdate__isnull=False,
+                eligibility_diagnosis__job_seeker__first_name__isnull=False,
+                eligibility_diagnosis__job_seeker__last_name__isnull=False,
+                eligibility_diagnosis__job_seeker__title__isnull=False,
+            )
+            .exclude(Q(certified__isnull=False) | Q(data_returned_by_api__error__contains="not_found"))  # exclude 404
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        if limit:
+            criteria_pks = criteria_pks[:limit]
+
+        total_criteria = len(criteria_pks)
+        if total_criteria == 0:
+            logger.info("No criteria to certify. Stop now and enjoy your day! ")
+            return
+
+        users_count = User.objects.filter(
+            Exists(
+                SelectedAdministrativeCriteria.objects.filter(
+                    eligibility_diagnosis__job_seeker_id=OuterRef("pk"),
+                    id__in=criteria_pks,
+                )
+            )
+        ).count()
+        logger.info(
+            f"Candidats à certifier pour le modèle {SelectedAdministrativeCriteriaModel.__name__}: {users_count}"
+        )
+
+        chunks_total = ceil(total_criteria / 1000)
+        chunks_count = 0
+        for criteria_pk_subgroup in chunks(criteria_pks, 1000):
+            criteria = SelectedAdministrativeCriteriaModel.objects.filter(pk__in=criteria_pk_subgroup).select_related(
+                "administrative_criteria",
+                "eligibility_diagnosis__job_seeker",
+                "eligibility_diagnosis__job_seeker__jobseeker_profile",
+                "eligibility_diagnosis__job_seeker__jobseeker_profile__birth_place",
+                "eligibility_diagnosis__job_seeker__jobseeker_profile__birth_country",
+            )
+
+            with api_particulier.client() as client:
+                for criterion in criteria:
+                    criterion.certify(client, save=False)
+                    data_returned_by_api = criterion.data_returned_by_api
+                    if data_returned_by_api is None:
+                        continue
+
+                    if data_returned_by_api.get("status"):
+                        total_criteria_with_certification += 1
+                        if criterion.certified:
+                            found_beneficiaries.add(criterion.eligibility_diagnosis.job_seeker.pk)
+                        else:
+                            found_not_beneficiaries.add(criterion.eligibility_diagnosis.job_seeker.pk)
+
+                    if data_returned_by_api.get("error"):
+                        if data_returned_by_api["error"] == "not_found":
+                            not_found_users.add(criterion.eligibility_diagnosis.job_seeker.pk)
+                        else:
+                            server_errors += 1
+
+            if wet_run:
+                SelectedAdministrativeCriteriaModel.objects.bulk_update(
+                    criteria,
+                    fields=[
+                        "data_returned_by_api",
+                        "certified",
+                        "certification_period",
+                        "certified_at",
+                    ],
+                )
+
+            chunks_count += 1
+            logger.info(f"########### {chunks_count/chunks_total*100:.2f}%")
+
+        logger.info(f"Total criteria to be certified: {total_criteria}")
+        logger.info(f"Total criteria with certification: {total_criteria_with_certification}")
+        logger.info(f"Not beneficiaries: {len(found_not_beneficiaries)}")
+        logger.info(f"Beneficiaries: {len(found_beneficiaries)}")
+        logger.info(f"Not found: {len(not_found_users)}")
+        logger.info(f"Server errors: {server_errors}")
+        users_found = total_criteria_with_certification / total_criteria * 100
+        logger.info(f"That's {users_found:.2f}% users found.")
+
+    def handle(self, limit, verbose, wet_run, *args, **kwargs):
+        options = {"wet_run": wet_run, "limit": limit, "verbose": verbose}
+        self.call_api_and_store_result(GEIQSelectedAdministrativeCriteria, GEIQAdministrativeCriteria, **options)
+        self.call_api_and_store_result(SelectedAdministrativeCriteria, AdministrativeCriteria, **options)


### PR DESCRIPTION
## :thinking: Pourquoi ?

La PR #4524 permet d'appeler l'API Particulier pour certifier certains critères sélectionnés dans le cadre des diagnostics d'éligibilité.
Il convient maintenant de certifier les critères sélectionnés dans les diagnostics des six derniers mois.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ?

L'API ne mentionne pas de limite et n'explique pas les nombreuses 503 qui apparaissent plus souvent que les 429. J'ai contacté l'équipe pour en savoir plus mais, en attendant, c'est plus sûr de laisser tourner jusqu'à ce que l'API nous ait fourni toutes les informations demandées.
En effectuant quelques tests, j'ai l'impression que les erreurs 503 sont stables car je l'ai eue systématiquement avec certains bénéficiaires sans pour autant en trouver de raison vraiment pertinente. Je ne sais pas s'il s'agit d'un souci avec les données, d'une limite soudainement imposée ou d'une panne.
C'est pourquoi je propose qu'une commande de gestion tourne tous les soirs pendant quelques semaines afin d'appeler l'API et de récupérer le stock.

Autre point : le script est beaucoup plus rapide lorsque les appels sont lancés en parallèle (c'est logique) mais il certifie moins de critères car l’API emet plus d’erreurs. Les codes 429, 503 et 504 ne sont pas retentés. J'ai donc ajouté une option pour le lancer en synchrone, au cas où, même si je privilégie l'asynchrone car le script est censé tourner tous les soirs. La reprise se fera progressivement.

La rapidité d'exécution du script dépend beaucoup des codes 500 car les 200 sont plus lentes à répondre. À titre indicatif, voici les résultats sur une base réelle.

```
# Synchronously in dry run
# Total criteria to be certified: 25356
# Not found: 4439
# Server errors: 725
# That's 78.37% users found.
# Management command succeeded in 33919.55 seconds // about 9h 25min.

# Asynchronously in dry run
# Total criteria to be certified: 23657
# Not found: 1153
# Server errors: 16976
# That's 21.79% users found.
# Management command succeeded in 6448.19 seconds // about 1h and 50 minutes.

```

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Avec une base réelle en local. 
