### PR TITLE
Corriger l’import de JobApplicationState dans des tests

### DIFF
--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -44,7 +44,7 @@ class JobApplicationFactory(AutoNowOverrideMixin, factory.django.DjangoModelFact
             job_seeker=factory.SubFactory(JobSeekerFactory, with_mocked_address=True)
         )
         with_approval = factory.Trait(
-            state=models.JobApplicationState.ACCEPTED,
+            state=JobApplicationState.ACCEPTED,
             approval=factory.SubFactory(
                 ApprovalFactory,
                 user=factory.SelfAttribute("..job_seeker"),
@@ -216,7 +216,7 @@ class JobApplicationSentByPrescriberPoleEmploiFactory(JobApplicationSentByPrescr
 class JobApplicationWithoutApprovalFactory(JobApplicationSentByPrescriberFactory):
     """Generates a JobApplication() object without an Approval() object."""
 
-    state = models.JobApplicationState.ACCEPTED
+    state = JobApplicationState.ACCEPTED
     hiring_without_approval = True
 
 

--- a/tests/job_applications/test_admin.py
+++ b/tests/job_applications/test_admin.py
@@ -20,7 +20,7 @@ from tests.utils.test import parse_response_to_soup
 
 def test_create_employee_record(admin_client):
     job_application = factories.JobApplicationFactory(
-        state=models.JobApplicationState.ACCEPTED,
+        state=JobApplicationState.ACCEPTED,
         with_approval=True,
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

The enum comes from the enums module, not models.
