### PR TITLE
Toujours passer le bon type de PK aux factories

### DIFF
--- a/tests/api/test_geiq.py
+++ b/tests/api/test_geiq.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -105,7 +106,7 @@ def test_candidatures_geiq_nominal(snapshot):
     job_seeker = JobSeekerWithAddressFactory(for_snapshot=True, jobseeker_profile__education_level="51")
 
     job_application = JobApplicationFactory(
-        pk="bf657b69-3245-430c-b461-09c6792b9504",
+        pk=uuid.UUID("bf657b69-3245-430c-b461-09c6792b9504"),
         sent_by_authorized_prescriber_organisation=True,
         with_geiq_eligibility_diagnosis=True,
         was_hired=True,
@@ -125,7 +126,7 @@ def test_candidatures_geiq_nominal(snapshot):
     )
 
     JobApplicationFactory(
-        pk="bf657b69-3245-430c-b461-09c6792b9505",
+        pk=uuid.UUID("bf657b69-3245-430c-b461-09c6792b9505"),
         sent_by_authorized_prescriber_organisation=True,
         with_geiq_eligibility_diagnosis_from_prescriber=True,
         was_hired=True,

--- a/tests/employee_record/test_transfer_employee_records.py
+++ b/tests/employee_record/test_transfer_employee_records.py
@@ -1,5 +1,6 @@
 import io
 import json
+import uuid
 
 import freezegun
 import pytest
@@ -84,7 +85,7 @@ def test_preflight_with_error(snapshot, command):
         job_application__approval=None,
         # Data used by the snapshot
         pk=42,
-        job_application__pk="49536a29-88b5-49c3-8c46-333bbbc36308",
+        job_application__pk=uuid.UUID("49536a29-88b5-49c3-8c46-333bbbc36308"),
         job_application__to_company__siret="17483349486512",
         job_application__to_company__convention__asp_id="21",
         job_application__approval__number="XXXXX3724456",

--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime
 
 import factory
@@ -97,7 +98,7 @@ class JobApplicationFactory(factory.django.DjangoModelFactory):
             hired_job=factory.SubFactory(JobDescriptionFactory, company=factory.SelfAttribute("..to_company")),
         )
         for_snapshot = factory.Trait(
-            pk="11111111-1111-1111-1111-111111111111",
+            pk=uuid.UUID("11111111-1111-1111-1111-111111111111"),
             to_company__for_snapshot=True,
             sender__for_snapshot=True,
             job_seeker__for_snapshot=True,

--- a/tests/www/apply/test_list.py
+++ b/tests/www/apply/test_list.py
@@ -1,3 +1,5 @@
+import uuid
+
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from django.utils import timezone
@@ -21,7 +23,7 @@ def test_list_warns_about_long_awaiting_applications(client, snapshot):
     sender = org.active_members.get()
     job_seeker = JobSeekerFactory(first_name="Jacques", last_name="Henry")
     JobApplicationFactory(
-        id="11111111-1111-1111-1111-111111111111",
+        id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         to_company=hit_pit,
         job_seeker=job_seeker,
         sender=sender,
@@ -29,7 +31,7 @@ def test_list_warns_about_long_awaiting_applications(client, snapshot):
         created_at=now - relativedelta(weeks=2),
     )
     JobApplicationFactory(
-        id="22222222-2222-2222-2222-222222222222",
+        id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
         to_company=hit_pit,
         job_seeker=job_seeker,
         sender=sender,
@@ -37,7 +39,7 @@ def test_list_warns_about_long_awaiting_applications(client, snapshot):
         created_at=now - relativedelta(weeks=3, days=5),
     )
     JobApplicationFactory(
-        id="33333333-3333-3333-3333-333333333333",
+        id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
         to_company=hit_pit,
         job_seeker=job_seeker,
         sender=sender,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les changements introduits dans 97df9372 ont un effet de bord : on a un certain nombre de factories où l'on passe une PK uuid sous forme littérale, et du coup si effectue une comparaison ensuite (ex: `assert response.context["job_application"] == job_created_by_factory`) Django compare un objet clean hydraté depuis la db (`pk: UUID`) et l’objet créé par la factory (`pk: str`) et échoue

Cf. https://itou-inclusion.slack.com/archives/C0412CTV63D/p1723652479641059

## :cake: Comment ? <!-- optionnel -->

Passer les bons types aux factories
