### PR TITLE
tests: Définir la variable boost pour la pagination

### DIFF
--- a/itou/templates/includes/pagination.html
+++ b/itou/templates/includes/pagination.html
@@ -8,10 +8,11 @@
 {% if page.display_pager %}
     {% with request.get_full_path as url %}
         <nav role="navigation"
-             aria-label="Pagination"
-             {% if boost %}hx-boost="true"{% endif %}
-             {% if boost_target %}hx-target="{{ boost_target }}"{% endif %}
-             {% if boost_indicator %}hx-indicator="{{ boost_indicator }}"{% endif %}>
+            aria-label="Pagination"
+            {% if boost|default:False %}hx-boost="true"{% endif %}
+            {# Don’t specify a default for boost_target and boost_indicator, keeping them required when boost. #}
+            {% if boost|default:False or boost_target %}hx-target="{{ boost_target }}"{% endif %}
+            {% if boost|default:False or boost_indicator %}hx-indicator="{{ boost_indicator }}"{% endif %}>
             {# Pagination is not responsive by default https://github.com/twbs/bootstrap/issues/23504 #}
             <ul class="pagination flex-wrap justify-content-center">
                 {# First page. #}

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -1,6 +1,5 @@
 import datetime
 
-import pytest
 from dateutil.relativedelta import relativedelta
 from django.template.defaultfilters import urlencode
 from django.urls import reverse
@@ -302,7 +301,6 @@ class TestApprovalsListView:
         response = client.get(url)
         assertContains(response, "0 résultat")
 
-    @pytest.mark.ignore_unknown_variable_template_error("boost", "boost_target", "boost_indicator")
     def test_approval_expiry_filter_default(self, client):
         company = CompanyFactory(with_membership=True)
         # Make sure we have access to page 2


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de gérer des variables inconnues lors du rendu du template.
