### PR TITLE
Admin : Ajout de la date de fin du délai de grâce ainsi que la date de création des AF dans la page des conventions [GEN-1863] [GEN-1864]

### DIFF
--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin, messages
+from django.contrib.admin.utils import display_for_value
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import format_html
@@ -301,6 +302,7 @@ class SiaeConventionAdmin(ItouModelAdmin):
         "kind",
         "siret_signature",
         "deactivated_at",
+        "grace_period_end_at",
         "reactivated_by",
         "reactivated_at",
         "created_at",
@@ -323,6 +325,7 @@ class SiaeConventionAdmin(ItouModelAdmin):
                 "fields": (
                     "is_active",
                     "deactivated_at",
+                    "grace_period_end_at",
                     "reactivated_by",
                     "reactivated_at",
                 )
@@ -359,6 +362,15 @@ class SiaeConventionAdmin(ItouModelAdmin):
                 # Start grace period.
                 obj.deactivated_at = timezone.now()
         super().save_model(request, obj, form, change)
+
+    @admin.display(description="fin de délai de grâce")
+    def grace_period_end_at(self, obj):
+        if not obj.deactivated_at:
+            return None
+        return display_for_value(
+            obj.deactivated_at + timezone.timedelta(days=models.SiaeConvention.DEACTIVATION_GRACE_PERIOD_IN_DAYS),
+            empty_value_display="-",
+        )
 
 
 @admin.register(models.SiaeFinancialAnnex)

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -53,8 +53,8 @@ class JobsInline(ItouTabularInline):
 
 class FinancialAnnexesInline(ItouTabularInline):
     model = models.SiaeFinancialAnnex
-    fields = ("number", "state", "start_at", "end_at", "is_active")
-    readonly_fields = ("number", "state", "start_at", "end_at", "is_active")
+    fields = ("number", "is_active", "state", "start_at", "end_at", "created_at")
+    readonly_fields = ("number", "is_active", "state", "start_at", "end_at", "created_at")
     can_delete = False
 
     ordering = (

--- a/itou/companies/migrations/0001_initial.py
+++ b/itou/companies/migrations/0001_initial.py
@@ -498,7 +498,7 @@ class Migration(migrations.Migration):
                         blank=True,
                         db_index=True,
                         null=True,
-                        verbose_name="date de  désactivation et début de délai de grâce",
+                        verbose_name="date de désactivation et début de délai de grâce",
                     ),
                 ),
                 (

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -817,7 +817,7 @@ class SiaeConvention(models.Model):
     )
     # Grace period starts from this date.
     deactivated_at = models.DateTimeField(
-        verbose_name="date de  désactivation et début de délai de grâce",
+        verbose_name="date de désactivation et début de délai de grâce",
         blank=True,
         null=True,
         db_index=True,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Demandes support.
Le déplacement de la colonne "Active" est de mon fait, c'est l'information a lire ou qu'on recherche quand on est sur ce bloc donc c'est plus logique de la mettre au début plutôt qu'à la fin, et ça aidera les personnes avec une résolution plus contrainte ;).

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/6c3f10b6-2fce-4ace-86a3-004fc69c1cb6)
![image](https://github.com/user-attachments/assets/93ef6094-0587-48e6-bc9a-f9a2cde3c42c)
