### PR TITLE
Processus de candidature : réusinage des tests du processus d'acceptation

### DIFF
--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -287,10 +287,11 @@ class JobSeekerWithAddressFactory(JobSeekerFactory):
             # Do nothing
             return
 
-        first_address = [
-            address for address in BAN_GEOCODING_API_RESULTS_MOCK if address.get("ban_api_resolved_address")
-        ][0]
-        address = first_address if extracted is True else extracted
+        address = (
+            next(address for address in BAN_GEOCODING_API_RESULTS_MOCK if address.get("ban_api_resolved_address"))
+            if extracted is True
+            else extracted
+        )
 
         city, _ = City.objects.get_or_create(
             name=address["city"],


### PR DESCRIPTION
Le processus d'acceptation de candidature, central et complexe, fait partie des premières fonctionnalités de l'app et cela se reflète dans les tests. Ceux-ci ont évolué de manière tentaculaire. Le fichier de test fait plus de 3000 lignes !
Plus précisément, la processus d'acceptation de candidature intègre 3 formulaires différents. Les tests répétaient les mêmes `post_data` mais avec des variantes, les rendant difficiles à comprendre et à faire évoluer.
L'un de ces formulaires modifie l'adresse du candidat géré par `AddressMixin`. La champ `User.city` est une chaîne de caractères mais `User.insee_city` [a été introduit en septembre 23](https://github.com/gip-inclusion/les-emplois/pull/3043) pour garantir une meilleure cohérence des données. Or cette PK n'était pas utilisée correctement dans les tests. Par ailleurs, le mock de la BAN était difficile à prendre en main.

Idéalement, les _factories_ des adresses en général mériteraient un bon coup de bistouri.
Je pense que ce serait également mieux d'extraire les tests d'acceptation dans un nouveau fichier et d'en profiter pour les passer à Pytest, mais j'ai déjà passé du temps à les refondre ici et je dois m'atteler à l'API Particuliers. Ce sera pour la liste au Père Noël ! Cette PR constitute un premier pas.   
