### PR TITLE
[GEN-1937] Connexion: Empêcher l'écrasement des comptes France Travail (courriels dupliqués)

### DIFF
--- a/itou/templates/django_bootstrap5/messages.html
+++ b/itou/templates/django_bootstrap5/messages.html
@@ -1,6 +1,6 @@
 {% load i18n django_bootstrap5 %}
 {% for message in messages %}
-    {% if "toast" not in message.tags %}
+    {% if "toast" not in message.tags and "modal" not in message.tags %}
         <div class="alert alert-{{ message|bootstrap_message_alert_type }} alert-dismissible fade show" role="alert">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans 'close' %}"></button>
             {{ message }}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -264,6 +264,8 @@
             {% include "layout/_news_modal.html" %}
         {% endif %}
 
-        {% block modals %}{% endblock %}
+        {% block modals %}
+            {% include "utils/modals.html" %}
+        {% endblock %}
     </body>
 </html>

--- a/itou/templates/utils/modal_includes/france_travail_registration_failure.html
+++ b/itou/templates/utils/modal_includes/france_travail_registration_failure.html
@@ -1,0 +1,23 @@
+{% load static %}
+{% load theme_inclusion %}
+{% load django_bootstrap5 %}
+
+<div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+        <div class="modal-header">
+            <h3 class="modal-title text-danger" id="message-modal-{{ forloop.counter }}-label">
+                <i class="ri-xl ri-alert-line"></i>
+                L'inscription a échoué
+            </h3>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+        </div>
+        <div class="row modal-body">
+            <h2 class="h4">L'inscription via France Travail a échoué</h2>
+            <p>{{ message }}</p>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn" data-bs-dismiss="modal">Retour</button>
+            <a href="{% url 'signup:job_seeker' %}" class="btn btn-primary">Inscription</a>
+        </div>
+    </div>
+</div>

--- a/itou/templates/utils/modals.html
+++ b/itou/templates/utils/modals.html
@@ -1,0 +1,19 @@
+{% load static %}
+{% load theme_inclusion %}
+{% load django_bootstrap5 %}
+
+{% for message in messages %}
+    {% if "modal" in message.extra_tags %}
+        <div class="modal fade" id="message-modal-{{ forloop.counter }}" data-bs-backdrop="static" tabindex="-1" role="dialog" aria-labelledby="message-modal-{{ forloop.counter }}-label" aria-modal="true">
+            {% if "france_travail_registration_failure" in message.extra_tags %}
+                {% include "utils/modal_includes/france_travail_registration_failure.html" %}
+            {% endif %}
+        </div>
+
+        <script nonce="{{ CSP_NONCE }}">
+            window.onload = function() {
+                new bootstrap.Modal(document.getElementById("message-modal-{{ forloop.counter }}")).show();
+            };
+        </script>
+    {% endif %}
+{% endfor %}

--- a/itou/utils/templatetags/str_filters.py
+++ b/itou/utils/templatetags/str_filters.py
@@ -32,8 +32,8 @@ def pluralizefr(value, arg="s"):
 
 @register.filter(is_safe=True)
 @defaultfilters.stringfilter
-def mask_unless(value, predicate):
+def mask_unless(value, predicate, mask_function=(lambda x: x[0] + "…")):
     if predicate:
         return value
 
-    return " ".join(part[0] + "…" for part in re.split(f"[{re.escape(string.whitespace)}]+", value) if part)
+    return " ".join(mask_function(part) for part in re.split(f"[{re.escape(string.whitespace)}]+", value) if part)

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -661,6 +661,29 @@ class ModelTest(TestCase):
 
         assert len(JobSeekerFactory(first_name=too_long_name, last_name="maréchal").get_full_name()) == 70
 
+    def test_get_redacted_full_name(self):
+        user = JobSeekerFactory(first_name="", last_name="Bach")
+
+        def override_full_name(full_name):
+            names = full_name.split(" ")
+            user.first_name = " ".join(names[:-1]) if len(names) > 1 else names[0]
+            user.last_name = names[-1] if len(names) > 1 else ""
+
+        test_names = [
+            ("Johan Sebastian Bach", "J***n S*******n B**h"),
+            ("Max Weber", "M** W***r"),
+            ("Charlemagne", "C*********e"),
+            ("Salvador Felipe Jacinto Dalí y Domenech", "S******r F****e J*****o D**í Y D******h"),
+            ("Harald Blue-tooth", "H****d B********h"),
+            ("Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch", "L**********h"),
+            ("Max", "M**"),
+            ("", ""),
+        ]
+
+        for name, expected_output in test_names:
+            override_full_name(name)
+            assert user.get_redacted_full_name() == expected_output
+
 
 class JobSeekerProfileModelTest(TestCase):
     def setUp(self):

--- a/tests/www/invitations_views/test_company_accept.py
+++ b/tests/www/invitations_views/test_company_accept.py
@@ -169,7 +169,11 @@ class TestAcceptInvitation(MessagesTestMixin, InclusionConnectBaseTestCase):
     @respx.mock
     def test_accept_existing_user_not_logged_in_using_IC(self):
         invitation = SentEmployerInvitationFactory(email=OIDC_USERINFO["email"])
-        user = EmployerFactory(email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True)
+        user = EmployerFactory(
+            username=OIDC_USERINFO["sub"],
+            email=OIDC_USERINFO["email"],
+            has_completed_welcoming_tour=True,
+        )
         response = self.client.get(invitation.acceptance_link, follow=True)
         assert reverse("login:employer") in response.wsgi_request.get_full_path()
         assert not invitation.accepted

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -409,7 +409,11 @@ class TestAcceptPrescriberWithOrgInvitation(MessagesTestMixin, InclusionConnectB
     @respx.mock
     def test_accept_existing_user_not_logged_in_using_IC(self):
         invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
-        user = PrescriberFactory(email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True)
+        user = PrescriberFactory(
+            username=OIDC_USERINFO["sub"],
+            email=OIDC_USERINFO["email"],
+            has_completed_welcoming_tour=True,
+        )
         # The user verified its email
         EmailAddress(user_id=user.pk, email=user.email, verified=True, primary=True).save()
         invitation = PrescriberWithOrgSentInvitationFactory(

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -737,7 +737,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         He will be logged in instead as if he just used the login through IC button
         """
         #### User is a prescriber. Update it and connect. ####
-        PrescriberFactory(email=OIDC_USERINFO["email"])
+        PrescriberFactory(email=OIDC_USERINFO["email"], username=OIDC_USERINFO["sub"])
         self.client.get(reverse("signup:prescriber_check_already_exists"))
 
         # Step 2: register as a simple prescriber (orienteur).
@@ -772,7 +772,7 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         We should update his account and make him join this new organization.
         """
         org = PrescriberOrganizationFactory.build(kind=PrescriberOrganizationKind.OTHER)
-        user = PrescriberFactory(email=OIDC_USERINFO["email"])
+        user = PrescriberFactory(email=OIDC_USERINFO["email"], username=OIDC_USERINFO["sub"])
 
         self.client.get(reverse("signup:prescriber_check_already_exists"))
 
@@ -886,7 +886,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         The user is still created and can try again.
         """
         org = PrescriberOrganizationFactory(kind=PrescriberOrganizationKind.OTHER)
-        user = PrescriberFactory(email=OIDC_USERINFO["email"])
+        user = PrescriberFactory(email=OIDC_USERINFO["email"], username=OIDC_USERINFO["sub"])
 
         self.client.get(reverse("signup:prescriber_check_already_exists"))
 
@@ -958,7 +958,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         The user is still created and can try again.
         """
         org = PrescriberOrganizationFactory(kind=PrescriberOrganizationKind.OTHER)
-        EmployerFactory(email=OIDC_USERINFO["email"], with_company=True)
+        EmployerFactory(email=OIDC_USERINFO["email"], username=OIDC_USERINFO["sub"], with_company=True)
 
         response = self.client.get(reverse("signup:prescriber_check_already_exists"))
         assert response.status_code == 200
@@ -1034,7 +1034,7 @@ class InclusionConnectPrescribersViewsExceptionsTest(MessagesTestMixin, Inclusio
         Raise an exception.
         """
         org = PrescriberOrganizationFactory.build(kind=PrescriberOrganizationKind.OTHER)
-        user = EmployerFactory(email=OIDC_USERINFO["email"])
+        user = EmployerFactory(email=OIDC_USERINFO["email"], username=OIDC_USERINFO["sub"])
         self.client.get(reverse("signup:prescriber_check_already_exists"))
 
         session_signup_data = self.client.session.get(global_constants.ITOU_SESSION_PRESCRIBER_SIGNUP_KEY)

--- a/tests/www/signup/test_siae.py
+++ b/tests/www/signup/test_siae.py
@@ -127,7 +127,9 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
         company = CompanyFactory(kind=CompanyKind.ETTI)
         assert 0 == company.members.count()
 
-        user = EmployerFactory(email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True)
+        user = EmployerFactory(
+            username=OIDC_USERINFO["sub"], email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True
+        )
         CompanyMembershipFactory(user=user)
         assert 1 == user.company_set.count()
 
@@ -170,7 +172,9 @@ class CompanySignupTest(MessagesTestMixin, InclusionConnectBaseTestCase):
         """
         company = CompanyFactory(kind=CompanyKind.ETTI)
 
-        user = EmployerFactory(email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True)
+        user = EmployerFactory(
+            username=OIDC_USERINFO["sub"], email=OIDC_USERINFO["email"], has_completed_welcoming_tour=True
+        )
         CompanyMembershipFactory(user=user)
 
         magic_link = company.signup_magic_link


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le SSO permet l’existence de plusieurs comptes avec le même email, ce qui fait qu’à chaque connexion depuis un compte ou un autre attaché au même email, on va écraser les données.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran <!-- optionnel -->

<img width="792" alt="Screenshot 2024-08-29 at 18 15 06" src="https://github.com/user-attachments/assets/6f4d27d9-9b7f-4c5e-b766-b7f96f07d04a">
