### PR TITLE
UX/UI: renommer “organisation” en “structure” pour les employeurs

### DIFF
--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Organisation</h1>
+    <h1>Structure</h1>
     <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
 {% endblock %}
 

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Organisation</h1>
+    <h1>Structure</h1>
     <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
 {% endblock %}
 

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Organisation</h1>
+    <h1>Structure</h1>
     <h2>{{ siae.kind }} {{ siae.display_name }}</h2>
 {% endblock %}
 

--- a/itou/templates/dashboard/includes/employer_company_card.html
+++ b/itou/templates/dashboard/includes/employer_company_card.html
@@ -4,7 +4,7 @@
     <div class="c-box p-0 h-100">
         <div class="d-flex p-3 p-lg-4">
             <div class="flex-grow-1">
-                <span class="h4 m-0">Organisation</span>
+                <span class="h4 m-0">Structure</span>
             </div>
             <div class="ms-2">
                 <span class="badge rounded-pill badge-sm bg-primary">{{ request.current_organization.kind }} - ID {{ request.current_organization.id }}</span>

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -217,7 +217,7 @@ def nav(request):
                 company_group_items.append(NAV_ENTRIES["employer-members"])
             if request.current_organization.convention_can_be_accessed_by(request.user):
                 company_group_items.append(NAV_ENTRIES["employer-financial-annexes"])
-            menu_items.append(NavGroup(label="Organisation", icon="ri-community-line", items=company_group_items))
+            menu_items.append(NavGroup(label="Structure", icon="ri-community-line", items=company_group_items))
         elif request.user.is_labor_inspector:
             menu_items.append(
                 NavGroup(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement ça s’appelle “organisation” mais les employeurs n’utilisent pas ce terme
