### PR TITLE
Pilotage : Augmenter la durée de vie des tableaux de bord à 1 heure

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -306,7 +306,7 @@ def metabase_embedded_url(request=None, dashboard_id=None, params=None, with_tit
     payload = {
         "resource": {"dashboard": dashboard_id},
         "params": params,
-        "exp": int((timezone.now() + datetime.timedelta(minutes=30)).timestamp()),
+        "exp": int((timezone.now() + datetime.timedelta(minutes=60)).timestamp()),
     }
     is_titled = "true" if with_title else "false"
     return settings.METABASE_SITE_URL + "/embed/dashboard/" + _get_token(payload) + f"#titled={is_titled}"


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Iframe-Metabase-Augmenter-le-temps-d-affichage-des-donn-es-lors-de-la-consultation-d-un-TB-ef2f3f085c8147259bbb51341f6b4aac?pvs=4