### PR TITLE
Simplification des migrations companies relatives au renommage de rdv_insertion_id

### DIFF
--- a/itou/companies/migrations/0009_remove_company_rdv_insertion_id.py
+++ b/itou/companies/migrations/0009_remove_company_rdv_insertion_id.py
@@ -9,16 +9,8 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.RemoveField(
-                    model_name="company",
-                    name="rdv_insertion_id",
-                ),
-            ],
-            # Don't drop anything yet, since the previous will still be running when this migration will be run.
-            # Keeping this field around should not be an issue since it is NULLABLE.
-            # It will be dropped in a following migration.
-            database_operations=[],
+        migrations.RemoveField(
+            model_name="company",
+            name="rdv_insertion_id",
         ),
     ]

--- a/itou/companies/migrations/0010_remove_company_rdv_insertion_id_for_real.py
+++ b/itou/companies/migrations/0010_remove_company_rdv_insertion_id_for_real.py
@@ -8,7 +8,4 @@ class Migration(migrations.Migration):
         ("companies", "0009_remove_company_rdv_insertion_id"),
     ]
 
-    operations = [
-        # TODO(leo): merge this with 0009_remove_company_rdv_insertion_id once run in production
-        migrations.RunSQL('ALTER TABLE "companies_company" DROP COLUMN "rdv_insertion_id";', elidable=True),
-    ]
+    operations = []


### PR DESCRIPTION
## :thinking: Pourquoi ?

Remplacement de la colonne `rdv_insertion_id` en `rdv_solidarités_id`

PR 3/3 (zero-downtime)

## :cake: Comment ? <!-- optionnel -->

- PR 1/3 : Ajout de la nouvelle colonne, migrations
- PR 2/3 : Suppression de l'ancienne colonne
- **PR 3/3 : Cleanup**
