### PR TITLE
dependabot : Correction d'une erreur de syntaxe

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,4 +19,4 @@ updates:
     open-pull-requests-limit: 20
     allow:
       # Allow both direct and indirect updates for all packages
-      dependency-type: all
+      - dependency-type: all


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à #4531 :
> The property '#/updates/1/allow' of type object did not match the following type: array
> https://github.com/gip-inclusion/les-emplois/pull/4577/checks?check_run_id=29041932076 