### PR TITLE
Candidature et fiche salarié : activation du champ « Commune de naissance » si le pays de naissance est la France

### DIFF
--- a/itou/asp/forms.py
+++ b/itou/asp/forms.py
@@ -28,3 +28,18 @@ def formfield_for_birth_place(**kwargs):
         ),
         **kwargs,
     )
+
+
+def formfield_for_birth_country(**kwargs):
+    france = Country.objects.get(code=Country._CODE_FRANCE)
+    return forms.ModelChoiceField(
+        Country.objects,
+        label="Pays de naissance",
+        required=False,
+        widget=forms.Select(
+            attrs={
+                "data-disable-target": "#id_birth_place",
+                "data-disable-target-unless-value": f"{france.pk}",
+            },
+        ),
+    )

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -53,11 +53,17 @@ htmx.onLoad((target) => {
   **/
   function toggleDisableAndSetValue() {
     const targetId = this.getAttribute("data-disable-target");
+    const unlessValue = this.getAttribute("data-disable-target-unless-value");
     const isSet = $(this).val().length > 0;
     if (isSet) {
       $(targetId).val(this.getAttribute("data-target-value"));
     }
-    $(targetId).attr("disabled", isSet);
+    if (unlessValue) {
+      $(targetId).attr("disabled", $(this).val() != unlessValue);
+    }
+    else {
+      $(targetId).attr("disabled", isSet);
+    }
   }
   target.querySelectorAll('select[data-disable-target]').forEach(function (selectFieldWithDisable) {
     toggleDisableAndSetValue.call(selectFieldWithDisable);

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -14,7 +14,7 @@ from django_select2.forms import Select2MultipleWidget, Select2Widget
 
 from itou.approvals.models import Approval
 from itou.asp import models as asp_models
-from itou.asp.forms import formfield_for_birth_place
+from itou.asp.forms import formfield_for_birth_country, formfield_for_birth_place
 from itou.common_apps.address.departments import DEPARTMENTS
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
@@ -882,18 +882,13 @@ class CertifiedCriteriaInfoRequiredForm(forms.ModelForm):
     https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_allocation_adulte_handicape/200_beneficiaire.yaml
     """
 
-    birth_country = forms.ModelChoiceField(
-        asp_models.Country.objects,
-        label="Pays de naissance",
-        required=False,
-    )
-
     class Meta:
         model = JobSeekerProfile
-        fields = ("birth_place", "birth_country")
+        fields = ("birth_country", "birth_place")
 
     def __init__(self, birthdate, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields["birth_country"] = formfield_for_birth_country()
         self.fields["birth_place"] = formfield_for_birth_place()
         self.birthdate = birthdate
 

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -5,7 +5,7 @@ from django.urls import reverse_lazy
 from django.utils import timezone
 from django_select2.forms import Select2Widget
 
-from itou.asp.forms import formfield_for_birth_place
+from itou.asp.forms import formfield_for_birth_country, formfield_for_birth_place
 from itou.asp.models import Commune, Country, RSAAllocation
 from itou.companies.models import SiaeFinancialAnnex
 from itou.employee_record.enums import Status
@@ -115,9 +115,6 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
         "birthdate",
     ]
 
-    # This is a JobSeekerProfile field
-    birth_country = forms.ModelChoiceField(Country.objects, label="Pays de naissance", required=False)
-
     class Meta:
         model = User
         fields = [
@@ -130,6 +127,7 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.fields["birth_country"] = formfield_for_birth_country()
         self.fields["birth_place"] = formfield_for_birth_place()
 
         for field_name in self.REQUIRED_FIELDS:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour rester cohérent.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran 

![image](https://github.com/user-attachments/assets/cf620fcc-3f8a-4424-ae28-89591e549454)
![image](https://github.com/user-attachments/assets/94ab4c24-c12f-46d4-aa4d-de7c100ef33a)

