### PR TITLE
UX/UI: Passer “Salariés et PASS IAE” et “Fiches salariés ASP” en onglets

### DIFF
--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -1,6 +1,8 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load matomo %}
+{% load str_filters %}
 
 {% block title %}Salariés et PASS IAE {{ block.super }}{% endblock %}
 
@@ -8,35 +10,54 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Salariés et PASS IAE</h1>{% endblock %}
+{% block title_content %}<h1>Salariés</h1>{% endblock %}
+
+{% block title_extra %}
+    {% if request.current_organization.can_use_employee_record %}
+        <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true">
+            <li class="nav-item active">
+                <a class="nav-link active" href="{% url 'approvals:list' %}" {% matomo_event "employeurs" "clic" "onglet-salaries-pass-iae" %}>
+                    Salariés et PASS IAE
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'employee_record_views:list' %}?status=NEW" {% matomo_event "employeurs" "clic" "onglet-fiches-salaries" %}>
+                    <span>Fiches salariés ASP</span>
+                    {% if num_rejected_employee_records %}
+                        <span class="badge badge-sm rounded-pill bg-warning text-white ms-2">{{ num_rejected_employee_records }}</span>
+                    {% endif %}
+                </a>
+            </li>
+        </ul>
+    {% endif %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="col-12">
-                    <form hx-get="{% url 'approvals:list' %}"
-                          hx-trigger="change delay:.5s, change from:#id_job_seeker"
-                          hx-indicator="#approvals-list"
-                          hx-target="#approvals-list"
-                          hx-swap="outerHTML"
-                          hx-push-url="true"
-                          hx-include="#id_job_seeker">
-                        <div class="btn-dropdown-filter-group mb-3 mb-md-4">
-                            {% include "approvals/includes/approvals_filters/status.html" %}
-                            {% include "includes/btn_dropdown_filter/radio.html" with field=filters_form.expiry only %}
-                            {% include "approvals/includes/list_reset_filters.html" %}
+                    <div class="tab-content">
+                        <h2 class="mb-3 mb-md-4">Salariés et PASS IAE</h2>
+                        <form hx-get="{% url 'approvals:list' %}"
+                              hx-trigger="change delay:.5s, change from:#id_job_seeker"
+                              hx-indicator="#approvals-list"
+                              hx-target="#approvals-list"
+                              hx-swap="outerHTML"
+                              hx-push-url="true"
+                              hx-include="#id_job_seeker">
+                            <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                                {% include "approvals/includes/approvals_filters/status.html" %}
+                                {% include "includes/btn_dropdown_filter/radio.html" with field=filters_form.expiry only %}
+                                {% include "approvals/includes/list_reset_filters.html" %}
+                            </div>
+                        </form>
+                        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                            {% include "approvals/includes/list_counter.html" %}
+                            <div class="flex-column flex-md-row mt-3 mt-md-0">{% bootstrap_field filters_form.job_seeker layout="inline" %}</div>
                         </div>
-                    </form>
-                </div>
-            </div>
-            <div class="s-section__row row">
-                <div class="col-12">
-                    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
-                        {% include "approvals/includes/list_counter.html" %}
-                        <div class="flex-column flex-md-row mt-3 mt-md-0">{% bootstrap_field filters_form.job_seeker layout="inline" %}</div>
+                        {% include "approvals/includes/list_results.html" %}
                     </div>
-                    {% include "approvals/includes/list_results.html" %}
                 </div>
             </div>
         </div>
@@ -45,6 +66,7 @@
 
 {% block script %}
     {{ block.super }}
+    <script src='{% static "js/sliding_tabs.js" %}'></script>
     <script src='{% static "js/htmx_compat.js" %}'></script>
     <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
     <!-- Needed to use the Select2MultipleWidget JS widget. -->

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -19,14 +19,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true">
         <li class="nav-item">
             <a class="nav-link active" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                <span>Métiers et recrutements</span>
-                <span class="badge badge-sm rounded-pill ms-2">{{ job_pager.paginator.count }}</span>
+                Métiers et recrutements
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:members' %}" {% matomo_event "employeurs" "clic" "gerer-collaborateurs" %}>
-                <span>Collaborateurs</span>
-                <span class="badge badge-sm rounded-pill ms-2">{{ members_count }}</span>
+                Collaborateurs
             </a>
         </li>
         {% if can_show_financial_annexes %}

--- a/itou/templates/companies/members.html
+++ b/itou/templates/companies/members.html
@@ -18,14 +18,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="1">
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                <span>Métiers et recrutements</span>
-                <span class="badge badge-sm rounded-pill ms-2">{{ jobs_count }}</span>
+                Métiers et recrutements
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link active" href="{% url 'companies_views:members' %}" {% matomo_event "employeurs" "clic" "gerer-collaborateurs" %}>
-                <span>Collaborateurs</span>
-                <span class="badge badge-sm rounded-pill ms-2">{{ siae.active_members.count }}</span>
+                Collaborateurs
             </a>
         </li>
         {% if can_show_financial_annexes %}

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -40,14 +40,12 @@
     <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true" data-it-sliding-tabs-startindex="2">
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:job_description_list' %}" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                <span>Métiers et recrutements</span>
-                <span class="badge badge-sm rounded-pill ms-2">{{ jobs_count }}</span>
+                Métiers et recrutements
             </a>
         </li>
         <li class="nav-item">
             <a class="nav-link" href="{% url 'companies_views:members' %}" {% matomo_event "employeurs" "clic" "gerer-collaborateurs" %}>
-                <span>Collaborateurs</span>
-                <span class="badge badge-sm rounded-pill ms-2">{{ members_count }}</span>
+                Collaborateurs
             </a>
         </li>
         <li class="nav-item">

--- a/itou/templates/dashboard/includes/employer_employees_card.html
+++ b/itou/templates/dashboard/includes/employer_employees_card.html
@@ -18,7 +18,7 @@
                             <span>Fiches salariés ASP</span>
                         </a>
                         {% if num_rejected_employee_records %}
-                            <span class="badge rounded-pill badge-xs bg-danger">{{ num_rejected_employee_records }}</span>
+                            <span class="badge rounded-pill badge-xs bg-warning">{{ num_rejected_employee_records }}</span>
                         {% endif %}
                         {% if request.current_organization.kind == CompanyKind.EITI %}
                             {% include "dashboard/includes/stats_new_badge.html" %}

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% load matomo %}
 
 {% block title %}Fiches salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}{% endblock %}
 
@@ -29,20 +30,26 @@
     {% endif %}
 {% endblock %}
 
-{% block title_content %}
-    <h1>Fiches salarié ASP - {{ request.current_organization.display_name }}</h1>
-    <h2 class="h3">Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</h2>
-    <p>Une fois envoyées et validées, vous retrouverez directement vos données sur l'extranet de l'ASP.</p>
-    <ul>
-        <li>
-            Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à partir du <b>{{ feature_availability_date|date }}</b>.
-        </li>
-        <li>
-            Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.
-        </li>
-        <li>La visualisation dans l’Extranet IAE 2.0 interviendra dans les 2 heures suivant l’envoi.</li>
-    </ul>
-    {% include "employee_record/includes/list_status_help.html" with request=request status=form.status.value only %}
+{% block title_content %}<h1>Salariés</h1>{% endblock %}
+
+{% block title_extra %}
+    {% if request.current_organization.can_use_employee_record %}
+        <ul class="s-tabs-01__nav nav nav-tabs" data-it-sliding-tabs="true">
+            <li class="nav-item">
+                <a class="nav-link" href="{% url 'approvals:list' %}" {% matomo_event "employeurs" "clic" "onglet-salaries-pass-iae" %}>
+                    Salariés et PASS IAE
+                </a>
+            </li>
+            <li class="nav-item">
+                <a class="nav-link active" href="{% url 'employee_record_views:list' %}?status=NEW" {% matomo_event "employeurs" "clic" "onglet-fiches-salaries" %}>
+                    <span>Fiches salariés ASP</span>
+                    {% if num_rejected_employee_records %}
+                        <span class="badge badge-sm rounded-pill bg-warning text-white ms-2">{{ num_rejected_employee_records }}</span>
+                    {% endif %}
+                </a>
+            </li>
+        </ul>
+    {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -50,46 +57,63 @@
         <div class="s-section__container container">
             <div class="row my-3 my-md-5">
                 <div class="col-12">
-                    <div class="c-box p-3 p-md-4 d-flex align-items-center">
-                        <div class="p-0 flex-grow-1 h5 m-0">Vous ne trouvez pas la fiche salarié d’un de vos salariés ?</div>
-                        <a class="btn btn-primary" href="{% url "employee_record_views:add" %}">Créer une fiche salarié</a>
-                    </div>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-12">
-                    <form hx-get="{% url 'employee_record_views:list' %}"
-                          hx-trigger="change delay:.5s, change from:#id_job_seeker"
-                          hx-indicator="#employee-records-container"
-                          hx-target="#employee-records-container"
-                          hx-swap="outerHTML"
-                          hx-push-url="true"
-                          hx-include="#id_job_seeker">
-                        <div class="btn-dropdown-filter-group mb-3 mb-md-4">
-                            <div class="dropdown">
-                                <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
-                                    Statut
-                                </button>
-                                <ul class="dropdown-menu">
-                                    {% include "employee_record/includes/employee_record_filters/status.html" %}
+                    <div class="tab-content">
+                        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
+                            <h2 class="mb-0">Fiches salarié ASP</h2>
+                            <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les collaborateurs">
+                                <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}">
+                                    <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
+                                    <span>Créer une fiche salarié</span>
+                                </a>
+                            </div>
+                        </div>
+                        {% include "employee_record/includes/list_status_help.html" with request=request status=form.status.value only %}
+                        <div class="c-info mb-3 mb-md-4">
+                            <button class="c-info__summary collapsed" data-bs-toggle="collapse" data-bs-target="#collapseInfoASP" aria-expanded="false" aria-controls="collapseInfoASP">
+                                <span>Nous transférons vos fiches salarié à l'ASP afin de vous faire gagner du temps</span>
+                            </button>
+                            <div class="c-info__detail collapse" id="collapseInfoASP">
+                                <p>Une fois envoyées et validées, vous retrouverez directement vos données sur l'extranet de l'ASP.</p>
+                                <ul>
+                                    <li>
+                                        Ne sont présentes dans cette liste que les candidatures acceptées (embauches) à partir du <b>{{ feature_availability_date|date }}</b>.
+                                    </li>
+                                    <li>
+                                        Vous devez avoir une annexe financière valide dans l'extranet de l'ASP pour pouvoir déclarer une fiche salarié dans les emplois.
+                                    </li>
+                                    <li>La visualisation dans l’Extranet IAE 2.0 interviendra dans les 2 heures suivant l’envoi.</li>
                                 </ul>
                             </div>
                         </div>
-                        {# Filled via jQuery. Does not need reloading with HTMX, its content is static. #}
-                        {{ form.order.as_hidden }}
-                    </form>
-                </div>
-            </div>
-            <div class="row">
-                <div class="col-12">
-                    <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
-                        {% include "employee_record/includes/list_counter.html" %}
-                        {% include "employee_record/includes/list_order.html" %}
-                        <div class="flex-column flex-md-row mt-3 mt-md-0 ms-md-3">
-                            {% bootstrap_field filters_form.job_seeker layout="inline" %}
+                        <form hx-get="{% url 'employee_record_views:list' %}"
+                              hx-trigger="change delay:.5s, change from:#id_job_seeker"
+                              hx-indicator="#employee-records-container"
+                              hx-target="#employee-records-container"
+                              hx-swap="outerHTML"
+                              hx-push-url="true"
+                              hx-include="#id_job_seeker">
+                            <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                                <div class="dropdown">
+                                    <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+                                        Statut
+                                    </button>
+                                    <ul class="dropdown-menu">
+                                        {% include "employee_record/includes/employee_record_filters/status.html" %}
+                                    </ul>
+                                </div>
+                            </div>
+                            {# Filled via jQuery. Does not need reloading with HTMX, its content is static. #}
+                            {{ form.order.as_hidden }}
+                        </form>
+                        <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                            {% include "employee_record/includes/list_counter.html" %}
+                            {% include "employee_record/includes/list_order.html" %}
+                            <div class="flex-column flex-md-row mt-3 mt-md-0 ms-md-3">
+                                {% bootstrap_field filters_form.job_seeker layout="inline" %}
+                            </div>
                         </div>
+                        {% include "employee_record/includes/list_results.html" %}
                     </div>
-                    {% include "employee_record/includes/list_results.html" %}
                 </div>
             </div>
         </div>
@@ -98,6 +122,7 @@
 
 {% block script %}
     {{ block.super }}
+    <script src='{% static "js/sliding_tabs.js" %}'></script>
     <script src='{% static "js/htmx_compat.js" %}'></script>
     <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
     <!-- Needed to use Select2MultipleWidget. -->

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -19,12 +19,9 @@ from formtools.wizard.views import NamedUrlSessionWizardView
 
 from itou.approvals import enums as approvals_enums
 from itou.approvals.constants import PROLONGATION_REPORT_FILE_REASONS
-from itou.approvals.models import (
-    Approval,
-    ProlongationRequest,
-    ProlongationRequestDenyInformation,
-    Suspension,
-)
+from itou.approvals.models import Approval, ProlongationRequest, ProlongationRequestDenyInformation, Suspension
+from itou.employee_record.enums import Status
+from itou.employee_record.models import EmployeeRecord
 from itou.files.models import File
 from itou.utils import constants as global_constants
 from itou.utils.pagination import ItouPaginator, pager
@@ -114,6 +111,9 @@ class ApprovalListView(ApprovalBaseViewMixin, ListView):
         context["filters_form"] = self.form
         context["filters_counter"] = self.form.get_filters_counter()
         context["back_url"] = reverse("dashboard:index")
+        context["num_rejected_employee_records"] = (
+            EmployeeRecord.objects.for_company(self.siae).filter(status=Status.REJECTED).count()
+        )
         return context
 
 

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -17,7 +17,7 @@ from django.views.generic.base import TemplateView
 from itou.cities.models import City
 from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.organizations.views import deactivate_org_member, update_org_admin_role
-from itou.companies.models import Company, CompanyMembership, JobDescription, SiaeFinancialAnnex
+from itou.companies.models import Company, JobDescription, SiaeFinancialAnnex
 from itou.jobs.models import Appellation
 from itou.users.models import User
 from itou.utils import constants as global_constants
@@ -237,7 +237,6 @@ def job_description_list(request, template_name="companies/job_description_list.
         "form": form,
         "job_pager": job_pager,
         "page": page,
-        "members_count": CompanyMembership.objects.filter(company_id=company.pk).active().count(),
         "can_show_financial_annexes": company.convention_can_be_accessed_by(request.user),
         "back_url": reverse("dashboard:index"),
     }
@@ -397,8 +396,6 @@ def show_financial_annexes(request, template_name="companies/show_financial_anne
         "can_select_af": current_siae.convention_can_be_changed_by(request.user),
         "siae_is_asp": current_siae.source == Company.SOURCE_ASP,
         "siae_is_user_created": current_siae.source == Company.SOURCE_USER_CREATED,
-        "jobs_count": JobDescription.objects.filter(company_id=current_siae.pk).count(),
-        "members_count": CompanyMembership.objects.filter(company_id=current_siae.pk).active().count(),
         "back_url": reverse("dashboard:index"),
     }
     return render(request, template_name, context)
@@ -626,7 +623,6 @@ def members(request, template_name="companies/members.html"):
         "members": active_company_members,
         "members_stats": active_company_members_stats,
         "pending_invitations": pending_invitations,
-        "jobs_count": JobDescription.objects.filter(company_id=company.pk).count(),
         "can_show_financial_annexes": company.convention_can_be_accessed_by(request.user),
         "back_url": reverse("dashboard:index"),
     }

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -259,6 +259,9 @@ def list_employee_records(request, template_name="employee_record/list.html"):
         "ordered_by_label": order_by.label,
         "matomo_custom_title": "Fiches salarié ASP",
         "back_url": reverse("dashboard:index"),
+        "num_rejected_employee_records": EmployeeRecord.objects.for_company(siae)
+        .filter(status=Status.REJECTED)
+        .count(),
     }
 
     return render(request, "employee_record/includes/list_results.html" if request.htmx else template_name, context)

--- a/tests/www/approvals_views/__snapshots__/test_list.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_list.ambr
@@ -1,0 +1,432 @@
+# serializer version: 1
+# name: TestApprovalsListView.test_job_seeker_filters[approvals list]
+  dict({
+    'num_queries': 15,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "companies_companymembership"."notifications"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "companies_companymembership"."is_active")
+          ORDER BY "companies_companymembership"."created_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_insertion_id",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_siaeconvention" U0
+             WHERE (U0."deactivated_at" >= %s
+                    AND U0."id" = ("companies_company"."convention_id"))
+             LIMIT 1) AS "has_convention_in_grace_period"
+          FROM "companies_company"
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND "companies_companymembership"."user_id" = %s
+                 AND "companies_company"."id" IN (%s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."deactivated_at" >= %s
+                                AND U0."id" = ("companies_company"."convention_id"))
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'ApprovalForm._get_choices_for_job_seekers[www/approvals_views/forms.py]',
+          'ApprovalForm.__init__[www/approvals_views/forms.py]',
+          'ApprovalListView.setup[www/approvals_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          INNER JOIN "approvals_approval" ON ("users_user"."id" = "approvals_approval"."user_id")
+          WHERE ("approvals_approval"."id" IN
+                   (SELECT V0."id"
+                    FROM "approvals_approval" V0
+                    WHERE EXISTS
+                        (SELECT %s AS "a"
+                         FROM "job_applications_jobapplication" U0
+                         WHERE (U0."approval_id" = (V0."id")
+                                AND U0."state" = %s
+                                AND U0."to_company_id" = %s)
+                         LIMIT 1))
+                 AND "users_user"."kind" = %s)
+          ORDER BY "users_user"."first_name" ASC,
+                   "users_user"."last_name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ApprovalListView.get_context_data[www/approvals_views/views.py]',
+          'ApprovalListView.get_context_data[www/approvals_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT DISTINCT "approvals_approval"."id" AS "col1",
+                             "approvals_approval"."start_at" AS "col2",
+                             "approvals_approval"."end_at" AS "col3",
+                             "approvals_approval"."created_at" AS "col4",
+                             "approvals_approval"."number" AS "col5",
+                             "approvals_approval"."pe_notification_status" AS "col6",
+                             "approvals_approval"."pe_notification_time" AS "col7",
+                             "approvals_approval"."pe_notification_endpoint" AS "col8",
+                             "approvals_approval"."pe_notification_exit_code" AS "col9",
+                             "approvals_approval"."user_id" AS "col10",
+                             "approvals_approval"."created_by_id" AS "col11",
+                             "approvals_approval"."origin" AS "col12",
+                             "approvals_approval"."eligibility_diagnosis_id" AS "col13",
+                             "approvals_approval"."updated_at" AS "col14",
+                             "approvals_approval"."origin_siae_siret" AS "col15",
+                             "approvals_approval"."origin_siae_kind" AS "col16",
+                             "approvals_approval"."origin_sender_kind" AS "col17",
+                             "approvals_approval"."origin_prescriber_organization_kind" AS "col18"
+             FROM "approvals_approval"
+             WHERE EXISTS
+                 (SELECT %s AS "a"
+                  FROM "job_applications_jobapplication" U0
+                  WHERE (U0."approval_id" = ("approvals_approval"."id")
+                         AND U0."state" = %s
+                         AND U0."to_company_id" = %s)
+                  LIMIT 1)) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Company.is_active[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[approvals/list.html]',
+        ]),
+        'sql': '''
+          SELECT "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_siaeconvention"
+          WHERE "companies_siaeconvention"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.has_admin[common_apps/organizations/models.py]',
+          'Company.convention_can_be_accessed_by[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[approvals/list.html]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE ("companies_companymembership"."id" IN
+                   (SELECT U0."id"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = %s
+                           AND U2."is_active"
+                           AND U0."is_active"
+                           AND U0."is_admin"
+                           AND U2."is_active"))
+                 AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[approvals/includes/list_results.html]',
+          'IncludeNode[approvals/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[approvals/list.html]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT "approvals_approval"."id",
+                          "approvals_approval"."start_at",
+                          "approvals_approval"."end_at",
+                          "approvals_approval"."created_at",
+                          "approvals_approval"."number",
+                          "approvals_approval"."pe_notification_status",
+                          "approvals_approval"."pe_notification_time",
+                          "approvals_approval"."pe_notification_endpoint",
+                          "approvals_approval"."pe_notification_exit_code",
+                          "approvals_approval"."user_id",
+                          "approvals_approval"."created_by_id",
+                          "approvals_approval"."origin",
+                          "approvals_approval"."eligibility_diagnosis_id",
+                          "approvals_approval"."updated_at",
+                          "approvals_approval"."origin_siae_siret",
+                          "approvals_approval"."origin_siae_kind",
+                          "approvals_approval"."origin_sender_kind",
+                          "approvals_approval"."origin_prescriber_organization_kind",
+                          "users_user"."id",
+                          "users_user"."password",
+                          "users_user"."last_login",
+                          "users_user"."is_superuser",
+                          "users_user"."username",
+                          "users_user"."first_name",
+                          "users_user"."last_name",
+                          "users_user"."is_staff",
+                          "users_user"."is_active",
+                          "users_user"."date_joined",
+                          "users_user"."address_line_1",
+                          "users_user"."address_line_2",
+                          "users_user"."post_code",
+                          "users_user"."city",
+                          "users_user"."department",
+                          "users_user"."coords",
+                          "users_user"."geocoding_score",
+                          "users_user"."geocoding_updated_at",
+                          "users_user"."ban_api_resolved_address",
+                          "users_user"."insee_city_id",
+                          "users_user"."title",
+                          "users_user"."email",
+                          "users_user"."phone",
+                          "users_user"."kind",
+                          "users_user"."identity_provider",
+                          "users_user"."has_completed_welcoming_tour",
+                          "users_user"."created_by_id",
+                          "users_user"."external_data_source_history",
+                          "users_user"."last_checked_at",
+                          "users_user"."public_id",
+                          "users_user"."address_filled_at",
+                          "users_user"."first_login"
+          FROM "approvals_approval"
+          INNER JOIN "users_user" ON ("approvals_approval"."user_id" = "users_user"."id")
+          WHERE EXISTS
+              (SELECT %s AS "a"
+               FROM "job_applications_jobapplication" U0
+               WHERE (U0."approval_id" = ("approvals_approval"."id")
+                      AND U0."state" = %s
+                      AND U0."to_company_id" = %s)
+               LIMIT 1)
+          ORDER BY "approvals_approval"."created_at" DESC
+          LIMIT 2
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[approvals/includes/list_results.html]',
+          'IncludeNode[approvals/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[approvals/list.html]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."approval_id" IN (%s,
+                                                         %s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          UPDATE "django_session"
+          SET "session_data" = %s,
+              "expire_date" = %s
+          WHERE "django_session"."session_key" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---

--- a/tests/www/approvals_views/__snapshots__/test_list.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_list.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestApprovalsListView.test_job_seeker_filters[approvals list]
   dict({
-    'num_queries': 15,
+    'num_queries': 16,
     'queries': list([
       dict({
         'origin': list([
@@ -246,6 +246,18 @@
                          AND U0."state" = %s
                          AND U0."to_company_id" = %s)
                   LIMIT 1)) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ApprovalListView.get_context_data[www/approvals_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          WHERE ("job_applications_jobapplication"."to_company_id" = %s
+                 AND "employee_record_employeerecord"."status" = %s)
         ''',
       }),
       dict({

--- a/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
@@ -1,0 +1,415 @@
+# serializer version: 1
+# name: JobDescriptionListViewTest.test_job_application_list_response_content[job applications list]
+  dict({
+    'num_queries': 17,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "companies_companymembership"."notifications"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "companies_companymembership"."is_active")
+          ORDER BY "companies_companymembership"."created_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_insertion_id",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_siaeconvention" U0
+             WHERE (U0."deactivated_at" >= %s
+                    AND U0."id" = ("companies_company"."convention_id"))
+             LIMIT 1) AS "has_convention_in_grace_period"
+          FROM "companies_company"
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND "companies_companymembership"."user_id" = %s
+                 AND "companies_company"."id" IN (%s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."deactivated_at" >= %s
+                                AND U0."id" = ("companies_company"."convention_id"))
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'pager[utils/pagination.py]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "companies_jobdescription"
+          WHERE "companies_jobdescription"."company_id" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("companies_companymembership"."company_id" = %s
+                 AND "users_user"."is_active"
+                 AND "companies_companymembership"."is_active")
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.has_admin[common_apps/organizations/models.py]',
+          'Company.convention_can_be_accessed_by[companies/models.py]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE ("companies_companymembership"."id" IN
+                   (SELECT U0."id"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = %s
+                           AND U2."is_active"
+                           AND U0."is_active"
+                           AND U0."is_admin"
+                           AND U2."is_active"))
+                 AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.is_active[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[companies/job_description_list.html]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_siaeconvention"
+          WHERE "companies_siaeconvention"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.has_admin[common_apps/organizations/models.py]',
+          'Company.convention_can_be_accessed_by[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[companies/job_description_list.html]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE ("companies_companymembership"."id" IN
+                   (SELECT U0."id"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = %s
+                           AND U2."is_active"
+                           AND U0."is_active"
+                           AND U0."is_admin"
+                           AND U2."is_active"))
+                 AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[companies/job_description_list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[companies/job_description_list.html]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."contract_nature",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_insertion_id",
+                 "cities_city"."id",
+                 "cities_city"."name",
+                 "cities_city"."slug",
+                 "cities_city"."department",
+                 "cities_city"."post_codes",
+                 "cities_city"."code_insee",
+                 "cities_city"."coords",
+                 "cities_city"."edition_mode"
+          FROM "companies_jobdescription"
+          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
+          WHERE "companies_jobdescription"."company_id" = %s
+          ORDER BY "companies_jobdescription"."updated_at" DESC,
+                   "companies_jobdescription"."created_at" DESC
+          LIMIT 4
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[companies/job_description_list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[companies/job_description_list.html]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "jobs_appellation"."updated_at",
+                 "jobs_appellation"."code",
+                 "jobs_appellation"."name",
+                 "jobs_appellation"."rome_id",
+                 "jobs_appellation"."full_text"
+          FROM "jobs_appellation"
+          WHERE "jobs_appellation"."code" IN (%s,
+                                              %s,
+                                              %s,
+                                              %s)
+          ORDER BY "jobs_appellation"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[companies/job_description_list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[companies/job_description_list.html]',
+          'job_description_list[www/companies_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "jobs_rome"."updated_at",
+                 "jobs_rome"."code",
+                 "jobs_rome"."name"
+          FROM "jobs_rome"
+          WHERE "jobs_rome"."code" IN (%s,
+                                       %s,
+                                       %s,
+                                       %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          UPDATE "django_session"
+          SET "session_data" = %s,
+              "expire_date" = %s
+          WHERE "django_session"."session_key" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---

--- a/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: JobDescriptionListViewTest.test_job_application_list_response_content[job applications list]
   dict({
-    'num_queries': 17,
+    'num_queries': 16,
     'queries': list([
       dict({
         'origin': list([
@@ -165,19 +165,6 @@
           SELECT COUNT(*) AS "__count"
           FROM "companies_jobdescription"
           WHERE "companies_jobdescription"."company_id" = %s
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'job_description_list[www/companies_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT COUNT(*) AS "__count"
-          FROM "companies_companymembership"
-          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
-          WHERE ("companies_companymembership"."company_id" = %s
-                 AND "users_user"."is_active"
-                 AND "companies_companymembership"."is_active")
         ''',
       }),
       dict({

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -62,7 +62,6 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
         "Votre compte utilisateur n’est rattaché à aucune agence France Travail, "
         "par conséquent vous ne pouvez pas bénéficier du statut de prescripteur habilité."
     )
-    DANGER_CLASS = "bg-danger"
     SUSPEND_TEXT = "Suspendre un PASS IAE"
     HIRE_LINK_LABEL = "Déclarer une embauche"
     DORA_LABEL = "DORA"
@@ -137,6 +136,7 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
         self.assertContains(response, "Liste de mes candidats")
 
     def test_dashboard_displays_asp_badge(self):
+        WARNING_CLASS = "bg-warning"
         company = CompanyFactory(kind=CompanyKind.EI, with_membership=True)
         other_company = CompanyFactory(kind=CompanyKind.ETTI, with_membership=True)
         last_company = CompanyFactory(kind=CompanyKind.ETTI, with_membership=True)
@@ -150,7 +150,7 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
         url = reverse("dashboard:index")
         response = self.client.get(url)
         self.assertContains(response, "Fiches salariés ASP")
-        self.assertNotContains(response, self.DANGER_CLASS)
+        self.assertNotContains(response, WARNING_CLASS)
         assert response.context["num_rejected_employee_records"] == 0
 
         # create rejected job applications
@@ -170,14 +170,14 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
         session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = company.pk
         session.save()
         response = self.client.get(url)
-        self.assertContains(response, self.DANGER_CLASS)
+        self.assertContains(response, WARNING_CLASS)
         assert response.context["num_rejected_employee_records"] == 2
 
         # select the second company's in the session
         session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = other_company.pk
         session.save()
         response = self.client.get(url)
-        self.assertContains(response, self.DANGER_CLASS)
+        self.assertContains(response, WARNING_CLASS)
         assert response.context["num_rejected_employee_records"] == 1
 
         # select the third company's in the session

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -44,11 +44,7 @@ from tests.siae_evaluations.factories import (
     EvaluatedSiaeFactory,
     EvaluationCampaignFactory,
 )
-from tests.users.factories import (
-    EmployerFactory,
-    JobSeekerFactory,
-    PrescriberFactory,
-)
+from tests.users.factories import EmployerFactory, JobSeekerFactory, PrescriberFactory
 from tests.utils.test import TestCase, parse_response_to_soup
 
 

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -139,3 +139,558 @@
               </div>
   '''
 # ---
+# name: ListEmployeeRecordsTest.test_new_employee_records_sorted[employee records]
+  dict({
+    'num_queries': 12,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "companies_companymembership"."notifications"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "companies_companymembership"."is_active")
+          ORDER BY "companies_companymembership"."created_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_insertion_id",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_siaeconvention" U0
+             WHERE (U0."deactivated_at" >= %s
+                    AND U0."id" = ("companies_company"."convention_id"))
+             LIMIT 1) AS "has_convention_in_grace_period"
+          FROM "companies_company"
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND "companies_companymembership"."user_id" = %s
+                 AND "companies_company"."id" IN (%s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."deactivated_at" >= %s
+                                AND U0."id" = ("companies_company"."convention_id"))
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'JobApplicationQuerySet.get_unique_fk_objects[job_applications/models.py]',
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT DISTINCT ON ("job_applications_jobapplication"."job_seeker_id") "job_applications_jobapplication"."id",
+                             "job_applications_jobapplication"."job_seeker_id",
+                             "job_applications_jobapplication"."eligibility_diagnosis_id",
+                             "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                             "job_applications_jobapplication"."create_employee_record",
+                             "job_applications_jobapplication"."resume_link",
+                             "job_applications_jobapplication"."sender_id",
+                             "job_applications_jobapplication"."sender_kind",
+                             "job_applications_jobapplication"."sender_company_id",
+                             "job_applications_jobapplication"."sender_prescriber_organization_id",
+                             "job_applications_jobapplication"."to_company_id",
+                             "job_applications_jobapplication"."state",
+                             "job_applications_jobapplication"."archived_at",
+                             "job_applications_jobapplication"."archived_by_id",
+                             "job_applications_jobapplication"."hired_job_id",
+                             "job_applications_jobapplication"."message",
+                             "job_applications_jobapplication"."answer",
+                             "job_applications_jobapplication"."answer_to_prescriber",
+                             "job_applications_jobapplication"."refusal_reason",
+                             "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                             "job_applications_jobapplication"."hiring_start_at",
+                             "job_applications_jobapplication"."hiring_end_at",
+                             "job_applications_jobapplication"."hiring_without_approval",
+                             "job_applications_jobapplication"."origin",
+                             "job_applications_jobapplication"."approval_id",
+                             "job_applications_jobapplication"."approval_delivery_mode",
+                             "job_applications_jobapplication"."approval_number_sent_by_email",
+                             "job_applications_jobapplication"."approval_number_sent_at",
+                             "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                             "job_applications_jobapplication"."approval_manually_refused_by_id",
+                             "job_applications_jobapplication"."approval_manually_refused_at",
+                             "job_applications_jobapplication"."transferred_at",
+                             "job_applications_jobapplication"."transferred_by_id",
+                             "job_applications_jobapplication"."transferred_from_id",
+                             "job_applications_jobapplication"."created_at",
+                             "job_applications_jobapplication"."updated_at",
+                             "job_applications_jobapplication"."processed_at",
+                             "job_applications_jobapplication"."prehiring_guidance_days",
+                             "job_applications_jobapplication"."contract_type",
+                             "job_applications_jobapplication"."nb_hours_per_week",
+                             "job_applications_jobapplication"."contract_type_details",
+                             "job_applications_jobapplication"."qualification_type",
+                             "job_applications_jobapplication"."qualification_level",
+                             "job_applications_jobapplication"."planned_training_hours",
+                             "job_applications_jobapplication"."inverted_vae_contract",
+                             "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                             "users_user"."id",
+                             "users_user"."password",
+                             "users_user"."last_login",
+                             "users_user"."is_superuser",
+                             "users_user"."username",
+                             "users_user"."first_name",
+                             "users_user"."last_name",
+                             "users_user"."is_staff",
+                             "users_user"."is_active",
+                             "users_user"."date_joined",
+                             "users_user"."address_line_1",
+                             "users_user"."address_line_2",
+                             "users_user"."post_code",
+                             "users_user"."city",
+                             "users_user"."department",
+                             "users_user"."coords",
+                             "users_user"."geocoding_score",
+                             "users_user"."geocoding_updated_at",
+                             "users_user"."ban_api_resolved_address",
+                             "users_user"."insee_city_id",
+                             "users_user"."title",
+                             "users_user"."email",
+                             "users_user"."phone",
+                             "users_user"."kind",
+                             "users_user"."identity_provider",
+                             "users_user"."has_completed_welcoming_tour",
+                             "users_user"."created_by_id",
+                             "users_user"."external_data_source_history",
+                             "users_user"."last_checked_at",
+                             "users_user"."public_id",
+                             "users_user"."address_filled_at",
+                             "users_user"."first_login"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          WHERE ("job_applications_jobapplication"."state" = %s
+                 AND "job_applications_jobapplication"."to_company_id" = %s)
+          ORDER BY "job_applications_jobapplication"."job_seeker_id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecord"."status",
+                 COUNT("employee_record_employeerecord"."status") AS "cnt"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          WHERE "job_applications_jobapplication"."to_company_id" = %s
+          GROUP BY "employee_record_employeerecord"."status"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordQuerySet.for_asp_company[employee_record/models.py]',
+          'JobApplicationQuerySet.eligible_as_employee_record[job_applications/models.py]',
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_siaeconvention"
+          WHERE "companies_siaeconvention"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_link",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "approvals_suspension" U0
+             INNER JOIN "approvals_approval" U1 ON (U0."approval_id" = U1."id")
+             INNER JOIN "job_applications_jobapplication" U2 ON (U1."id" = U2."approval_id")
+             WHERE (U2."id" = ("job_applications_jobapplication"."id")
+                    AND U0."siae_id" = %s)
+             LIMIT 1) AS "has_suspension",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "approvals_prolongation" U0
+             INNER JOIN "approvals_approval" U1 ON (U0."approval_id" = U1."id")
+             INNER JOIN "job_applications_jobapplication" U2 ON (U1."id" = U2."approval_id")
+             WHERE (U2."id" = ("job_applications_jobapplication"."id")
+                    AND U0."declared_by_siae_id" = %s)
+             LIMIT 1) AS "has_prolongation",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."ata_allocation_since",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "job_applications_jobapplication"
+          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          WHERE ("job_applications_jobapplication"."id" IN (
+                                                              (SELECT U0."id" AS "col1"
+                                                               FROM "job_applications_jobapplication" U0
+                                                               INNER JOIN "employee_record_employeerecord" U1 ON (U0."id" = U1."job_application_id")
+                                                               WHERE (U1."status" = %s
+                                                                      AND U0."to_company_id" = %s)
+                                                               ORDER BY U0."created_at" DESC)
+                                                            UNION
+                                                              (SELECT U0."id" AS "col1"
+                                                               FROM "job_applications_jobapplication" U0
+                                                               LEFT OUTER JOIN "employee_record_employeerecord" U2 ON (U0."id" = U2."job_application_id")
+                                                               WHERE (U0."state" = %s
+                                                                      AND U0."approval_id" IS NOT NULL
+                                                                      AND U0."create_employee_record"
+                                                                      AND U2."id" IS NULL
+                                                                      AND U0."hiring_start_at" >= %s
+                                                                      AND U0."to_company_id" = %s)
+                                                               ORDER BY U0."created_at" DESC)
+                                                            UNION
+                                                              (SELECT V0."id" AS "col1"
+                                                               FROM "job_applications_jobapplication" V0
+                                                               LEFT OUTER JOIN "employee_record_employeerecord" V3 ON (V0."id" = V3."job_application_id")
+                                                               WHERE (V0."state" = %s
+                                                                      AND ((V0."create_employee_record"
+                                                                            AND EXISTS
+                                                                              (SELECT %s AS "a"
+                                                                               FROM "approvals_suspension" U0
+                                                                               WHERE (U0."approval_id" = (V0."approval_id")
+                                                                                      AND U0."created_at" >= %s
+                                                                                      AND U0."siae_id" = (V0."to_company_id"))
+                                                                               LIMIT 1))
+                                                                           OR EXISTS
+                                                                             (SELECT %s AS "a"
+                                                                              FROM "approvals_prolongation" U0
+                                                                              WHERE (U0."approval_id" = (V0."approval_id")
+                                                                                     AND U0."created_at" >= %s
+                                                                                     AND U0."declared_by_siae_id" = (V0."to_company_id"))
+                                                                              LIMIT 1))
+                                                                      AND V3."id" IS NULL
+                                                                      AND V0."to_company_id" = %s)
+                                                               ORDER BY V0."created_at" DESC))
+                 AND NOT ("approvals_approval"."number" IN
+                            (SELECT V0."approval_number"
+                             FROM "employee_record_employeerecord" V0
+                             INNER JOIN "job_applications_jobapplication" V1 ON (V0."job_application_id" = V1."id")
+                             WHERE (V1."to_company_id" IN
+                                      (SELECT U0."id"
+                                       FROM "companies_company" U0
+                                       WHERE (NOT (U0."siret" = %s)
+                                              AND U0."convention_id" = %s))
+                                    AND NOT (V0."status" IN (%s))))
+                          AND "approvals_approval"."number" IS NOT NULL))
+          ORDER BY "job_applications_jobapplication"."hiring_start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecord"."asp_processing_code",
+                 "employee_record_employeerecord"."asp_processing_label",
+                 "employee_record_employeerecord"."asp_batch_file",
+                 "employee_record_employeerecord"."asp_batch_line_number",
+                 "employee_record_employeerecord"."archived_json",
+                 "employee_record_employeerecord"."created_at",
+                 "employee_record_employeerecord"."updated_at",
+                 "employee_record_employeerecord"."processed_at",
+                 "employee_record_employeerecord"."status",
+                 "employee_record_employeerecord"."job_application_id",
+                 "employee_record_employeerecord"."financial_annex_id",
+                 "employee_record_employeerecord"."approval_number",
+                 "employee_record_employeerecord"."asp_id",
+                 "employee_record_employeerecord"."asp_measure",
+                 "employee_record_employeerecord"."siret",
+                 "employee_record_employeerecord"."processed_as_duplicate"
+          FROM "employee_record_employeerecord"
+          WHERE "employee_record_employeerecord"."job_application_id" IN (%s,
+                                                                          %s,
+                                                                          %s)
+          ORDER BY "employee_record_employeerecord"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.has_admin[common_apps/organizations/models.py]',
+          'Company.convention_can_be_accessed_by[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[employee_record/list.html]',
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE ("companies_companymembership"."id" IN
+                   (SELECT U0."id"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = %s
+                           AND U2."is_active"
+                           AND U0."is_active"
+                           AND U0."is_admin"
+                           AND U2."is_active"))
+                 AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -141,7 +141,7 @@
 # ---
 # name: ListEmployeeRecordsTest.test_new_employee_records_sorted[employee records]
   dict({
-    'num_queries': 12,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -655,6 +655,18 @@
                                                                           %s,
                                                                           %s)
           ORDER BY "employee_record_employeerecord"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          WHERE ("job_applications_jobapplication"."to_company_id" = %s
+                 AND "employee_record_employeerecord"."status" = %s)
         ''',
       }),
       dict({

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -21,7 +21,7 @@ from tests.employee_record import factories as employee_record_factories
 from tests.employee_record.factories import EmployeeRecordFactory
 from tests.job_applications.factories import JobApplicationWithApprovalNotCancellableFactory
 from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
-from tests.utils.test import TestCase, assert_previous_step, parse_response_to_soup
+from tests.utils.test import TestCase, assert_previous_step, assertSnapshotQueries, parse_response_to_soup
 
 
 @pytest.mark.usefixtures("unittest_compatibility")
@@ -377,21 +377,7 @@ class ListEmployeeRecordsTest(MessagesTestMixin, TestCase):
         self._check_employee_record_order(self.URL + "?order=name", job_applicationA, job_applicationZ)
         self._check_employee_record_order(self.URL + "?order=-name", job_applicationZ, job_applicationA)
 
-        # Count queries
-        # 1.  SELECT django_session
-        # 2.  SELECT users_user
-        # 3.  SELECT companies_companymembership
-        # 4.  SELECT companies_company
-        # END of middlewares
-        # 5.  SAVEPOINT
-        # 6.  SELECT DISTINCT job_applications_jobapplication.job_seeker_id
-        # 7.  SELECT employee_record_employeerecord.status counts
-        # 8.  SELECT companies_siaeconvention (`.eligible_as_employee_record()`)
-        # 9.  SELECT job_applications_jobapplication
-        # 10. SELECT employee_record_employeerecord
-        # 11. SELECT EXISTS users_user (menu checks for active admin)
-        # 12. RELEASE SAVEPOINT
-        with self.assertNumQueries(12):
+        with assertSnapshotQueries(self.snapshot(name="employee records")):
             self.client.get(self.URL)
 
     def test_rejected_employee_records_sorted(self):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Tout comme la catégorie structure avec 3 sous sections, on considère maintenant que “Salariés et PASS IAE” et “Fiches salariés ASP” sont des sous sections de “Salariés”, ils doivent donc avoir des onglets


## :computer: Captures d'écran <!-- optionnel -->
**Avant**
![capture 2024-09-10 à 17 29 28](https://github.com/user-attachments/assets/b07a8512-8463-432e-b509-5174c9f54685)

**Apres**
![capture 2024-09-10 à 17 29 37](https://github.com/user-attachments/assets/3217bba2-2229-4a64-a0a8-73eda4ac5a04)


