### PR TITLE
Admin : Corriger l'affichage de la période de grâce quand c'est vide et utilisation de `.get_empty_value_display()` partout

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -105,7 +105,7 @@ class JobApplicationInline(ItouStackedInline):
         if obj.hiring_start_at and obj.hiring_start_at < get_availability_date_for_kind(obj.to_company.kind).date():
             return "Date de début du contrat avant l'interopérabilité"
 
-        return "-"
+        return self.get_empty_value_display()
 
 
 class SuspensionInline(ItouTabularInline):
@@ -388,7 +388,7 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
                 get_admin_view_link(company, content=company.display_name),
                 company.siret,
             )
-        return "-"
+        return self.get_empty_value_display()
 
 
 class IsInProgressFilter(admin.SimpleListFilter):
@@ -562,7 +562,7 @@ class ProlongationRequestAdmin(ProlongationCommonAdmin):
     @admin.display(description="actions envisagées")
     def denied_proposed_actions(self, obj):
         if obj.deny_information.proposed_actions is None:
-            return "-"
+            return self.get_empty_value_display()
         return "\n".join(obj.deny_information.get_proposed_actions_display())
 
     @admin.display(description="explications des actions envisagées")

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -69,9 +69,8 @@ class JobApplicationInline(ItouStackedInline):
     # Custom read-only fields as workaround :
     # there is no direct relation between approvals and employee records
     # (YET...)
-    @staticmethod
     @admin.display(description="situation fiches salariés")
-    def employee_record_status(obj):
+    def employee_record_status(self, obj):
         if obj.employee_record.exists():
             return mark_safe(
                 ", ".join(

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -366,7 +366,7 @@ class SiaeConventionAdmin(ItouModelAdmin):
     @admin.display(description="fin de délai de grâce")
     def grace_period_end_at(self, obj):
         if not obj.deactivated_at:
-            return None
+            return "-"
         return display_for_value(
             obj.deactivated_at + timezone.timedelta(days=models.SiaeConvention.DEACTIVATION_GRACE_PERIOD_IN_DAYS),
             empty_value_display="-",

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -252,7 +252,7 @@ class CompanyAdmin(ItouGISMixin, OrganizationAdmin):
     @admin.display(description="Liste des PASS IAE pour cette entreprise")
     def approvals_list(self, obj):
         if obj.pk is None:
-            return "-"
+            return self.get_empty_value_display()
         url = add_url_params(reverse("admin:approvals_approval_changelist"), {"assigned_company": obj.id, "o": -6})
         count = Approval.objects.is_assigned_to(obj.id).count()
         valid_count = Approval.objects.is_assigned_to(obj.id).valid().count()
@@ -366,10 +366,10 @@ class SiaeConventionAdmin(ItouModelAdmin):
     @admin.display(description="fin de délai de grâce")
     def grace_period_end_at(self, obj):
         if not obj.deactivated_at:
-            return "-"
+            return self.get_empty_value_display()
         return display_for_value(
             obj.deactivated_at + timezone.timedelta(days=models.SiaeConvention.DEACTIVATION_GRACE_PERIOD_IN_DAYS),
-            empty_value_display="-",
+            empty_value_display=self.get_empty_value_display(),
         )
 
 

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -63,7 +63,7 @@ class ASPExchangeInformationAdminMixin:
     @admin.display(description="données SIAE envoyées")
     def company_data_sent(self, obj):
         if not obj.archived_json:
-            return "-"
+            return self.get_empty_value_display()
 
         # Handle older data serialized from the JSON as string
         if not isinstance(obj.archived_json, dict):
@@ -76,7 +76,7 @@ class ASPExchangeInformationAdminMixin:
     @admin.display(description="données candidat envoyées")
     def user_data_sent(self, obj):
         if not obj.archived_json:
-            return "-"
+            return self.get_empty_value_display()
 
         # Handle older data serialized from the JSON as string
         if not isinstance(obj.archived_json, dict):
@@ -90,7 +90,7 @@ class ASPExchangeInformationAdminMixin:
     @admin.display(description="données PASS IAE envoyées")
     def approval_data_sent(self, obj):
         if not obj.archived_json:
-            return "-"
+            return self.get_empty_value_display()
 
         # Handle older data serialized from the JSON as string
         if not isinstance(obj.archived_json, dict):
@@ -234,7 +234,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
         if job_seeker := obj.job_application.job_seeker:
             return get_admin_view_link(job_seeker, content=job_seeker)
 
-        return "-"
+        return self.get_empty_value_display()
 
     @admin.display(description="profil du salarié")
     def job_seeker_profile_link(self, obj):
@@ -247,7 +247,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
             return "Intégrée par les emplois suite à une erreur 3436 (doublon PASS IAE/SIRET)"
         if obj.asp_processing_code == obj.ASP_PROCESSING_SUCCESS_CODE:
             return "Intégrée par l'ASP"
-        return "-"
+        return self.get_empty_value_display()
 
     def has_add_permission(self, request):
         return False

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -56,12 +56,12 @@ class EvaluatedJobApplicationsInline(ItouTabularInline):
     def approval(self, obj):
         if obj.job_application.approval:
             return obj.job_application.approval.number
-        return "-"
+        return self.get_empty_value_display()
 
     def job_seeker(self, obj):
         if obj.job_application.job_seeker:
             return obj.job_application.job_seeker
-        return "-"
+        return self.get_empty_value_display()
 
 
 class EvaluatedAdministrativeCriteriaInline(ItouTabularInline):
@@ -268,12 +268,12 @@ class EvaluatedJobApplicationAdmin(ItouModelAdmin):
     def approval(self, obj):
         if obj.job_application.approval:
             return obj.job_application.approval.number
-        return "-"
+        return self.get_empty_value_display()
 
     def job_seeker(self, obj):
         if obj.job_application.job_seeker:
             return obj.job_application.job_seeker
-        return "-"
+        return self.get_empty_value_display()
 
 
 @admin.register(models.EvaluatedAdministrativeCriteria)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car comme d'hab je me suis fait avoir dans #4494 parce que Django ne réécrit pas les `None` dans les `@admin.display()`
![image](https://github.com/user-attachments/assets/b2d1571e-607c-4c7c-97e4-400eadcfdbc2)

Et vu que je me suis demandé si il n'y avais pas une constante pour le `"-"` j'en profite pour changer partout avec la fonction de Django qui va bien :).