### PR TITLE
Ajouter une règle resetdb au Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,16 +117,10 @@ $ make runserver
 
 Vous pouvez y accéder à l'adresse http://localhost:8000/.
 
-## Créer le schéma de base de données
+## Obtenir une base de données de développement
 
 ```sh
-$ python manage.py migrate
-```
-
-## Peupler la base de données
-
-```sh
-$ make populate_db
+$ make resetdb
 ```
 
 ## Charger une base de données de production


### PR DESCRIPTION
## :thinking: Pourquoi ?

Recharger une base de données vide plus rapidement.

## :cake: Comment ? <!-- optionnel -->

Mettre en cache un dump d’une base de données complète créée à partir des fixtures.
Grâce aux dépendances du `Makefile`, la base cachée sera reconstruite si le schéma de base de données ou les fixtures changent.

Performances sur ma machine:
- création de la base, migration et chargement des données: 50s
- `pg_restore` de la base cachée : 15s

## :nerd_face: Comment tester ?
```
make resetdb
```

## Et après ?

À voir si ça vous intéresse. Les avantages principaux :
- éviter de taper plusieurs commandes pour créer une base de données avec les données fictives
- gagner un peu de temps

Après, le mécanisme est un peu complexe et pas parfait (ex.: oubli de dépendance, ou `mtime` qui change alors que le contenu du fichier de dépendance n’a pas changé de manière significative).

Dans les idées qui suivraient, je cacherais bien la base générée avec les GH actions, pour pouvoir l’utiliser lors du déploiement sur une recette jetable chez Clever, pour essayer d’aller un peu plus vite.