### PR TITLE
Candidature : Correction de l'acception quand la ville de naissance n'est pas référencée pour la date de naissance renseignée

### DIFF
--- a/itou/asp/forms.py
+++ b/itou/asp/forms.py
@@ -24,6 +24,7 @@ def formfield_for_birth_place(**kwargs):
                 "data-placeholder": "Nom de la commune",
                 "data-disable-target": "#id_birth_country",
                 "data-target-value": f"{france.pk}",
+                "data-select2-link-with-birthdate": "id_birthdate",
             },
         ),
         **kwargs,

--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -131,4 +131,23 @@ htmx.onLoad((target) => {
     container.querySelector(".file-dropzone-clear").addEventListener("click", handleFileClear);
   }
   target.querySelectorAll(".file-dropzone").forEach(initDropZone);
+
+  /**
+   * JS to add the birthdate parameter when querying Commune for birthplace
+   **/
+  $('select[data-select2-link-with-birthdate]', target).each(function () {
+    const identifier = this.getAttribute("data-select2-link-with-birthdate")
+    const birthdatePicker = document.querySelector('duet-date-picker[identifier="' + identifier + '"]')
+
+    $(this).select2({
+      ajax: {
+        data: function(params) {
+          return {
+            term: params.term,
+            date: birthdatePicker.getAttribute("value"),
+          }
+        }
+      }
+    })
+  })
 });

--- a/itou/templates/employee_record/create.html
+++ b/itou/templates/employee_record/create.html
@@ -47,25 +47,3 @@
         </div>
     </section>
 {% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    {% if step == 1 %}
-        {# It is only useful there #}
-        <script nonce="{{ CSP_NONCE }}">
-            const birthdatePicker = document.querySelector('duet-date-picker[name="birthdate"]')
-            $(document).ready(function() {
-                $('#id_birth_place').select2({
-                    ajax: {
-                        data: function(params) {
-                            return {
-                                term: params.term,
-                                date: birthdatePicker.getAttribute("value"),
-                            }
-                        }
-                    }
-                })
-            })
-        </script>
-    {% endif %}
-{% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Remonté par le support suite au TZ 18185.

## :cake: Comment ? <!-- optionnel -->

Extraction du code actuellement utilisé dans les vues FS pour être accessible globalement.

## :desert_island: Comment tester

- Acceptation d'une candidature (gabarits + htmx)
- Étape 1 du parcours de création d'une fiche salarié