### PR TITLE
Verifier que les prescripteurs habilités voient leurs candidatures comme éligibles à l’IAE

### DIFF
--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -156,6 +156,14 @@ def test_filtered_by_company(client):
     assert len(applications) == 3
 
 
+def test_filtered_by_eligibility_validated_prescriber(client):
+    prescriber_jobapp = JobApplicationFactory()
+    client.force_login(prescriber_jobapp.sender)
+    response = client.get(reverse("apply:list_prescriptions"), {"eligiblity_validated": "on"})
+    applications = response.context["job_applications_page"].object_list
+    assert applications == [prescriber_jobapp]
+
+
 def test_filters(client, snapshot):
     client.force_login(PrescriberFactory())
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Consolider les tests avant https://www.notion.so/plateforme-inclusion/Investigation-Cacher-les-diags-SIAE-aux-prescripteurs-lors-des-candidatures-3227290de5b248759a5fe43079868292.