### PR TITLE
Demandeur d’emploi: Mettre à jour le conseiller FT toutes les 15 minutes

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -26,6 +26,7 @@
 
   "25 8-18/2 * * 1-5 $ROOT/clevercloud/transfer_employee_records.sh --download",
   "55 8-18/2 * * 1-5 $ROOT/clevercloud/transfer_employee_records.sh --upload",
+  "*/15 6-16 * * 1-5 $ROOT/clevercloud/run_management_command.sh import_advisor_information shared_bucket/imports-gps/export_gps.xlsx --wet-run",
 
   "0 0 * * 1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
   "0 2 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dès un nouveau candidat s'inscrit sur la plateforme, on veut que son conseiller est mis à jour avec les meilleurs de délais

## :cake: Comment ?

Avec une tâche cron de chaque 15 minutes, pendant les heures de travail

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?