### PR TITLE
openid_connect: Add FT users to their new workplace at every connection

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -294,7 +294,7 @@ def inclusion_connect_callback(request):
 
     code_safir_pole_emploi = user_data.get("structure_pe")
     # Only handle user creation for the moment, not updates.
-    if is_successful and user_created and code_safir_pole_emploi:
+    if is_successful and code_safir_pole_emploi:
         try:
             ic_user_data.join_org(user=user, safir=code_safir_pole_emploi)
         except PrescriberOrganization.DoesNotExist:

--- a/tests/openid_connect/inclusion_connect/tests.py
+++ b/tests/openid_connect/inclusion_connect/tests.py
@@ -554,6 +554,19 @@ class InclusionConnectCallbackViewTest(MessagesTestMixin, InclusionConnectBaseTe
             ],
         )
 
+    @respx.mock
+    def test_callback_update_FT_organization(self):
+        user = PrescriberFactory(**dataclasses.asdict(InclusionConnectPrescriberData.from_user_info(OIDC_USERINFO)))
+        org = PrescriberPoleEmploiFactory(code_safir_pole_emploi=OIDC_USERINFO_WITH_ORG["structure_pe"])
+        assert not org.members.exists()
+
+        mock_oauth_dance(
+            self.client,
+            UserKind.PRESCRIBER,
+            oidc_userinfo=OIDC_USERINFO_WITH_ORG.copy(),
+        )
+        self.assertQuerySetEqual(org.members.all(), [user])
+
 
 class InclusionConnectAccountActivationTest(InclusionConnectBaseTestCase):
     def test_new_user(self):


### PR DESCRIPTION
## :thinking: Pourquoi ?

On ne souhaite pas le faire qu'à la création de compte, cela permettra de rattraper le stock
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
