### PR TITLE
Pilotage : Ajouter des encarts pour les prochains webinaires

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -20,6 +20,29 @@
     {% endif %}
 {% endblock %}
 
+{% block title_messages %}
+    {{ block.super }}
+    {% for banner in pilotage_webinar_banners %}
+        <div class="alert alert-info alert-dismissible fade show" role="status">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-important" aria-hidden="true"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-2">
+                        <strong>{{ banner.title }}</strong>
+                    </p>
+                    <p class="mb-0">{{ banner.description }}</p>
+                </div>
+                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                    <a class="btn btn-sm btn-primary btn-block btn-ico" href="{{ banner.url }}" target="_blank" rel="noopener"><span>Je m’inscris</span> <i class="ri-external-link-line font-weight-medium" aria-hidden="true"></i></a>
+                </div>
+            </div>
+        </div>
+    {% endfor %}
+{% endblock %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">


### PR DESCRIPTION
## :thinking: Pourquoi ?

1. https://www.notion.so/gip-inclusion/Encart-Ajouter-un-encart-webinaire-sur-le-TB149-pour-les-ML-et-Cap-Emploi-ad4009abda4d4c71b3b60c8abf3bfd37
2. https://www.notion.so/gip-inclusion/Encart-Ajouter-un-encart-webinaire-sur-le-TB-330-et-346-50f2c7764ac849a3bf1c9d19faf48dd9
3. https://www.notion.so/gip-inclusion/Encart-Ajouter-un-encart-pour-annoncer-un-webinaire-dans-presque-tous-les-TB-priv-s-76b8d2405a4f4d6da2a678c3437927f3
4. https://www.notion.so/gip-inclusion/Encart-Ajouter-un-encart-sur-le-TB-289-262223184ae946ad9f52836e1cf8bc6e?pvs=4

## :cake: Comment ? <!-- optionnel -->

Réutilisation de ce qui avais été fait dans #4207, sauf que cette fois les bannières sont afficher sur les pages des TB.