### PR TITLE
Préférer timezone.localdate()

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -75,8 +75,7 @@ class CommonApprovalMixin(models.Model):
         ]
 
     def is_valid(self):
-        now = timezone.now().date()
-        return now <= self.end_at
+        return timezone.localdate() <= self.end_at
 
     @classmethod
     def last_number(cls):
@@ -96,7 +95,7 @@ class CommonApprovalMixin(models.Model):
 
     @property
     def is_in_progress(self):
-        return self.start_at <= timezone.now().date() <= self.end_at
+        return self.start_at <= timezone.localdate() <= self.end_at
 
     @property
     def waiting_period_end(self):
@@ -104,13 +103,11 @@ class CommonApprovalMixin(models.Model):
 
     @property
     def is_in_waiting_period(self):
-        now = timezone.now().date()
-        return self.end_at < now <= self.waiting_period_end
+        return self.end_at < timezone.localdate() <= self.waiting_period_end
 
     @property
     def waiting_period_has_elapsed(self):
-        now = timezone.now().date()
-        return now > self.waiting_period_end
+        return timezone.localdate() > self.waiting_period_end
 
     @property
     def is_pass_iae(self):
@@ -207,8 +204,7 @@ class CommonApprovalQuerySet(models.QuerySet):
 
     @property
     def valid_lookup(self):
-        now = timezone.now().date()
-        return Q(end_at__gte=now)
+        return Q(end_at__gte=timezone.localdate())
 
     def valid(self):
         return self.filter(self.valid_lookup)
@@ -217,16 +213,13 @@ class CommonApprovalQuerySet(models.QuerySet):
         return self.exclude(self.valid_lookup)
 
     def starts_in_the_past(self):
-        now = timezone.now().date()
-        return self.filter(Q(start_at__lt=now))
+        return self.filter(Q(start_at__lt=timezone.localdate()))
 
     def starts_today(self):
-        now = timezone.now().date()
-        return self.filter(start_at=now)
+        return self.filter(start_at=timezone.localdate())
 
     def starts_in_the_future(self):
-        now = timezone.now().date()
-        return self.filter(Q(start_at__gt=now))
+        return self.filter(Q(start_at__gt=timezone.localdate()))
 
 
 class ApprovalQuerySet(CommonApprovalQuerySet):
@@ -785,7 +778,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
 
     @property
     def can_postpone_start_date(self):
-        return self.start_at > timezone.now().date()
+        return self.start_at > timezone.localdate()
 
     def update_start_date(self, new_start_date):
         """
@@ -1006,8 +999,8 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
 class SuspensionQuerySet(models.QuerySet):
     @property
     def in_progress_lookup(self):
-        now = timezone.now().date()
-        return models.Q(start_at__lte=now, end_at__gte=now)
+        today = timezone.localdate()
+        return models.Q(start_at__lte=today, end_at__gte=today)
 
     def in_progress(self):
         return self.filter(self.in_progress_lookup)
@@ -1016,8 +1009,7 @@ class SuspensionQuerySet(models.QuerySet):
         return self.exclude(self.in_progress_lookup)
 
     def old(self):
-        now = timezone.now().date()
-        return self.filter(end_at__lt=now)
+        return self.filter(end_at__lt=timezone.localdate())
 
 
 class Suspension(models.Model):
@@ -1256,7 +1248,7 @@ class Suspension(models.Model):
 
     @property
     def is_in_progress(self):
-        return self.start_at <= timezone.now().date() <= self.end_at
+        return self.start_at <= timezone.localdate() <= self.end_at
 
     @property
     def start_in_approval_boundaries(self):
@@ -1550,7 +1542,7 @@ class CommonProlongation(models.Model):
 
     @property
     def is_in_progress(self):
-        return self.start_at <= timezone.now().date() <= self.end_at
+        return self.start_at <= timezone.localdate() <= self.end_at
 
     @staticmethod
     def get_max_end_at(approval_id, start_at, reason, ignore=None):
@@ -1689,8 +1681,8 @@ class ProlongationQuerySet(models.QuerySet):
     @property
     def in_progress_lookup(self):
         # This logic was duplicated in Approval.is_suspended for performance issues
-        now = timezone.now().date()
-        return models.Q(start_at__lte=now, end_at__gte=now)
+        today = timezone.localdate()
+        return models.Q(start_at__lte=today, end_at__gte=today)
 
     def in_progress(self):
         return self.filter(self.in_progress_lookup)

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -1292,7 +1292,7 @@ class Suspension(models.Model):
         Returns the minimum date on which a suspension can begin.
         """
         if referent_date is None:
-            referent_date = datetime.date.today()
+            referent_date = timezone.localdate()
 
         start_at = None
         last_accepted_job_application = get_user_last_accepted_siae_job_application(approval.user)

--- a/itou/communications/cache.py
+++ b/itou/communications/cache.py
@@ -1,6 +1,7 @@
-from datetime import date, datetime
+from datetime import datetime
 
 from django.core.cache import cache
+from django.utils import timezone
 
 from itou.communications.models import AnnouncementCampaign
 
@@ -11,7 +12,7 @@ SENTINEL_ACTIVE_ANNOUNCEMENT = object()
 
 def update_active_announcement_cache():
     campaign = (
-        AnnouncementCampaign.objects.filter(start_date=date.today().replace(day=1), live=True)
+        AnnouncementCampaign.objects.filter(start_date=timezone.localdate().replace(day=1), live=True)
         .prefetch_related("items")
         .first()
     )

--- a/itou/companies/management/commands/_import_siae/vue_af.py
+++ b/itou/companies/management/commands/_import_siae/vue_af.py
@@ -138,7 +138,7 @@ class Convention:
 
     @property
     def is_active(self):
-        return self.has_active_state and timezone.now().date() <= self.end_at
+        return self.has_active_state and timezone.localdate() <= self.end_at
 
 
 def get_conventions_by_siae_key(vue_af_df):

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -1,4 +1,3 @@
-import datetime
 import uuid
 
 from django.conf import settings
@@ -894,7 +893,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     @property
     def hiring_starts_in_future(self):
         if self.hiring_start_at:
-            return datetime.date.today() < self.hiring_start_at
+            return timezone.localdate() < self.hiring_start_at
         return False
 
     @property

--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import timedelta
 from functools import partial
 
 from django.utils import timezone
@@ -28,7 +28,7 @@ AUTHOR_KIND_CHOICES = (
 
 def get_user_age_in_years(user):
     if user.birthdate:
-        return date.today().year - user.birthdate.year
+        return timezone.localdate().year - user.birthdate.year
     return None
 
 

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -21,7 +21,7 @@ class DuetDatePickerWidget(forms.DateInput):
 
     Dates can be passed as date objects or as strings (YYYY-MM-DD).
     E.g.:
-        my_date = forms.DateField(initial=datetime.date.today())
+        my_date = forms.DateField(initial=datetime.date(2020, 1, 1))
         my_date = forms.DateField(initial="2021-07-18")
 
     See:

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -523,11 +523,11 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
             # "parcours IAE" and the payment of the "aide au poste".
             "hiring_start_at": (
                 "Au format JJ/MM/AAAA, par exemple {}. Il n'est pas possible d'antidater un contrat.".format(
-                    datetime.date.today().strftime("%d/%m/%Y")
+                    timezone.localdate().strftime("%d/%m/%Y")
                 )
             ),
             "hiring_end_at": "Au format JJ/MM/AAAA, par exemple {}.".format(
-                (datetime.date.today() + datetime.timedelta(days=Approval.DEFAULT_APPROVAL_DAYS)).strftime("%d/%m/%Y")
+                (timezone.localdate() + datetime.timedelta(days=Approval.DEFAULT_APPROVAL_DAYS)).strftime("%d/%m/%Y")
             ),
             "prehiring_guidance_days": """Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche""",
             "contract_type_details": (
@@ -575,7 +575,7 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
             self.initial["prehiring_guidance_days"] = 0
             self.initial["planned_training_hours"] = 0
             self.fields["hiring_start_at"].help_text = "Au format JJ/MM/AAAA, par exemple {}.".format(
-                datetime.date.today().strftime("%d/%m/%Y"),
+                timezone.localdate().strftime("%d/%m/%Y"),
             )
             # Dynamic selection of qualification level
             self.fields["qualification_type"].widget.attrs.update(
@@ -671,9 +671,9 @@ class AcceptForm(JobAppellationAndLocationMixin, forms.ModelForm):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
 
         # Hiring in the past is *temporarily* possible for GEIQ
-        if hiring_start_at and hiring_start_at < datetime.date.today() and not self.is_geiq:
+        if hiring_start_at and hiring_start_at < timezone.localdate() and not self.is_geiq:
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_PAST))
-        elif hiring_start_at and hiring_start_at > datetime.date.today() + relativedelta(months=6):
+        elif hiring_start_at and hiring_start_at > timezone.localdate() + relativedelta(months=6):
             self.add_error("hiring_start_at", forms.ValidationError(JobApplication.ERROR_START_IN_FAR_FUTURE))
         else:
             return hiring_start_at
@@ -824,10 +824,10 @@ class EditHiringDateForm(forms.ModelForm):
     def clean_hiring_start_at(self):
         hiring_start_at = self.cleaned_data["hiring_start_at"]
 
-        if hiring_start_at < datetime.date.today():
+        if hiring_start_at < timezone.localdate():
             raise forms.ValidationError(JobApplication.ERROR_START_IN_PAST)
 
-        if hiring_start_at > datetime.date.today() + relativedelta(days=JobApplication.MAX_CONTRACT_POSTPONE_IN_DAYS):
+        if hiring_start_at > timezone.localdate() + relativedelta(days=JobApplication.MAX_CONTRACT_POSTPONE_IN_DAYS):
             raise forms.ValidationError(JobApplication.ERROR_POSTPONE_TOO_FAR)
 
         return hiring_start_at

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
 import urllib.parse
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -126,7 +126,7 @@ class ApprovalDetailView(ApprovalBaseViewMixin, DetailView):
         if approval.is_in_progress:
             for suspension in approval.suspensions_by_start_date_asc:
                 if suspension.is_in_progress:
-                    suspension_duration = date.today() - suspension.start_at
+                    suspension_duration = timezone.localdate() - suspension.start_at
                     has_hirings_after_suspension = False
                 else:
                     suspension_duration = suspension.duration

--- a/tests/approvals/factories.py
+++ b/tests/approvals/factories.py
@@ -64,7 +64,7 @@ class ApprovalFactory(AutoNowOverrideMixin, factory.django.DjangoModelFactory):
 
     user = factory.SubFactory(JobSeekerFactory)
     number = factory.fuzzy.FuzzyText(length=7, chars=string.digits, prefix=Approval.ASP_ITOU_PREFIX)
-    start_at = factory.LazyFunction(datetime.date.today)
+    start_at = factory.LazyFunction(timezone.localdate)
     end_at = factory.LazyAttribute(lambda obj: Approval.get_default_end_date(obj.start_at))
     eligibility_diagnosis = factory.SubFactory(
         IAEEligibilityDiagnosisFactory, from_prescriber=True, job_seeker=factory.SelfAttribute("..user")
@@ -94,7 +94,7 @@ class CancelledApprovalFactory(factory.django.DjangoModelFactory):
         model = CancelledApproval
 
     number = factory.fuzzy.FuzzyText(length=7, chars=string.digits, prefix=Approval.ASP_ITOU_PREFIX)
-    start_at = factory.LazyFunction(datetime.date.today)
+    start_at = factory.LazyFunction(timezone.localdate)
     end_at = factory.LazyAttribute(lambda obj: Approval.get_default_end_date(obj.start_at))
 
     user_first_name = factory.Faker("first_name")
@@ -223,7 +223,7 @@ class PoleEmploiApprovalFactory(factory.django.DjangoModelFactory):
     number = factory.fuzzy.FuzzyText(length=12, chars=string.digits)
     birth_name = factory.SelfAttribute("last_name")
     birthdate = factory.fuzzy.FuzzyDate(datetime.date(1968, 1, 1), datetime.date(2000, 1, 1))
-    start_at = factory.LazyFunction(datetime.date.today)
+    start_at = factory.LazyFunction(timezone.localdate)
     end_at = factory.LazyAttribute(lambda obj: obj.start_at + relativedelta(years=2) - relativedelta(days=1))
     siae_siret = factory.fuzzy.FuzzyText(length=13, chars=string.digits, prefix="1")
     siae_kind = factory.fuzzy.FuzzyChoice(CompanyKind.values)

--- a/tests/approvals/test_notify_pole_emploi.py
+++ b/tests/approvals/test_notify_pole_emploi.py
@@ -477,13 +477,13 @@ class TestCancelledApprovalNotifyPoleEmploiIntegration:
             200, json=API_RECHERCHE_RESULT_KNOWN
         )
         respx.post("https://pe.fake/maj-pass-iae/v1/passIAE/miseAjour").respond(200, json=API_MAJPASS_RESULT_OK)
-        tomorrow = (timezone.now() + datetime.timedelta(days=1)).date()
+        tomorrow = timezone.localdate() + datetime.timedelta(days=1)
         cancelled_approval = CancelledApprovalFactory(start_at=tomorrow)
         cancelled_approval.notify_pole_emploi()
         assert (
             f"! notify_pole_emploi cancelledapproval={cancelled_approval} "
             f"start_at={cancelled_approval.start_at} "
-            f"starts after today={timezone.now().date()}" == caplog.messages[0]
+            f"starts after today={timezone.localdate()}" == caplog.messages[0]
         )
         cancelled_approval.refresh_from_db()
         assert cancelled_approval.pe_notification_status == "notification_pending"

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -772,7 +772,7 @@ class TestPoleEmploiApprovalManager:
     def test_find_for_user(self):
         # given a User, ensure we can find a PE approval using its pole_emploi_id and not the others.
         user = JobSeekerFactory(with_pole_emploi_id=True)
-        today = datetime.date.today()
+        today = timezone.localdate()
         pe_approval = PoleEmploiApprovalFactory(
             pole_emploi_id=user.jobseeker_profile.pole_emploi_id,
             birthdate=user.birthdate,

--- a/tests/communications/factories.py
+++ b/tests/communications/factories.py
@@ -1,6 +1,5 @@
-from datetime import date
-
 import factory
+from django.utils import timezone
 
 from itou.communications.models import AnnouncementCampaign, AnnouncementItem
 
@@ -10,7 +9,7 @@ class AnnouncementCampaignFactory(factory.django.DjangoModelFactory):
         model = AnnouncementCampaign
         skip_postgeneration_save = True
 
-    start_date = factory.LazyFunction(lambda: date.today().replace(day=1))
+    start_date = factory.LazyFunction(lambda: timezone.localdate().replace(day=1))
 
     @factory.post_generation
     def with_item(obj, create, extracted, **kwargs):

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -72,7 +70,7 @@ class TestEligibilityDiagnosisManager:
         assert last_expired is None
 
     def test_expired_pole_emploi_diagnosis(self):
-        end_at = datetime.date.today() - relativedelta(years=2)
+        end_at = timezone.localdate() - relativedelta(years=2)
         start_at = end_at - relativedelta(years=2)
         PoleEmploiApprovalFactory(
             pole_emploi_id=self.job_seeker.jobseeker_profile.pole_emploi_id,

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -2,7 +2,7 @@ import datetime
 import functools
 import itertools
 import json
-from datetime import date, timedelta
+from datetime import timedelta
 from unittest import mock
 
 import pytest
@@ -595,7 +595,7 @@ class TestEmployeeRecordJobApplicationConstraints:
     def setUp(self, _mock):
         super().setUp()
         # Make job application cancellable
-        hiring_date = date.today() + timedelta(days=7)
+        hiring_date = timezone.localdate() + timedelta(days=7)
 
         self.job_application = JobApplicationWithCompleteJobSeekerProfileFactory(hiring_start_at=hiring_date)
         self.employee_record = EmployeeRecord.from_job_application(self.job_application)

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -903,7 +903,7 @@ class JobApplicationNotificationsTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             state=JobApplicationState.ACCEPTED,
-            hiring_start_at=datetime.date.today(),
+            hiring_start_at=timezone.localdate(),
         )
         accepted_by = job_application.to_company.members.first()
         email = job_application.email_manual_approval_delivery_required_notification(accepted_by)
@@ -930,7 +930,7 @@ class JobApplicationNotificationsTest(TestCase):
         job_application = JobApplicationFactory(
             sent_by_authorized_prescriber_organisation=True,
             state=JobApplicationState.ACCEPTED,
-            hiring_start_at=datetime.date.today(),
+            hiring_start_at=timezone.localdate(),
             hiring_end_at=None,
         )
         accepted_by = job_application.to_company.members.first()
@@ -1451,7 +1451,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         user = JobSeekerFactory(with_pole_emploi_id=True)
         # Ended 1 year ago.
-        end_at = datetime.date.today() - relativedelta(years=1)
+        end_at = timezone.localdate() - relativedelta(years=1)
         start_at = end_at - relativedelta(years=2)
         approval = PoleEmploiApprovalFactory(
             pole_emploi_id=user.jobseeker_profile.pole_emploi_id,
@@ -1494,7 +1494,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         user = JobSeekerFactory()
         # Ended 1 year ago.
-        end_at = datetime.date.today() - relativedelta(years=1)
+        end_at = timezone.localdate() - relativedelta(years=1)
         start_at = end_at - relativedelta(years=2)
         approval = PoleEmploiApprovalFactory(
             pole_emploi_id=user.jobseeker_profile.pole_emploi_id,
@@ -1518,7 +1518,7 @@ class JobApplicationWorkflowTest(TestCase):
         """
         user = JobSeekerFactory()
         # Ended 1 year ago.
-        end_at = datetime.date.today() - relativedelta(years=1)
+        end_at = timezone.localdate() - relativedelta(years=1)
         start_at = end_at - relativedelta(years=2)
         approval = PoleEmploiApprovalFactory(
             pole_emploi_id=user.jobseeker_profile.pole_emploi_id,
@@ -1671,7 +1671,7 @@ class JobApplicationWorkflowTest(TestCase):
         assert job_application.approval
 
     def test_cancellation_not_allowed(self, *args, **kwargs):
-        today = datetime.date.today()
+        today = timezone.localdate()
 
         # Linked employee record with blocking status
         job_application = JobApplicationFactory(with_approval=True, hiring_start_at=(today - relativedelta(days=365)))

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -50,7 +50,7 @@ from tests.users.factories import EmployerFactory, JobSeekerFactory, PrescriberF
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.usefixtures("metabase")
 def test_populate_analytics():
-    date_maj = datetime.date.today() + datetime.timedelta(days=-1)
+    date_maj = timezone.localdate() + datetime.timedelta(days=-1)
     data0 = DatumFactory(code="ER-101", bucket="2021-12-31")
     data1 = DatumFactory(code="ER-102", bucket="2020-10-17")
     data2 = DatumFactory(code="ER-102-3436", bucket="2022-08-16")
@@ -238,12 +238,12 @@ def test_populate_job_seekers():
             79,
             3,
             get_user_age_in_years(user_1),
-            datetime.date.today(),
+            timezone.localdate(),
             "par prescripteur",
             1,
             0,
-            datetime.date.today(),
-            datetime.date.today(),
+            timezone.localdate(),
+            timezone.localdate(),
             1,
             "33360",
             "33",
@@ -281,7 +281,7 @@ def test_populate_job_seekers():
             None,
             None,
             0,
-            datetime.date.today() - datetime.timedelta(days=1),
+            timezone.localdate() - datetime.timedelta(days=1),
         ),
         (
             user_2.pk,
@@ -290,7 +290,7 @@ def test_populate_job_seekers():
             71,
             4,
             get_user_age_in_years(user_2),
-            datetime.date.today(),
+            timezone.localdate(),
             "par employeur",
             0,
             1,
@@ -333,7 +333,7 @@ def test_populate_job_seekers():
             1,
             1,
             1,
-            datetime.date.today() - datetime.timedelta(days=1),
+            timezone.localdate() - datetime.timedelta(days=1),
         ),
         (
             user_3.pk,
@@ -342,7 +342,7 @@ def test_populate_job_seekers():
             97,
             1,
             get_user_age_in_years(user_3),
-            datetime.date.today(),
+            timezone.localdate(),
             "autonome",
             0,
             1,
@@ -385,7 +385,7 @@ def test_populate_job_seekers():
             0,
             0,
             0,
-            datetime.date.today() - datetime.timedelta(days=1),
+            timezone.localdate() - datetime.timedelta(days=1),
         ),
     ]
 

--- a/tests/www/apply/test_edit.py
+++ b/tests/www/apply/test_edit.py
@@ -27,7 +27,7 @@ class EditContractTest(TestCase):
         self.user2 = company_2.members.get(first_name="Roscoe")
 
         # JA with creation of a new approval
-        tomorrow = (timezone.now() + relativedelta(days=1)).date()
+        tomorrow = timezone.localdate() + relativedelta(days=1)
         self.job_application_1 = JobApplicationFactory(
             with_approval=True, to_company=company_1, hiring_start_at=tomorrow, approval__start_at=tomorrow
         )
@@ -66,8 +66,8 @@ class EditContractTest(TestCase):
 
         assert response.status_code == 200
 
-        future_start_date = (timezone.now() + relativedelta(days=10)).date()
-        future_end_date = (timezone.now() + relativedelta(days=15)).date()
+        future_start_date = timezone.localdate() + relativedelta(days=10)
+        future_end_date = timezone.localdate() + relativedelta(days=15)
 
         post_data = {
             "hiring_start_at": future_start_date.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -99,7 +99,7 @@ class EditContractTest(TestCase):
 
         assert response.status_code == 200
 
-        future_start_date = (timezone.now() + relativedelta(days=11)).date()
+        future_start_date = timezone.localdate() + relativedelta(days=11)
         future_end_date = None
 
         # empty "hiring_end_at"
@@ -145,7 +145,7 @@ class EditContractTest(TestCase):
 
         assert response.status_code == 200
 
-        future_start_date = (timezone.now() - relativedelta(days=10)).date()
+        future_start_date = timezone.localdate() - relativedelta(days=10)
 
         post_data = {
             "hiring_start_at": future_start_date.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -185,8 +185,8 @@ class EditContractTest(TestCase):
         self.client.force_login(self.user1)
         response = self.client.get(self.url)
 
-        future_start_date = (timezone.now() + relativedelta(days=20)).date()
-        future_end_date = (timezone.now() + relativedelta(days=60)).date()
+        future_start_date = timezone.localdate() + relativedelta(days=20)
+        future_end_date = timezone.localdate() + relativedelta(days=60)
 
         post_data = {
             "hiring_start_at": future_start_date.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
@@ -210,8 +210,8 @@ class EditContractTest(TestCase):
         self.client.force_login(self.user2)
         response = self.client.get(self.old_url)
 
-        future_start_date = (timezone.now() + relativedelta(days=5)).date()
-        future_end_date = (timezone.now() + relativedelta(days=60)).date()
+        future_start_date = timezone.localdate() + relativedelta(days=5)
+        future_end_date = timezone.localdate() + relativedelta(days=60)
 
         post_data = {
             "hiring_start_at": future_start_date.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -386,7 +386,7 @@ class TestApprovalDetailView:
 
     @override_settings(TALLY_URL="https://tally.so")
     def test_link_immersion_facile(self, client, snapshot):
-        today = datetime.date.today()
+        today = timezone.localdate()
         approval = ApprovalFactory(
             with_jobapplication=True,
             start_at=(today - datetime.timedelta(days=90)),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pas d’erreur en pratique, parce que django définit la variable d’environnement `TZ` [1] ce qui fait que Python se comporte dans la time zone définit par `settings.TIME_ZONE`. Mais ce mécanisme, assez bien caché et peu clair en intention, tombera en panne si on change la timezone (par exemple au moment du render d’un template).

[1] https://github.com/django/django/blob/cdcd604ef8f650533eff6bd63a517ebb4ffddf96/django/conf/__init__.py#L204
