### PR TITLE
docker: add a cache dir writable by docker user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       - PGPASSWORD=password
       - PYTHONPATH=.
       - ITOU_LOG_LEVEL=DEBUG
-      - ITOU_CACHE=/app/.cache
       - CELLAR_ADDON_HOST=minio:${MINIO_PORT_ON_DOCKER_HOST:-9000}
       - VIRTUAL_ENV=/app/.venv-docker
       - REDIS_URL=redis://redis:6379

--- a/docker/dev/django/Dockerfile
+++ b/docker/dev/django/Dockerfile
@@ -6,6 +6,9 @@ FROM python:$PYTHON_VERSION-slim
 ARG APP_USER
 ARG APP_DIR
 ARG PG_MAJOR
+ARG XDG_CACHE_HOME="/app_cache"
+
+VOLUME $XDG_CACHE_HOME
 
 # Inspiration
 # https://github.com/azavea/docker-django/blob/1ef366/Dockerfile-slim.template
@@ -16,6 +19,7 @@ ENV PYTHONUNBUFFERED=1
 # Set ipdb as the default debugger.
 # https://www.andreagrandi.it/2018/10/16/using-ipdb-with-python-37-breakpoint/
 ENV PYTHONBREAKPOINT=ipdb.set_trace
+ENV XDG_CACHE_HOME=$XDG_CACHE_HOME
 
 # Install tools to setup the PostgreSQL reposity
 RUN set -ex; \
@@ -48,6 +52,10 @@ RUN set -ex \
     && adduser --ingroup $APP_USER --home /home --disabled-password $APP_USER;
 
 RUN echo '. "$VIRTUAL_ENV"/bin/activate' >> /home/.bashrc
+
+# Setup app cache dir
+RUN mkdir -p $XDG_CACHE_HOME \
+    && chown $APP_USER: $XDG_CACHE_HOME
 
 # Setup the entrypoint
 COPY --chown=$APP_USER:$APP_USER --chmod=755 ./docker/dev/django/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## :thinking: Pourquoi ?

`uv` requiert un dossier de cache.
`/home` est own par root donc l'utilisateur courant ne peut écrire dans `/home/.cache`.

## :cake: Comment ? <!-- optionnel -->

- Utilisation d'un volume pour le cache du conteneur django (sous compose)
- Utilisation de `XDG_CACHE_HOME` à la place de `ITOU_CACHE`
    - La conf des statics des emplois supporte `XDG_CACHE_HOME`
    - `pip` et `uv` supportent `XDG_CACHE_HOME`

## :desert_island: Comment tester

Lancer les emplois avec django (`docker compose --profile django up`)
