### PR TITLE
UX/UI: Retirer l’item “tableau de bord” du menu “mon espace”

### DIFF
--- a/itou/templates/layout/_header_user_dropdown_menu.html
+++ b/itou/templates/layout/_header_user_dropdown_menu.html
@@ -14,15 +14,12 @@
     <li>
         <div class="dropdown-divider"></div>
     </li>
-    <li>
-        <a class="dropdown-item" href="{% url 'dashboard:index' %}">Tableau de bord</a>
-    </li>
     {% if not user.is_staff and not user.is_labor_inspector %}
         <li>
             <a class="dropdown-item" href="{% url 'dashboard:edit_user_notifications' %}">Mes notifications</a>
         </li>
+        <li class="dropdown-divider"></li>
     {% endif %}
-    <li class="dropdown-divider"></li>
     <li>
         <a class="dropdown-item" href="{% url 'dashboard:edit_user_info' %}">Modifier mon profil</a>
     </li>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -25,15 +25,12 @@
       <li>
           <div class="dropdown-divider"></div>
       </li>
-      <li>
-          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
-      </li>
       
           <li>
               <a class="dropdown-item" href="/dashboard/edit_user_notifications">Mes notifications</a>
           </li>
+          <li class="dropdown-divider"></li>
       
-      <li class="dropdown-divider"></li>
       <li>
           <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
       </li>
@@ -81,15 +78,12 @@
       <li>
           <div class="dropdown-divider"></div>
       </li>
-      <li>
-          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
-      </li>
       
           <li>
               <a class="dropdown-item" href="/dashboard/edit_user_notifications">Mes notifications</a>
           </li>
+          <li class="dropdown-divider"></li>
       
-      <li class="dropdown-divider"></li>
       <li>
           <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
       </li>
@@ -142,15 +136,12 @@
       <li>
           <div class="dropdown-divider"></div>
       </li>
-      <li>
-          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
-      </li>
       
           <li>
               <a class="dropdown-item" href="/dashboard/edit_user_notifications">Mes notifications</a>
           </li>
+          <li class="dropdown-divider"></li>
       
-      <li class="dropdown-divider"></li>
       <li>
           <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
       </li>
@@ -205,11 +196,7 @@
       <li>
           <div class="dropdown-divider"></div>
       </li>
-      <li>
-          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
-      </li>
       
-      <li class="dropdown-divider"></li>
       <li>
           <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
       </li>
@@ -264,15 +251,12 @@
       <li>
           <div class="dropdown-divider"></div>
       </li>
-      <li>
-          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
-      </li>
       
           <li>
               <a class="dropdown-item" href="/dashboard/edit_user_notifications">Mes notifications</a>
           </li>
+          <li class="dropdown-divider"></li>
       
-      <li class="dropdown-divider"></li>
       <li>
           <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
       </li>
@@ -320,15 +304,12 @@
       <li>
           <div class="dropdown-divider"></div>
       </li>
-      <li>
-          <a class="dropdown-item" href="/dashboard/">Tableau de bord</a>
-      </li>
       
           <li>
               <a class="dropdown-item" href="/dashboard/edit_user_notifications">Mes notifications</a>
           </li>
+          <li class="dropdown-divider"></li>
       
-      <li class="dropdown-divider"></li>
       <li>
           <a class="dropdown-item" href="/dashboard/edit_user_info">Modifier mon profil</a>
       </li>


### PR DESCRIPTION
## :thinking: Pourquoi ?

En doublon  car on peut y accéder via le menu prinicpal (accueil)
