### PR TITLE
Admin: retour du champ date de naissance dans la liste des utilisateurs

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -309,6 +309,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
         "email",
         "first_name",
         "last_name",
+        "birthdate",
         "kind",
         "identity_provider",
         "is_created_by_a_proxy",
@@ -328,6 +329,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
         "public_id",
         "identity_provider",
         "address_in_qpv",
+        "birthdate",
         "is_staff",
         "jobseeker_profile_link",
         "disabled_notifications",
@@ -373,6 +375,10 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
             lambda q: Approval.objects.filter(user__in=q).inconsistent_eligibility_diagnosis_job_seeker(),
         ),
     ]
+
+    @admin.display(description="date de naissance")
+    def birthdate(self, obj):
+        return obj.jobseeker_profile.birthdate if obj.is_job_seeker else None
 
     @admin.display(boolean=True, description="email validé", ordering="_has_verified_email")
     def has_verified_email(self, obj):
@@ -452,7 +458,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
         Exclude superusers. The purpose is to prevent staff users
         to change the password of a superuser.
         """
-        qs = super().get_queryset(request)
+        qs = super().get_queryset(request).select_related("jobseeker_profile")
         if not request.user.is_superuser:
             qs = qs.exclude(is_superuser=True)
         if request.resolver_match.view_name.endswith("changelist"):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Utile au support pour trouver des doublons.

Mais je me demande si pour trouver les candidats ils ne devraient pas prendre l'habitude d'aller chercher dans les profils de demandeur d'emploi ?

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
