### PR TITLE
Clarifier que l’envoi de fichier ne permet d’envoyer qu’un seul fichier [GEN-1889]

### DIFF
--- a/itou/templates/utils/widgets/file_input.html
+++ b/itou/templates/utils/widgets/file_input.html
@@ -6,7 +6,7 @@
             <i class="ri-upload-cloud-2-line ri-2x"></i>
         </p>
         <p class="mb-2">
-            Glissez vos fichiers ici ou <strong>rechercher</strong> dans vos fichiers
+            Glissez votre fichier ici ou <strong>rechercher</strong> dans vos fichiers
         </p>
         <label for="{{ widget.attrs.id }}" class="btn btn-link btn-sm btn-ico mb-2 stretched-link">
             <i class="ri-folder-line ri-xl"></i>

--- a/tests/www/geiq_views/__snapshots__/tests.ambr
+++ b/tests/www/geiq_views/__snapshots__/tests.ambr
@@ -3047,7 +3047,7 @@
               <i class="ri-upload-cloud-2-line ri-2x"></i>
           </p>
           <p class="mb-2">
-              Glissez vos fichiers ici ou <strong>rechercher</strong> dans vos fichiers
+              Glissez votre fichier ici ou <strong>rechercher</strong> dans vos fichiers
           </p>
           <label class="btn btn-link btn-sm btn-ico mb-2 stretched-link" for="id_activity_report_file">
               <i class="ri-folder-line ri-xl"></i>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de perturber les utilisateurs.
