### PR TITLE
Admin: PASS IAE cliquable dans la fiche salarié

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -2,7 +2,9 @@ import itertools
 
 from django import forms
 from django.contrib import admin, messages
+from django.urls import reverse
 from django.utils import timezone
+from django.utils.html import format_html
 
 import itou.employee_record.models as models
 from itou.companies import models as companies_models
@@ -159,7 +161,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
         "created_at",
         "updated_at",
         "processed_at",
-        "approval_number",
+        "approval_number_link",
         "job_application",
         "job_seeker_link",
         "job_seeker_profile_link",
@@ -197,7 +199,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
                     "pk",
                     "status",
                     "job_application",
-                    "approval_number",
+                    "approval_number_link",
                     "job_seeker_link",
                     "job_seeker_profile_link",
                     "siret",
@@ -227,6 +229,12 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
             },
         ),
     )
+
+    @admin.display(description="numéro d'agrément")
+    def approval_number_link(self, obj):
+        if approval_number := obj.approval_number:
+            url = reverse("admin:approvals_approval_change", args=(obj.job_application.approval_id,))
+            return format_html('<a href="{}">{}</a>', url, approval_number)
 
     @admin.display(description="salarié")
     def job_seeker_link(self, obj):

--- a/tests/employee_record/test_admin.py
+++ b/tests/employee_record/test_admin.py
@@ -4,6 +4,7 @@ from django.contrib.admin import helpers
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertMessages
 
+from itou.approvals.models import Approval
 from itou.employee_record import models
 from tests.employee_record import factories
 
@@ -68,3 +69,12 @@ def test_job_seeker_profile_from_employee_record(admin_client):
     response = admin_client.get(employee_record_view_url)
     assertContains(response, "Profil salarié")
     assertContains(response, job_seeker.jobseeker_profile.pk)
+
+
+def test_approval_number_from_employee_record(admin_client):
+    er = factories.EmployeeRecordFactory()
+    approval_number = Approval.objects.get(number=er.approval_number)
+    employee_record_view_url = reverse("admin:employee_record_employeerecord_change", args=[er.pk])
+    approval_number_url = reverse("admin:approvals_approval_change", args=[approval_number.pk])
+    response = admin_client.get(employee_record_view_url)
+    assertContains(response, f'<a href="{approval_number_url}">{approval_number.number}</a>')


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand on est sur l’admin de la fiche salarié, le n° du PASS est affiché mais n’est pas cliquable. 
Si on souhaite de nouveau avoir le visu sur le PASS, on doit faire un retour en arrière.
Or si le n° de PASS sur la FS devient cliquable, cela nous simplifiera la vie.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
