### PR TITLE
tests: correction d'un test instable

### DIFF
--- a/tests/communications/test_models.py
+++ b/tests/communications/test_models.py
@@ -120,7 +120,7 @@ class AnnouncementCampaignModelTest(TestCase):
             AnnouncementCampaignFactory(start_date=date(2024, 1, 2))
 
     def test_start_date_conflict_constraint(self):
-        existing_campaign = AnnouncementCampaignFactory()
+        existing_campaign = AnnouncementCampaignFactory(start_date=date(2023, 1, 1))
 
         # can modify existing value without triggering constraint
         existing_campaign = AnnouncementCampaignFactory(start_date=date(2024, 1, 1))


### PR DESCRIPTION


## :thinking: Pourquoi ?

Cf https://github.com/gip-inclusion/les-emplois/actions/runs/10787394093/job/29916000581

```
         except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           django.db.utils.IntegrityError: duplicate key value violates unique constraint "communications_announcementcampaign_start_date_key"
E           DETAIL:  Key (start_date)=(2024-02-01) already exists.
```
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
