### PR TITLE
Prescripteur: Permettre aux agents France Travail de rejoindre une agence même si l'agence indiquée par NEPTUNE n'existe pas sur les emplois. [GEN-1991]

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -11,7 +11,6 @@ from django.utils import crypto
 from django.utils.html import format_html
 from django.utils.http import urlencode
 
-from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import KIND_EMPLOYER, KIND_PRESCRIBER, IdentityProvider, UserKind
 from itou.users.models import User
@@ -299,52 +298,18 @@ def inclusion_connect_callback(request):
         try:
             ic_user_data.join_org(user=user, safir=code_safir_pole_emploi)
         except PrescriberOrganization.DoesNotExist:
-            if user.prescriberorganization_set.filter(kind=PrescriberOrganizationKind.PE).exists():
-                messages.warning(
-                    request,
-                    format_html(
-                        "L'agence indiquée par NEPTUNE (code SAFIR {}) n'est pas référencée dans notre service. "
-                        "Cela arrive quand vous appartenez à un Point Relais mais que vous êtes rattaché à une agence "
-                        "mère sur la plateforme des emplois. "
-                        "Si vous pensez qu'il y a une erreur, vérifiez que le code SAFIR est le bon "
-                        "puis <a href='{}'>contactez le support</a> en indiquant le code SAFIR.",
-                        code_safir_pole_emploi,
-                        global_constants.ITOU_HELP_CENTER_URL,
-                    ),
-                )
-            else:
-                messages.error(
-                    request,
-                    format_html(
-                        "En tant qu'agent France Travail vous devez appartenir à une agence pour vous connecter à la "
-                        "plateforme des emplois.<br>"
-                        "Malheureusement l'agence indiquée par NEPTUNE (code SAFIR {}) n'est pas référencée dans "
-                        "notre service. "
-                        "Cela arrive quand vous appartenez à un Point Relais mais que vous êtes rattaché à une agence "
-                        "mère sur la plateforme des emplois.<br>"
-                        "Vous pouvez vous faire inviter par l'administrateur de votre agence. "
-                        "Si vous pensez qu'il y a une erreur, vérifiez que le code SAFIR est le bon "
-                        "puis <a href='{}'>contactez le support</a> en indiquant le code SAFIR.",
-                        code_safir_pole_emploi,
-                        global_constants.ITOU_HELP_CENTER_URL,
-                    ),
-                )
-                is_successful = False
-
-    # NEPTUNE does not always return a safir code
-    if (
-        is_successful
-        and user.email.endswith(global_constants.FRANCE_TRAVAIL_EMAIL_SUFFIX)
-        and not user.prescriberorganization_set.filter(kind=PrescriberOrganizationKind.PE).exists()
-        and not ic_state.data["next_url"] == reverse("signup:prescriber_join_org")
-    ):
-        messages.error(
-            request,
-            "En tant qu'agent France Travail vous devez appartenir à une agence pour vous connecter à la "
-            "plateforme des emplois. Veuillez vous faire inviter par l'administrateur d'une agence afin "
-            "d'accéder au service.",
-        )
-        is_successful = False
+            messages.warning(
+                request,
+                format_html(
+                    "L'agence indiquée par NEPTUNE (code SAFIR {}) n'est pas référencée dans notre service. "
+                    "Cela arrive quand vous appartenez à un Point Relais mais que vous êtes rattaché à une agence "
+                    "mère sur la plateforme des emplois. "
+                    "Si vous pensez qu'il y a une erreur, vérifiez que le code SAFIR est le bon "
+                    "puis <a href='{}'>contactez le support</a> en indiquant le code SAFIR.",
+                    code_safir_pole_emploi,
+                    global_constants.ITOU_HELP_CENTER_URL,
+                ),
+            )
 
     if not is_successful:
         logout_url_params = {

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -1014,7 +1014,6 @@
       }),
       dict({
         'origin': list([
-          'extract_membership_infos_and_update_session[utils/perms/middleware.py]',
           'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
         ]),
         'sql': '''

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -145,7 +145,6 @@
       }),
       dict({
         'origin': list([
-          'extract_membership_infos_and_update_session[utils/perms/middleware.py]',
           'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
         ]),
         'sql': '''


### PR DESCRIPTION
## :thinking: Pourquoi ?

C'est quand même plus sympa pour eux :)

Ne pas lire le 1er commit qui vient de la PR #4629

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
