### PR TITLE
UX/UI : Privilégier l’ouverture d’onglet [ GEN-1872 ]

### DIFF
--- a/itou/templates/apply/includes/accept_section.html
+++ b/itou/templates/apply/includes/accept_section.html
@@ -12,7 +12,7 @@
                 <p>
                     Êtes-vous sûr(e) de vouloir confirmer l’embauche de <strong>{{ job_seeker.get_full_name }}</strong> dans la structure suivante ?
                 </p>
-                {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" only %}
+                {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -104,7 +104,7 @@
         <li>
             <small>Curriculum vitae</small>
             {% if job_application.resume_link %}
-                <a href="{{ job_application.resume_link }}" class="btn-link btn-ico">
+                <a href="{{ job_application.resume_link }}" class="btn-link btn-ico" target="_blank" rel="noreferrer noopener">
                     <span>Télécharger le CV</span>
                     <i class="ri-download-2-line"></i>
                 </a>

--- a/itou/templates/apply/includes/transfer_job_application.html
+++ b/itou/templates/apply/includes/transfer_job_application.html
@@ -51,7 +51,7 @@
                         <p>
                             Êtes-vous sûr de vouloir transférer la candidature de <b>{{ job_application.job_seeker.get_full_name }}</b> dans la structure suivante ?
                         </p>
-                        {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" only %}
+                        {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Retour</button>

--- a/itou/templates/apply/process_internal_transfer.html
+++ b/itou/templates/apply/process_internal_transfer.html
@@ -29,7 +29,7 @@
                                     Êtes-vous sûr de vouloir transférer la candidature de <b>{{ job_app_to_transfer.job_seeker.get_full_name }}</b> dans la structure suivante ?
                                 </p>
                             {% endif %}
-                            {% include "companies/includes/_company_info.html" with company=company extra_box_class="mb-3 mb-lg-5" only %}
+                            {% include "companies/includes/_company_info.html" with company=company extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
                         </div>
 
                         {% if job_app_to_transfer.to_company == company %}

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -76,7 +76,7 @@
                 <div class="col-12{% if not full_content_width %} col-lg-8{% endif %}">
                     <div class="c-form">
                         <div class="col-12 p-0 {% if full_content_width %}col-lg-8 pe-lg-4{% endif %}">
-                            {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" only %}
+                            {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
                         </div>
                         <div class="col-12 p-0 {% if full_content_width %}col-lg-8 pe-lg-4{% endif %}">
                             {% block pre_step_title %}{% endblock %}

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -38,7 +38,7 @@
                             </h1>
                         </div>
 
-                        {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" only %}
+                        {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
 
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}

--- a/itou/templates/companies/includes/_company_info.html
+++ b/itou/templates/companies/includes/_company_info.html
@@ -30,7 +30,9 @@
             <a href="{% url 'apply:job_application_external_transfer_step_1_company_card' job_application_id=job_app_to_transfer company_pk=company.pk %}{% if back_url|default:"" %}?back_url={{ back_url|urlencode }}{% endif %}"
                class="btn btn-secondary btn-block mt-4">Voir la fiche de l'entreprise</a>
         {% else %}
-            <a href="{% url 'companies_views:card' siae_id=company.pk %}{% if back_url|default:"" %}?back_url={{ back_url|urlencode }}{% endif %}" class="btn btn-secondary btn-block mt-4">Voir la fiche de l'entreprise</a>
+            <a href="{% url 'companies_views:card' siae_id=company.pk %}{% if back_url|default:"" and not open_in_tab|default:False %}?back_url={{ back_url|urlencode }}{% endif %}"
+               class="btn btn-secondary btn-block mt-4"
+               {% if open_in_tab|default:False %}target="_blank"{% endif %}>Voir la fiche de l'entreprise</a>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter que l’utilisateur ne sorte du parcours sur quelques composants clés (attention que j'ai proposé des pages non-définit sur le ticket):
- `job_seeker_info.html` : liens vers son CV sur les pages des applications et approbations
- `process_internal_transfer.html`, `transfer_job_application.html` : "voir la fiche de l'enterprise" sur la confirmation de transfert du candidat
- `accept_section.html` : confirmation de l'acceptation du candidat
- `edit_siae_preview.html` : sous la page "modifier les coordonnées de votre structure"
- `application/base.html` : un lien vers l'information de l'enterprise concernée et inclus sur plusieurs gabarits à la soumission de candidature

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
