### PR TITLE
Retirer le hack pour faire apparaître `.has-selected-item` en gras dans htmx_dropdown_filter

### DIFF
--- a/itou/static/js/htmx_dropdown_filter.js
+++ b/itou/static/js/htmx_dropdown_filter.js
@@ -27,9 +27,7 @@
     // Can be called from any element within a dropdown.
     const dropdown = this.closest('.dropdown');
     const btnFilter = dropdown.querySelector(".btn-dropdown-filter");
-    const hasValue = fieldHasValue(dropdown);
-    btnFilter.classList.toggle('has-selected-item', hasValue);
-    btnFilter.classList.toggle('font-weight-bold', hasValue);
+    btnFilter.classList.toggle('has-selected-item', fieldHasValue(dropdown));
   }
 
   function updateFiltersCount() {


### PR DESCRIPTION
## :thinking: Pourquoi ?

La classe `has-selected-item` définit le style en gras, et c’est maintenant dans la version du thème utilisée.
https://github.com/gip-inclusion/itou-theme/commit/778b39e6008478572b8e4ee89266232fd4e7b6e0
