### PR TITLE
Profil salarié: redonner l'accès aux anciens PASS IAE

### DIFF
--- a/itou/templates/approvals/includes/list_card.html
+++ b/itou/templates/approvals/includes/list_card.html
@@ -57,7 +57,7 @@
     <div class="c-box--results__footer">
 
         <div class="d-flex justify-content-md-end">
-            <a href="{% url 'employees:detail' public_id=approval.user.public_id %}?back_url={{ request.get_full_path|urlencode }}"
+            <a href="{% url 'employees:detail' public_id=approval.user.public_id %}?approval={{ approval.pk }}&back_url={{ request.get_full_path|urlencode }}"
                class="btn btn-outline-primary btn-block w-100 w-md-auto"
                {% matomo_event "salaries" "clic" "details-salarie" %}
                aria-label="Voir les informations de {{ approval.user.get_full_name }}">Voir les informations</a>

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -42,7 +42,7 @@ class TestApprovalsListView:
         assert_previous_step(response, reverse("dashboard:index"))
 
         employee_base_url = reverse("employees:detail", kwargs={"public_id": approval.user.public_id})
-        assertContains(response, f"{employee_base_url}?back_url={urlencode(url)}")
+        assertContains(response, f"{employee_base_url}?approval={approval.pk}&back_url={urlencode(url)}")
         assertContains(response, self.TABS_CLASS)
 
     def test_multiple_approvals_for_the_same_user(self, client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à #4713 l'accès au Profile salarié se fait via l'identifiant public du compte candidat.
Or certains candidats ont plusieurs PASS et apparaissent plusieurs fois dans la liste mais avec toujours le même lien menant au profil salarié affichant le dernier PASS (depuis #4731) et avec impossibilité de revoir les infos des anciens PASS.

Cette PR corrige ce soucis.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
