### PR TITLE
Tableau de bord : Déplacer le contenu de l'onglet "Statistique" dans sa propre vue

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -1,5 +1,4 @@
 {% extends "layout/base.html" %}
-{% load format_filters %}
 {% load static tally %}
 {% load matomo %}
 {% load theme_inclusion %}
@@ -142,59 +141,7 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div>
-            <h1 class="mb-0">
-                {% if user.is_job_seeker and user.get_full_name %}Tableau de bord - {{ user.get_full_name }}{% endif %}
-                {% if request.current_organization %}{{ request.current_organization.display_name }}{% endif %}
-            </h1>
-            {% if request.current_organization %}
-                <p class="mb-0">
-                    {% if user.is_prescriber %}
-                        {% if request.current_organization.code_safir_pole_emploi %}
-                            {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
-                            Code SAFIR {{ request.current_organization.code_safir_pole_emploi }}
-                        {% elif request.current_organization.siret %}
-                            {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
-                            {% if request.current_organization.kind != PrescriberOrganizationKind.OTHER %}
-                                {{ request.current_organization.kind }} -
-                            {% endif %}
-                            SIRET {{ request.current_organization.siret|format_siret }}
-                        {% endif %}
-                    {% elif user.is_employer %}
-                        {{ request.current_organization.kind }} -
-                        SIRET {{ request.current_organization.siret|format_siret }}
-                    {% endif %}
-                </p>
-            {% endif %}
-        </div>
-        {% if user.is_employer %}
-            {% if request.current_organization.is_subject_to_eligibility_rules or request.current_organization.kind == CompanyKind.GEIQ %}
-                {% comment %}
-                NOTE(vperron):
-                We currently do not allow OPCS users to apply for an offer.
-                We will have to discuss this matter further with AVE, but it has been
-                decided that it probably did not make much sense initially.
-                {% endcomment %}
-                <div>
-                    {% if siae_suspension_text_with_dates %}
-                        <span class="btn btn-lg btn-primary btn-ico disabled"
-                              data-bs-toggle="tooltip"
-                              data-bs-placement="top"
-                              title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
-                            <i class="ri-user-follow-line font-weight-medium"></i>
-                            <span>Déclarer une embauche</span>
-                        </span>
-                    {% else %}
-                        <a href="{% url 'apply:check_nir_for_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
-                            <i class="ri-user-follow-line font-weight-medium"></i>
-                            <span>Déclarer une embauche</span>
-                        </a>
-                    {% endif %}
-                </div>
-            {% endif %}
-        {% endif %}
-    </div>
+    {% include 'dashboard/includes/dashboard_title_content.html' %}
 {% endblock %}
 
 {% block title_extra %}
@@ -203,15 +150,8 @@
             <a class="nav-link active" id="ensemble-tab" data-bs-toggle="tab" href="#ensemble" role="tab" aria-controls="ensemble" aria-selected="true" {% matomo_event "dashboard" "clic-onglet" "vue-d-ensemble" %}>Vue d’ensemble</a>
         </li>
         {% if can_view_stats_dashboard_widget %}
-            <li class="nav-item" role="presentation">
-                <a class="nav-link"
-                   id="statistiques-tab"
-                   data-bs-toggle="tab"
-                   href="#statistiques"
-                   role="tab"
-                   aria-controls="statistiques"
-                   aria-selected="false"
-                   {% matomo_event "dashboard" "clic-onglet" "statistiques" %}>Statistiques</a>
+            <li class="nav-item">
+                <a class="nav-link" href="{% url "dashboard:index_stats" %}" {% matomo_event "dashboard" "clic-onglet" "statistiques" %}>Statistiques</a>
             </li>
         {% endif %}
         {% if user.is_employer or user.is_prescriber %}
@@ -281,12 +221,11 @@
                                     {% if request.current_organization.kind == InstitutionKind.DDETS_GEIQ or request.current_organization.kind == InstitutionKind.DREETS_GEIQ %}
                                         {% include "dashboard/includes/labor_inspector_geiq_assessment_card.html" %}
                                     {% endif %}
+                                    {% if active_campaigns or closed_campaigns %}
+                                        {% include "dashboard/includes/labor_inspector_evaluation_campains_card.html" %}
+                                    {% endif %}
                                 {% endif %}
                                 {# end of if user.is_labor_inspector #}
-
-                                {% if can_view_stats_ddets_iae and active_campaigns or can_view_stats_ddets_iae and closed_campaigns %}
-                                    {% include "dashboard/includes/labor_inspector_evaluation_campains_card.html" %}
-                                {% endif %}
                             </div>
                             {% if user.is_employer or user.is_prescriber %}
                                 <h2>Services partenaires</h2>
@@ -298,19 +237,6 @@
                                 </div>
                             {% endif %}
                         </div>
-                        {% if can_view_stats_dashboard_widget %}
-                            <div class="tab-pane fade" id="statistiques" role="tabpanel" aria-labelledby="statistiques-tab">
-                                <h2>Statistiques</h2>
-                                <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
-                                    <img src="{% static_theme_images 'logo-pilotage-inclusion.svg' %}" height="80" alt="Le pilotage de l'inclusion">
-                                </div>
-                                <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4">
-                                    {% if can_view_stats_dashboard_widget %}
-                                        {% include "dashboard/includes/stats.html" %}
-                                    {% endif %}
-                                </div>
-                            </div>
-                        {% endif %}
                         {% if user.is_employer or user.is_prescriber %}
                             <div class="tab-pane fade" id="evenements" role="tabpanel" aria-labelledby="evenements-tab">
                                 <h2>Événements à venir</h2>

--- a/itou/templates/dashboard/dashboard_stats.html
+++ b/itou/templates/dashboard/dashboard_stats.html
@@ -1,0 +1,67 @@
+{% extends "layout/base.html" %}
+{% load static tally %}
+{% load matomo %}
+{% load theme_inclusion %}
+
+{% block title %}Tableau de bord {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% include 'dashboard/includes/dashboard_title_content.html' %}
+{% endblock %}
+
+{% block title_extra %}
+    <ul class="s-tabs-01__nav nav nav-tabs mb-0" role="tablist" data-it-sliding-tabs="true">
+        <li class="nav-item">
+            <a class="nav-link" href="{% url "dashboard:index" %}" {% matomo_event "dashboard" "clic-onglet" "vue-d-ensemble" %}>Vue d’ensemble</a>
+        </li>
+        <li class="nav-item" role="presentation">
+            <a class="nav-link active"
+               id="statistiques-tab"
+               data-bs-toggle="tab"
+               href="#statistiques"
+               role="tab"
+               aria-controls="statistiques"
+               aria-selected="true"
+               {% matomo_event "dashboard" "clic-onglet" "statistiques" %}>Statistiques</a>
+        </li>
+        {% if user.is_employer or user.is_prescriber %}
+            <li class="nav-item">
+                <a class="nav-link" id="evenements-tab" data-bs-toggle="tab" href="#evenements" role="tab" aria-controls="evenements" aria-selected="false" {% matomo_event "dashboard" "clic-onglet" "evenements" %}>Événements à venir</a>
+            </li>
+        {% endif %}
+    </ul>
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="col-12">
+                    <div class="tab-content">
+                        <div class="tab-pane fade show active" id="statistiques" role="tabpanel" aria-labelledby="statistiques-tab">
+                            <h2>Statistiques</h2>
+                            <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                <img src="{% static_theme_images 'logo-pilotage-inclusion.svg' %}" height="80" alt="Le pilotage de l'inclusion">
+                            </div>
+                            <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4">{% include "dashboard/includes/stats.html" %}</div>
+                        </div>
+                        {% if user.is_employer or user.is_prescriber %}
+                            <div class="tab-pane fade" id="evenements" role="tabpanel" aria-labelledby="evenements-tab">
+                                <h2>Événements à venir</h2>
+                                <div class="mt-3 mt-md-4">
+                                    <div class="js-tac-livestorm" data-url="https://app.livestorm.co/itou/upcoming?limit=10" title="Événements des emplois de l'inclusion | Livestorm">
+                                    </div>
+                                </div>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    <script src="{% static 'js/sliding_tabs.js'%}"></script>
+{% endblock %}

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -1,0 +1,56 @@
+{% load format_filters %}
+{% load matomo %}
+
+<div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
+    <div>
+        <h1 class="mb-0">
+            {% if user.is_job_seeker and user.get_full_name %}Tableau de bord - {{ user.get_full_name }}{% endif %}
+            {% if request.current_organization %}{{ request.current_organization.display_name }}{% endif %}
+        </h1>
+        {% if request.current_organization %}
+            <p class="mb-0">
+                {% if user.is_prescriber %}
+                    {% if request.current_organization.code_safir_pole_emploi %}
+                        {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
+                        Code SAFIR {{ request.current_organization.code_safir_pole_emploi }}
+                    {% elif request.current_organization.siret %}
+                        {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
+                        {% if request.current_organization.kind != PrescriberOrganizationKind.OTHER %}
+                            {{ request.current_organization.kind }} -
+                        {% endif %}
+                        SIRET {{ request.current_organization.siret|format_siret }}
+                    {% endif %}
+                {% elif user.is_employer %}
+                    {{ request.current_organization.kind }} -
+                    SIRET {{ request.current_organization.siret|format_siret }}
+                {% endif %}
+            </p>
+        {% endif %}
+    </div>
+    {% if user.is_employer %}
+        {% if request.current_organization.is_subject_to_eligibility_rules or request.current_organization.kind == CompanyKind.GEIQ %}
+            {% comment %}
+            NOTE(vperron):
+            We currently do not allow OPCS users to apply for an offer.
+            We will have to discuss this matter further with AVE, but it has been
+            decided that it probably did not make much sense initially.
+            {% endcomment %}
+            <div>
+                {% if siae_suspension_text_with_dates %}
+                    <span class="btn btn-lg btn-primary btn-ico disabled"
+                          data-bs-toggle="tooltip"
+                          data-bs-placement="top"
+                          title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
+                        <i class="ri-user-follow-line font-weight-medium"></i>
+                        <span>Déclarer une embauche</span>
+                    </span>
+                {% else %}
+                    <a href="{% url 'apply:check_nir_for_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
+                        <i class="ri-user-follow-line font-weight-medium"></i>
+                        <span>Déclarer une embauche</span>
+                    </a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+</div>

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -70,7 +70,7 @@ NAV_ENTRIES = {
         label="Accueil",
         icon="ri-home-line",
         target=reverse("dashboard:index"),
-        active_view_names=["dashboard:index"],
+        active_view_names=["dashboard:index", "dashboard:index_stats"],
     ),
     "employers-search": NavItem(
         label="Un emploi inclusif",

--- a/itou/www/dashboard/urls.py
+++ b/itou/www/dashboard/urls.py
@@ -8,6 +8,7 @@ app_name = "dashboard"
 
 urlpatterns = [
     path("", views.dashboard, name="index"),
+    path("stats", views.dashboard_stats, name="index_stats"),
     path("token_api", views.api_token, name="api_token"),
     path("edit_user_email", views.edit_user_email, name="edit_user_email"),
     path("edit_user_info", views.edit_user_info, name="edit_user_info"),

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -345,7 +345,7 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
     def test_dashboard_siae_stats(self):
         membership = CompanyMembershipFactory()
         self.client.force_login(membership.user)
-        response = self.client.get(reverse("dashboard:index"))
+        response = self.client.get(reverse("dashboard:index_stats"))
         self.assertContains(response, "Traitement et résultats des candidatures reçues par ma ou mes structures")
         self.assertContains(response, reverse("stats:stats_siae_hiring"))
         self.assertContains(response, "Auto-prescription réalisées par ma ou mes structures")
@@ -361,28 +361,28 @@ class DashboardViewTest(ParametrizedTestCase, TestCase):
     def test_dashboard_ddets_log_institution_stats(self):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_LOG)
         self.client.force_login(membershipfactory.user)
-        response = self.client.get(reverse("dashboard:index"))
+        response = self.client.get(reverse("dashboard:index_stats"))
         self.assertContains(response, "Prescriptions des acteurs AHI de ma région")
         self.assertContains(response, reverse("stats:stats_ddets_log_state"))
 
     def test_dashboard_dihal_institution_stats(self):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DIHAL)
         self.client.force_login(membershipfactory.user)
-        response = self.client.get(reverse("dashboard:index"))
+        response = self.client.get(reverse("dashboard:index_stats"))
         self.assertContains(response, "Prescriptions des acteurs AHI")
         self.assertContains(response, reverse("stats:stats_dihal_state"))
 
     def test_dashboard_drihl_institution_stats(self):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DRIHL)
         self.client.force_login(membershipfactory.user)
-        response = self.client.get(reverse("dashboard:index"))
+        response = self.client.get(reverse("dashboard:index_stats"))
         self.assertContains(response, "Prescriptions des acteurs AHI")
         self.assertContains(response, reverse("stats:stats_drihl_state"))
 
     def test_dashboard_iae_network_institution_stats(self):
         membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.IAE_NETWORK)
         self.client.force_login(membershipfactory.user)
-        response = self.client.get(reverse("dashboard:index"))
+        response = self.client.get(reverse("dashboard:index_stats"))
         self.assertContains(response, "Traitement et résultats des candidatures orientées par mes adhérents")
         self.assertContains(response, reverse("stats:stats_iae_network_hiring"))
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Besoin initial : [Modifier l’action retour sur les emplois pour revenir à l’onglet stats au lieu de l’onglet vue d’ensemble](https://www.notion.so/gip-inclusion/UX-Modifier-l-action-retour-sur-les-emplois-pour-revenir-l-onglet-stats-au-lieu-de-l-onglet-vue-d-5e7c1d3ba36b4eba992121d135729426?pvs=4)

Cela aurais pu être gérer d'une autre manière (i.e. full frontend) mais j'ai préféré saisir l'occasion au vol pour diverses raisons.

_tl;dr_: La page étant la première sur laquelle les gens arrivent, l'onglet "Statistiques" étant moins vue et utile que l'onglet principal, et avec les divers ajouts anticipés autant découper quand c'est facile.

- Ça complexifiais et rendais la vue plus verbeuse que nécessaire
- C'est pas très lourd mais on commence à ajouter des choses autres que des liens dans cette partie : #4589 
- Un besoin qui devient récurrent est l'ajout de bannière pour les webinaires, pour le moment on les gères en dure donc ça évitera déjà de polluer la vue, mais dans le futur ces bannières seront configurables directement par le bizdev donc le coût machine ne sera plus si faible
- Un jour (plus lointain) il est aussi prévu de refondre la partie sur la gestion des droits d'accès pour ne plus avoir besoin d'un dev pour ouvrer l'accès des TB aux gens

## :cake: Remarques

Je vous met tout les deux en relecteur par rapport à la refonte.

Un `hx-boost` pourrais être pertinent mais on n'en fait pas trop ailleurs donc à vous de me dire si ça rentre dans la nouvelle doctrine ou pas :).

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/66366737-5eff-4ccb-abde-236e5e80f41a)

![image](https://github.com/user-attachments/assets/3133a1bf-f4d4-4404-a12d-deb3462c4bae)
