### PR TITLE
Tech: correction de l'HTML généré dans la barre de navigation en anonyme

### DIFF
--- a/itou/templates/utils/templatetags/nav_anonymous.html
+++ b/itou/templates/utils/templatetags/nav_anonymous.html
@@ -16,7 +16,7 @@
         <ul>
             {% for item in menu_items %}
                 <li>
-                    <a {% if item.active %}class="is-active"{% endif %}href="{{ item.target }}">{{ item.label }}</a>
+                    <a {% if item.active %}class="is-active"{% endif %} href="{{ item.target }}">{{ item.label }}</a>
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, on a du `<a class="is-active"href="/search/employers">Rechercher un emploi inclusif</a>` dans https://emplois.inclusion.beta.gouv.fr/search/employers

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
