### PR TITLE
UX/UI: dégriser la modale de transfert de candidature

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -394,11 +394,3 @@ an input field being invalid, generating an uncontrolled red box-shadow. */
 .w-lg-400px .select2-selection__rendered {
     white-space: nowrap !important;
 }
-
-/* News Page
---------------------------------------------------------------------------- */
-/* utility class soon included in the itou theme */
-.img-muted {
-    filter: grayscale(100%);
-    opacity: 0.3;
-}

--- a/itou/templates/apply/includes/transfer_job_application.html
+++ b/itou/templates/apply/includes/transfer_job_application.html
@@ -31,39 +31,3 @@
         {% endif %}
     </div>
 </div>
-{% comment %}
-          Tranfer confirmation modal:
-          Was supposed to be within the for-loop above.
-          But apparently being in a dropdown-menu DIV prevents display of the modal.
-          Hence a new loop to generate modals for each SIAE.
-          Not pretty, but if anybody has a cleaner solution...
-{% endcomment %}
-{% for siae in request.organizations %}
-    {% if siae != request.current_organization %}
-        <div id="transfer_confirmation_modal_{{ siae.pk }}" class="modal" tabindex="-1" aria-labelledby="modal_title" aria-hidden="true">
-            <div class="modal-dialog modal-dialog-centered">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="modal_title">Confirmation du transfert</h5>
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
-                    </div>
-                    <div class="modal-body">
-                        <p>
-                            Êtes-vous sûr de vouloir transférer la candidature de <b>{{ job_application.job_seeker.get_full_name }}</b> dans la structure suivante ?
-                        </p>
-                        {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Retour</button>
-                        <form method="post" action="{% url 'apply:transfer' job_application_id=job_application.id %}">
-                            {% csrf_token %}
-                            <input type="hidden" name="target_company_id" value="{{ siae.pk }}" />
-                            <input type="hidden" name="back_url" value="{{ back_url }}" />
-                            <button class="btn btn-sm btn-primary">Confirmer</button>
-                        </form>
-                    </div>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-{% endfor %}

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -131,11 +131,11 @@
     {% if job_application.is_in_transferable_state %}
         {% for siae in request.organizations %}
             {% if siae != request.current_organization %}
-                <div id="transfer_confirmation_modal_{{ siae.pk }}" class="modal" tabindex="-1" aria-labelledby="modal_title" aria-hidden="true">
+                <div id="transfer_confirmation_modal_{{ siae.pk }}" class="modal" tabindex="-1" aria-labelledby="modal_title_{{ siae.pk }}" aria-hidden="true">
                     <div class="modal-dialog modal-dialog-centered">
                         <div class="modal-content">
                             <div class="modal-header">
-                                <h5 class="modal-title" id="modal_title">Confirmation du transfert</h5>
+                                <h5 class="modal-title" id="modal_title_{{ siae.pk }}">Confirmation du transfert</h5>
                                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                             </div>
                             <div class="modal-body">

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -122,3 +122,41 @@
     {{ block.super }}
     <script src="{% static 'js/sliding_tabs.js'%}"></script>
 {% endblock %}
+
+{% block modals %}
+    {{ block.super }}
+    {% comment %}
+    Job application transfer modals triggered by apply/includes/transfer_job_application.html
+    {% endcomment %}
+    {% if job_application.is_in_transferable_state %}
+        {% for siae in request.organizations %}
+            {% if siae != request.current_organization %}
+                <div id="transfer_confirmation_modal_{{ siae.pk }}" class="modal" tabindex="-1" aria-labelledby="modal_title" aria-hidden="true">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="modal_title">Confirmation du transfert</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                            </div>
+                            <div class="modal-body">
+                                <p>
+                                    Êtes-vous sûr de vouloir transférer la candidature de <b>{{ job_application.job_seeker.get_full_name }}</b> dans la structure suivante ?
+                                </p>
+                                {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-sm btn-outline-secondary" data-bs-dismiss="modal">Retour</button>
+                                <form method="post" action="{% url 'apply:transfer' job_application_id=job_application.id %}">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="target_company_id" value="{{ siae.pk }}" />
+                                    <input type="hidden" name="back_url" value="{{ back_url }}" />
+                                    <button class="btn btn-sm btn-primary">Confirmer</button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        {% endfor %}
+    {% endif %}
+{% endblock %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -263,5 +263,7 @@
         {% if active_campaign_announce %}
             {% include "layout/_news_modal.html" %}
         {% endif %}
+
+        {% block modals %}{% endblock %}
     </body>
 </html>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -190,11 +190,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.1.5.zip",
-            "sha256": "0dbe44fe1f2b18e40ef358f48ee87d8ca2ca0f516d16a39021f7cb94743412f8",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.1.7.zip",
+            "sha256": "394c8861018cd0be49b0937784f360fb517753de397c4c35024f786d98dc6cc3",
         },
         "extract": {
-            "origin": "itou-theme-2.1.5/dist",
+            "origin": "itou-theme-2.1.7/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lorsque je transfère une candidature, la modale de confirmation est grisée et non cliquable, je dois faire un retour navigateur pour avoir de nouveau accès au site.



<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

Déplacer la génération du HTML des modales plus haut dans le DOM, et donc plus haut dans l'arborescence des templates.
@hellodeloo m'a pointé vers le projet `le-marché` où un `{% block modals %}` [existe](https://github.com/gip-inclusion/le-marche/blob/master/lemarche/templates/pages/home.html#L325), tout comme nous avons un `{% block scripts %}`.

Si je ne me trompe pas :
1. on ne peut pas utiliser de `{% block * %}` dans les fichiers html inclus avec `{% include * %}`
2. l'arborescence des templates est la suivante : 
```
 base.html
└ process_base.html
    └ process_details_company.html  # {% block modals %} à mettre ici
        └ <une série d'includes ici> 
```


## :rotating_light: À vérifier

Ça ne gêne pas d'autres pages ? Je ne suis pas encore familier avec l'organisation des templates.

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

Un [quickfix](https://github.com/gip-inclusion/itou-theme/commit/12a47defb80a517ea048768419b0873d1294d76d) a été déployé par David dans le thème : enlever le `sticky` du bandeau titre. Pour tester, j'ai donc utilisé le thème version 2.1.0. 

`itou/utils/staticfiles.py`
```python
…
    "theme-inclusion": {
        "download": {
            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.1.0.zip",
            "sha256": "bee559639f0a2c3f91d19d474cd10c4413a3775136830c6f240deddfa61a655c",
        },
        "extract": {
            "origin": "itou-theme-2.1.0/dist",
            "destination": "vendor/theme-inclusion/",
            "files": [
…
```

## :computer: Captures d'écran <!-- optionnel -->

Avant : 
![notworking](https://github.com/user-attachments/assets/f8110246-6696-4d8f-8370-0b6c3de9aebf)


Après : 
![working](https://github.com/user-attachments/assets/8dda0194-815a-46a2-bce4-3a2d50298b82)


