### PR TITLE
GPS : cacher l'information « Référent » sous un bouton

### DIFF
--- a/itou/templates/users/includes/gps_group.html
+++ b/itou/templates/users/includes/gps_group.html
@@ -43,11 +43,23 @@
                             <li class="py-1">
                                 <i class="ri-calendar-line font-weight-normal me-1" aria-hidden="true"></i>Suivi depuis le <strong>{{ membership.created_at|date:"d/m/Y" }}</strong>
                             </li>
-                            {% if membership.is_referent %}
-                                <li class="py-1">
-                                    <i class="ri-map-pin-user-line font-weight-normal me-1" aria-hidden="true"></i><strong>Référent</strong>
-                                </li>
-                            {% endif %}
+                            <li class="py-1 js-swap-elements">
+                                <button type="button"
+                                        class="btn btn-sm btn-outline-primary {{ forloop.counter }}-js-hide-on-click"
+                                        {% matomo_event "gps" "clic" "show_is_referent" %}
+                                        data-swap-element-with="#{{ forloop.counter }}-js-show-on-click"
+                                        data-swap-element=".{{ forloop.counter }}-js-hide-on-click">
+                                    Afficher le statut référent
+                                </button>
+                                <div id="{{ forloop.counter }}-js-show-on-click" class="d-none">
+                                    <i class="ri-map-pin-user-line font-weight-normal me-1" aria-hidden="true"></i>
+                                    {% if membership.is_referent %}
+                                        <strong>Référent</strong>
+                                    {% else %}
+                                        <span>Non référent</span>
+                                    {% endif %}
+                                </div>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -139,11 +139,17 @@
                               <li class="py-1">
                                   <i aria-hidden="true" class="ri-calendar-line font-weight-normal me-1"></i>Suivi depuis le <strong>21/06/2024</strong>
                               </li>
-                              
-                                  <li class="py-1">
-                                      <i aria-hidden="true" class="ri-map-pin-user-line font-weight-normal me-1"></i><strong>Référent</strong>
-                                  </li>
-                              
+                              <li class="py-1 js-swap-elements">
+                                  <button class="btn btn-sm btn-outline-primary 1-js-hide-on-click" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="show_is_referent" data-swap-element=".1-js-hide-on-click" data-swap-element-with="#1-js-show-on-click" type="button">
+                                      Afficher le statut référent
+                                  </button>
+                                  <div class="d-none" id="1-js-show-on-click">
+                                      <i aria-hidden="true" class="ri-map-pin-user-line font-weight-normal me-1"></i>
+                                      
+                                          <strong>Référent</strong>
+                                      
+                                  </div>
+                              </li>
                           </ul>
                       </div>
                   </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour mesurer l'attractivité de l'information.
Le clic envoie l'événement suivant à Matomo : `catégorie : "gps", action : "clic", nom :  "show_is_referent"`. 

![image](https://github.com/user-attachments/assets/42582419-e556-4c5c-90b7-a2b686c9694d)
