### PR TITLE
Connexion: Suppression d'un paramètre inutilisé 

### DIFF
--- a/itou/openid_connect/inclusion_connect/enums.py
+++ b/itou/openid_connect/inclusion_connect/enums.py
@@ -7,6 +7,5 @@ class InclusionConnectChannel(str, enum.Enum):
     """
 
     INVITATION = "invitation"
-    POLE_EMPLOI = "pole_emploi"
     ACTIVATION = "activation"
     MAP_CONSEILLER = "map_conseiller"

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -23,7 +23,6 @@ from django.views.generic import FormView, TemplateView, View
 from itou.common_apps.address.models import lat_lon_to_coords
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company, CompanyMembership
-from itou.openid_connect.inclusion_connect.enums import InclusionConnectChannel
 from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.users.adapter import UserAdapter
@@ -605,7 +604,6 @@ def prescriber_pole_emploi_user(request, template_name="signup/prescriber_pole_e
     )
     params = {
         "user_email": session_data["email"],
-        "channel": InclusionConnectChannel.POLE_EMPLOI.value,
         "user_kind": KIND_PRESCRIBER,
         "previous_url": request.get_full_path(),
         "next_url": reverse("signup:prescriber_join_org"),

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -96,7 +96,6 @@ class PrescriberSignupTest(InclusionConnectBaseTestCase):
         next_url = reverse("signup:prescriber_join_org")
         params = {
             "user_email": email,
-            "channel": "pole_emploi",
             "user_kind": KIND_PRESCRIBER,
             "previous_url": previous_url,
             "next_url": next_url,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cette valeur d'enum n'est pas utile car il n'y a pas de parcours particulier à faire (contrairement à l'activation, l'invitation et map).
On traite un channel "POLE_EMPLOI" comme les autres prescripteurs.

C'est un reliquat des commits suivant
mise en place dans c11e0ec96e1eec5fda69e18dc8b49e5c626caa7b
plus utile depuis d347c391538951e7afd10a3191424d570ced7348

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
