### PR TITLE
UX/UI: Ajout du bouton "Imprimer” sur la page de détail Candidat

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -21,6 +21,13 @@
             {% endif %}
         </h1>
         {% state_badge job_application extra_class="badge-base" %}
+        <button class="btn btn-lg btn-ico-only btn-link"
+                type="button"
+                data-it-action="print"
+                {% matomo_event "candidature" "click" "impression-fiche-candidature" %}
+                aria-label="Imprimer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
+            <i class="ri-printer-line font-weight-normal" aria-hidden="true"></i>
+        </button>
     </div>
     {% block actions %}{% endblock %}
 {% endblock %}

--- a/itou/templates/approvals/printable_approval.html
+++ b/itou/templates/approvals/printable_approval.html
@@ -9,12 +9,6 @@
 
 {% block content %}
     <div class="container py-4 px-5">
-        <div class="row">
-            <div class="col-sm-3 offset-sm-3 text-end">
-                <img src="{% static 'img/pdf/logoMinTravail.png' %}" class="w-75" alt="Logo du Ministère du travail, de l'emploi et de l'insertion">
-            </div>
-        </div>
-
         <section class="mt-5">
             <span class="d-block font-weight-bold">Votre contact en direct :</span>
             <a target="_blank" href="{{ itou_help_center_url }}" class="d-block text-decoration">{{ itou_help_center_url }}</a>
@@ -36,7 +30,6 @@
                             {{ siae.post_code }} - {{ siae.city }}
                         </address>
                     {% endif %}
-                    <p class="my-4 text-justify">Paris, le {% now "d F Y" %}</p>
                 </div>
             </div>
         </section>
@@ -54,25 +47,19 @@
         </section>
 
         <section class="mt-5">
-            <h1 class="ff-base fs-base">
+            <p>
                 Objet : <b>Décision d'agrément pour un parcours d'insertion par l'activité économique</b>
-            </h1>
+            </p>
         </section>
         <section class="mt-5">
             <p class="text-justify">
                 {% if diagnosis_author %}
                     Au vu du diagnostic individuel réalisé par {{ diagnosis_author|title }}
-
                     {% if diagnosis_author_org_name %}({{ diagnosis_author_org_name|title }}){% endif %}
-
                     portant sur
-
                 {% else %}
-
                     Au vu de
-
                 {% endif %}
-
                 la situation sociale et professionnelle de {{ approval.user.get_full_name }}
                 et de votre promesse d'embauche, les emplois de l'inclusion vous délivrent
                 un PASS IAE pour un parcours d'insertion par l'activité économique,
@@ -87,20 +74,11 @@
 
         <div class="row justify-content-center d-print-none">
             <div class="mt-5 mb-2">
-                <button id="printButton" class="btn btn-primary btn-primary-lg btn-ico" aria-label="Imprimer le PASS IAE de {{ approval.user.get_full_name }}">
-                    <i class="ri-printer-line ri-xl" aria-hidden="true"></i>
+                <button class="btn btn-primary btn-ico" type="button" data-it-action="print" aria-label="Imprimer le PASS IAE de {{ approval.user.get_full_name }}">
+                    <i class="ri-printer-line" aria-hidden="true"></i>
                     <span>Imprimer ce PASS IAE</span>
                 </button>
             </div>
         </div>
     </div>
 {% endblock %}
-
-{% block script %}
-    {{ block.super }}
-    <script nonce="{{ CSP_NONCE }}">
-        document.getElementById("printButton").addEventListener("click", function print() {
-            window.print();
-        });
-    </script>
-{% endblock script %}

--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -3,6 +3,7 @@
 {% load theme_inclusion %}
 
 <header role="banner" id="header">
+    {% include "layout/_header_print.html" %}
     <section class="s-header">
         <div class="s-header__container container">
             <div class="s-header__row row">

--- a/itou/templates/layout/_header_authenticated.html
+++ b/itou/templates/layout/_header_authenticated.html
@@ -5,6 +5,7 @@
 {% load theme_inclusion %}
 
 <header role="banner" id="header">
+    {% include "layout/_header_print.html" %}
     <section class="s-header-authenticated">
         <div class="s-header-authenticated__container container">
             <div class="s-header-authenticated__row row">

--- a/itou/templates/layout/_header_print.html
+++ b/itou/templates/layout/_header_print.html
@@ -1,0 +1,15 @@
+{% load theme_inclusion %}
+
+<section class="s-header-print">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-auto d-flex align-items-center py-2">
+                <img src="{% static_theme_images 'logo-republique-francaise.svg' %}" height="70" alt="République Française">
+            </div>
+            <div class="col d-flex align-items-center">
+                <img src="{% static_theme_images 'logo-emploi-inclusion.svg' %}" height="60" alt="Les emplois de l'inclusion">
+            </div>
+            <div class="col-auto d-flex align-items-center fs-sm d-none d-print-inline-flex">Imprimé le {% now "d F Y" %}</div>
+        </div>
+    </div>
+</section>

--- a/itou/templates/layout/base_printable.html
+++ b/itou/templates/layout/base_printable.html
@@ -14,22 +14,20 @@
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}">
         <link rel="stylesheet" href="{% static 'css/itou.css' %}">
         <style>
-            html {
-                background: transparent !important;
-            }
-
-            @page {
-                margin: 0mm;
-                /* hides title and date */
-                size: A4;
+            .s-header-print {
+                display: block !important;
             }
         </style>
         {% block extra_head %}{% endblock %}
     </head>
     <body>
+        <header>
+            {% include "layout/_header_print.html" %}
+        </header>
         <main>
             {% block content %}{% endblock %}
-            {% block script %}{% endblock %}
         </main>
+        <script src="{% static "vendor/theme-inclusion/javascripts/app.js" %}"></script>
+        {% block script %}{% endblock %}
     </body>
 </html>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -205,11 +205,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.1.1.zip",
-            "sha256": "6a838b62e93e94e7b78a58b3a08440b7c67a94d452964835db7e1ec7c1f25f56",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.1.5.zip",
+            "sha256": "0dbe44fe1f2b18e40ef358f48ee87d8ca2ca0f516d16a39021f7cb94743412f8",
         },
         "extract": {
-            "origin": "itou-theme-2.1.1/dist",
+            "origin": "itou-theme-2.1.5/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Quoi ?

- Maj du thème pour supporter les règles globales d'impression
- Ajout du `header_print`
- Adaptation de la page "attestation imprimable" aux règles globales d'impression 
- Ajout du bouton "Imprimer” sur la page de détail Candidat


## :computer: Captures d'écran <!-- optionnel -->
![capture 2024-09-02 à 15 39 02](https://github.com/user-attachments/assets/4be6e034-1d30-42d9-b3b2-bffd849a0f47)
