### PR TITLE
Fiches salarié : Supprimer la voiture balai pour les erreurs 3436

### DIFF
--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -28,30 +28,6 @@ class Command(BaseCommand):
 
     # Check and fix methods: add as many as needed.
 
-    def _check_3436_error_code(self, dry_run):
-        # Report all employee records with ASP error code 3436
-
-        err_3436 = EmployeeRecord.objects.asp_duplicates()
-        count_3436 = err_3436.count()
-
-        self.stdout.write("* Checking REJECTED employee records with error 3436 (duplicates):")
-
-        if count_3436 == 0:
-            self.stdout.write(" - none found (great!)")
-        else:
-            self.stdout.write(f" - found {count_3436} error(s)")
-
-            if dry_run:
-                return
-
-            self.stdout.write(" - fixing 3436 errors: forcing status to PROCESSED")
-
-            with transaction.atomic():
-                for to_fix in err_3436:
-                    to_fix.update_as_processed_as_duplicate(to_fix.archived_json)
-
-            self.stdout.write(" - done!")
-
     def _check_approvals(self, dry_run):
         # Report employee records with no approvals
         # (approvals can be deleted after processing)
@@ -128,7 +104,6 @@ class Command(BaseCommand):
             self.stdout.write(" - DRY-RUN mode: not fixing, just reporting")
 
         self._check_approvals(dry_run)
-        self._check_3436_error_code(dry_run)
         self._check_missed_notifications(dry_run)
 
         self.stdout.write("+ Employee records sanitizing done. Have a great day!")

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -137,13 +137,6 @@ class EmployeeRecordQuerySet(models.QuerySet):
             )
         )
 
-    def asp_duplicates(self):
-        """
-        Return REJECTED employee records with error code '3436'.
-        These employee records are considered as duplicates by ASP.
-        """
-        return self.filter(status=Status.REJECTED).filter(asp_processing_code=EmployeeRecord.ASP_DUPLICATE_ERROR_CODE)
-
 
 class EmployeeRecord(ASPExchangeInformation):
     """

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -583,18 +583,6 @@ class TestEmployeeRecordJobApplicationConstraints:
 
 
 class TestEmployeeRecordQueryset:
-    def test_asp_duplicates(self):
-        # Filter REJECTED employee records with error code 3436
-        EmployeeRecordWithProfileFactory(status=Status.REJECTED)
-
-        assert EmployeeRecord.objects.asp_duplicates().count() == 0
-
-        EmployeeRecordWithProfileFactory(
-            status=Status.REJECTED, asp_processing_code=EmployeeRecord.ASP_DUPLICATE_ERROR_CODE
-        )
-
-        assert EmployeeRecord.objects.asp_duplicates().count() == 1
-
     def test_for_company(self):
         employee_record_1, employee_record_2 = EmployeeRecordFactory.create_batch(2)
 

--- a/tests/employee_record/test_sanitize_employee_records.py
+++ b/tests/employee_record/test_sanitize_employee_records.py
@@ -16,7 +16,6 @@ def command_fixture():
 
 def test_handle_dry_run_option(mocker, command):
     mocker.patch.object(command, "_check_approvals")
-    mocker.patch.object(command, "_check_3436_error_code")
     mocker.patch.object(command, "_check_missed_notifications")
 
     command.handle(dry_run=True)
@@ -24,29 +23,6 @@ def test_handle_dry_run_option(mocker, command):
         "+ Checking employee records coherence before transferring to ASP",
         " - DRY-RUN mode: not fixing, just reporting",
         "+ Employee records sanitizing done. Have a great day!",
-        "",
-    ]
-
-
-def test_3436_errors_check(command):
-    # Check for 3436 errors fix (ASP duplicates)
-
-    employee_record = factories.EmployeeRecordWithProfileFactory(
-        status=models.Status.REJECTED,
-        asp_processing_code=models.EmployeeRecord.ASP_DUPLICATE_ERROR_CODE,
-    )
-
-    command._check_3436_error_code(dry_run=False)
-
-    # Exterminate 3436s
-    employee_record.refresh_from_db()
-    assert employee_record.status == models.Status.PROCESSED
-    assert employee_record.processed_as_duplicate is True
-    assert command.stdout.getvalue().split("\n") == [
-        "* Checking REJECTED employee records with error 3436 (duplicates):",
-        " - found 1 error(s)",
-        " - fixing 3436 errors: forcing status to PROCESSED",
-        " - done!",
         "",
     ]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce système avais été mis en place afin de faire ceinture-bretelle pour l'auto-intégration des 3436, mais depuis un certain temps je ne l'ai jamais [1] vu en récupérer qui n'auraient pas déjà été gérées au moment de la réception des fichiers retours.
De plus la fonction n'envoyant pas une notification la date de fin de PASS ne sera pas à jour coté ASP donc création de ticket support au final, alors autant les laisser arriver naturellement et améliorer l'autre bout de code.