### PR TITLE
Stats : Ouverture des stats CD à 2 nouveaux départements

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -441,7 +441,23 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User pks or Company asp_ids in clear in the code.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 STATS_SIAE_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_PK_WHITELIST", "[]"))
-STATS_CD_DEPARTMENT_WHITELIST = ["13", "16", "18", "31", "37", "38", "41", "45", "48", "49", "55", "63", "93"]
+STATS_CD_DEPARTMENT_WHITELIST = [
+    "02",
+    "13",
+    "16",
+    "18",
+    "31",
+    "37",
+    "38",
+    "41",
+    "45",
+    "48",
+    "49",
+    "55",
+    "63",
+    "93",
+    "94",
+]
 STATS_ACI_DEPARTMENT_WHITELIST = ["31", "84"]
 
 # Slack notifications sent by Metabase cronjobs.


### PR DESCRIPTION
https://www.notion.so/gip-inclusion/Liste-blanche-CD-Donner-acc-s-au-CD-de-l-Aisne-et-du-Val-de-Marne-l-acc-s-2-TB-priv-s-ff2e91592d334639b21e5ffcde8b49cd?pvs=4

## :thinking: Pourquoi ?

Donner accès au CD de l’Aisne et du Val de Marne l’accès à 2 TB privés

## :cake: Comment ? 

màj de la liste blanche