### PR TITLE
Tech: simplification des migrations de suppression du champ date de naissance

### DIFF
--- a/itou/users/migrations/0012_remove_user_birthdate.py
+++ b/itou/users/migrations/0012_remove_user_birthdate.py
@@ -9,17 +9,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.RemoveField(
-                    model_name="user",
-                    name="birthdate",
-                ),
-            ],
-            # Don't drop anything yet, since the previous will still be running
-            # when this migration will be run.
-            # Keeping this field around should be an issue since it is NULLABLE.
-            # It will be dropped in a following migration.
-            database_operations=[],
+        migrations.RemoveField(
+            model_name="user",
+            name="birthdate",
         ),
     ]

--- a/itou/users/migrations/0013_drop_users_user_birthdate_for_real.py
+++ b/itou/users/migrations/0013_drop_users_user_birthdate_for_real.py
@@ -8,7 +8,4 @@ class Migration(migrations.Migration):
         ("users", "0012_remove_user_birthdate"),
     ]
 
-    operations = [
-        # TODO(xfernandez): merge this with 0012_remove_user_birthdate once run in production
-        migrations.RunSQL('ALTER TABLE "users_user" DROP COLUMN birthdate;', elidable=True),
-    ]
+    operations = []


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite de #4662 & #4666 .

Maintenant que les migrations sont passées en production, on peut se débarasser du `SeparateDatabaseAndState` et faciliter un futur squash.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
