### PR TITLE
Autocompletion: suppression de code déprécié - partie 2

### DIFF
--- a/itou/www/companies_views/forms.py
+++ b/itou/www/companies_views/forms.py
@@ -3,7 +3,6 @@ from django.db.models.fields import BLANK_CHOICE_DASH
 from django.urls import reverse_lazy
 from django.utils import timezone
 from django.utils.safestring import mark_safe
-from django.utils.text import format_lazy
 
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENTS, department_from_postcode
@@ -228,7 +227,7 @@ class JobAppellationAndLocationMixin(forms.Form):
         label="Poste (code ROME)",
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
-                "data-ajax--url": format_lazy("{}?select2=", reverse_lazy("autocomplete:jobs")),
+                "data-ajax--url": reverse_lazy("autocomplete:jobs"),
                 "data-ajax--cache": "true",
                 "data-ajax--type": "GET",
                 "data-minimum-input-length": 2,
@@ -243,7 +242,7 @@ class JobAppellationAndLocationMixin(forms.Form):
         label="Localisation du poste (si différente du siège)",
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
-                "data-ajax--url": format_lazy("{}?select2=", reverse_lazy("autocomplete:cities")),
+                "data-ajax--url": reverse_lazy("autocomplete:cities"),
                 "data-ajax--cache": "true",
                 "data-ajax--type": "GET",
                 "data-minimum-input-length": 2,

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -3,7 +3,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator, RegexValidator
 from django.urls import reverse_lazy
 from django.utils import timezone
-from django.utils.text import format_lazy
 from django_select2.forms import Select2Widget
 
 from itou.asp.models import Commune, Country, RSAAllocation
@@ -122,7 +121,7 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
         help_text="La commune de naissance ne doit être saisie que lorsque le salarié est né en France",
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
-                "data-ajax--url": format_lazy("{}?select2=", reverse_lazy("autocomplete:communes")),
+                "data-ajax--url": reverse_lazy("autocomplete:communes"),
                 "data-ajax--cache": "true",
                 "data-ajax--type": "GET",
                 "data-minimum-input-length": 2,
@@ -216,7 +215,7 @@ class NewEmployeeRecordStep2Form(forms.ModelForm):
         label="Commune",
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
-                "data-ajax--url": format_lazy("{}?select2=", reverse_lazy("autocomplete:communes")),
+                "data-ajax--url": reverse_lazy("autocomplete:communes"),
                 "data-ajax--cache": "true",
                 "data-ajax--type": "GET",
                 "data-minimum-input-length": 2,

--- a/itou/www/gps/forms.py
+++ b/itou/www/gps/forms.py
@@ -1,6 +1,5 @@
 from django import forms
 from django.urls import reverse_lazy
-from django.utils.text import format_lazy
 from django_select2.forms import Select2Widget
 
 from itou.companies import enums as companies_enums
@@ -19,7 +18,7 @@ class GpsUserSearchForm(forms.Form):
         label="Nom et prénom du bénéficiaire",
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
-                "data-ajax--url": format_lazy("{}?select2=", reverse_lazy("autocomplete:gps_users")),
+                "data-ajax--url": reverse_lazy("autocomplete:gps_users"),
                 "data-ajax--cache": "true",
                 "data-ajax--type": "GET",
                 "data-minimum-input-length": 2,

--- a/itou/www/search/forms.py
+++ b/itou/www/search/forms.py
@@ -38,7 +38,7 @@ class SiaeSearchForm(forms.Form):
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
                 "class": "form-control",
-                "data-ajax--url": format_lazy("{}?select2=&slug=", reverse_lazy("autocomplete:cities")),
+                "data-ajax--url": format_lazy("{}?slug=", reverse_lazy("autocomplete:cities")),
                 "data-minimum-input-length": 2,
                 "data-placeholder": "Rechercher un emploi inclusif autour de…",
             }
@@ -144,7 +144,7 @@ class PrescriberSearchForm(forms.Form):
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
                 "class": "form-control",
-                "data-ajax--url": format_lazy("{}?select2=&slug=", reverse_lazy("autocomplete:cities")),
+                "data-ajax--url": format_lazy("{}?slug=", reverse_lazy("autocomplete:cities")),
                 "data-minimum-input-length": 2,
                 "data-placeholder": "Rechercher un prescripteur autour de…",
             }

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -14,7 +14,7 @@
               <div class="input-group-text bg-white rounded-start ps-3 pe-2">
                   <i aria-hidden="true" class="ri-map-pin-line ri-lg text-disabled"></i>
               </div>
-              <select class="form-control django-select2" data-ajax--url="/autocomplete/cities?select2=&amp;slug=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Rechercher un emploi inclusif autour de…" data-theme="bootstrap-5" id="id_city" lang="fr" name="city" required="">
+              <select class="form-control django-select2" data-ajax--url="/autocomplete/cities?slug=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Rechercher un emploi inclusif autour de…" data-theme="bootstrap-5" id="id_city" lang="fr" name="city" required="">
   </select>
               <div class="input-group-text bg-white p-0">
                   <button aria-label="Rechercher un emploi inclusif" class="btn btn-ico btn-link">

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -242,7 +242,7 @@
                               <div class="form-group"><label class="form-label" for="id_hexa_additional_address">Complément d'adresse</label><input class="form-control" id="id_hexa_additional_address" maxlength="32" name="hexa_additional_address" placeholder="Complément d'adresse" type="text"/></div>
                               <div class="form-row">
                                   <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_post_code">Code postal</label><input class="form-control" id="id_hexa_post_code" maxlength="6" name="hexa_post_code" placeholder="Code postal" required="" type="text" value="58160"/></div></div>
-                                  <div class="col-12 col-md-9"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_commune">Commune</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes?select2=" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Nom de la commune" data-theme="bootstrap-5" id="id_hexa_commune" lang="fr" name="hexa_commune" required="">
+                                  <div class="col-12 col-md-9"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_commune">Commune</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Nom de la commune" data-theme="bootstrap-5" id="id_hexa_commune" lang="fr" name="hexa_commune" required="">
     <option selected="" value="47612">SAUVIGNY-LES-BOIS (058)</option>
   
   </select></div></div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite de #4444.
À merger une fois #4444 en production (pour éviter d'éventuelles erreurs lors du déploiement où le nouveau front appellerait l'ancien back sans `?select2=` et n'obtiendrait pas le bon format).

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
