### PR TITLE
Statistiques: Correction du funnel Matomo d'acceptation de candidature

### DIFF
--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -66,6 +66,6 @@
         {% bootstrap_field form_accept.hiring_end_at %}
         {% bootstrap_field form_accept.answer %}
 
-        {% itou_buttons_form primary_label="Valider l'embauche" primary_aria_label="Valider l’embauche de "|add:job_seeker.get_full_name|mask_unless:can_view_personal_information reset_url=back_url %}
+        {% itou_buttons_form primary_label="Valider l'embauche" primary_aria_label="Valider l’embauche de "|add:job_seeker.get_full_name|mask_unless:can_view_personal_information reset_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="accept_application_submit" %}
     </form>
 </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il a fallu corriger les noms d'événements dans matomo : 
![image](https://github.com/user-attachments/assets/42a3762a-eb7c-4660-91f5-0e2a7b7a8fef)


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
