### PR TITLE
Tests : `INCLUSION_CONNECT` est le défaut pour `PrescriberFactory()` et correction d'un test bagottant

### DIFF
--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -251,7 +251,7 @@ class FranceConnectTest(TestCase):
         then raise an error.
         """
         fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
-        user = PrescriberFactory(email=fc_user_data.email, identity_provider=IdentityProvider.INCLUSION_CONNECT)
+        user = PrescriberFactory(email=fc_user_data.email)
         with pytest.raises(InvalidKindException):
             fc_user_data.create_or_update_user()
         assert user.last_name != FC_USERINFO["family_name"]

--- a/tests/openid_connect/pe_connect/tests.py
+++ b/tests/openid_connect/pe_connect/tests.py
@@ -218,7 +218,7 @@ class TestPoleEmploiConnect:
         then raise an error.
         """
         peamu_user_data = PoleEmploiConnectUserData.from_user_info(PEAMU_USERINFO)
-        user = PrescriberFactory(email=peamu_user_data.email, identity_provider=IdentityProvider.INCLUSION_CONNECT)
+        user = PrescriberFactory(email=peamu_user_data.email)
         with pytest.raises(InvalidKindException):
             peamu_user_data.create_or_update_user()
         user.refresh_from_db()

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -541,14 +541,12 @@ class TestCommandNewUsersToMailJet:
             first_name="Alice",
             last_name="Aamar",
             email="alice.aamar@mailinator.com",
-            identity_provider=IdentityProvider.INCLUSION_CONNECT,
         )
         PrescriberMembershipFactory(user=alice, organization=pe)
         justin = PrescriberFactory(
             first_name="Justin",
             last_name="Wood",
             email="justin.wood@mailinator.com",
-            identity_provider=IdentityProvider.INCLUSION_CONNECT,
         )
         PrescriberMembershipFactory(user=justin, organization=other_org)
 
@@ -690,13 +688,11 @@ class TestCommandNewUsersToMailJet:
             first_name="Billy",
             last_name="Boo",
             email="billy.boo@mailinator.com",
-            identity_provider=IdentityProvider.INCLUSION_CONNECT,
         )
         sonny = PrescriberFactory(
             first_name="Sonny",
             last_name="Sunder",
             email="sonny.sunder@mailinator.com",
-            identity_provider=IdentityProvider.INCLUSION_CONNECT,
         )
         # Inactive memberships are considered orienteur.
         PrescriberMembershipFactory(user=sonny, is_active=False)
@@ -705,7 +701,6 @@ class TestCommandNewUsersToMailJet:
             first_name="Timmy",
             last_name="Timber",
             email="timmy.timber@mailinator.com",
-            identity_provider=IdentityProvider.INCLUSION_CONNECT,
         )
         PrescriberMembershipFactory(user=timmy, organization__kind=PrescriberOrganizationKind.OTHER)
         # Past users are ignored.

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -219,6 +219,9 @@ class ModelTest(TestCase):
         user = JobSeekerFactory(identity_provider=IdentityProvider.FRANCE_CONNECT)
         assert user.has_sso_provider
 
+        user = PrescriberFactory()
+        assert user.has_sso_provider
+
         user = PrescriberFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
         assert user.has_sso_provider
 

--- a/tests/www/dashboard/test_edit_user_email.py
+++ b/tests/www/dashboard/test_edit_user_email.py
@@ -83,7 +83,7 @@ class ChangeEmailViewTest(TestCase):
         response = self.client.get(url)
         assert response.status_code == 403
 
-        prescriber = PrescriberFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
+        prescriber = PrescriberFactory()
         self.client.force_login(prescriber)
         response = self.client.get(url)
         assert response.status_code == 403

--- a/tests/www/dashboard/test_edit_user_info.py
+++ b/tests/www/dashboard/test_edit_user_info.py
@@ -480,27 +480,6 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         self.assertNotContains(response, self.LACK_OF_NIR_FIELD_ID)
         self.assertNotContains(response, self.LACK_OF_NIR_REASON_FIELD_ID)
         self.assertNotContains(response, self.BIRTHDATE_FIELD_NAME)
-
-        post_data = {
-            "first_name": "Bob",
-            "last_name": "Saint Clar",
-            "phone": "0610203050",
-        }
-        response = self.client.post(url, data=post_data)
-        assert response.status_code == 302
-
-        user = User.objects.get(id=user.id)
-        assert user.phone == post_data["phone"]
-
-    def test_edit_as_prescriber_with_ic(self):
-        user = PrescriberFactory()
-        self.client.force_login(user)
-        url = reverse("dashboard:edit_user_info")
-        response = self.client.get(url)
-        self.assertNotContains(response, self.NIR_FIELD_ID)
-        self.assertNotContains(response, self.LACK_OF_NIR_FIELD_ID)
-        self.assertNotContains(response, self.LACK_OF_NIR_REASON_FIELD_ID)
-        self.assertNotContains(response, self.BIRTHDATE_FIELD_NAME)
         self.assertContains(response, f"Prénom : <strong>{user.first_name.title()}</strong>")
         self.assertContains(response, f"Nom : <strong>{user.last_name.upper()}</strong>")
         self.assertContains(response, f"Adresse e-mail : <strong>{user.email}</strong>")

--- a/tests/www/dashboard/test_edit_user_info.py
+++ b/tests/www/dashboard/test_edit_user_info.py
@@ -493,7 +493,7 @@ class EditUserInfoViewTest(InclusionConnectBaseTestCase):
         assert user.phone == post_data["phone"]
 
     def test_edit_as_prescriber_with_ic(self):
-        user = PrescriberFactory(identity_provider=IdentityProvider.INCLUSION_CONNECT)
+        user = PrescriberFactory()
         self.client.force_login(user)
         url = reverse("dashboard:edit_user_info")
         response = self.client.get(url)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Échec de la CI : https://github.com/gip-inclusion/les-emplois/actions/runs/10388984508/job/28765914812

## :desert_island: Comment tester

```
pytest -vv tests/www/dashboard/test_edit_user_info.py::EditUserInfoViewTest -k test_edit_as_prescriber --randomly-seed=1992427615
```