### PR TITLE
Fiches salarié : correctif sur la commune de naissance

### DIFF
--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -192,11 +192,6 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
         self.client.get(self.url)
 
         data = _get_user_form_data(self.job_seeker)
-        data.pop("birth_country")
-
-        # Missing birth country
-        response = self.client.post(self.url, data=data)
-        assert 200 == response.status_code
 
         # France as birth country without commune
         data["birth_country"] = CountryFranceFactory().pk
@@ -208,9 +203,12 @@ class CreateEmployeeRecordStep1Test(AbstractCreateEmployeeRecordTest):
     def test_birthplace_in_france(self):
         self.client.force_login(self.user)
         self.client.get(self.url)
-
         data = _get_user_form_data(self.job_seeker)
-        data["birth_place"] = CommuneFactory().pk
+        birth_place = Commune.objects.by_insee_code_and_period("07141", self.job_seeker.birthdate)
+        data["birth_place"] = birth_place.pk
+        # Birth country field is automatically set with Javascript and disabled.
+        # Disabled fields are not sent with POST data.
+        del data["birth_country"]
         response = self.client.post(self.url, data=data)
 
         # Redirects must go to step 2


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à la PR  #4420 , le formulaire de création de fiche salarié est cassé.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->