### PR TITLE
Candidature : certification des critères sélectionnés pour les diags d'origine employeur ou GEIQ uniquement

### DIFF
--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -71,7 +71,10 @@ class AbstractEligibilityDiagnosisModel(models.Model):
         return bool(self.expires_at and self.expires_at > timezone.now())
 
     def criteria_can_be_certified(self):
-        return self.author_kind != AuthorKind.PRESCRIBER and self.administrative_criteria.certifiable().exists()
+        return (
+            self.author_kind in (AuthorKind.GEIQ, AuthorKind.EMPLOYER)
+            and self.administrative_criteria.certifiable().exists()
+        )
 
 
 class AdministrativeCriteriaQuerySet(models.QuerySet):

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -70,7 +70,7 @@ class AbstractEligibilityDiagnosisModel(models.Model):
     def is_valid(self):
         return bool(self.expires_at and self.expires_at > timezone.now())
 
-    def criteria_certification_available(self):
+    def criteria_can_be_certified(self):
         return self.author_kind != AuthorKind.PRESCRIBER and self.administrative_criteria.certifiable().exists()
 
 

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -71,7 +71,7 @@ class AbstractEligibilityDiagnosisModel(models.Model):
         return bool(self.expires_at and self.expires_at > timezone.now())
 
     def criteria_certification_available(self):
-        return self.administrative_criteria.certifiable().exists()
+        return self.author_kind != AuthorKind.PRESCRIBER and self.administrative_criteria.certifiable().exists()
 
 
 class AdministrativeCriteriaQuerySet(models.QuerySet):

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -66,7 +66,7 @@ def _accept(request, siae, job_seeker, error_url, back_url, template_name, extra
             job_seeker=job_seeker, for_geiq=siae
         ).first()
 
-    if valid_diagnosis and valid_diagnosis.criteria_certification_available():
+    if valid_diagnosis and valid_diagnosis.criteria_can_be_certified():
         form_certified_criteria = CertifiedCriteriaInfoRequiredForm(
             instance=job_seeker.jobseeker_profile, birthdate=birthdate, data=request.POST or None
         )

--- a/tests/eligibility/test_geiq.py
+++ b/tests/eligibility/test_geiq.py
@@ -442,3 +442,27 @@ def test_administrativecriteria_level_annex_consistency():
                 level=AdministrativeCriteriaLevel.LEVEL_2,
                 annex=AdministrativeCriteriaAnnex.NO_ANNEX,
             )
+
+
+@pytest.mark.parametrize(
+    "factory_params,expected",
+    [
+        pytest.param(
+            {"from_prescriber": True, "with_certifiable_criteria": True}, False, id="prescriber_certified_criteria"
+        ),
+        pytest.param(
+            {"from_prescriber": True, "with_not_certifiable_criteria": True},
+            False,
+            id="prescriber_no_certified_criteria",
+        ),
+        pytest.param(
+            {"from_geiq": True, "with_not_certifiable_criteria": True},
+            False,
+            id="employer_no_certified_criteria",
+        ),
+        pytest.param({"from_geiq": True, "with_certifiable_criteria": True}, True, id="employer_certified_criteria"),
+    ],
+)
+def test_criteria_can_be_certified(factory_params, expected):
+    diagnosis = GEIQEligibilityDiagnosisFactory(**factory_params)
+    assert diagnosis.criteria_can_be_certified() == expected

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -398,9 +398,9 @@ class TestEligibilityDiagnosisModel(ParametrizedTestCase):
             param({"from_employer": True, "with_certifiable_criteria": True}, True, id="employer_certified_criteria"),
         ],
     )
-    def test_criteria_certification_available(self, factory_params, expected):
+    def test_criteria_can_be_certified(self, factory_params, expected):
         diagnosis = IAEEligibilityDiagnosisFactory(**factory_params)
-        assert diagnosis.criteria_certification_available() == expected
+        assert diagnosis.criteria_can_be_certified() == expected
 
 
 class TestAdministrativeCriteriaModel:

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -2419,7 +2419,7 @@ class ProcessAcceptViewsTest(ParametrizedTestCase, MessagesTestMixin, TestCase):
         assert approval.start_at == job_application.hiring_start_at
         assert job_application.state.is_accepted
 
-    def test_accept_iae__criteria_certification_available(self):
+    def test_accept_iae__criteria_can_be_certified(self):
         ######### Case 1: if BRSA is one the diagnosis criteria,
         ######### birth place and birth country are required.
         birthdate = datetime.date(1995, 12, 27)
@@ -2477,7 +2477,7 @@ class ProcessAcceptViewsTest(ParametrizedTestCase, MessagesTestMixin, TestCase):
         assert jobseeker_profile.birth_country == birth_country
         assert jobseeker_profile.birth_place == birth_place
 
-    def test_accept_geiq__criteria_certification_available(self):
+    def test_accept_geiq__criteria_can_be_certified(self):
         birthdate = datetime.date(1995, 12, 27)
         self.company.kind = CompanyKind.GEIQ
         self.company.save()
@@ -2522,7 +2522,7 @@ class ProcessAcceptViewsTest(ParametrizedTestCase, MessagesTestMixin, TestCase):
         assert jobseeker_profile.birth_country == birth_country
         assert jobseeker_profile.birth_place == birth_place
 
-    def test_accept_no_siae__criteria_certification_available(self):
+    def test_accept_no_siae__criteria_can_be_certified(self):
         company = CompanyFactory(not_subject_to_eligibility=True, with_membership=True, with_jobs=True)
         job_application = self.create_job_application(
             eligibility_diagnosis__with_certifiable_criteria=True,
@@ -2576,7 +2576,7 @@ class ProcessAcceptViewsTest(ParametrizedTestCase, MessagesTestMixin, TestCase):
         # required assumptions for the test case
         assert self.company.is_subject_to_eligibility_rules
         ed = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=self.job_seeker, for_siae=self.company)
-        assert ed and ed.criteria_certification_available()
+        assert ed and ed.criteria_can_be_certified()
 
         employer = self.company.members.first()
         self.client.force_login(employer)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4614,7 +4614,7 @@ class HireConfirmationTestCase(TestCase):
             + 1  # companies_jobdescription (AcceptForm.__init__)
             + 1  # eligibility_administrativecriteria (/apply/includes/eligibility_diagnosis.html)
             + 1  # asp_country: countries dropdown list.
-            + 1  # eligibility_diagnosis.criteria_certification_available()
+            + 1  # eligibility_diagnosis.criteria_can_be_certified()
             + 3  # update session with savepoint & release
         ):
             response = self.client.get(self._reverse("apply:hire_confirmation"))

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4614,15 +4614,12 @@ class HireConfirmationTestCase(TestCase):
             + 1  # companies_jobdescription (AcceptForm.__init__)
             + 1  # eligibility_administrativecriteria (/apply/includes/eligibility_diagnosis.html)
             + 1  # asp_country: countries dropdown list.
-            + 1  # eligibility_diagnosis.criteria_can_be_certified()
             + 3  # update session with savepoint & release
         ):
             response = self.client.get(self._reverse("apply:hire_confirmation"))
         self.assertContains(response, "Déclarer l’embauche de Clara SION")
         self.assertContains(response, "Éligible à l’IAE")
 
-        birth_country = CountryFranceFactory()
-        birth_place = CommuneFactory()
         hiring_start_at = timezone.localdate()
         post_data = {
             "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -4638,9 +4635,6 @@ class HireConfirmationTestCase(TestCase):
             "phone": self.job_seeker.phone,
             "fill_mode": "ban_api",
             "address_for_autocomplete": "0",
-            # CertifiedCriteriaForm
-            "birth_country": birth_country.pk,
-            "birth_place": birth_place.pk,
         }
         response = self.client.post(
             self._reverse("apply:hire_confirmation"),


### PR DESCRIPTION
## :thinking: Pourquoi ?

La version précédente était moins restrictive : les diagnostics des prescripteurs aussi étaient pris en compte. Or le métier ne souhaite appeler l'API et certifier les critères uniquement si ceux-ci sont liés à un diagnostic d'origine employeur ou GEIQ.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Créer un diagnostic et une candidature en tant que prescripteur. En tant qu'employeur, l'accepter. Les champs « ville de naissance » et « pays de naissance » ne devraient pas s'afficher.

Créer un diagnostic et une candidature en tant qu'employeur puis l'accepter. Les champs « ville de naissance » et « pays de naissance » devraient s'afficher.

Créer un diagnostic et une candidature en tant que GEIQ puis l'accepter. Les champs « ville de naissance » et « pays de naissance » devraient s'afficher.

