### PR TITLE
Admin : Permettre l’édition du champ `website` pour les organisations prescriptrices

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -92,6 +92,7 @@ class PrescriberOrganizationAdmin(ItouGISMixin, OrganizationAdmin):
                     "name",
                     "phone",
                     "email",
+                    "website",
                     "code_safir_pole_emploi",
                     "is_authorized",
                     "description",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Besoin support.

![image](https://github.com/user-attachments/assets/a241bfc5-5563-4b5f-aad5-b390718dbb59)
