### PR TITLE
Tableau de bord : le bouton Postuler pour un candidat envoie directement dans la page des résultats de recherche

### DIFF
--- a/itou/templates/apply/includes/list_job_applications.html
+++ b/itou/templates/apply/includes/list_job_applications.html
@@ -37,7 +37,7 @@
                 </i>
             </p>
             {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
-                <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
+                <a href="{% url 'search:employers_results' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
                     <i class="ri-user-follow-line ri-lg font-weight-normal"></i>
                     <span>Postuler pour un candidat</span>
                 </a>

--- a/itou/templates/apply/list_prescriptions.html
+++ b/itou/templates/apply/list_prescriptions.html
@@ -16,7 +16,7 @@
         {% include "apply/includes/list_job_applications_title.html" %}
         <div class="d-flex flex-column flex-md-row gap-3" role="group" aria-label="Actions sur les candidatures">
             {% include "apply/includes/job_applications_export_button.html" %}
-            <a href="{% url 'search:employers_home' %}" class="btn btn-lg btn-primary btn-ico">
+            <a href="{% url 'search:employers_results' %}" class="btn btn-lg btn-primary btn-ico">
                 <i class="ri-draft-line font-weight-medium" aria-hidden="true"></i>
                 <span>Postuler pour un candidat</span>
             </a>

--- a/itou/templates/dashboard/includes/employer_prescription_card.html
+++ b/itou/templates/dashboard/includes/employer_prescription_card.html
@@ -7,7 +7,7 @@
             <span class="badge badge-sm rounded-pill bg-important float-end">Nouveau</span>
         </div>
         <div class="px-3 px-lg-4">
-            <a href="{% url "search:employers_home" %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
+            <a href="{% url "search:employers_results" %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
                 <i class="ri-draft-line ri-lg font-weight-normal"></i>
                 <span>Postuler pour un candidat</span>
             </a>

--- a/itou/templates/dashboard/includes/prescriber_job_applications_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_applications_card.html
@@ -10,7 +10,7 @@
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
-                    <a href="{% url 'search:employers_home' %}" class="btn-link btn-ico">
+                    <a href="{% url 'search:employers_results' %}" class="btn-link btn-ico">
                         <i class="ri-draft-line ri-lg font-weight-normal"></i>
                         <span>Postuler pour un candidat</span>
                     </a>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Demande : 
> Postuler pour un candidat : on arrive sur la homepage intégrée dans le layout connecté.
> Est-ce qu’il y a moyen de mettre direct sur la page de résultat de recherche d’emploi mais sans avoir rentré de ville ? 

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

Dans la demande, on n'a pas précisé quels boutons changer. Il y en a plusieurs : sur le tableau de bord des employeurs, dans les pages qui listent les candidats et candidatures. 
Par souci d'homogénéité, j'ai tout modifié.