### PR TITLE
Stabiliser tests/gps/test_views.py::test_beneficiary_details

### DIFF
--- a/tests/gps/test_views.py
+++ b/tests/gps/test_views.py
@@ -290,7 +290,7 @@ def test_beneficiary_details(client, snapshot):
         membership__organization__name="Les Olivades",
         membership__organization__authorized=True,
     )
-    beneficiary = JobSeekerFactory(for_snapshot=True)
+    beneficiary = JobSeekerFactory(for_snapshot=True, department="24")
     FollowUpGroupFactory(beneficiary=beneficiary, memberships=1, memberships__member=prescriber)
 
     client.force_login(prescriber)


### PR DESCRIPTION
LE département est utilisé pour décider d’activer ou non la fonctionnalité.

```diff
FAILED tests/gps/test_views.py::test_beneficiary_details - assert [+ received] == [- snapshot]
    '''
                        ...
                                            <div class="c-info c-info--secondary" id="advisor-info-details-collapsable">
  -                                             <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-ailleurs">
  +                                             <button aria-controls="collapseAdvisorInfoDetails" aria-expanded="false" class="c-info__summary collapsed" data-bs-target="#collapseAdvisorInfoDetails" data-bs-toggle="collapse" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="coordonnees-conseiller-55">
                                                    <span>Voir les coordonnées du
                                                    ...

  -                                                     <p class="mb-0">
  +                                                     <p class="mb-0">Le conseiller emploi France Travail de ce bénéficiaire n’est pas connu.</p>
  -                                                         La fonctionnalité est en test dans deux départements et sera bientôt disponible pour votre territoire.
  -                                                     </p>

                            ...
    '''
```