### PR TITLE
Pilotage : Simplification de code pour `populate_metabase_matomo`

### DIFF
--- a/itou/utils/date.py
+++ b/itou/utils/date.py
@@ -1,0 +1,8 @@
+import datetime
+
+from django.utils import timezone
+
+
+def monday_of_the_week(value=None):
+    the_day = timezone.localdate(value)
+    return the_day - datetime.timedelta(days=the_day.weekday())

--- a/tests/utils/test_date.py
+++ b/tests/utils/test_date.py
@@ -1,0 +1,23 @@
+import datetime
+
+import freezegun
+
+from itou.utils.date import monday_of_the_week
+
+
+def test_monday_of_the_week_with_arguments():
+    mondays = set()
+    for day in range(1, 32):
+        mondays.add(monday_of_the_week(datetime.datetime(2024, 8, day, tzinfo=datetime.UTC)))
+    assert mondays == {
+        datetime.date(2024, 7, 29),
+        datetime.date(2024, 8, 5),
+        datetime.date(2024, 8, 12),
+        datetime.date(2024, 8, 19),
+        datetime.date(2024, 8, 26),
+    }
+
+
+def test_monday_of_the_week_without_arguments():
+    with freezegun.freeze_time(datetime.date(2024, 8, 1)):
+        assert monday_of_the_week() == datetime.date(2024, 7, 29)


### PR DESCRIPTION
## :thinking: Pourquoi ?

J'ai aussi besoin de `monday_of_the_week()` dans une autre PR (import EA/EATT) donc autant l'utiliser partout.
En plus ça simplifie le code, la compréhension et rend la commande plus robuste dans le cas où elle ne serais plus lancée le lundi.