### PR TITLE
GPS : ajout d'un événement Matomo

### DIFF
--- a/itou/templates/gps/includes/memberships_results.html
+++ b/itou/templates/gps/includes/memberships_results.html
@@ -1,4 +1,5 @@
 {% load str_filters %}
+{% load matomo %}
 
 <section aria-labelledby="results" id="follow-up-groups-section">
     {% if not memberships_page %}
@@ -109,7 +110,8 @@
                             {% endif %}
                             <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}"
                                class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto"
-                               aria-label="Consulter la fiche de {{ membership.follow_up_group.beneficiary.get_full_name }}">
+                               aria-label="Consulter la fiche de {{ membership.follow_up_group.beneficiary.get_full_name }}"
+                               {% matomo_event "GPS_liste_groupes" "clic" "consulter_fiche_candidat" %}>
                                 <i class="ri-eye-line ri-xl font-weight-medium" aria-hidden="true"></i>
                                 <span>Consulter la fiche</span>
                             </a>

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -254,7 +254,7 @@
                                   </a>
   
                               
-                              <a aria-label="Consulter la fiche de Jane DOE" class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                              <a aria-label="Consulter la fiche de Jane DOE" class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="GPS_liste_groupes" data-matomo-event="true" data-matomo-option="consulter_fiche_candidat" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a">
                                   <i aria-hidden="true" class="ri-eye-line ri-xl font-weight-medium"></i>
                                   <span>Consulter la fiche</span>
                               </a>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suivre le nombre de clic sur le bouton « Consulter la fiche ».
