### PR TITLE
Simplifier Announcement test_start_date_conflict_constraint

### DIFF
--- a/tests/communications/test_models.py
+++ b/tests/communications/test_models.py
@@ -120,8 +120,6 @@ class AnnouncementCampaignModelTest(TestCase):
             AnnouncementCampaignFactory(start_date=date(2024, 1, 2))
 
     def test_start_date_conflict_constraint(self):
-        existing_campaign = AnnouncementCampaignFactory(start_date=date(2023, 1, 1))
-
         # can modify existing value without triggering constraint
         existing_campaign = AnnouncementCampaignFactory(start_date=date(2024, 1, 1))
         existing_campaign.start_date = date(2024, 2, 1)


### PR DESCRIPTION
The first existing_campaign is unused in the test and looks like an oversight.