### PR TITLE
Dette technique : remplacement de l'obsolète PE par FT dans certains types d'institution et dans le code de certaines stats de Pilotage

### DIFF
--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -85,8 +85,8 @@ class PrescriberAuthorizationStatus(models.TextChoices):
     NOT_REQUIRED = "NOT_REQUIRED", "Pas d'habilitation nécessaire"
 
 
-# DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
-DGPE_SAFIR_CODE = "00162"
+# DGFT, as in "Direction Générale France Travail" is a special FT agency which oversees the whole country.
+DGFT_SAFIR_CODE = "00162"
 
 # DRFT, as in "Direction Régionale France Travail", are special FT agencies which oversee their whole region.
 # We keep it simple by hardcoding their (short) list here to avoid the complexity of adding a field or a kind.

--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -88,9 +88,9 @@ class PrescriberAuthorizationStatus(models.TextChoices):
 # DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
 DGPE_SAFIR_CODE = "00162"
 
-# DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
+# DRFT, as in "Direction Régionale France Travail", are special FT agencies which oversee their whole region.
 # We keep it simple by hardcoding their (short) list here to avoid the complexity of adding a field or a kind.
-DRPE_SAFIR_CODES = [
+DRFT_SAFIR_CODES = [
     "13992",  # Provence-Alpes-Côte d'Azur
     "20010",  # Corse
     "21069",  # Bourgogne-Franche-Comté

--- a/itou/prescribers/enums.py
+++ b/itou/prescribers/enums.py
@@ -111,11 +111,11 @@ DRPE_SAFIR_CODES = [
     "97600",  # Mayotte
 ]
 
-# DTPE, as in "Direction Territoriale Pôle emploi", are special PE agencies which generally oversee
+# DTFT, as in "Direction Territoriale France Travail", are special FT agencies which generally oversee
 # their whole department and sometimes more than one department.
 # We keep it simple by hardcoding their list here to avoid the complexity of adding a field or a kind.
-# By default (`None`) a DTPE oversees its own department unless a list of several departments is specified below.
-DTPE_SAFIR_CODE_TO_DEPARTMENTS = {
+# By default (`None`) a DTFT oversees its own department unless a list of several departments is specified below.
+DTFT_SAFIR_CODE_TO_DEPARTMENTS = {
     # Note that the first two digits of the SAFIR code usually indicate the department.
     "04016": ["04", "05"],
     "10038": None,

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -12,7 +12,7 @@ from itou.common_apps.organizations.models import MembershipAbstract, Organizati
 from itou.prescribers.enums import (
     DGPE_SAFIR_CODE,
     DRPE_SAFIR_CODES,
-    DTPE_SAFIR_CODE_TO_DEPARTMENTS,
+    DTFT_SAFIR_CODE_TO_DEPARTMENTS,
     PrescriberAuthorizationStatus,
     PrescriberOrganizationKind,
 )
@@ -324,14 +324,14 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi in DRPE_SAFIR_CODES
 
     @property
-    def is_dtpe(self):
+    def is_dtft(self):
         """
-        DTPE, as in "Direction Territoriale Pôle emploi", are special PE agencies which generally oversee
+        DTFT, as in "Direction Territoriale France Travail", are special FT agencies which generally oversee
         their whole department and sometimes more than one department.
         """
         return (
             self.kind == PrescriberOrganizationKind.PE
-            and self.code_safir_pole_emploi in DTPE_SAFIR_CODE_TO_DEPARTMENTS
+            and self.code_safir_pole_emploi in DTFT_SAFIR_CODE_TO_DEPARTMENTS
         )
 
 

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -11,7 +11,7 @@ from itou.common_apps.address.models import AddressMixin
 from itou.common_apps.organizations.models import MembershipAbstract, OrganizationAbstract, OrganizationQuerySet
 from itou.prescribers.enums import (
     DGPE_SAFIR_CODE,
-    DRPE_SAFIR_CODES,
+    DRFT_SAFIR_CODES,
     DTFT_SAFIR_CODE_TO_DEPARTMENTS,
     PrescriberAuthorizationStatus,
     PrescriberOrganizationKind,
@@ -317,11 +317,11 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi == DGPE_SAFIR_CODE
 
     @property
-    def is_drpe(self):
+    def is_drft(self):
         """
-        DRPE, as in "Direction Régionale Pôle emploi", are special PE agencies which oversee their whole region.
+        DRFT, as in "Direction Régionale France Travail", are special FT agencies which oversee their whole region.
         """
-        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi in DRPE_SAFIR_CODES
+        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi in DRFT_SAFIR_CODES
 
     @property
     def is_dtft(self):

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -10,7 +10,7 @@ from django.utils.http import urlencode
 from itou.common_apps.address.models import AddressMixin
 from itou.common_apps.organizations.models import MembershipAbstract, OrganizationAbstract, OrganizationQuerySet
 from itou.prescribers.enums import (
-    DGPE_SAFIR_CODE,
+    DGFT_SAFIR_CODE,
     DRFT_SAFIR_CODES,
     DTFT_SAFIR_CODE_TO_DEPARTMENTS,
     PrescriberAuthorizationStatus,
@@ -310,11 +310,11 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         return get_email_message(to, context, subject, body)
 
     @property
-    def is_dgpe(self):
+    def is_dgft(self):
         """
-        DGPE, as in "Direction Générale Pôle emploi" is a special PE agency which oversees the whole country.
+        DGFT, as in "Direction Générale France Travail" is a special FT agency which oversees the whole country.
         """
-        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi == DGPE_SAFIR_CODE
+        return self.kind == PrescriberOrganizationKind.PE and self.code_safir_pole_emploi == DGFT_SAFIR_CODE
 
     @property
     def is_drft(self):

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -48,7 +48,7 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    {% if export_for == "siae" or can_view_stats_pe %}
+                    {% if export_for == "siae" or can_view_stats_ft %}
                         <div class="c-info mb-3 mb-md-4" id="besoin-dun-chiffre">
                             <button class="c-info__summary collapsed" data-bs-toggle="collapse" data-bs-target="#collapseBesoinChiffre" aria-expanded="false" aria-controls="collapseBesoinChiffre">
                                 <span>Besoin d'un chiffre ?</span>
@@ -57,15 +57,15 @@
                                 <div id="collapseBesoinChiffre" class="c-info__detail collapse">
                                     Accédez aux <a href="{% url 'stats:stats_siae_hiring' %}"  target="_blank" rel="noopener">données de recrutement de votre structure</a> (non nominatives) compilées, calculées et mises à jour quotidiennement.
                                 </div>
-                            {% elif export_for == "prescriptions" and can_view_stats_pe %}
+                            {% elif export_for == "prescriptions" and can_view_stats_ft %}
                                 <div id="collapseBesoinChiffre" class="c-info__detail collapse">
                                     Accédez aux données de votre agence (non nominatives) compilées, calculées et mises à jour quotidiennement :
                                     <ul class="mb-0">
                                         <li>
-                                            <a href="{% url 'stats:stats_pe_state_main' %}"  target="_blank" rel="noopener">Voir les données de l'ensemble de l'état des candidatures orientées</a>
+                                            <a href="{% url 'stats:stats_ft_state_main' %}"  target="_blank" rel="noopener">Voir les données de l'ensemble de l'état des candidatures orientées</a>
                                         </li>
                                         <li>
-                                            <a href="{% url 'stats:stats_pe_conversion_main' %}"  target="_blank" rel="noopener">Voir les données du taux de transformation des candidatures</a>
+                                            <a href="{% url 'stats:stats_ft_conversion_main' %}"  target="_blank" rel="noopener">Voir les données du taux de transformation des candidatures</a>
                                         </li>
                                     </ul>
                                 </div>

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -99,7 +99,7 @@
                             </a>
                         </li>
                     {% endif %}
-                    {% if can_view_stats_pe %}
+                    {% if can_view_stats_ft %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9"
                                rel="noopener"
@@ -111,25 +111,25 @@
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_pe_state_main' %}" class="btn-link btn-ico">
+                            <a href="{% url 'stats:stats_ft_state_main' %}" class="btn-link btn-ico">
                                 <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                                 <span>Traitement et résultat des candidatures orientées par mes agences</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_pe_conversion_main' %}" class="btn-link btn-ico">
+                            <a href="{% url 'stats:stats_ft_conversion_main' %}" class="btn-link btn-ico">
                                 <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                                 <span>Taux de transformation de mes agences</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_pe_tension' %}" class="btn-link btn-ico">
+                            <a href="{% url 'stats:stats_ft_tension' %}" class="btn-link btn-ico">
                                 <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                                 <span>Fiches de poste en tension de mon territoire</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_pe_delay_main' %}" class="btn-link btn-ico">
+                            <a href="{% url 'stats:stats_ft_delay_main' %}" class="btn-link btn-ico">
                                 <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>
                                 <span>Délai d'entrée en IAE pour mon territoire</span>
                             </a>

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -84,33 +84,33 @@ METABASE_DASHBOARDS = {
         "dashboard_id": 327,
     },
     #
-    # Prescriber stats - PE.
+    # Prescriber stats - FT.
     #
-    "stats_pe_delay_main": {
+    "stats_ft_delay_main": {
         "dashboard_id": 168,
         "tally_popup_form_id": "3lb9XW",
         "tally_embed_form_id": "meM7DE",
     },
-    "stats_pe_delay_raw": {
+    "stats_ft_delay_raw": {
         "dashboard_id": 180,
     },
-    "stats_pe_conversion_main": {
+    "stats_ft_conversion_main": {
         "dashboard_id": 169,
         "tally_popup_form_id": "mODeK8",
         "tally_embed_form_id": "3xrPjJ",
     },
-    "stats_pe_conversion_raw": {
+    "stats_ft_conversion_raw": {
         "dashboard_id": 182,
     },
-    "stats_pe_state_main": {
+    "stats_ft_state_main": {
         "dashboard_id": 149,
         "tally_popup_form_id": "mRG61J",
         "tally_embed_form_id": "3qLKad",
     },
-    "stats_pe_state_raw": {
+    "stats_ft_state_raw": {
         "dashboard_id": 183,
     },
-    "stats_pe_tension": {
+    "stats_ft_tension": {
         "dashboard_id": 162,
         "tally_popup_form_id": "wobaYV",
         "tally_embed_form_id": "3EKJ5q",

--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -19,7 +19,7 @@ from itou.www.apply.forms import (
     FilterJobApplicationsForm,
     PrescriberFilterJobApplicationsForm,
 )
-from itou.www.stats.utils import can_view_stats_pe
+from itou.www.stats.utils import can_view_stats_ft
 
 
 class JobApplicationsListKind(enum.Enum):
@@ -182,7 +182,7 @@ def list_prescriptions_exports(request, template_name="apply/list_of_available_e
         "job_applications_by_month": job_applications_by_month,
         "total_job_applications": total_job_applications,
         "export_for": "prescriptions",
-        "can_view_stats_pe": can_view_stats_pe(request),
+        "can_view_stats_ft": can_view_stats_ft(request),
         "back_url": get_safe_url(request, "back_url", reverse("dashboard:index")),
     }
     return render(request, template_name, context)

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -129,7 +129,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_cd": stats_utils.can_view_stats_cd(request),
         "can_view_stats_cd_whitelist": stats_utils.can_view_stats_cd_whitelist(request),
         "can_view_stats_cd_aci": stats_utils.can_view_stats_cd_aci(request),
-        "can_view_stats_pe": stats_utils.can_view_stats_pe(request),
+        "can_view_stats_ft": stats_utils.can_view_stats_ft(request),
         "can_view_stats_ph": stats_utils.can_view_stats_ph(request),
         "can_view_stats_ddets_iae": stats_utils.can_view_stats_ddets_iae(request),
         "can_view_stats_ddets_iae_aci": stats_utils.can_view_stats_ddets_iae_aci(request),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -28,14 +28,15 @@ urlpatterns = [
     path("cd/hiring", views.stats_cd_hiring, name="stats_cd_hiring"),
     path("cd/brsa", views.stats_cd_brsa, name="stats_cd_brsa"),
     path("cd/aci", views.stats_cd_aci, name="stats_cd_aci"),
-    # Prescriber stats - PE.
-    path("pe/delay/main", views.stats_pe_delay_main, name="stats_pe_delay_main"),
-    path("pe/delay/raw", views.stats_pe_delay_raw, name="stats_pe_delay_raw"),
-    path("pe/conversion/main", views.stats_pe_conversion_main, name="stats_pe_conversion_main"),
-    path("pe/conversion/raw", views.stats_pe_conversion_raw, name="stats_pe_conversion_raw"),
-    path("pe/state/main", views.stats_pe_state_main, name="stats_pe_state_main"),
-    path("pe/state/raw", views.stats_pe_state_raw, name="stats_pe_state_raw"),
-    path("pe/tension", views.stats_pe_tension, name="stats_pe_tension"),
+    # Prescriber stats - FT.
+    # Legacy `pe` term is used in URLs for retroactivity in Matomo stats but in fact it means `ft`.
+    path("pe/delay/main", views.stats_ft_delay_main, name="stats_ft_delay_main"),
+    path("pe/delay/raw", views.stats_ft_delay_raw, name="stats_ft_delay_raw"),
+    path("pe/conversion/main", views.stats_ft_conversion_main, name="stats_ft_conversion_main"),
+    path("pe/conversion/raw", views.stats_ft_conversion_raw, name="stats_ft_conversion_raw"),
+    path("pe/state/main", views.stats_ft_state_main, name="stats_ft_state_main"),
+    path("pe/state/raw", views.stats_ft_state_raw, name="stats_ft_state_raw"),
+    path("pe/tension", views.stats_ft_tension, name="stats_ft_tension"),
     # Authorized prescribers' stats
     path("ph/state/main", views.stats_ph_state_main, name="stats_ph_state_main"),
     # Institution stats - DDETS IAE - department level.

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -7,7 +7,7 @@ from itou.companies.models import Company
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
 from itou.prescribers.enums import (
-    DTPE_SAFIR_CODE_TO_DEPARTMENTS,
+    DTFT_SAFIR_CODE_TO_DEPARTMENTS,
     PrescriberAuthorizationStatus,
     PrescriberOrganizationKind,
 )
@@ -225,7 +225,7 @@ def get_stats_pe_departments(request):
         return DEPARTMENTS.keys()
     if request.current_organization.is_drpe:
         return REGIONS[request.current_organization.region]
-    if request.current_organization.is_dtpe:
-        departments = DTPE_SAFIR_CODE_TO_DEPARTMENTS[request.current_organization.code_safir_pole_emploi]
+    if request.current_organization.is_dtft:
+        departments = DTFT_SAFIR_CODE_TO_DEPARTMENTS[request.current_organization.code_safir_pole_emploi]
         return [request.current_organization.department] if departments is None else departments
     return [request.current_organization.department]

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -106,7 +106,7 @@ def can_view_stats_cd_aci(request):
     )
 
 
-def can_view_stats_pe(request):
+def can_view_stats_ft(request):
     return (
         request.user.is_prescriber
         and isinstance(request.current_organization, PrescriberOrganization)
@@ -218,8 +218,8 @@ def can_view_stats_iae_network(request):
     )
 
 
-def get_stats_pe_departments(request):
-    if not can_view_stats_pe(request):
+def get_stats_ft_departments(request):
+    if not can_view_stats_ft(request):
         raise PermissionDenied
     if request.current_organization.is_dgft:
         return DEPARTMENTS.keys()

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -223,7 +223,7 @@ def get_stats_pe_departments(request):
         raise PermissionDenied
     if request.current_organization.is_dgpe:
         return DEPARTMENTS.keys()
-    if request.current_organization.is_drpe:
+    if request.current_organization.is_drft:
         return REGIONS[request.current_organization.region]
     if request.current_organization.is_dtft:
         departments = DTFT_SAFIR_CODE_TO_DEPARTMENTS[request.current_organization.code_safir_pole_emploi]

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -221,7 +221,7 @@ def can_view_stats_iae_network(request):
 def get_stats_pe_departments(request):
     if not can_view_stats_pe(request):
         raise PermissionDenied
-    if request.current_organization.is_dgpe:
+    if request.current_organization.is_dgft:
         return DEPARTMENTS.keys()
     if request.current_organization.is_drft:
         return REGIONS[request.current_organization.region]

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -398,7 +398,7 @@ def render_stats_pe(request, page_title, extra_params=None):
             "matomo_custom_url_suffix": f"{format_region_for_matomo(current_org.region)}/drpe",
             "region": current_org.region,
         }
-    elif current_org.is_dtpe:
+    elif current_org.is_dtft:
         context |= {
             "matomo_custom_url_suffix": f"{format_region_and_department_for_matomo(current_org.department)}/dtpe",
             "department": current_org.department,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -393,7 +393,7 @@ def render_stats_pe(request, page_title, extra_params=None):
         context |= {
             "matomo_custom_url_suffix": "dgpe",
         }
-    elif current_org.is_drpe:
+    elif current_org.is_drft:
         context |= {
             "matomo_custom_url_suffix": f"{format_region_for_matomo(current_org.region)}/drpe",
             "region": current_org.region,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -365,9 +365,9 @@ def stats_cd_aci(request):
     )
 
 
-def render_stats_pe(request, page_title, extra_params=None):
+def render_stats_ft(request, page_title, extra_params=None):
     """
-    PE ("Pôle emploi") stats shown to relevant members.
+    FT ("France Travail") stats shown to relevant members.
     They can view data for their whole departement, not only their agency.
     They cannot view data for other departments than their own.
 
@@ -375,9 +375,9 @@ def render_stats_pe(request, page_title, extra_params=None):
     `*_raw` views are not directly visible on the C1 dashboard but are linked from within their `*_main` counterpart.
     """
     current_org = get_current_org_or_404(request)
-    if not utils.can_view_stats_pe(request):
+    if not utils.can_view_stats_ft(request):
         raise PermissionDenied
-    departments = utils.get_stats_pe_departments(request)
+    departments = utils.get_stats_ft_departments(request)
     params = {
         mb.DEPARTMENT_FILTER_KEY: [DEPARTMENTS[d] for d in departments],
     }
@@ -412,8 +412,8 @@ def render_stats_pe(request, page_title, extra_params=None):
 
 
 @login_required
-def stats_pe_delay_main(request):
-    return render_stats_pe(
+def stats_ft_delay_main(request):
+    return render_stats_ft(
         request=request,
         page_title="Délai d'entrée en IAE",
         extra_params={
@@ -423,8 +423,8 @@ def stats_pe_delay_main(request):
 
 
 @login_required
-def stats_pe_delay_raw(request):
-    return render_stats_pe(
+def stats_ft_delay_raw(request):
+    return render_stats_ft(
         request=request,
         page_title="Données brutes de délai d'entrée en IAE",
         # No additional locked filter is needed for these PE stats.
@@ -432,8 +432,8 @@ def stats_pe_delay_raw(request):
 
 
 @login_required
-def stats_pe_conversion_main(request):
-    return render_stats_pe(
+def stats_ft_conversion_main(request):
+    return render_stats_ft(
         request=request,
         page_title="Taux de transformation",
         extra_params={
@@ -443,8 +443,8 @@ def stats_pe_conversion_main(request):
 
 
 @login_required
-def stats_pe_conversion_raw(request):
-    return render_stats_pe(
+def stats_ft_conversion_raw(request):
+    return render_stats_ft(
         request=request,
         page_title="Données brutes du taux de transformation",
         extra_params={
@@ -454,8 +454,8 @@ def stats_pe_conversion_raw(request):
 
 
 @login_required
-def stats_pe_state_main(request):
-    return render_stats_pe(
+def stats_ft_state_main(request):
+    return render_stats_ft(
         request=request,
         page_title="Etat des candidatures orientées",
         extra_params={
@@ -465,8 +465,8 @@ def stats_pe_state_main(request):
 
 
 @login_required
-def stats_pe_state_raw(request):
-    return render_stats_pe(
+def stats_ft_state_raw(request):
+    return render_stats_ft(
         request=request,
         page_title="Données brutes de l’état des candidatures orientées",
         extra_params={
@@ -476,8 +476,8 @@ def stats_pe_state_raw(request):
 
 
 @login_required
-def stats_pe_tension(request):
-    return render_stats_pe(
+def stats_ft_tension(request):
+    return render_stats_ft(
         request=request,
         page_title="Fiches de poste en tension",
         # No additional locked filter is needed for these PE stats.

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -389,7 +389,7 @@ def render_stats_pe(request, page_title, extra_params=None):
     context = {
         "page_title": page_title,
     }
-    if current_org.is_dgpe:
+    if current_org.is_dgft:
         context |= {
             "matomo_custom_url_suffix": "dgpe",
         }

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -182,7 +182,7 @@ def test_can_view_stats_pe_as_regular_pe_agency():
     )
     user = regular_pe_agency.members.get()
     assert not regular_pe_agency.is_dtft
-    assert not regular_pe_agency.is_drpe
+    assert not regular_pe_agency.is_drft
     assert not regular_pe_agency.is_dgpe
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
@@ -198,7 +198,7 @@ def test_can_view_stats_pe_as_dtft_with_single_department():
     )
     user = dtft_with_single_department.members.get()
     assert dtft_with_single_department.is_dtft
-    assert not dtft_with_single_department.is_drpe
+    assert not dtft_with_single_department.is_drft
     assert not dtft_with_single_department.is_dgpe
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
@@ -214,24 +214,24 @@ def test_can_view_stats_pe_as_dtft_with_multiple_departments():
     )
     user = dtft_with_multiple_departments.members.get()
     assert dtft_with_multiple_departments.is_dtft
-    assert not dtft_with_multiple_departments.is_drpe
+    assert not dtft_with_multiple_departments.is_drft
     assert not dtft_with_multiple_departments.is_dgpe
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == ["72", "53"]
 
 
-def test_can_view_stats_pe_as_drpe():
-    drpe = PrescriberOrganizationWithMembershipFactory(
+def test_can_view_stats_pe_as_drft():
+    drft = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
         department="93",
         code_safir_pole_emploi="75980",
     )
-    user = drpe.members.get()
-    assert drpe.is_drpe
-    assert not drpe.is_dgpe
-    assert not drpe.is_dtft
+    user = drft.members.get()
+    assert drft.is_drft
+    assert not drft.is_dgpe
+    assert not drft.is_dtft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == [
@@ -254,7 +254,7 @@ def test_can_view_stats_pe_as_dgpe():
         code_safir_pole_emploi="00162",
     )
     user = dgpe.members.get()
-    assert not dgpe.is_drpe
+    assert not dgpe.is_drft
     assert not dgpe.is_dtft
     assert dgpe.is_dgpe
     request = get_request(user)

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -183,7 +183,7 @@ def test_can_view_stats_pe_as_regular_pe_agency():
     user = regular_pe_agency.members.get()
     assert not regular_pe_agency.is_dtft
     assert not regular_pe_agency.is_drft
-    assert not regular_pe_agency.is_dgpe
+    assert not regular_pe_agency.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == ["93"]
@@ -199,7 +199,7 @@ def test_can_view_stats_pe_as_dtft_with_single_department():
     user = dtft_with_single_department.members.get()
     assert dtft_with_single_department.is_dtft
     assert not dtft_with_single_department.is_drft
-    assert not dtft_with_single_department.is_dgpe
+    assert not dtft_with_single_department.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == ["49"]
@@ -215,7 +215,7 @@ def test_can_view_stats_pe_as_dtft_with_multiple_departments():
     user = dtft_with_multiple_departments.members.get()
     assert dtft_with_multiple_departments.is_dtft
     assert not dtft_with_multiple_departments.is_drft
-    assert not dtft_with_multiple_departments.is_dgpe
+    assert not dtft_with_multiple_departments.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == ["72", "53"]
@@ -230,7 +230,7 @@ def test_can_view_stats_pe_as_drft():
     )
     user = drft.members.get()
     assert drft.is_drft
-    assert not drft.is_dgpe
+    assert not drft.is_dgft
     assert not drft.is_dtft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
@@ -246,17 +246,17 @@ def test_can_view_stats_pe_as_drft():
     ]
 
 
-def test_can_view_stats_pe_as_dgpe():
-    dgpe = PrescriberOrganizationWithMembershipFactory(
+def test_can_view_stats_pe_as_dgft():
+    dgft = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
         department="93",
         code_safir_pole_emploi="00162",
     )
-    user = dgpe.members.get()
-    assert not dgpe.is_drft
-    assert not dgpe.is_dtft
-    assert dgpe.is_dgpe
+    user = dgft.members.get()
+    assert not dgft.is_drft
+    assert not dgft.is_dtft
+    assert dgft.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request)

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -176,7 +176,7 @@ def test_can_view_stats_cd_aci(settings):
     assert utils.can_view_stats_dashboard_widget(request)
 
 
-def test_can_view_stats_pe_as_regular_pe_agency():
+def test_can_view_stats_ft_as_regular_pe_agency():
     regular_pe_agency = PrescriberOrganizationWithMembershipFactory(
         authorized=True, kind=PrescriberOrganizationKind.PE, department="93"
     )
@@ -185,11 +185,11 @@ def test_can_view_stats_pe_as_regular_pe_agency():
     assert not regular_pe_agency.is_drft
     assert not regular_pe_agency.is_dgft
     request = get_request(user)
-    assert utils.can_view_stats_pe(request)
-    assert utils.get_stats_pe_departments(request) == ["93"]
+    assert utils.can_view_stats_ft(request)
+    assert utils.get_stats_ft_departments(request) == ["93"]
 
 
-def test_can_view_stats_pe_as_dtft_with_single_department():
+def test_can_view_stats_ft_as_dtft_with_single_department():
     dtft_with_single_department = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
@@ -201,11 +201,11 @@ def test_can_view_stats_pe_as_dtft_with_single_department():
     assert not dtft_with_single_department.is_drft
     assert not dtft_with_single_department.is_dgft
     request = get_request(user)
-    assert utils.can_view_stats_pe(request)
-    assert utils.get_stats_pe_departments(request) == ["49"]
+    assert utils.can_view_stats_ft(request)
+    assert utils.get_stats_ft_departments(request) == ["49"]
 
 
-def test_can_view_stats_pe_as_dtft_with_multiple_departments():
+def test_can_view_stats_ft_as_dtft_with_multiple_departments():
     dtft_with_multiple_departments = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
@@ -217,11 +217,11 @@ def test_can_view_stats_pe_as_dtft_with_multiple_departments():
     assert not dtft_with_multiple_departments.is_drft
     assert not dtft_with_multiple_departments.is_dgft
     request = get_request(user)
-    assert utils.can_view_stats_pe(request)
-    assert utils.get_stats_pe_departments(request) == ["72", "53"]
+    assert utils.can_view_stats_ft(request)
+    assert utils.get_stats_ft_departments(request) == ["72", "53"]
 
 
-def test_can_view_stats_pe_as_drft():
+def test_can_view_stats_ft_as_drft():
     drft = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
@@ -233,8 +233,8 @@ def test_can_view_stats_pe_as_drft():
     assert not drft.is_dgft
     assert not drft.is_dtft
     request = get_request(user)
-    assert utils.can_view_stats_pe(request)
-    assert utils.get_stats_pe_departments(request) == [
+    assert utils.can_view_stats_ft(request)
+    assert utils.get_stats_ft_departments(request) == [
         "75",
         "77",
         "78",
@@ -246,7 +246,7 @@ def test_can_view_stats_pe_as_drft():
     ]
 
 
-def test_can_view_stats_pe_as_dgft():
+def test_can_view_stats_ft_as_dgft():
     dgft = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
@@ -258,8 +258,8 @@ def test_can_view_stats_pe_as_dgft():
     assert not dgft.is_dtft
     assert dgft.is_dgft
     request = get_request(user)
-    assert utils.can_view_stats_pe(request)
-    assert utils.get_stats_pe_departments(request)
+    assert utils.can_view_stats_ft(request)
+    assert utils.get_stats_ft_departments(request)
 
 
 @pytest.mark.parametrize(

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -181,7 +181,7 @@ def test_can_view_stats_pe_as_regular_pe_agency():
         authorized=True, kind=PrescriberOrganizationKind.PE, department="93"
     )
     user = regular_pe_agency.members.get()
-    assert not regular_pe_agency.is_dtpe
+    assert not regular_pe_agency.is_dtft
     assert not regular_pe_agency.is_drpe
     assert not regular_pe_agency.is_dgpe
     request = get_request(user)
@@ -189,33 +189,33 @@ def test_can_view_stats_pe_as_regular_pe_agency():
     assert utils.get_stats_pe_departments(request) == ["93"]
 
 
-def test_can_view_stats_pe_as_dtpe_with_single_department():
-    dtpe_with_single_department = PrescriberOrganizationWithMembershipFactory(
+def test_can_view_stats_pe_as_dtft_with_single_department():
+    dtft_with_single_department = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
         code_safir_pole_emploi="49104",
         department="49",
     )
-    user = dtpe_with_single_department.members.get()
-    assert dtpe_with_single_department.is_dtpe
-    assert not dtpe_with_single_department.is_drpe
-    assert not dtpe_with_single_department.is_dgpe
+    user = dtft_with_single_department.members.get()
+    assert dtft_with_single_department.is_dtft
+    assert not dtft_with_single_department.is_drpe
+    assert not dtft_with_single_department.is_dgpe
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == ["49"]
 
 
-def test_can_view_stats_pe_as_dtpe_with_multiple_departments():
-    dtpe_with_multiple_departments = PrescriberOrganizationWithMembershipFactory(
+def test_can_view_stats_pe_as_dtft_with_multiple_departments():
+    dtft_with_multiple_departments = PrescriberOrganizationWithMembershipFactory(
         authorized=True,
         kind=PrescriberOrganizationKind.PE,
         code_safir_pole_emploi="72203",
         department="72",
     )
-    user = dtpe_with_multiple_departments.members.get()
-    assert dtpe_with_multiple_departments.is_dtpe
-    assert not dtpe_with_multiple_departments.is_drpe
-    assert not dtpe_with_multiple_departments.is_dgpe
+    user = dtft_with_multiple_departments.members.get()
+    assert dtft_with_multiple_departments.is_dtft
+    assert not dtft_with_multiple_departments.is_drpe
+    assert not dtft_with_multiple_departments.is_dgpe
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == ["72", "53"]
@@ -231,7 +231,7 @@ def test_can_view_stats_pe_as_drpe():
     user = drpe.members.get()
     assert drpe.is_drpe
     assert not drpe.is_dgpe
-    assert not drpe.is_dtpe
+    assert not drpe.is_dtft
     request = get_request(user)
     assert utils.can_view_stats_pe(request)
     assert utils.get_stats_pe_departments(request) == [
@@ -255,7 +255,7 @@ def test_can_view_stats_pe_as_dgpe():
     )
     user = dgpe.members.get()
     assert not dgpe.is_drpe
-    assert not dgpe.is_dtpe
+    assert not dgpe.is_dtft
     assert dgpe.is_dgpe
     request = get_request(user)
     assert utils.can_view_stats_pe(request)

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -77,9 +77,9 @@ def assert_stats_dashboard_equal(values):
 @override_settings(METABASE_SITE_URL="http://metabase.fake", METABASE_SECRET_KEY="foobar")
 @pytest.mark.parametrize(
     "view_name",
-    [p.name for p in stats_urls.urlpatterns if p.name.startswith("stats_pe_")],
+    [p.name for p in stats_urls.urlpatterns if p.name.startswith("stats_ft_")],
 )
-def test_stats_pe_log_visit(client, view_name):
+def test_stats_ft_log_visit(client, view_name):
     prescriber_org = PrescriberOrganizationWithMembershipFactory(kind="PE", authorized=True)
     user = prescriber_org.members.get()
     client.force_login(user)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Je profite de ce mois calme d'août pour dépiler une petite dette technique, il restait des termes PE obsolètes dans le C2.

DTPE devient DTFT, DRPE devient DRFT et DGPE devient DGFT.

`stats_pe` dans le code devient `stats_ft` mais pour ne pas casser les stats Matomo je n'ai pas touché aux routes qui restent en `/pe/*`.

Comme je n'ai changé aucune route, je dirais que cette PR a peu de chance de casser quelque chose côté C2.

Note à moi-même : ca vaudrait peut-être le coup d'enfin casser les routes legacy `/pe/*` (devient `/ft/*`) et `/ddets/*` (devient `/ddets_iae/*`) même si ça perturbe potentiellement notre plomberie Matomo derrière. En parler aux datos à l'occasion.

Romain : si ok pour toi tu peux mepper sans attendre mon retour le 10 septembre, fais comme tu le sens.