### PR TITLE
UX/UI: Déplacer le texte d'intro dans les 3 onglets “organisation”

### DIFF
--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -12,9 +12,6 @@
 {% block title_content %}
     <h1>Organisation</h1>
     <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
-    <p>
-        Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
-    </p>
 {% endblock %}
 
 {% block title_extra %}
@@ -54,6 +51,9 @@
                                 </a>
                             </div>
                         </div>
+                        <p>
+                            Vous êtes connecté(e) en tant que <b>{{ user.get_full_name }}</b> ({{ user.email }})
+                        </p>
                         <p class="mb-0">
                             {{ siae.active_members.count }} collaborateur{{ siae.active_members.count|pluralizefr }} (dont {{ siae.active_admin_members.count }} administrateur{{ siae.active_admin_members.count|pluralizefr }})
                         </p>

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -34,11 +34,6 @@
 {% block title_content %}
     <h1>Organisation</h1>
     <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
-    <p>
-        Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières.
-        <br>
-        La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
-    </p>
 {% endblock %}
 
 {% block title_extra %}
@@ -78,6 +73,11 @@
                                 </div>
                             {% endif %}
                         </div>
+                        <p>
+                            Cette interface vous permet de vous assurer que votre structure est associée aux bonnes annexes financières.
+                            <br>
+                            La gestion de vos annexes financières continue de se faire dans l'extranet 2.0 de l'ASP.
+                        </p>
                         {% if financial_annexes %}
                             <div class="table-responsive-lg mt-3 mt-md-4">
                                 <table class="table">


### PR DESCRIPTION
## :thinking: Pourquoi ?

La section titre `s-title-02` ne doit pas contenir trop de texte pour limiter sa hauteur. Elle sera bientôt "siticky", donc toujours présente à l'écran. il faut donc limiter sa hauteur / son contenu
