### PR TITLE
Candidature : Ne plus appeler `.full_clean()` à chaque `.save()`

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -799,10 +799,6 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             if self.inverted_vae_contract is not None:
                 raise ValidationError("Un contrat associé à une VAE inversée n'est possible que pour les GEIQ")
 
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        return super().save(*args, **kwargs)
-
     @property
     def is_pending(self):
         return self.state in JobApplicationWorkflow.PENDING_STATES

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -545,7 +545,7 @@ def archive(request, job_application_id):
             siae_name = job_application.to_company.display_name
 
             job_application.hidden_for_company = True
-            job_application.save()
+            job_application.save(update_fields={"hidden_for_company"})
 
             success_message = f"La candidature de {username} chez {siae_name} a bien été supprimée."
             messages.success(request, success_message, extra_tags="toast")
@@ -736,7 +736,7 @@ class JobApplicationExternalTransferStep3View(ApplicationOverrideMixin, Applicat
         self.job_application.external_transfer(target_company=self.company, user=self.request.user)
         if self.form.cleaned_data.get("keep_original_resume"):
             new_job_application.resume_link = self.job_application.resume_link
-            new_job_application.save()
+            new_job_application.save(update_fields={"resume_link"})
         return new_job_application
 
     def get_next_url(self, job_application):

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -850,6 +850,7 @@ def pe_approval_create(request, pe_approval_id):
 
     # Link both and save the application
     job_application.approval = approval_from_pe
+    job_application.full_clean()  # Manual call because we don't use a form
     job_application.save()
 
     messages.success(

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1131,7 +1131,7 @@ class TestCustomApprovalAdminViews:
         assert msg == "Non proposé à la création"
 
         # When hiring start date is before employee record availability date
-        job_application = JobApplicationFactory(hiring_start_at="2021-09-26")
+        job_application = JobApplicationFactory(hiring_start_at=datetime.date(2021, 9, 26))
         msg = inline.employee_record_status(job_application)
         assert msg == "Date de début du contrat avant l'interopérabilité"
 

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -176,16 +176,12 @@ def test_model_fields():
     ContentType.objects.get_for_model(target_company)
     with assertNumQueries(
         2  # Check user is in both origin and dest siae
-        + 1  # Check if approvals are linked to diagnosis because of on_delete=set_null
-        + 1  # Check if job applications are linked because of on_delete=set_null
-        + 2  # Delete diagnosis and criteria made by the SIAE
+        + 4  # Delete (+ SET_NULL) diagnosis and criteria made by the SIAE
         + 1  # Select user for email
         + 1  # Select employer notification settings
         + 1  # Insert employer email in emails table
         + 1  # Select job seeker notification settings
         + 1  # Insert job seeker email in emails table
-        + 6  # Caused by `full_clean()` : `clean_fields()`
-        + 4  # Integrity constraints check (full clean)
         + 1  # Update job application
         + 1  # Add job application transition log
     ):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Forcer un appel à `.full_clean()` génère 10 requêtes SQL de vérification (FK + contraintes), ces vérifications sont en générales redondantes car soit le formulaire est déjà passé par là ou on ne modifie qu'un seul champs bien précis, et la DB va aussi bloquer si jamais un trop gros truc devais passer.

L'objet candidature étant central et une transition provoquant un `.save()` il me semble bénéfique de s'éviter ces traitements supplémentaire peu coûteux mais nombreux.

Pour trouver les utilisations dans le code j'ai utilisé : `job(_app(lication)?)?\.save\(`
J'ai également fait une recherche via `jobapplication_set` mais rien de probant.
