### PR TITLE
UX/UI : largeur réponsive pour les composants `.select2`

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -90,6 +90,10 @@ duet-date-picker.is-invalid ~ .invalid-feedback {
     border: 2px dashed var(--bs-danger);
 }
 
+.form-group > .select2-container--bootstrap-5 {
+    width: 100% !important;
+}
+
 .file-dropzone {
     width: 100%;
     border: 2px dashed var(--bs-gray-700);


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une fois qu'un widget select2 est téléchargé (`.select2-container--bootstrap-5`) la largeur est fixée selon la taille de l'écran :

```html
<span dir="ltr" data-select2-id="3" style="width: 694.667px;" class="select2 select2-container select2-container--bootstrap-5">
```

Le problème arrive quand on change la taille de l'écran, ces composants sont pas réponsive :

<img width="780" alt="Screenshot 2024-09-12 at 15 01 16" src="https://github.com/user-attachments/assets/8067138e-f4e1-4829-91ca-c8acdb8c6fd8">

## :cake: Comment ?

Dans ce PR je propose une fixe simple où on ajoute une classe qui enforce le composant ne peut pas manger plus de la page que son parent

<img width="593" alt="Screenshot 2024-09-12 at 15 03 08" src="https://github.com/user-attachments/assets/9430bd68-68a2-434b-9cd6-34e2f77b0cba">

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?