### PR TITLE
Admin: Afficher l'indentifiant public dans la page des utilisateurs

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -325,6 +325,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
     raw_id_fields = ("created_by",)
     readonly_fields = (
         "pk",
+        "public_id",
         "identity_provider",
         "address_in_qpv",
         "is_staff",
@@ -506,6 +507,10 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
                 },
             ),
         )
+
+        assert fieldsets[0] == (None, {"fields": ("username", "password")})
+        fieldsets[0] = (None, {"fields": ("username", "public_id", "password")})
+
         # Add last_checked_at in "Important dates" section, alongside last_login & date_joined
         assert "last_login" in fieldsets[-2][1]["fields"]
         fieldsets[-2] = ("Dates importantes", {"fields": ("last_login", "date_joined", "last_checked_at")})


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour plus facilement trouver les urls de certains pages quand on développe :D

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/c49c1c0b-da09-4987-90da-473b1570dfc8)
