### PR TITLE
Tests : Ne pas créer de diagnosique d'éligibilité par défaut pour les candidatures réalisées par le candidat

### DIFF
--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1020,6 +1020,7 @@ class TestCustomApprovalAdminViews:
             state=JobApplicationState.PROCESSING,
             approval=None,
             approval_number_sent_by_email=False,
+            with_iae_eligibility_diagnosis=True,
         )
         job_application.accept(user=job_application.to_company.members.first())
 

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import itertools
 import json
 from datetime import date, timedelta
@@ -242,7 +243,11 @@ class TestEmployeeRecordModel:
 @pytest.mark.parametrize(
     "factory,expected",
     [
-        (JobApplicationSentByJobSeekerFactory, "07"),
+        pytest.param(
+            functools.partial(JobApplicationSentByJobSeekerFactory, with_iae_eligibility_diagnosis=True),
+            "07",
+            id="JobApplicationSentByJobSeekerFactory-07",
+        ),
         (JobApplicationSentByCompanyFactory, "07"),
         (JobApplicationSentByPrescriberFactory, "08"),
         (JobApplicationSentByPrescriberOrganizationFactory, "08"),

--- a/tests/gps/test_management_commands.py
+++ b/tests/gps/test_management_commands.py
@@ -89,7 +89,7 @@ class TestGpsManagementCommand:
         # Empty group!
         # One processing job application sent by a job seeker.
         # A group should not be created.
-        JobApplicationSentByJobSeekerFactory(state=JobApplicationState.PROCESSING, eligibility_diagnosis=None)
+        JobApplicationSentByJobSeekerFactory(state=JobApplicationState.PROCESSING)
 
         self.call_command("init_follow_up_groups", wet_run=True)
 
@@ -141,6 +141,7 @@ class TestGpsManagementCommand:
         job_application_sent_by_job_seeker = JobApplicationSentByJobSeekerFactory(
             job_seeker__first_name="Dave",
             state=JobApplicationState.PROCESSING,
+            with_iae_eligibility_diagnosis=True,
             eligibility_diagnosis__author=prescriber,
         )
         should_be_created_groups_counter += 1
@@ -183,9 +184,7 @@ class TestGpsManagementCommand:
         )
 
     def test_job_application_sender_job_seeker(self):
-        JobApplicationSentByJobSeekerFactory(
-            state=JobApplicationState.NEW, to_company__kind=CompanyKind.GEIQ, eligibility_diagnosis=None
-        )
+        JobApplicationSentByJobSeekerFactory(state=JobApplicationState.NEW, to_company__kind=CompanyKind.GEIQ)
 
         assert FollowUpGroup.objects.count() == 0
         assert FollowUpGroupMembership.objects.count() == 0

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -169,6 +169,16 @@ class JobApplicationSentByJobSeekerFactory(JobApplicationFactory):
 
     sender = factory.SelfAttribute("job_seeker")
     sender_kind = SenderKind.JOB_SEEKER
+    eligibility_diagnosis = None
+
+    class Params:
+        with_iae_eligibility_diagnosis = factory.Trait(
+            eligibility_diagnosis=factory.SubFactory(
+                IAEEligibilityDiagnosisFactory,
+                from_prescriber=True,
+                job_seeker=factory.SelfAttribute("..job_seeker"),
+            )
+        )
 
 
 class JobApplicationSentByCompanyFactory(JobApplicationFactory):

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -194,7 +194,7 @@ class DeduplicateJobSeekersManagementCommandsTest(TestCase):
 
         # Create `user2` through a job application sent by him.
         job_app2 = JobApplicationSentByJobSeekerFactory(
-            with_approval=True, job_seeker__jobseeker_profile__nir="", **kwargs
+            with_approval=True, job_seeker__jobseeker_profile__nir="", with_iae_eligibility_diagnosis=True, **kwargs
         )
         user2 = job_app2.job_seeker
 

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -1684,6 +1684,8 @@ class ProcessAcceptViewsTest(ParametrizedTestCase, MessagesTestMixin, TestCase):
             "hiring_end_at": None,
             "eligibility_diagnosis__with_certifiable_criteria": True,
         } | kwargs
+        if "with_geiq_eligibility_diagnosis" not in kwargs:
+            kwargs.setdefault("with_iae_eligibility_diagnosis", True)
         return JobApplicationSentByJobSeekerFactory(**kwargs)
 
     def _accept_view_post_data(self, job_application, post_data=None):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car ça semble le plus logique, et que ça m'évite de faire des cabrioles pour corriger certains tests supprimant des informations pour le setup ou en cours de route dans la PR #3150 :grin:.