### PR TITLE
dependabot: Utiliser les versions mineures de Python au lieu des patchs

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.11.3
+python-3.11


### PR DESCRIPTION
## :thinking: Pourquoi ?

Trop de patchs, on oublie de mettre à jour.
Avec un peu de chance, on greppera `3.11` au moment de la migration vers Python `3.12`.
