### PR TITLE
Admin: ajout d'un bouton pour transférer des données entre entreprises [GEN-1527]

### DIFF
--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -1,18 +1,23 @@
 from django.contrib import admin, messages
 from django.contrib.admin.utils import display_for_value
-from django.urls import reverse
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404, redirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
 from django.utils import timezone
 from django.utils.html import format_html
 
 from itou.approvals.models import Approval
 from itou.common_apps.organizations.admin import HasMembersFilter, MembersInline, OrganizationAdmin
-from itou.companies import enums, models
-from itou.companies.admin_forms import CompanyAdminForm
+from itou.companies import enums, models, transfer
+from itou.companies.admin_forms import CompanyAdminForm, CompanyChooseFieldsToTransfer, SelectTargetCompanyForm
+from itou.siae_evaluations.models import EvaluatedSiae
 from itou.utils.admin import (
     ItouGISMixin,
     ItouModelAdmin,
     ItouTabularInline,
     PkSupportRemarkInline,
+    add_support_remark_to_obj,
     get_admin_view_link,
 )
 from itou.utils.apis.exceptions import GeocodingDataError
@@ -132,6 +137,7 @@ class CompanyAdmin(ItouGISMixin, OrganizationAdmin):
         )
 
     form = CompanyAdminForm
+    change_form_template = "admin/companies/change_company_form.html"
     list_display = ("pk", "siret", "kind", "name", "department", "geocoding_score", "member_count", "created_at")
     list_filter = (HasMembersFilter, "kind", "block_job_applications", "source", "department")
     raw_id_fields = ("created_by", "convention")
@@ -260,6 +266,144 @@ class CompanyAdmin(ItouGISMixin, OrganizationAdmin):
         count = Approval.objects.is_assigned_to(obj.id).count()
         valid_count = Approval.objects.is_assigned_to(obj.id).valid().count()
         return format_html('<a href="{}">Liste des {} Pass IAE (dont {} valides)</a>', url, count, valid_count)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        return [
+            path(
+                "transfer/<int:from_company_pk>",
+                self.admin_site.admin_view(self.transfer_view),
+                name="transfer_company_data",
+            ),
+            path(
+                "transfer/<int:from_company_pk>/<int:to_company_pk>",
+                self.admin_site.admin_view(self.transfer_view),
+                name="transfer_company_data",
+            ),
+        ] + urls
+
+    def transfer_view(self, request, from_company_pk, to_company_pk=None):
+        if not self.has_change_permission(request):
+            raise PermissionDenied
+
+        from_company = get_object_or_404(models.Company.objects, pk=from_company_pk)
+        to_company = get_object_or_404(models.Company, pk=to_company_pk) if to_company_pk is not None else None
+
+        transfer_data = {}
+        for transfer_field in transfer.TransferField:
+            spec = transfer.TRANSFER_SPECS[transfer_field]
+            if model_field := spec.get("model_field"):
+                from_data = [getattr(from_company, model_field.name)]
+            else:
+                from_data = transfer.get_transfer_queryset(from_company, to_company, spec)
+            transfer_data[transfer_field] = {
+                "data": from_data,
+            }
+
+        if not to_company:
+            form = SelectTargetCompanyForm(
+                from_company=from_company,
+                admin_site=self.admin_site,
+                data=request.POST or None,
+            )
+            if request.POST and form.is_valid():
+                return redirect(
+                    reverse(
+                        "admin:transfer_company_data",
+                        kwargs={
+                            "from_company_pk": from_company.pk,
+                            "to_company_pk": form.cleaned_data["to_company"].pk,
+                        },
+                    )
+                )
+        else:
+            fields_choices = []
+            for transfer_field in transfer.TransferField:
+                spec = transfer.TRANSFER_SPECS[transfer_field]
+                if model_field := spec.get("model_field"):
+                    if transfer_data[transfer_field]["data"] == [getattr(to_company, model_field.name)]:
+                        transfer_data[transfer_field]["data"] = None
+                    else:
+                        fields_choices.append((transfer_field.value, transfer_field.label))
+                elif from_data := transfer_data[transfer_field]["data"]:
+                    s = "s" if len(from_data) > 1 else ""
+                    fields_choices.append(
+                        (
+                            transfer_field.value,
+                            f"{transfer_field.label} ({len(from_data)} objet{s} à transférer)",
+                        )
+                    )
+
+            siae_evaluations = EvaluatedSiae.objects.filter(siae=from_company).exists()
+            form = CompanyChooseFieldsToTransfer(
+                fields_choices=sorted(fields_choices, key=lambda field: field[1]),
+                siae_evaluations=siae_evaluations,
+                data=request.POST or None,
+            )
+            if request.POST and form.is_valid():
+                if siae_evaluations and not form.cleaned_data["ignore_siae_evaluations"]:
+                    messages.error(
+                        request,
+                        (
+                            f"Impossible de transférer les objets de l'entreprise ID={from_company.pk}: "
+                            "il y a un contrôle a posteriori lié. Vérifiez avec l'équipe support."
+                        ),
+                    )
+                else:
+                    try:
+                        reporter = transfer.transfer_company_data(
+                            from_company,
+                            to_company,
+                            form.cleaned_data["fields_to_transfer"],
+                            disable_from_company=form.cleaned_data["disable_from_company"],
+                            ignore_siae_evaluations=form.cleaned_data.get("ignore_siae_evaluations", False),
+                        )
+                    except transfer.TransferError as e:
+                        messages.error(request, e.args[0])
+                    else:
+                        summary_lines = [
+                            "-" * 20,
+                            f"Transfert du {timezone.now():%Y-%m-%d %H:%M:%S} effectué par {request.user} ",
+                            f"de l'entreprise {from_company.pk} vers {to_company.pk}:",
+                        ]
+                        for report_field, items in reporter.changes.items():
+                            if items:
+                                summary_lines.extend([f"- {report_field.label}:"] + [f"  * {item}" for item in items])
+                        summary_lines += ["-" * 20]
+                        summary_text = "\n".join(summary_lines)
+                        add_support_remark_to_obj(from_company, summary_text)
+                        add_support_remark_to_obj(to_company, summary_text)
+                        message = format_html(
+                            "Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}.",
+                            from_company=from_company,
+                            to_company=to_company,
+                        )
+                        messages.info(request, message)
+
+                        return redirect(
+                            reverse(
+                                "admin:companies_company_change",
+                                kwargs={"object_id": from_company.pk},
+                            )
+                        )
+        title = f"Transfert des données de '{from_company}' [{from_company.kind}]"
+        if to_company:
+            title += f" vers '{to_company}' [{to_company.kind}]"
+        context = self.admin_site.each_context(request) | {
+            "media": self.media,
+            "opts": self.opts,
+            "form": form,
+            "from_company": from_company,
+            "to_company": to_company,
+            "transfer_data": transfer_data,
+            "title": title,
+        }
+
+        return TemplateResponse(
+            request,
+            "admin/companies/transfer_company.html",
+            context,
+        )
 
 
 @admin.register(models.JobDescription)

--- a/itou/companies/admin_forms.py
+++ b/itou/companies/admin_forms.py
@@ -1,6 +1,11 @@
+from collections import namedtuple
+
 from django import forms
+from django.contrib.admin import widgets
+from django.core.exceptions import ValidationError
 
 from itou.companies.models import Company
+from itou.utils.admin import ChooseFieldsToTransfer
 
 
 class CompanyAdminForm(forms.ModelForm):
@@ -17,3 +22,42 @@ class CompanyAdminForm(forms.ModelForm):
     class Meta:
         model = Company
         fields = "__all__"
+
+
+FakeField = namedtuple("FakeField", ("name",))
+
+
+class FakeRelForToCompanyRawIdWidget:
+    model = Company
+    limit_choices_to = {}
+
+    def get_related_field(self):
+        # This must return something that has the name of an existing field
+        return FakeField("id")
+
+
+class SelectTargetCompanyForm(forms.Form):
+    to_company = forms.ModelChoiceField(Company.objects.all(), required=True, label="Choisissez l’entreprise cible")
+
+    def __init__(self, *args, from_company, admin_site, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["to_company"].widget = widgets.ForeignKeyRawIdWidget(FakeRelForToCompanyRawIdWidget(), admin_site)
+        self.from_company = from_company
+
+    def clean_to_company(self):
+        to_company = self.cleaned_data["to_company"]
+        if to_company.pk == self.from_company.pk:
+            raise ValidationError("L’entreprise cible doit être différente de celle d’origine")
+        return to_company
+
+
+class CompanyChooseFieldsToTransfer(ChooseFieldsToTransfer):
+    disable_from_company = forms.BooleanField(label="Désactiver l’entreprise source", required=False, initial=True)
+
+    def __init__(self, *args, fields_choices, siae_evaluations, **kwargs):
+        super().__init__(*args, fields_choices=fields_choices, **kwargs)
+        if siae_evaluations:
+            self.fields["ignore_siae_evaluations"] = forms.BooleanField(
+                label="Ignorer la présence d'un contrôle a posteriori.",
+                required=True,
+            )

--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -1,0 +1,198 @@
+from django.db.models import TextChoices
+from django.utils import timezone
+
+from itou.approvals import models as approvals_models
+from itou.companies import enums, models
+from itou.eligibility import models as eligibility_models
+from itou.employee_record.models import EmployeeRecord
+from itou.invitations import models as invitations_models
+from itou.job_applications import models as job_applications_models
+from itou.siae_evaluations.models import EvaluatedSiae
+from itou.users import models as users_models
+
+
+class TransferField(TextChoices):
+    IAE_DIAG_CREATED = "iae_diag_created", "Diagnostics IAE créés"
+    GEIQ_DIAG_CREATED = "geiq_diag_created", "Diagnostics GEIQ créés"
+    JOB_APPLICATIONS_SENT = "job_applications_sent", "Candidatures envoyées"
+    JOB_APPLICATIONS_RECEIVED = "job_applications_received", "Candidatures reçues"
+    EMPLOYEE_RECORDS_CREATED = "employee_records_created", "Fiches salarié (transférées via les candidatures reçues)"
+    JOB_DESCRIPTIONS = "job_descriptions", "Fiches de poste"
+    MEMBERSHIPS = "memberships", "Utilisateurs membres"
+    INVITATIONS = "invitations", "Invitations"
+    PROLONGATIONS = "prolongations", "Prolongations déclarées"
+    SUSPENSIONS = "suspensions", "Suspensions déclarées"
+    BRAND = "brand", models.Company._meta.get_field("brand").verbose_name.capitalize()
+    DESCRIPTION = "description", models.Company._meta.get_field("description").verbose_name.capitalize()
+    IS_SEARCHABLE = "is_searchable", models.Company._meta.get_field("is_searchable").verbose_name.capitalize()
+    PHONE = "phone", models.Company._meta.get_field("phone").verbose_name.capitalize()
+
+
+class ReportSection(TextChoices):
+    JOB_UNLINK = "job_unlink", "Désassociation de fiche de poste"
+    COMPANY_DEACTIVATION = "company_deactivation", "Désactivation entreprise"
+
+
+TRANSFER_SPECS = {
+    TransferField.IAE_DIAG_CREATED: {
+        "related_model": eligibility_models.EligibilityDiagnosis,
+        "related_model_field": "author_siae",
+        "iae_only": True,
+    },
+    TransferField.GEIQ_DIAG_CREATED: {
+        "related_model": eligibility_models.GEIQEligibilityDiagnosis,
+        "related_model_field": "author_geiq",
+        "geiq_only": True,
+    },
+    TransferField.JOB_APPLICATIONS_SENT: {
+        "related_model": job_applications_models.JobApplication,
+        "related_model_field": "sender_company",
+    },
+    TransferField.JOB_APPLICATIONS_RECEIVED: {
+        "related_model": job_applications_models.JobApplication,
+        "related_model_field": "to_company",
+    },
+    TransferField.EMPLOYEE_RECORDS_CREATED: {
+        "related_model": EmployeeRecord,
+        "related_model_field": "job_application__to_company",
+        "iae_only": True,
+        # Nothing modified directly on this model (transfer happens through JOB_APPLICATIONS_RECEIVED)
+        "report_only": True,
+    },
+    TransferField.JOB_DESCRIPTIONS: {
+        "related_model": models.JobDescription,
+        "related_model_field": "company",
+    },
+    TransferField.MEMBERSHIPS: {
+        "related_model": models.CompanyMembership,
+        "related_model_field": "company",
+        "to_filter": lambda qs, to_company: qs.exclude(
+            user__in=users_models.User.objects.filter(companymembership__company=to_company)
+        ),
+    },
+    TransferField.INVITATIONS: {
+        "related_model": invitations_models.EmployerInvitation,
+        "related_model_field": "company",
+        "to_filter": lambda qs, to_company: qs.exclude(
+            email__in=users_models.User.objects.filter(companymembership__company=to_company).values_list(
+                "email", flat=True
+            )
+        ),
+    },
+    TransferField.PROLONGATIONS: {
+        "related_model": approvals_models.Prolongation,
+        "related_model_field": "declared_by_siae",
+        "iae_only": True,
+    },
+    TransferField.SUSPENSIONS: {
+        "related_model": approvals_models.Suspension,
+        "related_model_field": "siae",
+        "iae_only": True,
+    },
+    TransferField.BRAND: {
+        "model_field": models.Company._meta.get_field("brand"),
+    },
+    TransferField.DESCRIPTION: {
+        "model_field": models.Company._meta.get_field("description"),
+    },
+    TransferField.IS_SEARCHABLE: {
+        "model_field": models.Company._meta.get_field("is_searchable"),
+    },
+    TransferField.PHONE: {
+        "model_field": models.Company._meta.get_field("phone"),
+    },
+}
+
+# Consistency check
+assert set(TRANSFER_SPECS) == set(TransferField)
+
+
+def get_transfer_queryset(from_company, to_company, spec):
+    queryset = spec["related_model"].objects.filter(**{spec["related_model_field"]: from_company})
+    if (to_filter := spec.get("to_filter")) is not None and to_company:
+        queryset = to_filter(queryset, to_company)
+    return queryset
+
+
+class Reporter:
+    def __init__(self):
+        self.changes = {}
+
+    def add(self, section: TransferField | ReportSection, change: str):
+        self.changes.setdefault(section, []).append(change)
+
+
+class TransferError(Exception):
+    pass
+
+
+def _format_model(obj):
+    return f"{obj._meta.label}[{obj.pk}]"
+
+
+def transfer_company_data(
+    from_company,
+    to_company,
+    fields_to_transfer,
+    disable_from_company=False,
+    ignore_siae_evaluations=False,
+):
+    assert from_company.pk != to_company.pk, "Cannot transfer from one company to itself"
+    if not ignore_siae_evaluations and EvaluatedSiae.objects.filter(siae=from_company).exists():
+        raise TransferError(
+            f"Impossible de transférer les objets de l'entreprise ID={from_company.pk}: il y a un contrôle "
+            "a posteriori lié. Vérifiez avec l'équipe support."
+        )
+    if from_company.source == to_company.SOURCE_ASP and to_company.source == to_company.SOURCE_USER_CREATED:
+        raise TransferError("Impossible de transférer d'une entreprise provenant de l'ASP vers une antenne")
+    fields_to_transfer = [TransferField(field_to_transfer) for field_to_transfer in fields_to_transfer]
+
+    reporter = Reporter()
+    if (
+        TransferField.JOB_APPLICATIONS_RECEIVED in fields_to_transfer
+        and TransferField.JOB_DESCRIPTIONS not in fields_to_transfer
+    ):
+        for job_application in get_transfer_queryset(
+            from_company, to_company, TRANSFER_SPECS[TransferField.JOB_APPLICATIONS_RECEIVED]
+        ).prefetch_related("selected_jobs"):
+            selected_jobs = sorted(job.pk for job in job_application.selected_jobs.all())
+            if selected_jobs:
+                reporter.add(
+                    ReportSection.JOB_UNLINK,
+                    f"{job_application.pk}: {selected_jobs}",
+                )
+            job_application.selected_jobs.clear()
+
+    save_update_fields = []
+    for transfer_field in fields_to_transfer:
+        spec = TRANSFER_SPECS[transfer_field]
+        if model_field := spec.get("model_field"):
+            from_value = getattr(from_company, model_field.name)
+            old_to_value = getattr(to_company, model_field.name)
+            if from_value != old_to_value:
+                setattr(to_company, model_field.name, from_value)
+                save_update_fields.append(model_field.name)
+                reporter.add(transfer_field, f"{model_field.name}: {old_to_value!r} remplacé par {from_value!r}")
+        else:
+            for item in get_transfer_queryset(from_company, to_company, spec):
+                if spec.get("iae_only") and not to_company.is_subject_to_eligibility_rules:
+                    raise TransferError(f"Objets impossibles à transférer hors-IAE: {transfer_field.label}")
+                elif spec.get("geiq_only") and to_company.kind != enums.CompanyKind.GEIQ:
+                    raise TransferError(f"Objets impossibles à transférer hors-GEIQ: {transfer_field.label}")
+
+                if not spec.get("report_only"):
+                    setattr(item, spec["related_model_field"], to_company)
+                    item.save(update_fields=[spec["related_model_field"]])
+                reporter.add(transfer_field, _format_model(item))
+
+    if save_update_fields:
+        to_company.save(update_fields=save_update_fields)
+
+    if disable_from_company:
+        models.Company.objects.filter(pk=from_company.pk).update(
+            block_job_applications=True,
+            job_applications_blocked_at=timezone.now(),
+            is_searchable=False,
+        )
+        reporter.add(ReportSection.COMPANY_DEACTIVATION, _format_model(from_company))
+    return reporter

--- a/itou/templates/admin/companies/change_company_form.html
+++ b/itou/templates/admin/companies/change_company_form.html
@@ -1,0 +1,14 @@
+{% extends 'admin/change_form.html' %}
+
+{% block object-tools-items %}
+
+    {% if request.user.is_superuser %}
+        {# Change to if has_change_permission in a few weeks #}
+        <li>
+            <a href="{% url 'admin:transfer_company_data' from_company_pk=original.pk %}">Transférer</a>
+        </li>
+    {% endif %}
+
+    {{ block.super }}
+
+{% endblock %}

--- a/itou/templates/admin/companies/transfer_company.html
+++ b/itou/templates/admin/companies/transfer_company.html
@@ -1,0 +1,82 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{# Adapted from Django's admin/change_form.html #}
+{% block extrahead %}
+    {{ block.super }}
+    <script src="{% url 'admin:jsi18n' %}"></script>
+    {{ media }}
+    <script nonce="{{ CSP_NONCE }}">
+        document.addEventListener('DOMContentLoaded', function() {
+            const buttons = document.getElementsByClassName("with-confirm");
+            Array.from(buttons).forEach(function(button) {
+                button.addEventListener("click", function(event) {
+                    if (!confirm('Êtes vous certain ?')) {
+                        event.preventDefault();
+                    }
+                });
+            });
+        });
+    </script>
+{% endblock %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
+{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+        &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+        &rsaquo;
+        {% if has_view_permission %}
+            <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+        {% else %}
+            {{ opts.verbose_name_plural|capfirst }}
+        {% endif %}
+        &rsaquo; Transférer les données de <a href="{% url opts|admin_urlname:'change' object_id=from_company.pk %}">{{ from_company|truncatewords:"18" }}</a>
+        {% if to_company %}
+            vers <a href="{% url opts|admin_urlname:'change' object_id=to_company.pk %}">{{ to_company|truncatewords:"18" }}</a>
+        {% endif %}
+    </div>
+{% endblock %}
+
+{% block content %}
+    <h2>Données à transférer</h2>
+    {% for transfer_field, field_data in transfer_data.items %}
+        <h3>{{ transfer_field.label }}</h3>
+        <div class="form-row">
+            <div>
+                <ul>
+                    {% if field_data.data is None %}
+                        <li class="quiet">Rien à transférer: valeur identique pour les deux entreprises</li>
+                    {% else %}
+                        {% for item in field_data.data %}
+                            <li>
+                                <strong>{{ item }}</strong>
+                            </li>
+                        {% empty %}
+                            <li class="quiet">Rien à transférer</li>
+                        {% endfor %}
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+    {% endfor %}
+
+    <h2>Transfert</h2>
+    <form method="post" novalidate>
+        {% csrf_token %}
+        <div class="form-row">
+            {{ form }}
+            {% if to_company %}
+                <strong>Dans le cas d’un transfert partiel des objets : merci de vérifier que les objets ne seront pas orphelins.</strong>
+            {% endif %}
+        </div>
+        <div class="submit-row">
+            <input class="default{% if to_company %} with-confirm{% endif %}" type="submit" value="Valider">
+        </div>
+    </form>
+
+{% endblock %}

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -23,7 +23,6 @@ from itou.job_applications.models import JobApplication
 from itou.prescribers.models import PrescriberMembership
 from itou.users import models
 from itou.users.admin_forms import (
-    ChooseFieldsToTransfer,
     ItouUserCreationForm,
     JobSeekerProfileAdminForm,
     SelectTargetUserForm,
@@ -31,6 +30,7 @@ from itou.users.admin_forms import (
 )
 from itou.users.enums import IdentityProvider, UserKind
 from itou.utils.admin import (
+    ChooseFieldsToTransfer,
     InconsistencyCheckMixin,
     ItouModelAdmin,
     ItouTabularInline,

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -106,16 +106,3 @@ class SelectTargetUserForm(forms.Form):
         if to_user.pk == self.from_user.pk:
             raise ValidationError("L'utilisateur cible doit être différent de celui d'origine")
         return to_user
-
-
-class ChooseFieldsToTransfer(forms.Form):
-    fields_to_transfer = forms.MultipleChoiceField(
-        choices=[],
-        required=True,
-        label="Choisissez les objets à transférer",
-        widget=forms.CheckboxSelectMultiple(),
-    )
-
-    def __init__(self, *args, fields_choices, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["fields_to_transfer"].choices = fields_choices

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+from django import forms
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
 from django.contrib.contenttypes.admin import GenericStackedInline
 from django.contrib.contenttypes.fields import GenericRelation
@@ -166,3 +167,16 @@ class ReadonlyMixin:
 
     def has_delete_permission(self, *args, **kwargs):
         return False
+
+
+class ChooseFieldsToTransfer(forms.Form):
+    fields_to_transfer = forms.MultipleChoiceField(
+        choices=[],
+        required=True,
+        label="Choisissez les objets à transférer",
+        widget=forms.CheckboxSelectMultiple(),
+    )
+
+    def __init__(self, *args, fields_choices, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["fields_to_transfer"].choices = fields_choices

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -1,12 +1,18 @@
 import pytest
+from django.contrib import messages
 from django.contrib.admin import helpers
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from freezegun import freeze_time
-from pytest_django.asserts import assertContains, assertNumQueries, assertRedirects
+from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertNumQueries, assertRedirects
 
 from itou.companies.enums import CompanyKind
+from itou.companies.models import Company
+from itou.utils.models import PkSupportRemark
 from tests.common_apps.organizations.tests import assert_set_admin_role__creation, assert_set_admin_role__removal
 from tests.companies.factories import CompanyFactory
+from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import EmployerFactory, ItouStaffFactory
 from tests.utils.test import (
     BASE_NUM_QUERIES,
@@ -175,3 +181,157 @@ def test_companies_export(admin_client, snapshot):
         assert response.status_code == 200
         assert response["Content-Disposition"] == ("attachment; " 'filename="entreprises_2024-05-17_11-11-11.xlsx"')
         assert get_rows_from_streaming_response(response) == snapshot
+
+
+class TestTransferCompanyData:
+    CHOOSE_TARGET_TEXT = "Choisissez l’entreprise cible :"
+
+    def test_transfer_button(self, client):
+        company = CompanyFactory()
+        transfer_url = reverse("admin:transfer_company_data", kwargs={"from_company_pk": company.pk})
+
+        # Basic staff users without write access don't see the button
+        admin_user = ItouStaffFactory()
+        perms = Permission.objects.filter(codename="view_company")
+        admin_user.user_permissions.add(*perms)
+        client.force_login(admin_user)
+        response = client.get(reverse("admin:companies_company_change", kwargs={"object_id": company.pk}))
+        assertNotContains(response, transfer_url)
+
+        # A superuser, the button appears
+        # TODO(xfernandez): in a few weeks, show the buttons to user with change permission
+        # perms = Permission.objects.filter(codename="change_company")
+        # admin_user.user_permissions.add(*perms)
+        admin_user.is_superuser = True
+        admin_user.save(update_fields=("is_superuser",))
+        response = client.get(reverse("admin:companies_company_change", kwargs={"object_id": company.pk}))
+        assertContains(response, transfer_url)
+
+    def test_transfer_without_change_permission(self, client):
+        from_company = CompanyFactory()
+        to_company = CompanyFactory()
+        transfer_url_1 = reverse("admin:transfer_company_data", kwargs={"from_company_pk": from_company.pk})
+        transfer_url_2 = reverse(
+            "admin:transfer_company_data", kwargs={"from_company_pk": from_company.pk, "to_company_pk": to_company.pk}
+        )
+
+        admin_user = ItouStaffFactory()
+        perms = Permission.objects.filter(codename="view_company")
+        admin_user.user_permissions.add(*perms)
+        client.force_login(admin_user)
+        response = client.get(transfer_url_1)
+        assert response.status_code == 403
+        response = client.get(transfer_url_2)
+        assert response.status_code == 403
+
+    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "subtitle")
+    @freeze_time("2023-08-31 12:34:56")
+    def test_transfer_data(self, admin_client, snapshot):
+        job_application = JobApplicationFactory(with_approval=True)
+
+        from_company = job_application.to_company
+        to_company = CompanyFactory()
+
+        transfer_url_1 = reverse("admin:transfer_company_data", kwargs={"from_company_pk": from_company.pk})
+        transfer_url_2 = reverse(
+            "admin:transfer_company_data", kwargs={"from_company_pk": from_company.pk, "to_company_pk": to_company.pk}
+        )
+        response = admin_client.get(transfer_url_1)
+        assertContains(response, self.CHOOSE_TARGET_TEXT, html=True)
+        # Select same company
+        response = admin_client.post(transfer_url_1, data={"to_company": from_company.pk})
+        assertContains(response, "L’entreprise cible doit être différente de celle d’origine", html=True)
+        # Select valid target
+        response = admin_client.post(transfer_url_1, data={"to_company": to_company.pk})
+        assertRedirects(response, transfer_url_2, fetch_redirect_response=False)
+
+        response = admin_client.get(transfer_url_2)
+        assertContains(response, "Choisissez les objets à transférer")
+        assertContains(response, str(job_application))
+
+        response = admin_client.post(transfer_url_2, data={"fields_to_transfer": ["job_applications_received"]})
+        assertRedirects(response, reverse("admin:companies_company_change", kwargs={"object_id": from_company.pk}))
+
+        job_application.refresh_from_db()
+        assert job_application.to_company == to_company
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.INFO, f"Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}."
+                ),
+            ],
+        )
+        company_content_type = ContentType.objects.get_for_model(Company)
+        to_user_remark = PkSupportRemark.objects.filter(
+            content_type=company_content_type, object_id=to_company.pk
+        ).first()
+        from_user_remark = PkSupportRemark.objects.filter(
+            content_type=company_content_type, object_id=from_company.pk
+        ).first()
+        assert to_user_remark.remark == from_user_remark.remark
+        remark = to_user_remark.remark
+        assert "Transfert du 2023-08-31 12:34:56 effectué par" in remark
+        assert "Candidatures reçues" in remark
+
+    @pytest.mark.ignore_unknown_variable_template_error("has_view_permission", "subtitle")
+    @freeze_time("2023-08-31 12:34:56")
+    def test_transfer_data_is_searchable_and_disable_from_company(self, admin_client, snapshot):
+        job_application = JobApplicationFactory(with_approval=True)
+
+        from_company = job_application.to_company
+        assert from_company.is_searchable
+        assert not from_company.block_job_applications
+        assert not from_company.job_applications_blocked_at
+
+        to_company = CompanyFactory(is_searchable=False)
+
+        transfer_url = reverse(
+            "admin:transfer_company_data", kwargs={"from_company_pk": from_company.pk, "to_company_pk": to_company.pk}
+        )
+
+        response = admin_client.get(transfer_url)
+        assertContains(response, "Choisissez les objets à transférer")
+        assertContains(response, str(job_application))
+
+        response = admin_client.post(
+            transfer_url,
+            data={"fields_to_transfer": ["job_applications_received", "is_searchable"], "disable_from_company": True},
+        )
+        assertRedirects(response, reverse("admin:companies_company_change", kwargs={"object_id": from_company.pk}))
+
+        job_application.refresh_from_db()
+        assert job_application.to_company == to_company
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.INFO, f"Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}."
+                ),
+            ],
+        )
+
+        # Check that from_company has been properly disable
+        from_company.refresh_from_db()
+        assert not from_company.is_searchable
+        assert from_company.block_job_applications
+        assert from_company.job_applications_blocked_at
+
+        # and to_company should now be searchable
+        to_company.refresh_from_db()
+        assert to_company.is_searchable
+
+        # Check support remark
+        company_content_type = ContentType.objects.get_for_model(Company)
+        to_user_remark = PkSupportRemark.objects.filter(
+            content_type=company_content_type, object_id=to_company.pk
+        ).first()
+        from_user_remark = PkSupportRemark.objects.filter(
+            content_type=company_content_type, object_id=from_company.pk
+        ).first()
+        assert to_user_remark.remark == from_user_remark.remark
+        remark = to_user_remark.remark
+        assert "Transfert du 2023-08-31 12:34:56 effectué par" in remark
+        assert "Candidatures reçues" in remark
+        assert f"Désactivation entreprise:\n  * companies.Company[{from_company.pk}]" in remark
+        assert "Peut apparaître dans la recherche:\n  * is_searchable: False remplacé par True" in remark


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de passer par supportix et avoir plus de logs concernant les transferts.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
