### PR TITLE
Pilotage : Ouverture des TB 346 et 330 à tout les conseils départementaux

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -436,23 +436,6 @@ ACI_CONVERGENCE_SIRET_WHITELIST = json.loads(os.getenv("ACI_CONVERGENCE_SIRET_WH
 # Kept as a setting to not let User pks or Company asp_ids in clear in the code.
 STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIST", "[]"))
 STATS_SIAE_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_PK_WHITELIST", "[]"))
-STATS_CD_DEPARTMENT_WHITELIST = [
-    "02",
-    "13",
-    "16",
-    "18",
-    "31",
-    "37",
-    "38",
-    "41",
-    "45",
-    "48",
-    "49",
-    "55",
-    "63",
-    "93",
-    "94",
-]
 STATS_ACI_DEPARTMENT_WHITELIST = ["31", "84"]
 
 # Slack notifications sent by Metabase cronjobs.

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -76,8 +76,6 @@
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
                         </li>
-                    {% endif %}
-                    {% if can_view_stats_cd_whitelist %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_cd_hiring' %}" class="btn-link btn-ico">
                                 <i class="ri-bar-chart-line ri-lg font-weight-normal align-self-start"></i>

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -127,7 +127,6 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "can_view_stats_siae_etp": stats_utils.can_view_stats_siae_etp(request),
         "can_view_stats_siae_orga_etp": stats_utils.can_view_stats_siae_orga_etp(request),
         "can_view_stats_cd": stats_utils.can_view_stats_cd(request),
-        "can_view_stats_cd_whitelist": stats_utils.can_view_stats_cd_whitelist(request),
         "can_view_stats_cd_aci": stats_utils.can_view_stats_cd_aci(request),
         "can_view_stats_ft": stats_utils.can_view_stats_ft(request),
         "can_view_stats_ph": stats_utils.can_view_stats_ph(request),

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -92,13 +92,6 @@ def can_view_stats_cd(request):
     )
 
 
-def can_view_stats_cd_whitelist(request):
-    return (
-        can_view_stats_cd(request)
-        and request.current_organization.department in settings.STATS_CD_DEPARTMENT_WHITELIST
-    )
-
-
 def can_view_stats_cd_aci(request):
     return (
         can_view_stats_cd(request)

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -340,8 +340,6 @@ def stats_cd_iae(request):
 
 @login_required
 def stats_cd_hiring(request):
-    if not utils.can_view_stats_cd_whitelist(request):
-        raise PermissionDenied
     context = {
         "pilotage_webinar_banners": [
             {
@@ -357,8 +355,6 @@ def stats_cd_hiring(request):
 
 @login_required
 def stats_cd_brsa(request):
-    if not utils.can_view_stats_cd_whitelist(request):
-        raise PermissionDenied
     context = {
         "pilotage_webinar_banners": [
             {

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -2,7 +2,7 @@ import factory.fuzzy
 import pytest
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory, override_settings
+from django.test import RequestFactory
 
 from itou.common_apps.address.departments import DEPARTMENTS, REGIONS
 from itou.companies.enums import CompanyKind
@@ -58,63 +58,6 @@ def test_can_view_stats_siae_aci():
     user.companymembership_set.update(is_admin=False)
     request = get_request(user)
     assert utils.can_view_stats_siae_aci(request)
-    assert utils.can_view_stats_dashboard_widget(request)
-
-
-@override_settings(STATS_CD_DEPARTMENT_WHITELIST=["93"])
-def test_can_view_stats_cd_whitelist():
-    """
-    CD as in "Conseil Départemental".
-    """
-    # Department outside of the whitelist cannot access.
-    org = PrescriberOrganizationWithMembershipFactory(
-        authorized=True, kind=PrescriberOrganizationKind.DEPT, department="01"
-    )
-    request = get_request(org.members.get())
-    assert not utils.can_view_stats_cd_whitelist(request)
-    assert utils.can_view_stats_dashboard_widget(request)
-
-    # Admin prescriber of authorized CD can access.
-    org = PrescriberOrganizationWithMembershipFactory(
-        authorized=True, kind=PrescriberOrganizationKind.DEPT, department="93"
-    )
-    request = get_request(org.members.get())
-    assert utils.can_view_stats_cd_whitelist(request)
-    assert utils.can_view_stats_dashboard_widget(request)
-
-    # Non admin prescriber can access as well.
-    org = PrescriberOrganizationWithMembershipFactory(
-        authorized=True,
-        kind=PrescriberOrganizationKind.DEPT,
-        membership__is_admin=False,
-        department="93",
-    )
-    request = get_request(org.members.get())
-    assert utils.can_view_stats_cd_whitelist(request)
-    assert utils.can_view_stats_dashboard_widget(request)
-
-    # Non authorized organization does not give access.
-    org = PrescriberOrganizationWithMembershipFactory(
-        kind=PrescriberOrganizationKind.DEPT,
-        department="93",
-    )
-    request = get_request(org.members.get())
-    assert not utils.can_view_stats_cd_whitelist(request)
-    assert utils.can_view_stats_dashboard_widget(request)
-
-    # Non CD organization does not give access.
-    org = PrescriberOrganizationWithMembershipFactory(
-        authorized=True,
-        kind=PrescriberOrganizationKind.CHRS,
-        department="93",
-    )
-    request = get_request(org.members.get())
-    assert not utils.can_view_stats_cd_whitelist(request)
-    assert utils.can_view_stats_dashboard_widget(request)
-
-    # Prescriber without organization cannot access.
-    request = get_request(PrescriberFactory())
-    assert not utils.can_view_stats_cd_whitelist(request)
     assert utils.can_view_stats_dashboard_widget(request)
 
 

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -91,7 +91,6 @@ def test_stats_cd_log_visit(client, settings, view_name):
     prescriber_org = PrescriberOrganizationWithMembershipFactory(kind="DEPT", authorized=True)
     user = prescriber_org.members.get()
 
-    settings.STATS_CD_DEPARTMENT_WHITELIST = [prescriber_org.department]
     settings.STATS_ACI_DEPARTMENT_WHITELIST = [prescriber_org.department]
 
     client.force_login(user)


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Supprimer-liste-blanche-sur-TB-346-et-330-7f0e8f96415140c1b4fdd5215f8be596

@dejafait Avec le webinaire mardi prochain, plus c'est fusionné tôt mieux c'est, donc si c'est toi qui la tamponne demain (vendredi) tu pourras la mettre en prod dans la foulée :pray: .