### PR TITLE
PASS IAE: Simplification de la detection de pass valides

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -208,7 +208,7 @@ class CommonApprovalQuerySet(models.QuerySet):
     @property
     def valid_lookup(self):
         now = timezone.now().date()
-        return Q(start_at__lte=now, end_at__gte=now) | Q(start_at__gte=now)
+        return Q(end_at__gte=now)
 
     def valid(self):
         return self.filter(self.valid_lookup)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Comme start_at > end_at, il suffit de vérifier que `end_at>=now` pour que le passe soit valide. 

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
