### PR TITLE
GEIQ: correctif du champs "Commune de naissance" à l'acceptation d'une candidature

### DIFF
--- a/itou/asp/forms.py
+++ b/itou/asp/forms.py
@@ -5,7 +5,8 @@ from itou.asp.models import Commune, Country
 from itou.utils.widgets import RemoteAutocompleteSelect2Widget
 
 
-def formfield_for_birth_place(**kwargs):
+def formfield_for_birth_place(*, with_birthdate_field, **kwargs):
+    with_birthdate_attr = {"data-select2-link-with-birthdate": "id_birthdate"} if with_birthdate_field else {}
     france = Country.objects.get(code=Country._CODE_FRANCE)
     return forms.ModelChoiceField(
         queryset=Commune.objects,
@@ -24,8 +25,8 @@ def formfield_for_birth_place(**kwargs):
                 "data-placeholder": "Nom de la commune",
                 "data-disable-target": "#id_birth_country",
                 "data-target-value": f"{france.pk}",
-                "data-select2-link-with-birthdate": "id_birthdate",
-            },
+                **with_birthdate_attr,
+            }
         ),
         **kwargs,
     )

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -897,9 +897,10 @@ class CertifiedCriteriaInfoRequiredForm(forms.ModelForm):
         model = JobSeekerProfile
         fields = ("birth_place", "birth_country")
 
-    def __init__(self, birthdate, *args, **kwargs):
+    def __init__(self, birthdate, *args, with_birthdate_field, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["birth_place"] = formfield_for_birth_place()
+        # with_birthdate_field indicates if JS is needed to link birthdate & birth_place fields
+        self.fields["birth_place"] = formfield_for_birth_place(with_birthdate_field=with_birthdate_field)
         self.birthdate = birthdate
 
     def clean(self):

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -68,7 +68,10 @@ def _accept(request, siae, job_seeker, error_url, back_url, template_name, extra
 
     if valid_diagnosis and valid_diagnosis.criteria_can_be_certified():
         form_certified_criteria = CertifiedCriteriaInfoRequiredForm(
-            instance=job_seeker.jobseeker_profile, birthdate=birthdate, data=request.POST or None
+            instance=job_seeker.jobseeker_profile,
+            birthdate=birthdate,
+            data=request.POST or None,
+            with_birthdate_field=form_personal_data is not None,
         )
         forms.append(form_certified_criteria)
 

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -130,7 +130,7 @@ class NewEmployeeRecordStep1Form(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.fields["birth_place"] = formfield_for_birth_place()
+        self.fields["birth_place"] = formfield_for_birth_place(with_birthdate_field=True)
 
         for field_name in self.REQUIRED_FIELDS:
             self.fields[field_name].required = True

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -426,7 +426,9 @@ class CertifiedCriteriaInfoRequiredFormTest(TestCase):
             "birth_country": job_seeker.jobseeker_profile.birth_country.id,
             "birth_place": job_seeker.jobseeker_profile.birth_place.id,
         }
-        form = apply_forms.CertifiedCriteriaInfoRequiredForm(data=form_data, birthdate=valid_birthdate)
+        form = apply_forms.CertifiedCriteriaInfoRequiredForm(
+            data=form_data, birthdate=valid_birthdate, with_birthdate_field=False
+        )
         assert form.is_valid()
 
     def test_submit_commune_invalid_commune_lookup(self):
@@ -445,7 +447,9 @@ class CertifiedCriteriaInfoRequiredFormTest(TestCase):
             "birth_country": job_seeker.jobseeker_profile.birth_country.id,
             "birth_place": birth_place.id,
         }
-        form = apply_forms.CertifiedCriteriaInfoRequiredForm(data=form_data, birthdate=early_date)
+        form = apply_forms.CertifiedCriteriaInfoRequiredForm(
+            data=form_data, birthdate=early_date, with_birthdate_field=False
+        )
         assert not form.is_valid()
 
         expected_msg = (


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite de #4590 et de https://itou-inclusion.slack.com/archives/C01181Y04LT/p1725009789547099

Pour les GEIQ, le formulaire d'acceptation ne contient pas la date de naissance ce qui causait une erreur JS (`TypeError: birthdatePicker is null`) ici:
https://github.com/gip-inclusion/les-emplois/blob/73fa8368a884f06c71c87ff19d9d68b354d2a49d/itou/static/js/utils.js#L147

rendant le champs inutilisable (et empêchant l'acceptation d'une candidature).

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
