### PR TITLE
[GEN-1835] Profil salarié: Accès à la Immersion Facilitée sur la page de salarié

### DIFF
--- a/itou/templates/approvals/detail.html
+++ b/itou/templates/approvals/detail.html
@@ -13,66 +13,7 @@
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12 col-lg-8">
-                    <div class="c-box mb-3 mb-lg-5">
-                        {# Approval status. #}
-                        <div>{% include "approvals/includes/status.html" with common_approval=approval hiring_pending=False %}</div>
-
-                        {# Approval actions. #}
-                        {% if approval and request.user.is_employer %}
-                            <div class="row justify-content-end g-3">
-                                {% if approval_can_be_suspended_by_siae %}
-                                    <div class="col-12 col-lg-auto">
-                                        <a href="{% url 'approvals:suspend' approval_id=approval.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                           class="btn btn-block btn-outline-primary"
-                                           aria-label="Suspendre le PASS IAE de {{ approval.user.get_full_name }}">
-                                            Suspendre
-                                        </a>
-                                    </div>
-                                {% elif approval.can_be_suspended %}
-                                    <div class="col-12 col-lg-auto">
-                                        <div class="btn btn-ico">
-                                            <span class="disabled">Suspendre</span>
-                                            <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="La suspension n’est pas possible car un autre employeur a embauché le candidat."></i>
-                                        </div>
-                                    </div>
-                                {% endif %}
-                                {% if approval_can_be_prolonged %}
-                                    <div class="col-12 col-lg-auto">
-                                        <a href="{% url 'approvals:declare_prolongation' approval_id=approval.id %}?back_url={{ request.get_full_path|urlencode }}"
-                                           class="btn btn-block btn-outline-primary"
-                                           aria-label="Prolonger le PASS IAE de {{ approval.user.get_full_name }}">
-                                            Prolonger
-                                        </a>
-                                    </div>
-                                {% endif %}
-                                {% if approval_deletion_form_url %}
-                                    <div class="col-12 col-lg-auto">
-                                        <a href="{{ approval_deletion_form_url }}"
-                                           id="approval-deletion-link"
-                                           class="btn btn-block btn-outline-warning"
-                                           target="_blank"
-                                           rel="noopener"
-                                           aria-label="Mettre fin au PASS IAE de {{ approval.user.get_full_name }}">
-                                            Clôturer
-                                        </a>
-                                    </div>
-                                {% endif %}
-                                <div class="col-12 col-lg-auto">
-                                    <a class="btn btn-primary btn-block btn-ico"
-                                       {% matomo_event "telechargement-pdf" "agrement" "detail-agrement" %}
-                                       href="{% url 'approvals:display_printable_approval' approval_id=approval.id %}"
-                                       target="_blank"
-                                       rel="noopener"
-                                       aria-label="Afficher le PASS IAE de {{ approval.user.get_full_name }}">
-                                        <i class="ri-eye-line ri-xl font-weight-medium" aria-hidden="true"></i>
-                                        <span>Afficher l'attestation</span>
-                                    </a>
-                                </div>
-                            </div>
-                        {% endif %}
-                    </div>
-
+                <div class="col-12 col-lg-8 order-2 order-lg-1">
                     {# Job seeker info ------------------------------------------------------------------------- #}
                     <div class="c-box mb-3 mb-lg-5">
                         <h2>Informations du salarié</h2>
@@ -93,6 +34,75 @@
                             {% include "approvals/includes/job_applications.html" with job_application=job_application_for_card %}
                         {% endfor %}
                     </div>
+                </div>
+                <div class="col-12 col-lg-4 order-1 order-lg-2">
+                    <div class="c-box mb-4">
+                        {# Approval status. #}
+                        <div>{% include "approvals/includes/status.html" with common_approval=approval hiring_pending=False %}</div>
+                        {# Approval actions. #}
+                        {% if approval and request.user.is_employer %}
+                            {% if approval_can_be_suspended_by_siae %}
+                                <a href="{% url 'approvals:suspend' approval_id=approval.id %}?back_url={{ request.get_full_path|urlencode }}"
+                                   class="btn btn-block btn-outline-primary mt-3"
+                                   aria-label="Suspendre le PASS IAE de {{ approval.user.get_full_name }}">
+                                    Suspendre
+                                </a>
+                            {% elif approval.can_be_suspended %}
+                                <div class="btn btn-ico">
+                                    <span class="disabled">Suspendre</span>
+                                    <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="La suspension n’est pas possible car un autre employeur a embauché le candidat."></i>
+                                </div>
+                            {% endif %}
+                            {% if approval_can_be_prolonged %}
+                                <a href="{% url 'approvals:declare_prolongation' approval_id=approval.id %}?back_url={{ request.get_full_path|urlencode }}"
+                                   class="btn btn-block btn-outline-primary mt-3"
+                                   aria-label="Prolonger le PASS IAE de {{ approval.user.get_full_name }}">
+                                    Prolonger
+                                </a>
+                            {% endif %}
+                            {% if approval_deletion_form_url %}
+                                <a href="{{ approval_deletion_form_url }}"
+                                   id="approval-deletion-link"
+                                   class="btn btn-block btn-outline-warning mt-3"
+                                   target="_blank"
+                                   rel="noopener"
+                                   aria-label="Mettre fin au PASS IAE de {{ approval.user.get_full_name }}">
+                                    Clôturer
+                                </a>
+                            {% endif %}
+                            <a class="btn btn-primary btn-block btn-ico mt-3"
+                               {% matomo_event "telechargement-pdf" "agrement" "detail-agrement" %}
+                               href="{% url 'approvals:display_printable_approval' approval_id=approval.id %}"
+                               target="_blank"
+                               rel="noopener"
+                               aria-label="Afficher le PASS IAE de {{ approval.user.get_full_name }}">
+                                <i class="ri-eye-line ri-xl font-weight-medium" aria-hidden="true"></i>
+                                <span>Afficher l'attestation</span>
+                            </a>
+                        {% endif %}
+                    </div>
+                    {% if link_immersion_facile %}
+                        {# Immersion Facilitée proposal on expiring passes #}
+                        <div id="immersion-facile-opportunity-alert" class="alert alert-important alert-dismissible">
+                            <div class="row">
+                                <div class="col-auto pe-0">
+                                    <i class="ri-information-line ri-xl text-important" aria-hidden="true"></i>
+                                </div>
+                                <div class="col">
+                                    <p class="mb-2 font-weight-bold">Avez-vous pensé à proposer une immersion ?</p>
+                                    <p>
+                                        {% if approval_expired %}
+                                            Le pass de ce candidat est expiré.
+                                        {% else %}
+                                            Le pass de ce candidat arrive à expiration.
+                                        {% endif %}
+                                        Des employeurs de votre territoire proposent des immersions.
+                                    </p>
+                                    <a href="{{ link_immersion_facile }}" class="btn-link" rel="noopener" target="_blank" aria-label="Rechercher une Immersion Facilitée (ouverture dans un nouvel onglet)">Faire une recherche</a>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/itou/utils/constants.py
+++ b/itou/utils/constants.py
@@ -4,6 +4,7 @@ ITOU_EMAIL_PROLONGATION = "prolongation@inclusion.beta.gouv.fr"
 PILOTAGE_HELP_CENTER_URL = "https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr"
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"
 EMPLOIS_SITE_URL = "https://emplois.inclusion.beta.gouv.fr"
+IMMERSION_FACILE_SITE_URL = "https://immersion-facile.beta.gouv.fr"
 POLE_EMPLOI_EMAIL_SUFFIX = "@pole-emploi.fr"
 FRANCE_TRAVAIL_EMAIL_SUFFIX = "@francetravail.fr"
 

--- a/itou/utils/immersion_facile.py
+++ b/itou/utils/immersion_facile.py
@@ -1,0 +1,29 @@
+from urllib.parse import quote, urlencode
+
+from itou.utils.constants import IMMERSION_FACILE_SITE_URL
+
+
+def immersion_search_url(user):
+    """
+    :return: a search URL on Immersion Facilitée's site for parameterized user
+    """
+    params = {"mtm_campaign": "les-emplois-recherche-immersion", "mtm_kwd": "les-emplois-recherche-immersion"}
+
+    # in testing, there are some differences between how addresses are validated between
+    # IF's service and ours, so only we can only consider the geolocation reliable if
+    # lat/lng is present
+    if user.coords:
+        params["distanceKm"] = 20
+        params["latitude"] = user.latitude
+        params["longitude"] = user.longitude
+        params["sortedBy"] = "distance"
+
+        if user.insee_city:
+            address_parts = [user.insee_city.name, user.insee_city.region, "France"]
+        else:
+            address_parts = [user.city, user.region, "France"]
+
+        if all(address_parts):
+            params["place"] = ", ".join(address_parts)
+
+    return f"{IMMERSION_FACILE_SITE_URL}/recherche?{urlencode(params, quote_via=quote)}"

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -34,6 +34,7 @@ from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
 from itou.job_applications.models import JobApplication
 from itou.users.models import User
 from itou.utils import constants as global_constants
+from itou.utils.immersion_facile import immersion_search_url
 from itou.utils.pagination import ItouPaginator, pager
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.perms.prescriber import get_current_org_or_404
@@ -125,6 +126,7 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
         context["eligibility_diagnosis"] = job_application and job_application.get_eligibility_diagnosis()
         context["approval_deletion_form_url"] = None
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
+        context["link_immersion_facile"] = None
 
         if approval.is_in_progress:
             for suspension in approval.suspensions_by_start_date_asc:
@@ -155,6 +157,10 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
                         }
                     )
                     break
+
+        if approval.remainder.days < 90 and self.request.user.is_employer:
+            context["link_immersion_facile"] = immersion_search_url(approval.user)
+            context["approval_expired"] = not approval.is_in_progress
 
         context["all_job_applications"] = (
             JobApplication.objects.filter(

--- a/tests/utils/test_immersion_facile.py
+++ b/tests/utils/test_immersion_facile.py
@@ -1,0 +1,25 @@
+from itou.utils.constants import IMMERSION_FACILE_SITE_URL
+from itou.utils.immersion_facile import immersion_search_url
+from tests.users.factories import JobSeekerWithAddressFactory
+
+
+def test_immersion_search_url():
+    user = JobSeekerWithAddressFactory(for_snapshot=True)
+    expected_url = (
+        f"{IMMERSION_FACILE_SITE_URL}/recherche?"
+        f"mtm_campaign=les-emplois-recherche-immersion"
+        f"&mtm_kwd=les-emplois-recherche-immersion"
+        f"&distanceKm=20"
+        f"&latitude=0.0&longitude=0.0"
+        f"&sortedBy=distance"
+        f"&place=Sauvigny-les-Bois%2C%20Bourgogne-Franche-Comt%C3%A9%2C%20France"
+    )
+    assert immersion_search_url(user) == expected_url
+
+    user = JobSeekerWithAddressFactory(without_geoloc=True)
+    expected_url = (
+        f"{IMMERSION_FACILE_SITE_URL}/recherche?"
+        f"mtm_campaign=les-emplois-recherche-immersion"
+        f"&mtm_kwd=les-emplois-recherche-immersion"
+    )
+    assert immersion_search_url(user) == expected_url

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -93,10 +93,52 @@
               </div>
   '''
 # ---
+# name: TestApprovalDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expiré]
+  '''
+  <div class="alert alert-important alert-dismissible" id="immersion-facile-opportunity-alert">
+                              <div class="row">
+                                  <div class="col-auto pe-0">
+                                      <i aria-hidden="true" class="ri-information-line ri-xl text-important"></i>
+                                  </div>
+                                  <div class="col">
+                                      <p class="mb-2 font-weight-bold">Avez-vous pensé à proposer une immersion ?</p>
+                                      <p>
+                                          
+                                              Le pass de ce candidat est expiré.
+                                          
+                                          Des employeurs de votre territoire proposent des immersions.
+                                      </p>
+                                      <a aria-label="Rechercher une Immersion Facilitée (ouverture dans un nouvel onglet)" class="btn-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">Faire une recherche</a>
+                                  </div>
+                              </div>
+                          </div>
+  '''
+# ---
+# name: TestApprovalDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile]
+  '''
+  <div class="alert alert-important alert-dismissible" id="immersion-facile-opportunity-alert">
+                              <div class="row">
+                                  <div class="col-auto pe-0">
+                                      <i aria-hidden="true" class="ri-information-line ri-xl text-important"></i>
+                                  </div>
+                                  <div class="col">
+                                      <p class="mb-2 font-weight-bold">Avez-vous pensé à proposer une immersion ?</p>
+                                      <p>
+                                          
+                                              Le pass de ce candidat arrive à expiration.
+                                          
+                                          Des employeurs de votre territoire proposent des immersions.
+                                      </p>
+                                      <a aria-label="Rechercher une Immersion Facilitée (ouverture dans un nouvel onglet)" class="btn-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">Faire une recherche</a>
+                                  </div>
+                              </div>
+                          </div>
+  '''
+# ---
 # name: TestApprovalDetailView.test_remove_approval_button[bouton de suppression d'un PASS IAE]
   '''
-  <a aria-label="Mettre fin au PASS IAE de Doe JOHN" class="btn btn-block btn-outline-warning" href="https://tally.so/r/3je84Q?siaeID=999999&amp;nomSIAE=Aci+de+la+rochelle&amp;prenomemployeur=Milady&amp;nomemployeur=de+Winter&amp;emailemployeur=oph%40dewinter.com&amp;userID=123456&amp;numPASS=XXXXX+12+34568&amp;prenomsalarie=Doe&amp;nomsalarie=John" id="approval-deletion-link" rel="noopener" target="_blank">
-                                              Clôturer
-                                          </a>
+  <a aria-label="Mettre fin au PASS IAE de Doe JOHN" class="btn btn-block btn-outline-warning mt-3" href="https://tally.so/r/3je84Q?siaeID=999999&amp;nomSIAE=Aci+de+la+rochelle&amp;prenomemployeur=Milady&amp;nomemployeur=de+Winter&amp;emailemployeur=oph%40dewinter.com&amp;userID=123456&amp;numPASS=XXXXX+12+34568&amp;prenomsalarie=Doe&amp;nomsalarie=John" id="approval-deletion-link" rel="noopener" target="_blank">
+                                      Clôturer
+                                  </a>
   '''
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Permettre les employeurs accèder l'IF depuis la page d'un salarié, pour encourager les recherches à les immersions facilitées

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran

<img width="826" alt="Screenshot 2024-08-08 at 17 56 12" src="https://github.com/user-attachments/assets/5bc48906-a6b1-4f38-9c14-68364a89f621">
