### PR TITLE
Utiliser le nom de la vue au lieu de l’URL pour définir la partie active du header

### DIFF
--- a/itou/templates/layout/_header_nav_secondary_items.html
+++ b/itou/templates/layout/_header_nav_secondary_items.html
@@ -1,13 +1,16 @@
 <ul>
-    {% if user.is_authenticated %}
+    {% with view_name=request.resolver_match.view_name|default:None %}
+        {% if user.is_authenticated %}
+            <li>
+                <a class="{% if view_name == 'dashboard:index' %}is-active{% endif %}" href="{% url 'dashboard:index' %}">Tableau de bord</a>
+            </li>
+        {% endif %}
         <li>
-            <a class="{% if request.path == '/dashboard/' %}is-active{% endif %}" href="{% url 'dashboard:index' %}">Tableau de bord</a>
+            <a {% if view_name == "search:employers_home" or view_name == "search:employers_results" or view_name == "search:job_descriptions_results" %}class="is-active"{% endif %}
+               href="{% url 'search:employers_home' %}">Rechercher un emploi inclusif</a>
         </li>
-    {% endif %}
-    <li>
-        <a class="{% if '/search/employers' in request.path %}is-active{% endif %}" href="{% url 'search:employers_home' %}">Rechercher un emploi inclusif</a>
-    </li>
-    <li>
-        <a class="{% if '/search/prescribers' in request.path %}is-active{% endif %}" href="{% url 'search:prescribers_home' %}">Rechercher des prescripteurs habilités</a>
-    </li>
+        <li>
+            <a {% if view_name == "search:prescribers_home" or view_name == "search:prescribers_results" %}class="is-active" {% endif %}href="{% url 'search:prescribers_home' %}">Rechercher des prescripteurs habilités</a>
+        </li>
+    {% endwith %}
 </ul>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter que les changements de chemin ne cassent la fonctionnalité, mieux tracer la dépendance dans le code.
Aussi, ce mécanisme se multipliant avec la refonte, autant qu’il soit plus solide.
