### PR TITLE
Tableau de bord : Indiquer aux collaborateurs France Travail de contacter le support si l’adresse de leur agence est incorrecte [GEN-1919]

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -57,14 +57,24 @@
                 <br>
                 Cela peut affecter sa position dans les résultats de recherche.
                 <br>
-                {% if request.is_current_organization_admin %}
-                    <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
+                {% if request.current_organization.kind == PrescriberOrganizationKind.PE %}
+                    Afin de modifier l’adresse postale,
+                    <a href="{{ ITOU_HELP_CENTER_URL }}/requests/new"
+                       target="_blank"
+                       rel="noopener"
+                       aria-label="contactez-nous pour modifier l’adresse postale de votre agence France Travail (ouverture dans un nouvel onglet)">
+                        contactez nous
+                    </a>.
                 {% else %}
-                    {% with request.current_organization.active_admin_members.first as admin %}
-                        Veuillez contacter un de vos administrateurs (par exemple {{ admin.get_full_name }}) pour qu'il ou elle indique une autre adresse
-                    {% endwith %}
+                    {% if request.is_current_organization_admin %}
+                        <a href="{% url 'prescribers_views:edit_organization' %}">Indiquez une autre adresse</a>
+                    {% else %}
+                        {% with request.current_organization.active_admin_members.first as admin %}
+                            Veuillez contacter un de vos administrateurs (par exemple {{ admin.get_full_name }}) pour qu'il ou elle indique une autre adresse
+                        {% endwith %}
+                    {% endif %}
+                    ou <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
                 {% endif %}
-                ou <a href="{{ ITOU_HELP_CENTER_URL }}" target="_blank" rel="noopener" aria-label="Contactez-nous en cas de problème (ouverture dans un nouvel onglet)">contactez-nous</a> en cas de problème.
             </p>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
         </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les employés France Travail n’ont pas la possibilité de changer leur adresse en autonomie.

## :desert_island: Comment tester

1. ```sql
   UPDATE prescribers_prescriberorganization SET geocoding_score=0.001 WHERE kind='PE' and post_code='13200';
   ```
2. Se connecter en tant que prescripteur habilité

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/4d66d40b-2423-45c4-aaad-dd0f3ed2e2b3)
