### PR TITLE
Pilotage : Ajout d'un champ pour identifier les entreprises dîtes "Convergence"

### DIFF
--- a/itou/metabase/tables/companies.py
+++ b/itou/metabase/tables/companies.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.metabase.tables.utils import (
     MetabaseTable,
@@ -52,6 +55,12 @@ TABLE.add_columns(
         get_column_from_field(get_field("naf"), name="code_naf"),
         get_column_from_field(get_field("email"), name="email_public"),
         get_column_from_field(get_field("auth_email"), name="email_authentification"),
+        {
+            "name": "convergence_france",
+            "type": "boolean",
+            "comment": "Convergence France (contrats PHC et CVG)",
+            "fn": lambda o: o.kind == CompanyKind.ACI and o.siret in settings.ACI_CONVERGENCE_SIRET_WHITELIST,
+        },
     ]
 )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Besoin coté C2 afin de faire un TB pour ces entreprises : https://www.notion.so/gip-inclusion/Convergence-mettre-dispo-au-c2-les-structures-convergence-dans-une-table-9e8918c556c444acbcf4c02ff17eed67?pvs=4
