### PR TITLE
Suppression d'un moniteur de cron non enregistré

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -26,7 +26,6 @@ import tenacity
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Count, F, Max, Min, Prefetch, Q
 from django.utils import timezone
-from sentry_sdk.crons import monitor
 
 from itou.analytics.models import Datum, StatsDashboardVisit
 from itou.approvals.models import Approval, PoleEmploiApproval, Prolongation, ProlongationRequest
@@ -550,7 +549,6 @@ class Command(BaseCommand):
         build_dbt_daily()
 
     @timeit
-    @monitor(monitor_slug="populate-metabase-emplois")
     @tenacity.retry(
         retry=tenacity.retry_if_not_exception_type(RuntimeError),
         stop=tenacity.stop_after_attempt(3),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Non connu par Sentry :
![image](https://github.com/user-attachments/assets/e6ca7958-4b59-4df3-a08b-2985bbc0e91b)

Vu qu'il ne nous a pas manqué depuis le temps et que dans les faits c'est suivi via les alertes slacks autant le supprimer.