### PR TITLE
Fiches salarié : Afficher la PK plutôt que le `__str__()` du candidat pour le modèle `EmployeeRecord()`

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -225,8 +225,8 @@ class EmployeeRecord(ASPExchangeInformation):
 
     def __str__(self):
         return (
-            f"PK:{self.pk} PASS:{self.approval_number} SIRET:{self.siret} JA:{self.job_application} "
-            f"JOBSEEKER:{self.job_application.job_seeker} STATUS:{self.status}"
+            f"PK:{self.pk} PASS:{self.approval_number} SIRET:{self.siret} JA:{self.job_application_id} "
+            f"JOBSEEKER:{self.job_application.job_seeker_id} STATUS:{self.status}"
         )
 
     def _clean_job_application(self):

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -43,7 +43,7 @@
   Preflight activated, checking for possible serialization errors...
   Found 1 object(s) to check, split in chunks of 700 objects.
   Checking file #1 (chunk of 1 objects)
-  ERROR: serialization of PK:42 PASS: SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:Jonathan MARTINEZ — email@example.com STATUS:READY failed!
+  ERROR: serialization of PK:42 PASS: SIRET:17483349486512 JA:49536a29-88b5-49c3-8c46-333bbbc36308 JOBSEEKER:4242 STATUS:READY failed!
   > Got AttributeError when attempting to get a value for field `passDateDeb` on serializer `_PersonSerializer`.
   > The serializer field might be named incorrectly and not match any attribute or key on the `EmployeeRecord` instance.
   > Original exception text was: 'NoneType' object has no attribute 'start_at'.

--- a/tests/employee_record/test_transfer_employee_records.py
+++ b/tests/employee_record/test_transfer_employee_records.py
@@ -88,9 +88,7 @@ def test_preflight_with_error(snapshot, command):
         job_application__to_company__siret="17483349486512",
         job_application__to_company__convention__asp_id="21",
         job_application__approval__number="XXXXX3724456",
-        job_application__job_seeker__first_name="Jonathan",
-        job_application__job_seeker__last_name="Martinez",
-        job_application__job_seeker__email="email@example.com",
+        job_application__job_seeker__pk=4242,
     )
 
     command.handle(preflight=True, upload=False, download=False, wet_run=False)


### PR DESCRIPTION
## :thinking: Pourquoi ?

La PK nous permet de retrouver l'utilisateur mais sans dévoiler d'informations personnels, dans les logs par exemple :).