### PR TITLE
Metabase: ouverture du tb 394 à toutes les structures

### DIFF
--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -6,11 +6,9 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
-from itou.prescribers.enums import (
-    DTPE_SAFIR_CODE_TO_DEPARTMENTS,
-    PrescriberAuthorizationStatus,
-    PrescriberOrganizationKind,
-)
+from itou.prescribers.enums import (DTPE_SAFIR_CODE_TO_DEPARTMENTS,
+                                    PrescriberAuthorizationStatus,
+                                    PrescriberOrganizationKind)
 from itou.prescribers.models import PrescriberOrganization
 
 
@@ -69,10 +67,7 @@ def can_view_stats_siae_orga_etp(request):
 
 
 def can_view_stats_siae_hiring_report(request):
-    return (
-        can_view_stats_siae(request)
-        and request.current_organization.region in settings.STATS_SIAE_HIRING_REPORT_REGION_WHITELIST
-    )
+    return can_view_stats_siae(request)
 
 
 def can_view_stats_cd(request):

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -16,12 +16,9 @@ from itou.utils.perms.middleware import ItouCurrentOrganizationMiddleware
 from itou.www.stats import utils
 from tests.companies.factories import CompanyFactory
 from tests.institutions.factories import InstitutionWithMembershipFactory
-from tests.prescribers.factories import (
-    PrescriberOrganizationWithMembershipFactory,
-)
-from tests.users.factories import (
-    PrescriberFactory,
-)
+from tests.prescribers.factories import \
+    PrescriberOrganizationWithMembershipFactory
+from tests.users.factories import PrescriberFactory
 from tests.utils.tests import get_response_for_middlewaremixin
 
 
@@ -68,8 +65,7 @@ def test_can_view_stats_siae_aci():
 @pytest.mark.parametrize(
     "region,expected",
     itertools.chain(
-        [(region, True) for region in settings.STATS_SIAE_HIRING_REPORT_REGION_WHITELIST],
-        [(region, False) for region in set(REGIONS) - set(settings.STATS_SIAE_HIRING_REPORT_REGION_WHITELIST)],
+        [(region, True) for region in set(REGIONS)]
     ),
 )
 @pytest.mark.parametrize("is_admin", [True, False])

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -17,7 +17,8 @@ from itou.www.stats import urls as stats_urls
 from itou.www.stats.views import get_params_aci_asp_ids_for_department
 from tests.companies.factories import CompanyFactory
 from tests.institutions.factories import InstitutionWithMembershipFactory
-from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
+from tests.prescribers.factories import \
+    PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import PrescriberFactory
 from tests.utils.test import TestCase
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mise à disposition du TB pilotage sur l'espace privé.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

Attention: pas testé en local comme indiqué à Romain pour cause d'un pb de db en cours de résolution.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
