### PR TITLE
GEIQ: Afficher le diagnostic GEIQ d'une candidature acceptée dans le passé [GEN-1701]

### DIFF
--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -181,7 +181,7 @@ class EligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
 class GEIQEligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
     raw_id_fields = AbstractEligibilityDiagnosisAdmin.raw_id_fields + ("author_geiq",)
     readonly_fields = AbstractEligibilityDiagnosisAdmin.readonly_fields + (
-        "has_eligibility",
+        "is_valid",
         "allowance_amount",
     )
     inlines = (
@@ -189,10 +189,6 @@ class GEIQEligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
         JobApplicationInline,
         PkSupportRemarkInline,
     )
-
-    @admin.display(boolean=True, description="éligibilité GEIQ confirmée")
-    def has_eligibility(self, obj):
-        return obj.eligibility_confirmed
 
     @admin.display(description="montant de l'aide")
     def allowance_amount(self, obj):

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -37,10 +37,9 @@ from .common import (
 
 class GEIQEligibilityDiagnosisQuerySet(CommonEligibilityDiagnosisQuerySet):
     def authored_by_prescriber_or_geiq(self, geiq):
-        # In ordering, priority is given to prescriber authored diagnoses
         return self.filter(
             models.Q(author_geiq=geiq) | models.Q(author_prescriber_organization__isnull=False)
-        ).order_by(models.F("author_prescriber_organization").desc(nulls_last=True), "-created_at")
+        ).order_by("-created_at")
 
     def diagnoses_for(self, job_seeker, for_geiq=None):
         # Get *all* GEIQ diagnoses for given job seeker (even expired)

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -152,10 +152,6 @@ class GEIQEligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
         return result
 
     @property
-    def eligibility_confirmed(self) -> bool:
-        return bool(self.allowance_amount) and self.is_valid
-
-    @property
     def allowance_amount(self) -> int:
         return geiq_allowance_amount(self.author.is_prescriber_with_authorized_org, self.administrative_criteria.all())
 

--- a/itou/templates/apply/includes/eligibility_badge.html
+++ b/itou/templates/apply/includes/eligibility_badge.html
@@ -16,7 +16,7 @@
         </span>
     {% endif %}
 {% elif is_subject_to_geiq_eligibility_rules %}
-    {% if geiq_eligibility_diagnosis.eligibility_confirmed %}
+    {% if geiq_eligibility_diagnosis.is_valid and geiq_eligibility_diagnosis.allowance_amount %}
         <span class="badge badge-base rounded-pill bg-success-lighter text-success">
             <i class="ri-check-line" aria-hidden="true"></i>
             Éligibilité GEIQ confirmée

--- a/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
+++ b/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
@@ -52,7 +52,7 @@
                 </div>
             </div>
         {% endif %}
-    {% else %}
+    {% elif request.user.is_employer %}
         {# Existing GEIQ, diagnosis but no allowance #}
         <div class="alert alert-warning mt-4">
             <div class="row">
@@ -77,12 +77,12 @@
     {% endif %}
 {% else %}
     {# Diagnosis either does not exist or has expired : this part is for GEIQ only #}
-    {% if request.user.is_employer %}
-        <hr class="my-4">
-        <div class="row align-items-center">
-            <div class="col-12 col-md">
-                <h3 class="mb-2 mb-md-0">Éligibilité public prioritaire GEIQ non confirmée</h3>
-            </div>
+    <hr class="my-4">
+    <div class="row align-items-center">
+        <div class="col-12 col-md">
+            <h3 class="mb-2 mb-md-0">Éligibilité public prioritaire GEIQ non confirmée</h3>
+        </div>
+        {% if request.user.is_employer %}
             <div class="col-12 col-md-auto">
                 {% with back_and_next_url=request.get_full_path|urlencode %}
                     <a href="{% url 'apply:geiq_eligibility' job_application_id=job_application.pk %}?back_url={{ back_and_next_url }}&next_url={{ back_and_next_url }}" class="btn btn-secondary">
@@ -90,24 +90,24 @@
                     </a>
                 {% endwith %}
             </div>
-        </div>
-        {# GEIQ eligibility diagnosis expired #}
-        {% if diagnosis and not diagnosis.is_valid %}
-            <div class="alert alert-warning mt-4">
-                <div class="row">
-                    <div class="col-auto pe-0">
-                        <i class="ri-alert-line ri-xl text-warning"></i>
-                    </div>
-                    <div class="col">
-                        <p>
-                            <b>Aide à l'accompagement GEIQ</b>
-                        </p>
-                        <p>
-                            Le diagnostic du candidat a expiré le {{ diagnosis.expires_at|date:"d F Y" }}. Si vous souhaitez bénéficier d’une aide à l’accompagnement, veuillez renseigner à nouveau la situation administrative du candidat.
-                        </p>
+            {# GEIQ eligibility diagnosis expired #}
+            {% if diagnosis and not diagnosis.is_valid %}
+                <div class="alert alert-warning mt-4">
+                    <div class="row">
+                        <div class="col-auto pe-0">
+                            <i class="ri-alert-line ri-xl text-warning"></i>
+                        </div>
+                        <div class="col">
+                            <p>
+                                <b>Aide à l'accompagement GEIQ</b>
+                            </p>
+                            <p>
+                                Le diagnostic du candidat a expiré le {{ diagnosis.expires_at|date:"d F Y" }}. Si vous souhaitez bénéficier d’une aide à l’accompagnement, veuillez renseigner à nouveau la situation administrative du candidat.
+                            </p>
+                        </div>
                     </div>
                 </div>
-            </div>
+            {% endif %}
         {% endif %}
-    {% endif %}
+    </div>
 {% endif %}

--- a/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
+++ b/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
@@ -1,5 +1,5 @@
-{% if diagnosis.is_valid %}
-    {% if diagnosis.has_eligibility %}
+{% if diagnosis.is_valid or job_application.state.is_accepted and diagnosis %}
+    {% if diagnosis.allowance_amount %}
         <hr class="my-4">
         <h3>Éligibilité public prioritaire GEIQ validée</h3>
     {% else %}
@@ -7,7 +7,7 @@
         <h3>Éligibilité public prioritaire GEIQ non confirmée</h3>
     {% endif %}
 
-    {% if diagnosis.has_eligibility %}
+    {% if diagnosis.allowance_amount %}
         <p>
             Éligibilité GEIQ confirmée par <b>{{ diagnosis.author.get_full_name }} ({{ diagnosis.author_structure.display_name }})</b>
         </p>
@@ -26,7 +26,7 @@
         {% endif %}
     {% endwith %}
 
-    {% if diagnosis.has_eligibility %}
+    {% if diagnosis.allowance_amount %}
         <p>
             <b>Durée de validité du diagnostic :</b> du {{ diagnosis.created_at|date:"d/m/Y" }} au {{ diagnosis.expires_at|date:"d/m/Y" }}.
         </p>

--- a/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
+++ b/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
@@ -1,5 +1,5 @@
 {% if diagnosis.is_valid %}
-    {% if diagnosis.eligibility_confirmed %}
+    {% if diagnosis.has_eligibility %}
         <hr class="my-4">
         <h3>Éligibilité public prioritaire GEIQ validée</h3>
     {% else %}
@@ -7,7 +7,7 @@
         <h3>Éligibilité public prioritaire GEIQ non confirmée</h3>
     {% endif %}
 
-    {% if diagnosis.eligibility_confirmed %}
+    {% if diagnosis.has_eligibility %}
         <p>
             Éligibilité GEIQ confirmée par <b>{{ diagnosis.author.get_full_name }} ({{ diagnosis.author_structure.display_name }})</b>
         </p>
@@ -26,7 +26,7 @@
         {% endif %}
     {% endwith %}
 
-    {% if diagnosis.eligibility_confirmed %}
+    {% if diagnosis.has_eligibility %}
         <p>
             <b>Durée de validité du diagnostic :</b> du {{ diagnosis.created_at|date:"d/m/Y" }} au {{ diagnosis.expires_at|date:"d/m/Y" }}.
         </p>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -34,7 +34,7 @@
             <div class="c-box mb-4">
                 <h3>Informations personnelles</h3>
                 {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token SenderKind=SenderKind only %}
-                {% if job_application.to_company.kind == CompanyKind.GEIQ and geiq_eligibility_diagnosis %}
+                {% if job_application.to_company.kind == CompanyKind.GEIQ %}
                     {# GEIQ eligibility details #}
                     {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis %}
                 {% else %}

--- a/tests/companies/factories.py
+++ b/tests/companies/factories.py
@@ -1,4 +1,3 @@
-import functools
 import string
 
 import factory.fuzzy
@@ -174,7 +173,9 @@ class CompanyWith4MembershipsFactory(CompanyFactory):
     membership4 = factory.RelatedFactory(CompanyMembershipFactory, "company", is_admin=False, user__is_active=False)
 
 
-CompanyWithMembershipAndJobsFactory = functools.partial(CompanyFactory, with_membership=True, with_jobs=True)
+class CompanyWithMembershipAndJobsFactory(CompanyFactory):
+    with_membership = True
+    with_jobs = True
 
 
 class SiaeConventionPendingGracePeriodFactory(SiaeConventionFactory):

--- a/tests/eligibility/factories.py
+++ b/tests/eligibility/factories.py
@@ -1,6 +1,7 @@
 import random
 
 import factory
+from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from itou.companies.enums import CompanyKind
@@ -23,7 +24,10 @@ class AbstractEligibilityDiagnosisModelFactory(factory.django.DjangoModelFactory
             ),
             author=factory.LazyAttribute(lambda obj: obj.author_prescriber_organization.members.first()),
         )
-        expired = factory.Trait(expires_at=factory.LazyFunction(timezone.now))
+        expired = factory.Trait(
+            expires_at=factory.LazyFunction(timezone.now),
+            created_at=factory.LazyAttribute(lambda obj: obj.expires_at - relativedelta(months=6)),
+        )
 
     created_at = factory.LazyFunction(timezone.now)
     job_seeker = factory.SubFactory(JobSeekerFactory)

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -9,6 +9,7 @@ from itou.companies.models import JobDescription
 from itou.eligibility.enums import AuthorKind
 from itou.job_applications import models
 from itou.job_applications.enums import (
+    JobApplicationState,
     Prequalification,
     ProfessionalSituationExperience,
     SenderKind,
@@ -65,8 +66,8 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             eligibility_diagnosis=None,
         )
         with_geiq_eligibility_diagnosis_from_prescriber = factory.Trait(
+            sent_by_authorized_prescriber_organisation=True,
             to_company=factory.SubFactory(CompanyFactory, with_membership=True, kind=CompanyKind.GEIQ),
-            sender=factory.LazyAttribute(lambda obj: obj.sender_prescriber_organization.members.first()),
             geiq_eligibility_diagnosis=factory.SubFactory(
                 GEIQEligibilityDiagnosisFactory,
                 job_seeker=factory.SelfAttribute("..job_seeker"),
@@ -91,7 +92,7 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             sender=factory.LazyAttribute(lambda obj: obj.sender_company.members.first()),
         )
         was_hired = factory.Trait(
-            state="accepted",
+            state=JobApplicationState.ACCEPTED,
             to_company__with_jobs=True,
             hired_job=factory.SubFactory(JobDescriptionFactory, company=factory.SelfAttribute("..to_company")),
         )

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -50,6 +50,23 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
         assertContains(response, "Éligibilité public prioritaire GEIQ non confirmée")
 
+    def test_details_accepted_job_application_with_vaild_diangosis(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True, expired=True)
+        job_application = JobApplicationFactory(
+            to_company__kind=CompanyKind.GEIQ,
+            geiq_eligibility_diagnosis=diagnosis,
+            eligibility_diagnosis=None,
+            was_hired=True,
+        )
+        client.force_login(job_application.to_company.members.first())
+        response = client.get(
+            reverse(
+                "apply:details_for_company",
+                kwargs={"job_application_id": job_application.pk},
+            )
+        )
+        assertContains(response, "Éligibilité public prioritaire GEIQ validée")
+
     def test_details_as_geiq_with_valid_eligibility_diagnosis(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
         job_application = JobApplicationFactory(

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -1,10 +1,11 @@
+import pytest
 from django.urls import reverse
-from django.utils import dateformat
-from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertNotContains, assertTemplateNotUsed, assertTemplateUsed
 
 from itou.companies.enums import CompanyKind
-from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
+from itou.job_applications.enums import JobApplicationState
+from itou.users.enums import UserKind
+from itou.www.apply.views.process_views import _get_geiq_eligibility_diagnosis
 from tests.companies.factories import CompanyWithMembershipAndJobsFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
@@ -12,10 +13,28 @@ from tests.prescribers.factories import PrescriberOrganizationWithMembershipFact
 from tests.users.factories import JobSeekerFactory, JobSeekerWithAddressFactory
 
 
+@pytest.mark.ignore_unknown_variable_template_error("with_matomo_event")
 class TestJobApplicationGEIQEligibilityDetails:
+    VALID_DIAGNOSIS = "Éligibilité public prioritaire GEIQ validée"
+    # this string does not depends on the diagnosis author
+    ALLOWANCE_AND_COMPANY = "à une aide financière de l’État s’élevant à <b>1400 €</b>"
+    NO_ALLOWANCE = (
+        "Les critères que vous avez sélectionnés ne vous permettent pas de bénéficier d’une aide financière de l’État."
+    )
+    NO_VALID_DIAGNOSIS = "Éligibilité public prioritaire GEIQ non confirmée"
     EXPIRED_DIAGNOSIS_EXPLANATION = "Le diagnostic du candidat a expiré"
 
-    def test_with_geiq_eligibility_details(self, client):
+    def get_response(self, client, job_application, user):
+        client.force_login(user)
+        url_name = {
+            UserKind.EMPLOYER: "apply:details_for_company",
+            UserKind.PRESCRIBER: "apply:details_for_prescriber",
+            UserKind.JOB_SEEKER: "apply:details_for_jobseeker",
+        }[user.kind]
+        url = reverse(url_name, kwargs={"job_application_id": job_application.pk})
+        return client.get(url)
+
+    def test_with_valid_diagnosis(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
         job_application = JobApplicationFactory(
             to_company__kind=CompanyKind.GEIQ,
@@ -23,181 +42,258 @@ class TestJobApplicationGEIQEligibilityDetails:
             sender=diagnosis.author,
             eligibility_diagnosis=None,
         )
-        client.force_login(job_application.to_company.members.first())
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
 
-        assert response.status_code == 200
-        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        assertContains(response, "Éligibilité public prioritaire GEIQ validée")
-        assertContains(
-            response,
-            "Ce diagnostic émis par un prescripteur habilité vous donnera droit en cas d’embauche",
-        )
-        assertContains(
-            response,
-            f"une aide financière de l’État s’élevant à <b>{diagnosis.allowance_amount} €</b> ",
-        )
+        # as employer, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertNotContains(response, self.NO_ALLOWANCE)
 
-    def test_without_geiq_eligibility_details(self, client):
-        # No GEIQ diagnosis for this job seeker / job application
-        job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ)
-        client.force_login(job_application.to_company.members.first())
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
+        # as job seeker, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertNotContains(response, self.NO_ALLOWANCE)
 
-        assert response.status_code == 200
-        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        assertContains(response, "Éligibilité public prioritaire GEIQ non confirmée")
+        # as a prescriber, I see my diagnosis
+        assert diagnosis.author.is_prescriber
+        response = self.get_response(client, job_application, diagnosis.author)
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertNotContains(response, self.NO_ALLOWANCE)
 
-    def test_details_accepted_job_application_with_vaild_diangosis(self, client):
+    def test_with_expired_diagnosis(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True, expired=True)
         job_application = JobApplicationFactory(
             to_company__kind=CompanyKind.GEIQ,
-            geiq_eligibility_diagnosis=diagnosis,
-            eligibility_diagnosis=None,
-            was_hired=True,
-        )
-        client.force_login(job_application.to_company.members.first())
-        response = client.get(
-            reverse(
-                "apply:details_for_company",
-                kwargs={"job_application_id": job_application.pk},
-            )
-        )
-        assertContains(response, "Éligibilité public prioritaire GEIQ validée")
-
-    def test_details_as_geiq_with_valid_eligibility_diagnosis(self, client):
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
-        job_application = JobApplicationFactory(
             job_seeker=diagnosis.job_seeker,
-            to_company=diagnosis.author_geiq,
+            sender=diagnosis.author,
             eligibility_diagnosis=None,
         )
 
-        client.force_login(diagnosis.author_geiq.members.first())
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
-
-        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        assertContains(
-            response,
-            "Éligibilité public prioritaire GEIQ non confirmée",
-        )
-        assertContains(
-            response,
-            "Les critères que vous avez sélectionnés ne vous permettent pas de bénéficier d’une aide financière de l’État.",  # noqa: E501
-        )
-        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
-        # More in `test_allowance_details_for_geiq`
-
-    def test_details_as_geiq_with_expired_eligibility_diagnosis(self, client):
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, expired=True)
-        job_application = JobApplicationFactory(
-            to_company=diagnosis.author_geiq,
-            job_seeker=diagnosis.job_seeker,
-            eligibility_diagnosis=None,
-        )
-
-        client.force_login(diagnosis.author_geiq.members.first())
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
-
-        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        # as employer, I see the prescriber diagnosis isn't valid anymore
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.NO_ALLOWANCE)
         assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
-        assertContains(
-            response,
-            "Éligibilité public prioritaire GEIQ non confirmée",
-        )
 
-    @freeze_time("2024-02-15")
-    def test_details_as_authorized_prescriber_with_valid_diagnosis(self, client):
+        # as job seeker, I see the prescriber diagnosis isn't valid anymore without further details
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+
+        # as a prescriber, I see the prescriber diagnosis isn't valid anymore
+        assert diagnosis.author.is_prescriber
+        response = self.get_response(client, job_application, diagnosis.author)
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+
+    def test_without_diagnosis(self, client):
+        # No GEIQ diagnosis for this job seeker / job application
+        job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ)
+
+        # as employer, I see there's no diagnosis
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+
+        # as job seeker, I see there's no diagnosis
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+
+        # as a prescriber, I don't see anything
+        assert job_application.sender.is_prescriber
+        response = self.get_response(client, job_application, job_application.sender)
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+
+    def test_accepted_job_app_with_valid_diagnosis(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
         job_application = JobApplicationFactory(
             to_company__kind=CompanyKind.GEIQ,
             job_seeker=diagnosis.job_seeker,
+            sender=diagnosis.author,
             eligibility_diagnosis=None,
+            geiq_eligibility_diagnosis=diagnosis,
+            was_hired=True,
         )
-        client.force_login(job_application.to_company.members.first())
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
 
-        assertContains(
-            response,
-            f"Éligibilité GEIQ confirmée par "
-            f"<b>{diagnosis.author.get_full_name()} ({diagnosis.author_prescriber_organization.display_name})</b>",
+        # as employer, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertContains(response, self.ALLOWANCE_AND_COMPANY)
+
+        # as job seeker, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+
+        # as a prescriber, I see my diagnosis
+        assert diagnosis.author.is_prescriber
+        response = self.get_response(client, job_application, diagnosis.author)
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+
+    def test_accepted_job_app_with_expired_diagnosis(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True, expired=True)
+        # Create a valid diangosis to check we don't use this one in the display
+        GEIQEligibilityDiagnosisFactory(
+            job_seeker=diagnosis.job_seeker,
+            author=diagnosis.author,
+            author_kind=diagnosis.author_kind,
+            author_prescriber_organization=diagnosis.author_prescriber_organization,
         )
-        assertContains(response, "<b>Durée de validité du diagnostic :</b> du 15/02/2024 au 15/08/2024")
-
-    def test_details_as_authorized_prescriber_with_expired_diagnosis(self, client):
-        diagnosis = GEIQEligibilityDiagnosisFactory(expired=True, from_prescriber=True)
         job_application = JobApplicationFactory(
             to_company__kind=CompanyKind.GEIQ,
             job_seeker=diagnosis.job_seeker,
+            sender=diagnosis.author,
             eligibility_diagnosis=None,
+            geiq_eligibility_diagnosis=diagnosis,
+            was_hired=True,
         )
 
-        client.force_login(job_application.to_company.members.first())
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
+        # as employer, I still see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertContains(response, self.ALLOWANCE_AND_COMPANY)
+        assert response.context["geiq_eligibility_diagnosis"] == diagnosis
 
-        assertContains(
-            response,
-            f"{self.EXPIRED_DIAGNOSIS_EXPLANATION} le {dateformat.format(diagnosis.expires_at, 'd F Y')}",
-        )
+        # as job seeker, I still see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assert response.context["geiq_eligibility_diagnosis"] == diagnosis
 
-    def test_allowance_details_for_geiq(self, client):
-        # Slightly more complex than for prescribers :
-        # allowance amount is variable in function of chosen administrative criteria
+        # as a prescriber, I still see my diagnosis
+        assert diagnosis.author.is_prescriber
+        response = self.get_response(client, job_application, diagnosis.author)
+        assertContains(response, self.VALID_DIAGNOSIS)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assert response.context["geiq_eligibility_diagnosis"] == diagnosis
+
+    def test_with_valid_diagnosis_no_allowance(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
         job_application = JobApplicationFactory(
             to_company=diagnosis.author_geiq,
             job_seeker=diagnosis.job_seeker,
+            sender=diagnosis.author,
             eligibility_diagnosis=None,
         )
-        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
-        response = client.get(url)
 
-        # Annex 2, level 2 criteria: no allowance for GEIQ
-        diagnosis.administrative_criteria.set([GEIQAdministrativeCriteria.objects.get(pk=17)])
-        diagnosis.save()
+        # as employer, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
 
-        client.force_login(diagnosis.author_geiq.members.first())
-        response = client.get(url)
+        # as job seeker, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
 
-        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        assertContains(response, "Éligibilité public prioritaire GEIQ non confirmée")
-        assertContains(response, "Renseignée par")
-        assertContains(response, "Situation administrative du candidat")
-        assertContains(response, "Mettre à jour")
-        assertContains(
-            response,
-            "Les critères que vous avez sélectionnés ne vous permettent pas de "
-            "bénéficier d’une aide financière de l’État.",
+    def test_with_expired_diagnosis_no_allowance(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, expired=True)
+        job_application = JobApplicationFactory(
+            to_company=diagnosis.author_geiq,
+            job_seeker=diagnosis.job_seeker,
+            sender=diagnosis.author,
+            eligibility_diagnosis=None,
         )
 
-        diagnosis.administrative_criteria.set(
-            [
-                GEIQAdministrativeCriteria.objects.get(pk=18),
-                GEIQAdministrativeCriteria.objects.get(pk=17),
-            ]
-        )
-        # Diagnosis must be saved to reset cached properties (allowance amount)
-        diagnosis.save()
-        response = client.get(url)
+        # as employer, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.to_company.members.first())
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
 
-        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        assertContains(response, "Éligibilité public prioritaire GEIQ validée")
-        assertContains(response, "Éligibilité GEIQ confirmée par")
-        assertContains(response, "Situation administrative du candidat")
-        assertContains(
-            response,
-            "Les critères que vous avez sélectionnés vous donnent droit en cas d’embauche",
-        )
-        assertContains(
-            response,
-            f"une aide financière de l’État s’élevant à <b>{diagnosis.allowance_amount} €</b> ",
-        )
+        # as job seeker, I see the prescriber diagnosis
+        response = self.get_response(client, job_application, job_application.job_seeker)
+        assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
+        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+
+
+def test_get_geiq_eligibility_diagnosis(subtests):
+    expired_prescriber_diagnosis = GEIQEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        expired=True,
+    )
+    job_seeker = expired_prescriber_diagnosis.job_seeker
+    expired_company_diagnosis = GEIQEligibilityDiagnosisFactory(
+        from_geiq=True,
+        expired=True,
+        job_seeker=job_seeker,
+    )
+    geiq = expired_company_diagnosis.author_geiq
+    newer_company_diagnosis = GEIQEligibilityDiagnosisFactory(
+        from_geiq=True,
+        job_seeker=job_seeker,
+        author_geiq=geiq,
+    )
+    valid_prescriber_diagnosis = GEIQEligibilityDiagnosisFactory(
+        from_prescriber=True,
+        job_seeker=job_seeker,
+    )
+
+    # The new prescriber diagnosis changed the valid_company_diagnosis expiry date : it's now expired
+    newer_company_diagnosis.refresh_from_db()
+    assert not newer_company_diagnosis.is_valid
+
+    new_job_application = JobApplicationFactory(
+        to_company=geiq,
+        job_seeker=job_seeker,
+        eligibility_diagnosis=None,
+    )
+    accepted_job_application_with_company_diagnosis = JobApplicationFactory(
+        to_company=geiq,
+        job_seeker=job_seeker,
+        geiq_eligibility_diagnosis=expired_company_diagnosis,
+        eligibility_diagnosis=None,
+        state=JobApplicationState.ACCEPTED,
+    )
+    accepted_job_application_with_prescriber_diagnosis = JobApplicationFactory(
+        to_company=geiq,
+        job_seeker=job_seeker,
+        geiq_eligibility_diagnosis=expired_prescriber_diagnosis,
+        eligibility_diagnosis=None,
+        state=JobApplicationState.ACCEPTED,
+    )
+
+    # on accepted job application:
+    # the hiring company and jobseeker get the linked diagnosis
+    # a prescriber only sees the diagnosis if it was created by a prescriber
+    assert (
+        _get_geiq_eligibility_diagnosis(accepted_job_application_with_company_diagnosis, only_prescriber=False)
+        == expired_company_diagnosis
+    )
+    assert (
+        _get_geiq_eligibility_diagnosis(accepted_job_application_with_company_diagnosis, only_prescriber=True) is None
+    )
+    assert (
+        _get_geiq_eligibility_diagnosis(accepted_job_application_with_prescriber_diagnosis, only_prescriber=False)
+        == expired_prescriber_diagnosis
+    )
+    assert (
+        _get_geiq_eligibility_diagnosis(accepted_job_application_with_prescriber_diagnosis, only_prescriber=True)
+        == expired_prescriber_diagnosis
+    )
+
+    # On not accepted job application: if there's a valid prescriber diagnosis, return it
+    assert _get_geiq_eligibility_diagnosis(new_job_application, only_prescriber=False) == valid_prescriber_diagnosis
+    assert _get_geiq_eligibility_diagnosis(new_job_application, only_prescriber=True) == valid_prescriber_diagnosis
+
+    # If there's no prescriber valid diagnosis :
+    # the hiring company and jobseeker get the most recent diagnosis
+    # a prescriber get the most revent among prescriber diangoses
+    valid_prescriber_diagnosis.delete()
+    _valid_diagnois_from_other_company = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=job_seeker)
+    assert _get_geiq_eligibility_diagnosis(new_job_application, only_prescriber=False) == newer_company_diagnosis
+    assert _get_geiq_eligibility_diagnosis(new_job_application, only_prescriber=True) == expired_prescriber_diagnosis
 
 
 class TestJobSeekerGeoDetailsForGEIQDiagnosis:

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -1,171 +1,159 @@
-from dateutil.relativedelta import relativedelta
 from django.urls import reverse
-from django.utils import dateformat, timezone
+from django.utils import dateformat
 from freezegun import freeze_time
+from pytest_django.asserts import assertContains, assertNotContains, assertTemplateNotUsed, assertTemplateUsed
 
 from itou.companies.enums import CompanyKind
 from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
-from itou.utils.session import SessionNamespace
 from tests.companies.factories import CompanyWithMembershipAndJobsFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import JobSeekerFactory, JobSeekerWithAddressFactory
-from tests.utils.test import TestCase
 
 
-@freeze_time("2024-02-15")
-class JobApplicationGEIQEligibilityDetailsTest(TestCase):
+class TestJobApplicationGEIQEligibilityDetails:
     EXPIRED_DIAGNOSIS_EXPLANATION = "Le diagnostic du candidat a expiré"
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ)
-        cls.valid_diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
-        cls.expired_diagnosis = GEIQEligibilityDiagnosisFactory(
-            from_prescriber=True, expires_at=timezone.now() - relativedelta(months=1)
-        )
-        cls.prescriber_org = cls.valid_diagnosis.author_prescriber_organization
-        cls.author = cls.prescriber_org.members.first()
-        cls.job_seeker = cls.valid_diagnosis.job_seeker
-        cls.job_application = JobApplicationFactory(
-            to_company=cls.geiq,
-            job_seeker=cls.job_seeker,
-        )
-        cls.url = reverse(
-            "apply:details_for_company",
-            kwargs={"job_application_id": cls.job_application.pk},
-        )
-
-    def test_with_geiq_eligibility_details(self):
-        self.client.force_login(self.geiq.members.first())
-        response = self.client.get(self.url)
-
-        assert response.status_code == 200
-        self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-
-    def test_without_geiq_eligibility_details(self):
-        # No GEIQ diagnosis for this job seeker / job application
-        job_application = JobApplicationFactory(to_company=self.geiq)
-        self.client.force_login(self.geiq.members.first())
-        response = self.client.get(
-            reverse(
-                "apply:details_for_company",
-                kwargs={"job_application_id": job_application.pk},
-            )
-        )
-
-        assert response.status_code == 200
-        self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-
-    def test_details_as_geiq_with_valid_eligibility_diagnosis(self):
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
+    def test_with_geiq_eligibility_details(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
         job_application = JobApplicationFactory(
-            to_company=diagnosis.author_geiq,
-            geiq_eligibility_diagnosis=diagnosis,
+            to_company__kind=CompanyKind.GEIQ,
+            job_seeker=diagnosis.job_seeker,
+            sender=diagnosis.author,
             eligibility_diagnosis=None,
         )
-
-        self.client.force_login(diagnosis.author_geiq.members.first())
-        response = self.client.get(
-            reverse(
-                "apply:details_for_company",
-                kwargs={"job_application_id": job_application.pk},
-            )
-        )
-
-        self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        self.assertContains(
-            response,
-            "Éligibilité public prioritaire GEIQ non confirmée",
-        )
-        self.assertContains(
-            response,
-            "Les critères que vous avez sélectionnés ne vous permettent pas de bénéficier d’une aide financière de l’État.",  # noqa: E501
-        )
-        self.assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
-        # More in `test_allowance_details_for_geiq`
-
-    def test_details_as_geiq_with_expired_eligibility_diagnosis(self):
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, expired=True)
-        job_application = JobApplicationFactory(
-            to_company=diagnosis.author_geiq,
-            geiq_eligibility_diagnosis=diagnosis,
-            eligibility_diagnosis=None,
-        )
-
-        self.client.force_login(diagnosis.author_geiq.members.first())
-        response = self.client.get(
-            reverse(
-                "apply:details_for_company",
-                kwargs={"job_application_id": job_application.pk},
-            )
-        )
-
-        self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        self.assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
-        self.assertContains(
-            response,
-            "Éligibilité public prioritaire GEIQ non confirmée",
-        )
-
-    def test_details_as_authorized_prescriber_with_valid_diagnosis(self):
-        self.client.force_login(self.geiq.members.first())
-        response = self.client.get(self.url)
-
-        self.assertContains(
-            response,
-            f"Éligibilité GEIQ confirmée par "
-            f"<b>{self.author.get_full_name()} ({self.prescriber_org.display_name})</b>",
-        )
-        self.assertContains(response, "<b>Durée de validité du diagnostic :</b> du 15/02/2024 au 15/08/2024")
-
-    def test_details_as_authorized_prescriber_with_expired_diagnosis(self):
-        job_application = JobApplicationFactory(to_company=self.geiq, job_seeker=self.expired_diagnosis.job_seeker)
+        client.force_login(job_application.to_company.members.first())
         url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
 
-        self.client.force_login(self.geiq.members.first())
-        response = self.client.get(url)
-
-        self.assertContains(
-            response,
-            f"{self.EXPIRED_DIAGNOSIS_EXPLANATION} le {dateformat.format(self.expired_diagnosis.expires_at, 'd F Y')}",
-        )
-
-    def test_allowance_details_for_prescriber(self):
-        # Allowance amount is constant when diagnosis is made by an authorized prescriber
-        self.client.force_login(self.geiq.members.first())
-        response = self.client.get(self.url)
-
-        self.assertContains(
+        assert response.status_code == 200
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        assertContains(response, "Éligibilité public prioritaire GEIQ validée")
+        assertContains(
             response,
             "Ce diagnostic émis par un prescripteur habilité vous donnera droit en cas d’embauche",
         )
-        self.assertContains(
+        assertContains(
             response,
-            f"une aide financière de l’État s’élevant à <b>{self.valid_diagnosis.allowance_amount} €</b> ",
+            f"une aide financière de l’État s’élevant à <b>{diagnosis.allowance_amount} €</b> ",
         )
 
-    def test_allowance_details_for_geiq(self):
+    def test_without_geiq_eligibility_details(self, client):
+        # No GEIQ diagnosis for this job seeker / job application
+        job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ)
+        client.force_login(job_application.to_company.members.first())
+        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
+
+        assert response.status_code == 200
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        assertContains(response, "Éligibilité public prioritaire GEIQ non confirmée")
+
+    def test_details_as_geiq_with_valid_eligibility_diagnosis(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
+        job_application = JobApplicationFactory(
+            job_seeker=diagnosis.job_seeker,
+            to_company=diagnosis.author_geiq,
+            eligibility_diagnosis=None,
+        )
+
+        client.force_login(diagnosis.author_geiq.members.first())
+        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
+
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        assertContains(
+            response,
+            "Éligibilité public prioritaire GEIQ non confirmée",
+        )
+        assertContains(
+            response,
+            "Les critères que vous avez sélectionnés ne vous permettent pas de bénéficier d’une aide financière de l’État.",  # noqa: E501
+        )
+        assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        # More in `test_allowance_details_for_geiq`
+
+    def test_details_as_geiq_with_expired_eligibility_diagnosis(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, expired=True)
+        job_application = JobApplicationFactory(
+            to_company=diagnosis.author_geiq,
+            job_seeker=diagnosis.job_seeker,
+            eligibility_diagnosis=None,
+        )
+
+        client.force_login(diagnosis.author_geiq.members.first())
+        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
+
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        assertContains(
+            response,
+            "Éligibilité public prioritaire GEIQ non confirmée",
+        )
+
+    @freeze_time("2024-02-15")
+    def test_details_as_authorized_prescriber_with_valid_diagnosis(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
+        job_application = JobApplicationFactory(
+            to_company__kind=CompanyKind.GEIQ,
+            job_seeker=diagnosis.job_seeker,
+            eligibility_diagnosis=None,
+        )
+        client.force_login(job_application.to_company.members.first())
+        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
+
+        assertContains(
+            response,
+            f"Éligibilité GEIQ confirmée par "
+            f"<b>{diagnosis.author.get_full_name()} ({diagnosis.author_prescriber_organization.display_name})</b>",
+        )
+        assertContains(response, "<b>Durée de validité du diagnostic :</b> du 15/02/2024 au 15/08/2024")
+
+    def test_details_as_authorized_prescriber_with_expired_diagnosis(self, client):
+        diagnosis = GEIQEligibilityDiagnosisFactory(expired=True, from_prescriber=True)
+        job_application = JobApplicationFactory(
+            to_company__kind=CompanyKind.GEIQ,
+            job_seeker=diagnosis.job_seeker,
+            eligibility_diagnosis=None,
+        )
+
+        client.force_login(job_application.to_company.members.first())
+        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
+
+        assertContains(
+            response,
+            f"{self.EXPIRED_DIAGNOSIS_EXPLANATION} le {dateformat.format(diagnosis.expires_at, 'd F Y')}",
+        )
+
+    def test_allowance_details_for_geiq(self, client):
         # Slightly more complex than for prescribers :
         # allowance amount is variable in function of chosen administrative criteria
         diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
-        job_application = JobApplicationFactory(to_company=diagnosis.author_geiq, job_seeker=diagnosis.job_seeker)
+        job_application = JobApplicationFactory(
+            to_company=diagnosis.author_geiq,
+            job_seeker=diagnosis.job_seeker,
+            eligibility_diagnosis=None,
+        )
         url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
 
         # Annex 2, level 2 criteria: no allowance for GEIQ
         diagnosis.administrative_criteria.set([GEIQAdministrativeCriteria.objects.get(pk=17)])
         diagnosis.save()
 
-        self.client.force_login(diagnosis.author_geiq.members.first())
-        response = self.client.get(url)
+        client.force_login(diagnosis.author_geiq.members.first())
+        response = client.get(url)
 
-        self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        self.assertContains(response, "Éligibilité public prioritaire GEIQ non confirmée")
-        self.assertContains(response, "Renseignée par")
-        self.assertContains(response, "Situation administrative du candidat")
-        self.assertContains(response, "Mettre à jour")
-        self.assertContains(
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        assertContains(response, "Éligibilité public prioritaire GEIQ non confirmée")
+        assertContains(response, "Renseignée par")
+        assertContains(response, "Situation administrative du candidat")
+        assertContains(response, "Mettre à jour")
+        assertContains(
             response,
             "Les critères que vous avez sélectionnés ne vous permettent pas de "
             "bénéficier d’une aide financière de l’État.",
@@ -179,131 +167,121 @@ class JobApplicationGEIQEligibilityDetailsTest(TestCase):
         )
         # Diagnosis must be saved to reset cached properties (allowance amount)
         diagnosis.save()
-        response = self.client.get(url)
+        response = client.get(url)
 
-        self.assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
-        self.assertContains(response, "Éligibilité public prioritaire GEIQ validée")
-        self.assertContains(response, "Éligibilité GEIQ confirmée par")
-        self.assertContains(response, "Situation administrative du candidat")
-        self.assertContains(
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_diagnosis_details.html")
+        assertContains(response, "Éligibilité public prioritaire GEIQ validée")
+        assertContains(response, "Éligibilité GEIQ confirmée par")
+        assertContains(response, "Situation administrative du candidat")
+        assertContains(
             response,
             "Les critères que vous avez sélectionnés vous donnent droit en cas d’embauche",
         )
-        self.assertContains(
+        assertContains(
             response,
             f"une aide financière de l’État s’élevant à <b>{diagnosis.allowance_amount} €</b> ",
         )
 
 
-class TestJobSeekerGeoDetailsForGEIQDiagnosis(TestCase):
+class TestJobSeekerGeoDetailsForGEIQDiagnosis:
     """Check that QPV and ZRR details for job seeker are displayed in GEIQ eligibility diagnosis form"""
 
-    @classmethod
-    def setUpTestData(cls):
-        cls.job_seeker = JobSeekerFactory()
-        cls.job_seeker_in_qpv = JobSeekerWithAddressFactory(with_address_in_qpv=True)
-        cls.job_seeker_in_zrr = JobSeekerWithAddressFactory(with_city_in_zrr=True)
-        cls.geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
-        cls.prescriber_org = PrescriberOrganizationWithMembershipFactory(authorized=True)
-
-    def _setup_session(self):
-        apply_session = SessionNamespace(self.client.session, f"job_application-{self.geiq.pk}")
-        apply_session.init(
-            {
-                "selected_jobs": self.geiq.job_description_through.all(),
-            }
-        )
-        apply_session.save()
-
-    def test_job_seeker_not_resident_in_qpv_or_zrr(self):
+    def test_job_seeker_not_resident_in_qpv_or_zrr(self, client):
         # ZRR / QPV criteria info fragment is loaded before HTMX "zone"
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=self.job_seeker)
-        job_application = JobApplicationFactory(job_seeker=self.job_seeker, to_company=diagnosis.author_geiq)
+        job_seeker = JobSeekerFactory()
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=job_seeker)
+        job_application = JobApplicationFactory(job_seeker=job_seeker, to_company=diagnosis.author_geiq)
         url = reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
-        self.client.force_login(diagnosis.author_geiq.members.first())
-        response = self.client.get(url)
+        client.force_login(diagnosis.author_geiq.members.first())
+        response = client.get(url)
 
-        self.assertTemplateNotUsed(response, "apply/includes/known_criteria.html")
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
+        assertTemplateNotUsed(response, "apply/includes/known_criteria.html")
 
-    def test_job_seeker_not_resident_in_qpv_or_zrr_for_prescriber(self):
-        self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session()
-        response = self.client.get(
+    def test_job_seeker_not_resident_in_qpv_or_zrr_for_prescriber(self, client):
+        job_seeker = JobSeekerFactory()
+        geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
+        prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.get()
+        client.force_login(prescriber)
+        response = client.get(
             reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": self.job_seeker.public_id},
+                kwargs={"company_pk": geiq.pk, "job_seeker_public_id": job_seeker.public_id},
             )
         )
+        assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
+        assertTemplateNotUsed(response, "apply/includes/known_criteria.html")
 
-        self.assertTemplateNotUsed(response, "apply/includes/known_criteria.html")
-
-    def test_job_seeker_qpv_details_display(self):
+    def test_job_seeker_qpv_details_display(self, client):
         # Check QPV fragment is displayed:
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=self.job_seeker_in_qpv)
-        job_application = JobApplicationFactory(job_seeker=self.job_seeker_in_qpv, to_company=diagnosis.author_geiq)
+        job_seeker_in_qpv = JobSeekerWithAddressFactory(with_address_in_qpv=True)
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=job_seeker_in_qpv)
+        job_application = JobApplicationFactory(job_seeker=job_seeker_in_qpv, to_company=diagnosis.author_geiq)
         url = reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
 
-        self.client.force_login(diagnosis.author_geiq.members.first())
-        response = self.client.get(url)
+        client.force_login(diagnosis.author_geiq.members.first())
+        response = client.get(url)
 
-        self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
-        self.assertContains(response, "Résident QPV")
+        assertTemplateUsed(response, "apply/includes/known_criteria.html")
+        assertContains(response, "Résident QPV")
 
-    def test_job_seeker_qpv_details_display_for_prescriber(self):
+    def test_job_seeker_qpv_details_display_for_prescriber(self, client):
         # Check QPV fragment is displayed for prescriber:
-        self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session()
-        response = self.client.get(
+        job_seeker_in_qpv = JobSeekerWithAddressFactory(with_address_in_qpv=True)
+        prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.get()
+        client.force_login(prescriber)
+        geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
+        response = client.get(
             reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": self.job_seeker_in_qpv.public_id},
+                kwargs={"company_pk": geiq.pk, "job_seeker_public_id": job_seeker_in_qpv.public_id},
             )
         )
 
-        self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
-        self.assertContains(response, "Résident QPV")
+        assertTemplateUsed(response, "apply/includes/known_criteria.html")
+        assertContains(response, "Résident QPV")
 
-    def test_job_seeker_zrr_details_display(self):
+    def test_job_seeker_zrr_details_display(self, client):
         # Check ZRR fragment is displayed
-
-        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=self.job_seeker_in_zrr)
-        job_application = JobApplicationFactory(job_seeker=self.job_seeker_in_zrr, to_company=diagnosis.author_geiq)
+        job_seeker_in_zrr = JobSeekerWithAddressFactory(with_city_in_zrr=True)
+        diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True, job_seeker=job_seeker_in_zrr)
+        job_application = JobApplicationFactory(job_seeker=job_seeker_in_zrr, to_company=diagnosis.author_geiq)
         url = reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
 
-        self.client.force_login(diagnosis.author_geiq.members.first())
-        response = self.client.get(url)
+        client.force_login(diagnosis.author_geiq.members.first())
+        response = client.get(url)
 
-        self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
-        self.assertContains(response, "Résident en ZRR")
+        assertTemplateUsed(response, "apply/includes/known_criteria.html")
+        assertContains(response, "Résident en ZRR")
 
-    def test_job_seeker_zrr_details_display_for_prescriber(self):
+    def test_job_seeker_zrr_details_display_for_prescriber(self, client):
         # Check QPV fragment is displayed for prescriber:
-        self.client.force_login(self.prescriber_org.members.first())
-        self._setup_session()
-        response = self.client.get(
+        job_seeker_in_zrr = JobSeekerWithAddressFactory(with_city_in_zrr=True)
+        geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
+        prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.get()
+        client.force_login(prescriber)
+        response = client.get(
             reverse(
                 "apply:application_geiq_eligibility",
-                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": self.job_seeker_in_zrr.public_id},
+                kwargs={"company_pk": geiq.pk, "job_seeker_public_id": job_seeker_in_zrr.public_id},
             )
         )
 
-        self.assertTemplateUsed(response, "apply/includes/known_criteria.html")
-        self.assertContains(response, "Résident en ZRR")
+        assertTemplateUsed(response, "apply/includes/known_criteria.html")
+        assertContains(response, "Résident en ZRR")
 
-    def test_jobseeker_cannot_create_geiq_diagnosis(self):
-        job_application = JobApplicationFactory(job_seeker=self.job_seeker, to_company=self.geiq)
-        self.client.force_login(self.job_seeker)
+    def test_jobseeker_cannot_create_geiq_diagnosis(self, client):
+        job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ)
+        client.force_login(job_application.job_seeker)
         # Needed to setup session
-        response = self.client.get(
-            reverse("apply:geiq_eligibility", kwargs={"job_application_id": job_application.pk})
-        )
+        response = client.get(reverse("apply:geiq_eligibility", kwargs={"job_application_id": job_application.pk}))
         assert response.status_code == 404
-        response = self.client.post(
+        response = client.post(
             reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk}),
             data={
                 "jeune_26_ans": "on",
                 "sortant_ase": "on",
             },
         )
-        assert not self.job_seeker.geiq_eligibility_diagnoses.exists()
+        assert not job_application.job_seeker.geiq_eligibility_diagnoses.exists()
         assert response.status_code == 404

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3903,7 +3903,6 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         # Badge is KO if job seeker has a valid diagnosis without allowance
         diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
         assert diagnosis.allowance_amount == 0
-        assert not diagnosis.eligibility_confirmed
 
         self.client.force_login(self.prescriber_org.members.first())
         self._setup_session(diagnosis.author_geiq.pk)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour permettre de conserver l'information même quand le diagnostic n'est plus valide 

### Notes pour discussion métier : 

employeur et candidat                                     
                                                         
on prend dans l'ordre de présence
- le diag de la candidature
- le diag le plus récent fait par un prescripteur habilité
- le diag le plus récent fait par l'entreprise destinatrice 

=> tester le cas un diag expiré d'un prescritpeur et un diag valid de la structure
On ne veut pas d'abord le diag valide ?

prescripteur
------------
on prend le diag valide pour ce candidat fait par un presripteur habitilité (s'il existe)

mais on ne prend pas un diag d'un prescripteur habilité expiré ?
sur une candidature acceptée, on n'affiche pas non plus le diag de l'entreprise ?


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
