### PR TITLE
Admin : Permettre la modification des champs des e-mails

### DIFF
--- a/itou/emails/migrations/0001_initial.py
+++ b/itou/emails/migrations/0001_initial.py
@@ -20,6 +20,7 @@ class Migration(migrations.Migration):
                     "to",
                     django.contrib.postgres.fields.ArrayField(
                         base_field=citext.CIEmailField(max_length=254),
+                        blank=True,
                         size=None,
                         verbose_name="à",
                     ),
@@ -28,6 +29,7 @@ class Migration(migrations.Migration):
                     "cc",
                     django.contrib.postgres.fields.ArrayField(
                         base_field=citext.CIEmailField(max_length=254),
+                        blank=True,
                         default=list,
                         size=None,
                         verbose_name="cc",
@@ -37,18 +39,20 @@ class Migration(migrations.Migration):
                     "bcc",
                     django.contrib.postgres.fields.ArrayField(
                         base_field=citext.CIEmailField(max_length=254),
+                        blank=True,
                         default=list,
                         size=None,
                         verbose_name="cci",
                     ),
                 ),
-                ("subject", models.TextField(verbose_name="sujet")),
-                ("body_text", models.TextField(verbose_name="message")),
+                ("subject", models.TextField(blank=True, verbose_name="sujet")),
+                ("body_text", models.TextField(blank=True, verbose_name="message")),
                 ("from_email", citext.CIEmailField(max_length=254, verbose_name="de")),
                 (
                     "reply_to",
                     django.contrib.postgres.fields.ArrayField(
                         base_field=citext.CIEmailField(max_length=254),
+                        blank=True,
                         default=list,
                         size=None,
                         verbose_name="répondre à",

--- a/itou/emails/models.py
+++ b/itou/emails/models.py
@@ -6,13 +6,13 @@ from django.utils import timezone
 
 
 class Email(models.Model):
-    to = ArrayField(CIEmailField(), verbose_name="à")
-    cc = ArrayField(CIEmailField(), default=list, verbose_name="cc")
-    bcc = ArrayField(CIEmailField(), default=list, verbose_name="cci")
-    subject = models.TextField(verbose_name="sujet")
-    body_text = models.TextField(verbose_name="message")
+    to = ArrayField(CIEmailField(), blank=True, verbose_name="à")
+    cc = ArrayField(CIEmailField(), blank=True, default=list, verbose_name="cc")
+    bcc = ArrayField(CIEmailField(), blank=True, default=list, verbose_name="cci")
+    subject = models.TextField(verbose_name="sujet", blank=True)
+    body_text = models.TextField(verbose_name="message", blank=True)
     from_email = CIEmailField(verbose_name="de")
-    reply_to = ArrayField(CIEmailField(), default=list, verbose_name="répondre à")
+    reply_to = ArrayField(CIEmailField(), blank=True, default=list, verbose_name="répondre à")
     created_at = models.DateTimeField(default=timezone.now, db_index=True, verbose_name="demande d’envoi à")
     esp_response = models.JSONField(null=True, verbose_name="réponse du fournisseur d’e-mail")
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Permettre au support de corriger les typos évidentes.

https://itou.sentry.io/issues/5490570470/
