### PR TITLE
Fiches salarié : Option pour traiter un fichier de retour manuellement et améliorations de leur traitement

### DIFF
--- a/itou/employee_record/common_management.py
+++ b/itou/employee_record/common_management.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 from io import BytesIO
 
@@ -27,6 +28,12 @@ class EmployeeRecordTransferCommand(BaseCommand):
         )
         parser.add_argument(
             "--upload", dest="upload", action="store_true", help="Upload employee records ready for processing"
+        )
+        parser.add_argument(
+            "--parse-file",
+            dest="parse_file",
+            type=argparse.FileType(mode="rb"),
+            help="Parse an employee records feedback file",
         )
         parser.add_argument(
             "--wet-run", dest="wet_run", action="store_true", help="Perform *real* SFTP transfer operations"

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -113,10 +113,6 @@ class Command(EmployeeRecordTransferCommand):
             archived_json = JSONRenderer().render(raw_employee_record)
             # Employee record successfully processed by ASP :
             if processing_code == EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE:
-                # Archive a JSON copy of employee record (with processing code and label)
-                employee_record.asp_processing_code = processing_code
-                employee_record.asp_processing_label = processing_label
-
                 if not dry_run:
                     try:
                         if employee_record.status != Status.PROCESSED:

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -1,6 +1,8 @@
 import paramiko
 from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
+from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 from sentry_sdk.crons import monitor
 
@@ -189,10 +191,15 @@ class Command(EmployeeRecordTransferCommand):
         ):
             self._upload_batch_file(sftp, batch, dry_run)
 
-    def handle(self, *, upload, download, preflight, wet_run, asp_test=False, debug=False, **options):
+    def handle(self, *, upload, download, parse_file=None, preflight, wet_run, asp_test=False, debug=False, **options):
         if preflight:
             self.stdout.write("Preflight activated, checking for possible serialization errors...")
             self.preflight(EmployeeRecord)
+        elif parse_file:
+            # If we need to manually parse a feedback file then we probably have some kind of unexpected state,
+            # so use an atomic block to avoid creating more incoherence when something breaks.
+            with transaction.atomic():
+                self._parse_feedback_file(parse_file.name, JSONParser().parse(parse_file), dry_run=not wet_run)
         elif upload or download:
             if not settings.ASP_FS_SFTP_HOST:
                 self.stdout.write("Your environment is missing ASP_FS_SFTP_HOST to run this command.")

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -139,9 +139,9 @@ class Command(EmployeeRecordTransferCommand):
                     # One special case added for support concerns:
                     # 3436 processing code are automatically converted as PROCESSED
                     if processing_code == EmployeeRecord.ASP_DUPLICATE_ERROR_CODE:
-                        employee_record.status = Status.REJECTED
-                        employee_record.asp_processing_code = EmployeeRecord.ASP_DUPLICATE_ERROR_CODE
-                        employee_record.update_as_processed_as_duplicate(archived_json)
+                        employee_record.update_as_processed(
+                            processing_code, processing_label, archived_json, as_duplicate=True
+                        )
 
                         # If the ASP mark the employee record as duplicate,
                         # and there is a suspension or a prolongation for the associated approval,

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -109,9 +109,6 @@ class Command(EmployeeRecordTransferCommand):
             archived_json = JSONRenderer().render(employee_record)
             # Employee record notification successfully processed by ASP:
             if processing_code == EmployeeRecordUpdateNotification.ASP_PROCESSING_SUCCESS_CODE:
-                notification.asp_processing_code = processing_code
-                notification.asp_processing_label = processing_label
-
                 if not dry_run:
                     # Not an important issue if notification was previously processed
                     if notification.status != Status.PROCESSED:


### PR DESCRIPTION
## :thinking: Pourquoi ?

En allant chercher l'archive du flux EA2 j'ai vu que 3 fichiers retours étaient toujours présents :
- `RIAE_FS_20230822125603_FichierRetour.json`
- `RIAE_FS_20230921085512_FichierRetour.json`
- `RIAE_FS_20231205105514_FichierRetour.json`

Les fichiers n'étant pas supprimés si une erreur arrive lors du traitement j'ai commencé à creuser pour trouver ces erreurs.
Le traitement se bloquais dès lors que l'on essayais de changer de statut une FS dont le statut actuel (ie. `DISABLED`, `ARCHIVED`) n'était pas celui attendu (`SENT`).

## :cake: Comment ? <!-- optionnel -->

Au final la nouvelle option est ultra-simple car la logique reste dans le bout de code commun, et avec les améliorations on ne devrais plus trop avoir de fichier qui traînent ou alors avec une grosse erreur mais tout le fichier sera invalidé.

## :desert_island: Comment tester

Les fichiers sont dispo dans le FS partagé.
