### PR TITLE
Candidature: correction d'une erreur d'acceptation du siae dans de rares conditions

### DIFF
--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -1,6 +1,7 @@
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
+from django.forms import ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
 from django.template.response import TemplateResponse
@@ -51,7 +52,12 @@ def _accept(request, siae, job_seeker, error_url, back_url, template_name, extra
             tally_form_query=f"jobapplication={job_application.pk}" if job_application else None,
         )
         forms.append(form_personal_data)
-        birthdate = form_personal_data.data.get("birthdate")
+        try:
+            birthdate = JobSeekerPersonalDataForm.base_fields["birthdate"].clean(
+                form_personal_data.data.get("birthdate")
+            )
+        except ValidationError:
+            pass  # will be presented to user later
 
         form_user_address = JobSeekerAddressForm(instance=job_seeker, data=request.POST or None)
         forms.append(form_user_address)


### PR DESCRIPTION
## :thinking: Pourquoi ?

`CertifiedCriteriaInfoRequiredForm` utilise un champ `birthdate` qui est anticipé d'être une `date`, mais c'est dans l'utilisation c'est possible que c'est un `str`, qui cause un `ValueError`

## :cake: Comment ? <!-- optionnel -->

* Enforcer que le `birthdate` dans `CertifiedCriteriaInfoRequiredForm` est une date
* Sur [_accept](https://github.com/gip-inclusion/les-emplois/compare/calum/fix-date-format?expand=1#diff-c4816cd2f94ad06618d8ec2ed19b7c4d7109a1fde13565b2f756b73e6c8da948), ratrappe le cas rare où le date est mis à jour en string, et le convertir
* Ajout des tests pour `CertifiedCriteriaInfoRequiredForm`

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
