### PR TITLE
Tableau de bord : déplacer "déclarer une embauche" pour les GEIQ

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -169,7 +169,7 @@
             {% endif %}
         </div>
         {% if user.is_employer %}
-            {% if request.current_organization.is_subject_to_eligibility_rules %}
+            {% if request.current_organization.is_subject_to_eligibility_rules or request.current_organization.kind == CompanyKind.GEIQ %}
                 {% comment %}
                 NOTE(vperron):
                 We currently do not allow OPCS users to apply for an offer.

--- a/itou/templates/dashboard/includes/employer_job_applications_card.html
+++ b/itou/templates/dashboard/includes/employer_job_applications_card.html
@@ -20,14 +20,6 @@
                         <span class="badge rounded-pill badge-xs {{ category.badge }} text-info">{{ category.counter }}</span>
                     </li>
                 {% endfor %}
-                {% if request.current_organization.kind == CompanyKind.GEIQ %}
-                    <li class="d-flex justify-content-between align-items-center mb-3">
-                        <a href="{% url 'apply:check_nir_for_hire' company_pk=request.current_organization.pk %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
-                            <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
-                            <span>Déclarer une embauche</span>
-                        </a>
-                    </li>
-                {% endif %}
                 {% if request.current_organization.is_subject_to_eligibility_rules or request.current_organization.kind == CompanyKind.GEIQ %}
                     {% if siae_suspension_text_with_dates %}
                         <span class="btn-link btn-ico"

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -211,6 +211,7 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
             CompanyKind.EITI,
             CompanyKind.ACI,
             CompanyKind.ETTI,
+            CompanyKind.GEIQ,
         ]:
             with self.subTest(f"should display when company_kind={kind}"):
                 company = CompanyFactory(kind=kind, with_membership=True)
@@ -220,15 +221,14 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
                 response = self.client.get(reverse("dashboard:index"))
                 self.assertContains(response, self.HIRE_LINK_LABEL)
 
-        for kind in [CompanyKind.EA, CompanyKind.EATT, CompanyKind.GEIQ, CompanyKind.OPCS]:
+        for kind in [CompanyKind.EA, CompanyKind.EATT, CompanyKind.OPCS]:
             with self.subTest(f"should not display when company_kind={kind}"):
                 company = CompanyFactory(kind=kind, with_membership=True)
                 user = company.members.first()
                 self.client.force_login(user)
 
                 response = self.client.get(reverse("dashboard:index"))
-                assertion = self.assertContains if kind == CompanyKind.GEIQ else self.assertNotContains
-                assertion(response, self.HIRE_LINK_LABEL)
+                self.assertNotContains(response, self.HIRE_LINK_LABEL)
 
     def test_dashboard_job_applications(self):
         APPLICATION_SAVE_LABEL = "Enregistrer une candidature"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ajouter le bouton “Déclarer une embauche” en haut à droite (comme pour les SIAE) et le retirer de la rubrique candidature

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->