### PR TITLE
Stabiliser gps test_beneficiaries pour de vrai

### DIFF
--- a/tests/gps/test_views.py
+++ b/tests/gps/test_views.py
@@ -288,8 +288,9 @@ def test_beneficiary_details(client, snapshot):
         for_snapshot=True,
         membership__organization__name="Les Olivades",
         membership__organization__authorized=True,
+        membership__organization__department="24",
     )
-    beneficiary = JobSeekerFactory(for_snapshot=True, department="24")
+    beneficiary = JobSeekerFactory(for_snapshot=True)
     FollowUpGroupFactory(beneficiary=beneficiary, memberships=1, memberships__member=prescriber)
 
     client.force_login(prescriber)


### PR DESCRIPTION
## :thinking: Pourquoi ?

45d28219e6c49df3ac94adb2880517830e7c7089 fixed the beneficiary
department instead of the viewer department.
