### PR TITLE
GPS : Toujours afficher l’encart conseiller emploi France Travail

### DIFF
--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -147,35 +147,40 @@
                                             <i class="text-disabled">Non renseigné</i>
                                         {% endif %}
                                     </li>
-                                    {% if profile.advisor_information %}
-                                        <li>
-                                            <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
-                                                <button class="c-info__summary collapsed" data-bs-toggle="collapse" data-bs-target="#collapseAdvisorInfoDetails" aria-expanded="false" aria-controls="collapseAdvisorInfoDetails" {% matomo_event "gps" "clic" "coordonnees-conseiller-{{ render_advisor_matomo_option|default:'ailleurs' }}" %}>
-                                                    <span>Voir les coordonnées du
-                                                        <br class="d-none d-md-inline">
-                                                    conseiller emploi France Travail</span>
-                                                </button>
-                                                <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
-                                                    {% if render_advisor_matomo_option %}
-                                                        <ul class="list-unstyled">
-                                                            <li>
-                                                                <i class="ri-user-line font-weight-normal me-1" aria-hidden="true"></i>{{ profile.advisor_information.name }}
-                                                            </li>
-                                                            <li>
-                                                                <i class="ri-mail-line font-weight-normal me-1" aria-hidden="true"></i>
-                                                                <a href="mailto:{{ profile.advisor_information.email }}" class="text-break text-decoration-none" aria-label="Contacter {{ profile.advisor_information.name }} par e-mail">{{ profile.advisor_information.email }}</a>
-                                                                {% include 'includes/copy_to_clipboard.html' with content=profile.advisor_information.email only_icon=True css_classes="btn-link font-weight-medium ms-1" %}
-                                                            </li>
-                                                        </ul>
-                                                    {% else %}
-                                                        <p class="mb-0">
-                                                            La fonctionnalité est en test dans deux départements et sera bientôt disponible pour votre territoire
-                                                        </p>
-                                                    {% endif %}
-                                                </div>
+                                    <li>
+                                        <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
+                                            <button class="c-info__summary collapsed"
+                                                    data-bs-toggle="collapse"
+                                                    data-bs-target="#collapseAdvisorInfoDetails"
+                                                    aria-expanded="false"
+                                                    aria-controls="collapseAdvisorInfoDetails"
+                                                    {% matomo_event "gps" "clic" matomo_option %}>
+                                                <span>Voir les coordonnées du
+                                                    <br class="d-none d-md-inline">
+                                                conseiller emploi France Travail</span>
+                                            </button>
+                                            <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
+                                                {% if profile.advisor_information and render_advisor_matomo_option %}
+                                                    <ul class="list-unstyled">
+                                                        <li>
+                                                            <i class="ri-user-line font-weight-normal me-1" aria-hidden="true"></i>{{ profile.advisor_information.name }}
+                                                        </li>
+                                                        <li>
+                                                            <i class="ri-mail-line font-weight-normal me-1" aria-hidden="true"></i>
+                                                            <a href="mailto:{{ profile.advisor_information.email }}" class="text-break text-decoration-none" aria-label="Contacter {{ profile.advisor_information.name }} par e-mail">{{ profile.advisor_information.email }}</a>
+                                                            {% include 'includes/copy_to_clipboard.html' with content=profile.advisor_information.email only_icon=True css_classes="btn-link font-weight-medium ms-1" %}
+                                                        </li>
+                                                    </ul>
+                                                {% elif render_advisor_matomo_option %}
+                                                    <p class="mb-0">Le conseiller emploi France Travail de ce bénéficiaire n’est pas connu.</p>
+                                                {% else %}
+                                                    <p class="mb-0">
+                                                        La fonctionnalité est en test dans deux départements et sera bientôt disponible pour votre territoire.
+                                                    </p>
+                                                {% endif %}
                                             </div>
-                                        </li>
-                                    {% endif %}
+                                        </div>
+                                    </li>
                                 </ul>
                             </div>
                         </div>

--- a/itou/www/users_views/views.py
+++ b/itou/www/users_views/views.py
@@ -48,15 +48,15 @@ class UserDetailsView(LoginRequiredMixin, DetailView):
         }
 
         org_department = self.request.current_organization.department
+        matomo_option = org_department if org_department in self.get_live_department_codes() else None
 
         context = context | {
             "breadcrumbs": breadcrumbs,
             "gps_memberships": gps_memberships,
             "matomo_custom_title": "Profil GPS",
             "profile": self.object.jobseeker_profile,
-            "render_advisor_matomo_option": org_department
-            if org_department in self.get_live_department_codes()
-            else None,
+            "render_advisor_matomo_option": matomo_option,
+            "matomo_option": "coordonnees-conseiller-" + (matomo_option if matomo_option else "ailleurs"),
         }
 
         return context

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -82,7 +82,22 @@
                                               <i class="text-disabled">Non renseigné</i>
                                           
                                       </li>
-                                      
+                                      <li>
+                                          <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
+                                              <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-ailleurs">
+                                                  <span>Voir les coordonnées du
+                                                      <br class="d-none d-md-inline"/>
+                                                  conseiller emploi France Travail</span>
+                                              </button>
+                                              <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
+                                                  
+                                                      <p class="mb-0">
+                                                          La fonctionnalité est en test dans deux départements et sera bientôt disponible pour votre territoire.
+                                                      </p>
+                                                  
+                                              </div>
+                                          </div>
+                                      </li>
                                   </ul>
                               </div>
                           </div>
@@ -154,48 +169,64 @@
 # name: test_contact_information_display[info_displayed]
   '''
   <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
-                                                  <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-{{ render_advisor_matomo_option|default:'ailleurs' }}">
-                                                      <span>Voir les coordonnées du
-                                                          <br class="d-none d-md-inline"/>
-                                                      conseiller emploi France Travail</span>
-                                                  </button>
-                                                  <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
-                                                      
-                                                          <ul class="list-unstyled">
-                                                              <li>
-                                                                  <i aria-hidden="true" class="ri-user-line font-weight-normal me-1"></i>Test MacTest
-                                                              </li>
-                                                              <li>
-                                                                  <i aria-hidden="true" class="ri-mail-line font-weight-normal me-1"></i>
-                                                                  <a aria-label="Contacter Test MacTest par e-mail" class="text-break text-decoration-none" href="mailto:test.mactest@francetravail.fr">test.mactest@francetravail.fr</a>
-                                                                  <button class="btn-link font-weight-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="test.mactest@francetravail.fr" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_phone">
+                                              <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-30">
+                                                  <span>Voir les coordonnées du
+                                                      <br class="d-none d-md-inline"/>
+                                                  conseiller emploi France Travail</span>
+                                              </button>
+                                              <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
+                                                  
+                                                      <ul class="list-unstyled">
+                                                          <li>
+                                                              <i aria-hidden="true" class="ri-user-line font-weight-normal me-1"></i>Test MacTest
+                                                          </li>
+                                                          <li>
+                                                              <i aria-hidden="true" class="ri-mail-line font-weight-normal me-1"></i>
+                                                              <a aria-label="Contacter Test MacTest par e-mail" class="text-break text-decoration-none" href="mailto:test.mactest@francetravail.fr">test.mactest@francetravail.fr</a>
+                                                              <button class="btn-link font-weight-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="test.mactest@francetravail.fr" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="copied_user_phone">
       <i aria-hidden="true" class="ri-file-copy-line ri-lg font-weight-normal"></i>
       <span class="visually-hidden">Copier</span>
   </button>
   
-                                                              </li>
-                                                          </ul>
-                                                      
-                                                  </div>
+                                                          </li>
+                                                      </ul>
+                                                  
                                               </div>
+                                          </div>
+  '''
+# ---
+# name: test_contact_information_display[info_not_available]
+  '''
+  <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
+                                              <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-30">
+                                                  <span>Voir les coordonnées du
+                                                      <br class="d-none d-md-inline"/>
+                                                  conseiller emploi France Travail</span>
+                                              </button>
+                                              <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
+                                                  
+                                                      <p class="mb-0">Le conseiller emploi France Travail de ce bénéficiaire n’est pas connu.</p>
+                                                  
+                                              </div>
+                                          </div>
   '''
 # ---
 # name: test_contact_information_display_not_live[preview_displayed]
   '''
   <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
-                                                  <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-{{ render_advisor_matomo_option|default:'ailleurs' }}">
-                                                      <span>Voir les coordonnées du
-                                                          <br class="d-none d-md-inline"/>
-                                                      conseiller emploi France Travail</span>
-                                                  </button>
-                                                  <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
-                                                      
-                                                          <p class="mb-0">
-                                                              La fonctionnalité est en test dans deux départements et sera bientôt disponible pour votre territoire
-                                                          </p>
-                                                      
-                                                  </div>
+                                              <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-ailleurs">
+                                                  <span>Voir les coordonnées du
+                                                      <br class="d-none d-md-inline"/>
+                                                  conseiller emploi France Travail</span>
+                                              </button>
+                                              <div class="c-info__detail collapse" id="collapseAdvisorInfoDetails">
+                                                  
+                                                      <p class="mb-0">
+                                                          La fonctionnalité est en test dans deux départements et sera bientôt disponible pour votre territoire.
+                                                      </p>
+                                                  
                                               </div>
+                                          </div>
   '''
 # ---
 # name: test_dashboard_card

--- a/tests/gps/test_views.py
+++ b/tests/gps/test_views.py
@@ -420,7 +420,9 @@ def test_contact_information_display(client, snapshot):
     response = client.get(user_details_url)
     assert response.status_code == 200
     assert response.context["render_advisor_matomo_option"] == "30"
-    assert len(parse_response_to_soup(response).select("#advisor-info-details-collapsable")) == 0
+    assert str(parse_response_to_soup(response, selector="#advisor-info-details-collapsable")) == snapshot(
+        name="info_not_available"
+    )
 
     # contact information to display
     FranceTravailContact.objects.create(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faire la pub de cet encart à tous les utilisateurs.

## :computer: Captures d'écran <!-- optionnel -->

### Info conseiller emploi FT et dans le Gard
![image](https://github.com/user-attachments/assets/5c03c5ad-ffa1-48fd-ae4b-15d2503fa094)

### Pas d’info conseiller emplois et dans le Gard
![image](https://github.com/user-attachments/assets/04f6e768-992c-4c6c-a5d7-28cb819b5284)

### Hors du Gard et de la Meuse
![image](https://github.com/user-attachments/assets/3ab08346-ccc4-4665-9dc4-ed9795599594)

