### PR TITLE
docker: Changement mineur à l’entrypoint.sh

### DIFF
--- a/docker/dev/django/entrypoint.sh
+++ b/docker/dev/django/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 
-while ! pg_isready; do
+until pg_isready; do
     >&2 echo "Postgres is unavailable - sleeping"
     sleep 1
 done


### PR DESCRIPTION
## :thinking: Pourquoi ?

Préferer `until` à `while !`. C’est plus clair et aligné avec #4523.
