### PR TITLE
UX/UI : Rajouter l’entrée « Rechercher » dans le menu en mode connecté

### DIFF
--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load static %}
+{% load str_filters %}
 
 {% block title %}
     {% include "search/includes/prescribers_search_title.html" with city=city distance=distance only %}
@@ -29,7 +30,7 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="col-12">
-                    <h2 class="mb-3 mb-md-4">Prescripteurs</h2>
+                    <h2 class="mb-3 mb-md-4">Prescripteur{{ prescriber_orgs_page.paginator.count|pluralizefr }}</h2>
                     <div class="d-block w-100">
                         <form hx-get="{% url 'search:prescribers_results' %}"
                               hx-trigger="change delay:.5s"

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -13,10 +13,6 @@
     <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
 {% endblock %}
 
-{% block title_prevstep %}
-    {% include "layout/previous_step.html" with back_url=back_url only %}
-{% endblock %}
-
 {% block title_content %}<h1>Rechercher des prescripteurs habilités</h1>{% endblock %}
 
 {% block title_extra %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -7,10 +7,6 @@
     {{ block.super }}
 {% endblock %}
 
-{% block title_prevstep %}
-    {% include "layout/previous_step.html" with back_url=back_url only %}
-{% endblock %}
-
 {% block title_content %}<h1>Rechercher un emploi inclusif</h1>{% endblock %}
 
 {% block title_extra %}

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -70,6 +70,20 @@ NAV_ENTRIES = {
         target=reverse("home:hp"),
         active_view_names=["dashboard:index"],
     ),
+    "employers-search": NavItem(
+        label="Un emploi inclusif",
+        target=reverse("search:employers_results"),
+        active_view_names=[
+            "search:employers_home",
+            "search:employers_results",
+            "search:job_descriptions_results",
+        ],
+    ),
+    "prescribers-search": NavItem(
+        label="Un prescripteur habilité",
+        target=reverse("search:prescribers_results"),
+        active_view_names=["search:prescribers_home", "search:prescribers_results"],
+    ),
     # Job seekers.
     "job-seeker-job-apps": NavItem(
         label="Mes candidatures",
@@ -202,6 +216,16 @@ def nav(request):
                     items=[NAV_ENTRIES["labor-inspector-members"]],
                 )
             )
+        menu_items.append(
+            NavGroup(
+                label="Rechercher",
+                icon="ri-search-line",
+                items=[
+                    NAV_ENTRIES["employers-search"],
+                    NAV_ENTRIES["prescribers-search"],
+                ],
+            )
+        )
 
         if request.resolver_match:
             for group_or_item in menu_items:

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -471,7 +471,7 @@ class TestSearchPrescriber:
         PrescriberOrganizationFactory(authorized=True, coords=guerande.coords)
         PrescriberOrganizationFactory(authorized=True, coords=vannes.coords)
 
-        response = client.get(url, {"city": guerande.slug, "distance": 10})
+        response = client.get(url, {"city": guerande.slug, "distance": 50})
         simulated_page = parse_response_to_soup(response)
 
         def distance_radio(distance):
@@ -479,7 +479,7 @@ class TestSearchPrescriber:
             return elt
 
         distance_radio(100)["checked"] = ""
-        del distance_radio(10)["checked"]
+        del distance_radio(50)["checked"]
         response = client.get(url, {"city": guerande.slug, "distance": 100}, headers={"HX-Request": "true"})
         update_page_with_htmx(simulated_page, f"form[hx-get='{url}']", response)
         response = client.get(url, {"city": guerande.slug, "distance": 100})

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -17,7 +17,7 @@ from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.prescribers.factories import PrescriberOrganizationFactory
 from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
-from tests.utils.test import BASE_NUM_QUERIES, assert_previous_step, parse_response_to_soup
+from tests.utils.test import BASE_NUM_QUERIES, parse_response_to_soup
 
 
 DISTRICTS = "Arrondissements de Paris"
@@ -352,7 +352,6 @@ class TestSearchCompany:
             html=True,
             count=1,
         )
-        assert_previous_step(response, reverse("search:employers_home"))
 
         # Has link to company card with back_url
         company_url = (
@@ -437,7 +436,6 @@ class TestSearchPrescriber:
 
         response = client.get(url, {"city": guerande.slug, "distance": 100})
         assertContains(response, "2 résultats")
-        assert_previous_step(response, reverse("search:prescribers_home"))
 
         # Has link to organization card with back_url
         organization_url = f"{organization_1.get_card_url()}?back_url={urlencode_filter(url)}"


### PR DESCRIPTION
## :thinking: Pourquoi ?

La recherche prescripteurs manque aux utilisateurs.

## :desert_island: Comment tester

1. Se connecter
2. Vérifier que l’entrée est bien présente dans le menu, et qu’elle s’active lors de la navigation sur ces pages.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/98f1166e-0a44-4eeb-9bfb-157ec9a73b6a)

![image](https://github.com/user-attachments/assets/8a8e06fb-9d62-4861-9bd9-d62d56ff6bc4)

![image](https://github.com/user-attachments/assets/bf9d92c3-7a0d-48ba-8ce4-ac24a2e6c573)

![image](https://github.com/user-attachments/assets/6d5946c0-1e8d-4275-b152-c8aa818264b9)