### PR TITLE
Demandeur d’emploi : Ajout lieu de naissance dans le formulaire de création par un tiers [GEN-1944]

### DIFF
--- a/itou/asp/forms.py
+++ b/itou/asp/forms.py
@@ -1,14 +1,17 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.urls import reverse
+from django.utils.functional import SimpleLazyObject
 
 from itou.asp.models import Commune, Country
 from itou.utils.widgets import RemoteAutocompleteSelect2Widget
 
 
-def formfield_for_birth_place(*, with_birthdate_field, **kwargs):
-    with_birthdate_attr = {"data-select2-link-with-birthdate": "id_birthdate"} if with_birthdate_field else {}
-    france = Country.objects.get(code=Country._CODE_FRANCE)
-    return forms.ModelChoiceField(
+class BirthPlaceAndCountryMixin(forms.ModelForm):
+    with_birthdate_field = None
+
+    birth_country = forms.ModelChoiceField(Country.objects, label="Pays de naissance", required=False)
+    birth_place = forms.ModelChoiceField(
         queryset=Commune.objects,
         label="Commune de naissance",
         help_text=(
@@ -18,15 +21,73 @@ def formfield_for_birth_place(*, with_birthdate_field, **kwargs):
         required=False,
         widget=RemoteAutocompleteSelect2Widget(
             attrs={
-                "data-ajax--url": reverse("autocomplete:communes"),
+                "data-ajax--url": SimpleLazyObject(lambda: reverse("autocomplete:communes")),
                 "data-ajax--cache": "true",
                 "data-ajax--type": "GET",
                 "data-minimum-input-length": 1,
                 "data-placeholder": "Nom de la commune",
                 "data-disable-target": "#id_birth_country",
-                "data-target-value": f"{france.pk}",
-                **with_birthdate_attr,
+                "data-target-value": SimpleLazyObject(lambda: f"{Country.objects.get(code=Country._CODE_FRANCE).pk}"),
             }
         ),
-        **kwargs,
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # with_birthdate_field indicates if JS is needed to link birthdate & birth_place fields
+        if self.with_birthdate_field is None:
+            self.with_birthdate_field = "birthdate" in self.fields
+
+        if self.with_birthdate_field:
+            self.fields["birth_place"].widget.attrs |= {"data-select2-link-with-birthdate": "id_birthdate"}
+
+    def get_birth_date(self):
+        return self.cleaned_data.get("birthdate", getattr(self, "birthdate", None))
+
+    def clean(self):
+        super().clean()
+
+        birth_place = self.cleaned_data.get("birth_place")
+        birth_country = self.cleaned_data.get("birth_country")
+        birth_date = self.get_birth_date()
+
+        if not birth_country:
+            # Selecting a birth place sets the birth country field to France and disables it.
+            # However, disabled fields are ignored by Django.
+            # That's also why we can't make it mandatory.
+            # See utils.js > toggleDisableAndSetValue
+            if birth_place:
+                self.cleaned_data["birth_country"] = Country.objects.get(code=Country._CODE_FRANCE)
+            else:
+                # Display the error above the field instead of top of page.
+                self.add_error("birth_country", "Le pays de naissance est obligatoire.")
+
+        # Country coherence is done at model level (users.User)
+        # Here we must add coherence between birthdate and communes
+        # existing at this period (not a simple check of existence)
+        if birth_place and birth_date:
+            try:
+                self.cleaned_data["birth_place"] = Commune.objects.by_insee_code_and_period(
+                    birth_place.code, birth_date
+                )
+            except Commune.DoesNotExist:
+                msg = (
+                    f"Le code INSEE {birth_place.code} n'est pas référencé par l'ASP en date du {birth_date:%d/%m/%Y}"
+                )
+                self.add_error("birth_place", msg)
+
+    def treat_birth_fields(self):
+        # class targets User and JobSeekerProfile models
+        jobseeker_profile = self.instance.jobseeker_profile if hasattr(self.instance, "jobseeker_profile") else self.instance
+
+        try:
+            jobseeker_profile.birth_place = self.cleaned_data.get("birth_place")
+            jobseeker_profile.birth_country = self.cleaned_data.get("birth_country")
+            jobseeker_profile._clean_birth_fields()
+        except ValidationError as e:
+            self._update_errors(e)
+
+    def _post_clean(self):
+        super()._post_clean()
+        self.treat_birth_fields()

--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -6,7 +6,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.functional import cached_property
+from django.utils.functional import cached_property, classproperty
 from unidecode import unidecode
 
 from itou.utils.models import DateRange
@@ -463,7 +463,8 @@ class Country(PrettyPrintMixin, models.Model):
     Imported from ASP reference file: ref_grp_pays_v1, ref_insee_pays_v4.csv
     """
 
-    _CODE_FRANCE = "100"
+    INSEE_CODE_FRANCE = "100"
+    _ID_FRANCE = None
 
     class Group(models.TextChoices):
         FRANCE = "1", "France"
@@ -484,6 +485,12 @@ class Country(PrettyPrintMixin, models.Model):
         verbose_name = "pays"
         verbose_name_plural = "pays"
         ordering = ["name"]
+
+    @classproperty
+    def france_id(cls):
+        if cls._ID_FRANCE is None:
+            cls._ID_FRANCE = Country.objects.get(code=Country.INSEE_CODE_FRANCE).pk
+        return cls._ID_FRANCE
 
 
 class SiaeMeasure(models.TextChoices):

--- a/itou/templates/apply/includes/profile_infos.html
+++ b/itou/templates/apply/includes/profile_infos.html
@@ -18,6 +18,16 @@
     <li class="mb-3">
         Date de naissance : <b>le {{ profile.birthdate }}</b>
     </li>
+    {% if profile.birth_place %}
+        <li class="mb-3">
+            Commune de naissance : <b>{{ profile.birth_place.name }} {{ profile.birth_place.department_code }}</b>
+        </li>
+    {% endif %}
+    {% if profile.birth_country %}
+        <li class="mb-3">
+            Pays de naissance : <b>{{ profile.birth_country.name }}</b>
+        </li>
+    {% endif %}
 </ul>
 <hr class="my-4">
 

--- a/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
+++ b/itou/templates/apply/submit/create_or_update_job_seeker/step_1.html
@@ -29,6 +29,10 @@
         {% bootstrap_field form.lack_of_nir %}
         {% bootstrap_field form.lack_of_nir_reason wrapper_class=form.lack_of_nir_reason.field.form_group_class %}
         {% bootstrap_field form.birthdate %} {# TODO: Duet border-color button is not of the correct color #}
+        {% if form.birth_place %}
+            {% bootstrap_field form.birth_place %}
+            {% bootstrap_field form.birth_country %}
+        {% endif %}
     </fieldset>
 
     {% if confirmation_needed %}

--- a/itou/users/forms.py
+++ b/itou/users/forms.py
@@ -27,7 +27,8 @@ class JobSeekerProfileFieldsMixin:
         initial = kwargs.pop("initial", {})
         super().__init__(*args, instance=instance, initial=profile_initial | initial, **kwargs)
         for field in self.PROFILE_FIELDS:
-            self.fields[field] = JobSeekerProfile._meta.get_field(field).formfield()
+            if field not in self.fields:
+                self.fields[field] = JobSeekerProfile._meta.get_field(field).formfield()
 
     def save(self, commit=True):
         user = super().save(commit=commit)

--- a/itou/utils/validators.py
+++ b/itou/utils/validators.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
 from django.utils import timezone
 
+from itou.asp.models import Country
+
 
 alphanumeric = RegexValidator(r"^[0-9a-zA-Z]*$", "Seuls les caractères alphanumériques sont autorisés.")
 
@@ -88,6 +90,16 @@ def validate_birthdate(birthdate):
         raise ValidationError("La date de naissance doit être postérieure à 1900.")
     if birthdate >= get_max_birthdate():
         raise ValidationError("La personne doit avoir plus de 16 ans.")
+
+
+def validate_birth_location(birth_country, birth_place):
+    # If birth country is France, then birth place must be provided
+    if birth_country and birth_country.code == Country.INSEE_CODE_FRANCE and not birth_place:
+        raise ValidationError("Il n'est pas possible de saisir une commune de naissance hors de France.")
+
+    # If birth country is not France, do not fill a birth place (no ref file)
+    if birth_country and birth_country.code != Country.INSEE_CODE_FRANCE and birth_place:
+        raise ValidationError("Si le pays de naissance est la France, la commune de naissance est obligatoire.")
 
 
 AF_NUMBER_PREFIX_REGEXPS = [

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -161,7 +161,9 @@ class CheckJobSeekerInfoForm(JobSeekerProfileFieldsMixin, forms.ModelForm):
         JobSeekerProfile.clean_pole_emploi_fields(self.cleaned_data)
 
 
-class CreateOrUpdateJobSeekerStep1Form(JobSeekerNIRUpdateMixin, JobSeekerProfileFieldsMixin, forms.ModelForm):
+class CreateOrUpdateJobSeekerStep1Form(
+    JobSeekerNIRUpdateMixin, JobSeekerProfileFieldsMixin, BirthPlaceAndCountryMixin, forms.ModelForm
+):
     REQUIRED_FIELDS = [
         "title",
         "first_name",
@@ -169,7 +171,7 @@ class CreateOrUpdateJobSeekerStep1Form(JobSeekerNIRUpdateMixin, JobSeekerProfile
         "birthdate",
     ]
 
-    PROFILE_FIELDS = ["birthdate", "nir", "lack_of_nir_reason"]
+    PROFILE_FIELDS = ["birth_country", "birthdate", "birth_place", "nir", "lack_of_nir_reason"]
 
     class Meta:
         model = User
@@ -192,12 +194,6 @@ class CreateOrUpdateJobSeekerStep1Form(JobSeekerNIRUpdateMixin, JobSeekerProfile
                 "class": "js-period-date-input",
             }
         )
-
-
-class CreateOrUpdateJobSeekerWithBirthPlaceAndCountryStep1Form(
-    BirthPlaceAndCountryMixin, CreateOrUpdateJobSeekerStep1Form
-):
-    pass
 
 
 class CreateOrUpdateJobSeekerStep2Form(JobSeekerAddressForm, forms.ModelForm):

--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -107,7 +107,7 @@ class NewEmployeeRecordStep1Form(BirthPlaceAndCountryMixin, JobSeekerProfileFiel
     - birth place and birth country of the employee
     """
 
-    PROFILE_FIELDS = ["birthdate"]
+    PROFILE_FIELDS = ["birth_country", "birthdate", "birth_place"]
     READ_ONLY_FIELDS = []
     REQUIRED_FIELDS = [
         "title",

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -909,7 +909,7 @@
 # ---
 # name: UpdateJobSeekerForHireTestCase.test_as_company_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 13,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -1255,6 +1255,26 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'IfNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'BlockNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({
@@ -1962,7 +1982,7 @@
 # ---
 # name: UpdateJobSeekerForHireTestCase.test_with_job_seeker_without_nir[queries - step 1]
   dict({
-    'num_queries': 13,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -2308,6 +2328,26 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'IfNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'BlockNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({
@@ -3015,7 +3055,7 @@
 # ---
 # name: UpdateJobSeekerTestCase.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 11,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -3283,6 +3323,26 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'IfNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'BlockNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
+        ''',
       }),
       dict({
         'origin': list([
@@ -3831,7 +3891,7 @@
 # ---
 # name: UpdateJobSeekerTestCase.test_as_company_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 12,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -4157,6 +4217,26 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'IfNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'BlockNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({
@@ -4824,7 +4904,7 @@
 # ---
 # name: UpdateJobSeekerTestCase.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 11,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -5092,6 +5172,26 @@
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'IfNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'BlockNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
+        ''',
       }),
       dict({
         'origin': list([
@@ -5640,7 +5740,7 @@
 # ---
 # name: UpdateJobSeekerTestCase.test_with_job_seeker_without_nir[queries - step 1]
   dict({
-    'num_queries': 12,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -5966,6 +6066,26 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'IfNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+          'BlockNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_base.html]',
+          'ExtendsNode[apply/submit/create_or_update_job_seeker/step_1.html]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -14,7 +14,7 @@ from django.urls import resolve, reverse
 from django.utils import timezone
 from pytest_django.asserts import assertContains, assertRedirects
 
-from itou.asp.models import AllocationDuration, EducationLevel, RSAAllocation
+from itou.asp.models import AllocationDuration, Commune, Country, EducationLevel, RSAAllocation
 from itou.companies.enums import CompanyKind, ContractType
 from itou.eligibility.models import (
     AdministrativeCriteria,
@@ -860,18 +860,25 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
             ),
         )
 
+        geispolsheim = create_city_geispolsheim()
+        birthdate = dummy_job_seeker.jobseeker_profile.birthdate
+
         post_data = {
             "title": dummy_job_seeker.title,
             "first_name": dummy_job_seeker.first_name,
             "last_name": dummy_job_seeker.last_name,
-            "birthdate": dummy_job_seeker.jobseeker_profile.birthdate,
+            "birthdate": birthdate,
             "lack_of_nir": False,
             "lack_of_nir_reason": "",
+            "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+            "birth_country": Country.france_id,
         }
         response = self.client.post(next_url, data=post_data)
         assert response.status_code == 302
         expected_job_seeker_session["profile"]["birthdate"] = post_data.pop("birthdate")
         expected_job_seeker_session["profile"]["lack_of_nir_reason"] = post_data.pop("lack_of_nir_reason")
+        expected_job_seeker_session["profile"]["birth_place"] = post_data.pop("birth_place")
+        expected_job_seeker_session["profile"]["birth_country"] = post_data.pop("birth_country")
         expected_job_seeker_session["user"] |= post_data
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -1113,19 +1120,26 @@ class ApplyAsAuthorizedPrescriberTest(TestCase):
             ),
         )
 
+        geispolsheim = create_city_geispolsheim()
+        birthdate = dummy_job_seeker.jobseeker_profile.birthdate
+
         post_data = {
             "title": dummy_job_seeker.title,
             "first_name": dummy_job_seeker.first_name,
             "last_name": dummy_job_seeker.last_name,
-            "birthdate": dummy_job_seeker.jobseeker_profile.birthdate,
+            "birthdate": birthdate,
             "nir": dummy_job_seeker.jobseeker_profile.nir,
             "lack_of_nir": False,
             "lack_of_nir_reason": "",
+            "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+            "birth_country": Country.france_id,
         }
         response = self.client.post(next_url, data=post_data)
         assert response.status_code == 302
         expected_job_seeker_session["profile"]["birthdate"] = post_data.pop("birthdate")
         expected_job_seeker_session["profile"]["lack_of_nir_reason"] = post_data.pop("lack_of_nir_reason")
+        expected_job_seeker_session["profile"]["birth_place"] = post_data.pop("birth_place")
+        expected_job_seeker_session["profile"]["birth_country"] = post_data.pop("birth_country")
         post_data.pop("nir")
         expected_job_seeker_session["user"] |= post_data
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
@@ -1456,18 +1470,25 @@ class ApplyAsPrescriberTest(MessagesTestMixin, TestCase):
             ),
         )
 
+        geispolsheim = create_city_geispolsheim()
+        birthdate = dummy_job_seeker.jobseeker_profile.birthdate
+
         post_data = {
             "title": dummy_job_seeker.title,
             "first_name": dummy_job_seeker.first_name,
             "last_name": dummy_job_seeker.last_name,
-            "birthdate": dummy_job_seeker.jobseeker_profile.birthdate,
+            "birthdate": birthdate,
             "lack_of_nir": False,
             "lack_of_nir_reason": "",
+            "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+            "birth_country": Country.france_id,
         }
         response = self.client.post(next_url, data=post_data)
         assert response.status_code == 302
         expected_job_seeker_session["profile"]["birthdate"] = post_data.pop("birthdate")
         expected_job_seeker_session["profile"]["lack_of_nir_reason"] = post_data.pop("lack_of_nir_reason")
+        expected_job_seeker_session["profile"]["birth_place"] = post_data.pop("birth_place")
+        expected_job_seeker_session["profile"]["birth_country"] = post_data.pop("birth_country")
         expected_job_seeker_session["user"] |= post_data
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -1919,18 +1940,25 @@ class ApplyAsCompanyTest(TestCase):
             ),
         )
 
+        geispolsheim = create_city_geispolsheim()
+        birthdate = dummy_job_seeker.jobseeker_profile.birthdate
+
         post_data = {
             "title": dummy_job_seeker.title,
             "first_name": dummy_job_seeker.first_name,
             "last_name": dummy_job_seeker.last_name,
-            "birthdate": dummy_job_seeker.jobseeker_profile.birthdate,
+            "birthdate": birthdate,
             "lack_of_nir": False,
             "lack_of_nir_reason": "",
+            "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+            "birth_country": Country.france_id,
         }
         response = self.client.post(next_url, data=post_data)
         assert response.status_code == 302
         expected_job_seeker_session["profile"]["birthdate"] = post_data.pop("birthdate")
         expected_job_seeker_session["profile"]["lack_of_nir_reason"] = post_data.pop("lack_of_nir_reason")
+        expected_job_seeker_session["profile"]["birth_place"] = post_data.pop("birth_place")
+        expected_job_seeker_session["profile"]["birth_country"] = post_data.pop("birth_country")
         expected_job_seeker_session["user"] |= post_data
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -2209,7 +2237,6 @@ class DirectHireFullProcessTest(TestCase):
             with_ban_geoloc_address=True,
         )
 
-        # This is the city matching with_ban_geoloc_address trait
         geispolsheim = create_city_geispolsheim()
 
         # Step determine the job seeker with a NIR.
@@ -2269,18 +2296,24 @@ class DirectHireFullProcessTest(TestCase):
             ),
         )
 
+        birthdate = dummy_job_seeker.jobseeker_profile.birthdate
+
         post_data = {
             "title": dummy_job_seeker.title,
             "first_name": dummy_job_seeker.first_name,
             "last_name": dummy_job_seeker.last_name,
-            "birthdate": dummy_job_seeker.jobseeker_profile.birthdate,
+            "birthdate": birthdate,
             "lack_of_nir": False,
             "lack_of_nir_reason": "",
+            "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+            "birth_country": Country.france_id,
         }
         response = self.client.post(next_url, data=post_data)
         assert response.status_code == 302
         expected_job_seeker_session["profile"]["birthdate"] = post_data.pop("birthdate")
         expected_job_seeker_session["profile"]["lack_of_nir_reason"] = post_data.pop("lack_of_nir_reason")
+        expected_job_seeker_session["profile"]["birth_place"] = post_data.pop("birth_place")
+        expected_job_seeker_session["profile"]["birth_country"] = post_data.pop("birth_country")
         expected_job_seeker_session["user"] |= post_data
         assert self.client.session[job_seeker_session_name] == expected_job_seeker_session
 
@@ -3025,9 +3058,13 @@ class UpdateJobSeekerBaseTestCase(TestCase):
         lack_of_nir_reason = post_data.pop("lack_of_nir_reason")
         nir = post_data.pop("nir", None)
         birthdate = post_data.pop("birthdate", None)
+        birth_place = post_data.pop("birth_place", None)
+        birth_country = post_data.pop("birth_country", None)
         expected_job_seeker_session = {
             "user": post_data,
             "profile": {
+                "birth_place": birth_place or self.job_seeker.jobseeker_profile.birth_place,
+                "birth_country": birth_country or self.job_seeker.jobseeker_profile.birth_country,
                 "birthdate": birthdate or self.job_seeker.jobseeker_profile.birthdate,
                 "nir": nir or self.job_seeker.jobseeker_profile.nir,
                 "lack_of_nir_reason": lack_of_nir_reason,
@@ -3272,7 +3309,17 @@ class UpdateJobSeekerTestCase(UpdateJobSeekerBaseTestCase):
         self.job_seeker.created_by = prescriber
         self.job_seeker.last_login = None
         self.job_seeker.save(update_fields=["created_by", "last_login"])
-        self._check_everything_allowed(prescriber)
+
+        geispolsheim = create_city_geispolsheim()
+        birthdate = self.job_seeker.jobseeker_profile.birthdate
+
+        self._check_everything_allowed(
+            prescriber,
+            extra_post_data_1={
+                "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+                "birth_country": Country.france_id,
+            },
+        )
 
     def test_as_unauthorized_prescriber_that_created_the_non_proxied_job_seeker(self):
         prescriber = PrescriberOrganizationWithMembershipFactory(authorized=False).members.first()
@@ -3293,7 +3340,17 @@ class UpdateJobSeekerTestCase(UpdateJobSeekerBaseTestCase):
         self.job_seeker.last_login = None
         self.job_seeker.save(update_fields=["created_by", "last_login"])
         authorized_prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.first()
-        self._check_everything_allowed(authorized_prescriber)
+
+        geispolsheim = create_city_geispolsheim()
+        birthdate = self.job_seeker.jobseeker_profile.birthdate
+
+        self._check_everything_allowed(
+            authorized_prescriber,
+            extra_post_data_1={
+                "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+                "birth_country": Country.france_id,
+            },
+        )
 
     def test_as_authorized_prescriber_with_non_proxied_job_seeker(self):
         # Make sure the job seeker does manage its own account
@@ -3312,7 +3369,17 @@ class UpdateJobSeekerTestCase(UpdateJobSeekerBaseTestCase):
         self.job_seeker.created_by = EmployerFactory()
         self.job_seeker.last_login = None
         self.job_seeker.save(update_fields=["created_by", "last_login"])
-        self._check_everything_allowed(self.company.members.first())
+
+        geispolsheim = create_city_geispolsheim()
+        birthdate = self.job_seeker.jobseeker_profile.birthdate
+
+        self._check_everything_allowed(
+            self.company.members.first(),
+            extra_post_data_1={
+                "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+                "birth_country": Country.france_id,
+            },
+        )
 
     def test_as_company_with_non_proxied_job_seeker(self):
         # Make sure the job seeker does manage its own account
@@ -3344,12 +3411,18 @@ class UpdateJobSeekerTestCase(UpdateJobSeekerBaseTestCase):
         self.job_seeker.created_by = EmployerFactory()
         self.job_seeker.last_login = None
         self.job_seeker.save(update_fields=["created_by", "last_login"])
+
+        geispolsheim = create_city_geispolsheim()
+        birthdate = self.job_seeker.jobseeker_profile.birthdate
+
         self._check_everything_allowed(
             self.company.members.first(),
             extra_post_data_1={
                 "nir": "",
                 "lack_of_nir": True,
                 "lack_of_nir_reason": LackOfNIRReason.TEMPORARY_NUMBER.value,
+                "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+                "birth_country": Country.france_id,
             },
         )
         # Check that we could update its NIR infos
@@ -3438,7 +3511,17 @@ class UpdateJobSeekerForHireTestCase(UpdateJobSeekerBaseTestCase):
         self.job_seeker.created_by = EmployerFactory()
         self.job_seeker.last_login = None
         self.job_seeker.save(update_fields=["created_by", "last_login"])
-        self._check_everything_allowed(self.company.members.first())
+
+        geispolsheim = create_city_geispolsheim()
+        birthdate = self.job_seeker.jobseeker_profile.birthdate
+
+        self._check_everything_allowed(
+            self.company.members.first(),
+            extra_post_data_1={
+                "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+                "birth_country": Country.france_id,
+            },
+        )
 
     def test_as_company_with_non_proxied_job_seeker(self):
         # Make sure the job seeker does manage its own account
@@ -3470,12 +3553,18 @@ class UpdateJobSeekerForHireTestCase(UpdateJobSeekerBaseTestCase):
         self.job_seeker.created_by = EmployerFactory()
         self.job_seeker.last_login = None
         self.job_seeker.save(update_fields=["created_by", "last_login"])
+
+        geispolsheim = create_city_geispolsheim()
+        birthdate = self.job_seeker.jobseeker_profile.birthdate
+
         self._check_everything_allowed(
             self.company.members.first(),
             extra_post_data_1={
                 "nir": "",
                 "lack_of_nir": True,
                 "lack_of_nir_reason": LackOfNIRReason.TEMPORARY_NUMBER.value,
+                "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+                "birth_country": Country.france_id,
             },
         )
         # Check that we could update its NIR infos
@@ -3599,13 +3688,18 @@ def test_detect_existing_job_seeker(client):
     # Make sure the specified NIR is properly filled
     assertContains(response, NEW_NIR)
 
+    geispolsheim = create_city_geispolsheim()
+    birthdate = job_seeker.jobseeker_profile.birthdate
+
     post_data = {
         "title": job_seeker.title,
         "first_name": "JEREMY",  # Try without the accent and in uppercase
         "last_name": job_seeker.last_name,
-        "birthdate": job_seeker.jobseeker_profile.birthdate,
+        "birthdate": birthdate,
         "lack_of_nir_reason": "",
         "lack_of_nir": False,
+        "birth_place": Commune.objects.by_insee_code_and_period(geispolsheim.code_insee, birthdate).id,
+        "birth_country": Country.france_id,
     }
     response = client.post(next_url, data=post_data)
     assertContains(
@@ -3637,6 +3731,8 @@ def test_detect_existing_job_seeker(client):
     expected_job_seeker_session["profile"] |= {
         "lack_of_nir_reason": post_data.pop("lack_of_nir_reason", ""),
         "birthdate": post_data.pop("birthdate"),
+        "birth_country": post_data.pop("birth_country"),
+        "birth_place": post_data.pop("birth_place"),
     }
     expected_job_seeker_session["user"] |= post_data
     assert client.session[job_seeker_session_name] == expected_job_seeker_session


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les prescripteurs et les employeurs peuvent créer les demandeurs d'emploi et leurs candidatures sur les parcours de `apply/.../sender/...` et `apply/.../hire/...`. Deux champs importants sur leur fichier sont la commune et la pays de naissance qui sont avec ce PR inclusent lors de ces parcours.

## :cake: Comment ?

Ce besoin a impliqué la logique un peu particulière du gestion de `birth_place` et `birth_country`, partagée maintenant entre trois formulaires (`NewEmployeeRecordStep1Form`, `CertifiedCriteriaInfoRequiredForm` et `CreateJobSeekerWithBirthFieldsStep1Form`).

Cette logique gère la création et la modification des profils du candidat sur les formulaires qui peuvent cible le `JobSeekerProfile` en directe ou par le clé sur `User`. J'ai pu encacher cette complexité en `BirthPlaceAndCountryMixin`, afin de simplifier les formulaires qui utilisent ses fonctionalités

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran

<img width="1154" alt="Screenshot 2024-09-12 at 12 04 15" src="https://github.com/user-attachments/assets/8f555097-cab3-457a-bcec-2fbe3cd2abdf">
