### PR TITLE
Tableau de bord - Organisation : N'afficher le sous-menu des annexes financières que si il est utilisable

### DIFF
--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -29,9 +29,11 @@
                 <span class="badge badge-sm rounded-pill ms-2">{{ members_count }}</span>
             </a>
         </li>
-        <li class="nav-item">
-            <a class="nav-link" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
-        </li>
+        {% if can_show_financial_annexes %}
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
+            </li>
+        {% endif %}
     </ul>
 {% endblock %}
 

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -31,9 +31,11 @@
                 <span class="badge badge-sm rounded-pill ms-2">{{ siae.active_members.count }}</span>
             </a>
         </li>
-        <li class="nav-item">
-            <a class="nav-link" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
-        </li>
+        {% if can_show_financial_annexes %}
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'companies_views:show_financial_annexes' %}">Annexes financières</a>
+            </li>
+        {% endif %}
     </ul>
 {% endblock %}
 

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -242,6 +242,7 @@ def job_description_list(request, template_name="companies/job_description_list.
         "page": page,
         "breadcrumbs": breadcrumbs,
         "members_count": CompanyMembership.objects.filter(company_id=company.pk).active().count(),
+        "can_show_financial_annexes": company.convention_can_be_accessed_by(request.user),
         "back_url": reverse("dashboard:index"),
     }
     return render(request, template_name, context)
@@ -681,6 +682,7 @@ def members(request, template_name="companies/members.html"):
         "members_stats": active_company_members_stats,
         "pending_invitations": pending_invitations,
         "jobs_count": JobDescription.objects.filter(company_id=company.pk).count(),
+        "can_show_financial_annexes": company.convention_can_be_accessed_by(request.user),
         "back_url": reverse("dashboard:index"),
     }
     return render(request, template_name, context)

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -100,16 +100,17 @@ class JobDescriptionListViewTest(MessagesTestMixin, JobDescriptionAbstractTest):
         # 5.  SAVEPOINT
         # 6.  SELECT COUNT companies_jobdescription
         # 7.  SELECT COUNT companies_companymembership
-        # 8.  SELECT companies_siaeconvention (menu checks for financial annexes)
-        # 9.  SELECT EXISTS users_user (menu checks for active admin)
-        # 10. SELECT companies_jobdescription
-        # 11. SELECT jobs_appellation
-        # 12. SELECT jobs_rome
-        # 13. RELEASE SAVEPOINT
-        # 14. SAVEPOINT
-        # 15. UPDATE django_session
-        # 16. RELEASE SAVEPOINT
-        with self.assertNumQueries(16):
+        # 8.  SELECT EXISTS users_user (convention_can_be_accessed_by())
+        # 9.  SELECT companies_siaeconvention (menu checks for financial annexes)
+        # 10. SELECT EXISTS users_user (menu checks for active admin)
+        # 11. SELECT companies_jobdescription
+        # 12. SELECT jobs_appellation
+        # 13. SELECT jobs_rome
+        # 14. RELEASE SAVEPOINT
+        # 15. SAVEPOINT
+        # 16. UPDATE django_session
+        # 17. RELEASE SAVEPOINT
+        with self.assertNumQueries(17):
             response = self.client.get(self.url)
 
         assert self.company.job_description_through.count() == 4


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter une erreur évitable
![image](https://github.com/user-attachments/assets/7d71aeab-4a0f-4f19-8554-6a79e5f2e0dc)


## :desert_island: Comment tester

- Se connecter avec une EA/EATT
- Aller dans une des pages du bloc "Organisation"

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/e3870a41-feff-4396-bdb2-579c07f78af0)

