### PR TITLE
Profil salarié: limiter l'accès aux employeurs ayant une candidature acceptée les liant au salarié

### DIFF
--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -226,6 +226,13 @@
           FROM "users_user"
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "job_applications_jobapplication" U0
+                    WHERE (U0."job_seeker_id" = ("users_user"."id")
+                           AND U0."state" = %s
+                           AND U0."to_company_id" = %s)
+                    LIMIT 1)
                  AND "users_user"."public_id" = %s)
           LIMIT 21
         ''',
@@ -1245,7 +1252,8 @@
           FROM "companies_jobdescription"
           INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
-          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s,
+                                                                                        %s)
           ORDER BY "jobs_appellation"."name" ASC,
                    "companies_jobdescription"."ui_rank" ASC
         ''',
@@ -1796,6 +1804,13 @@
           FROM "users_user"
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "job_applications_jobapplication" U0
+                    WHERE (U0."job_seeker_id" = ("users_user"."id")
+                           AND U0."state" = %s
+                           AND U0."to_company_id" = %s)
+                    LIMIT 1)
                  AND "users_user"."public_id" = %s)
           LIMIT 21
         ''',
@@ -2741,7 +2756,8 @@
           FROM "companies_jobdescription"
           INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
-          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s,
+                                                                                        %s)
           ORDER BY "jobs_appellation"."name" ASC,
                    "companies_jobdescription"."ui_rank" ASC
         ''',
@@ -3482,6 +3498,13 @@
           FROM "users_user"
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "job_applications_jobapplication" U0
+                    WHERE (U0."job_seeker_id" = ("users_user"."id")
+                           AND U0."state" = %s
+                           AND U0."to_company_id" = %s)
+                    LIMIT 1)
                  AND "users_user"."public_id" = %s)
           LIMIT 21
         ''',
@@ -4196,7 +4219,8 @@
           FROM "companies_jobdescription"
           INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
-          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s,
+                                                                                        %s)
           ORDER BY "jobs_appellation"."name" ASC,
                    "companies_jobdescription"."ui_rank" ASC
         ''',

--- a/tests/www/employees_views/test_detail.py
+++ b/tests/www/employees_views/test_detail.py
@@ -102,10 +102,7 @@ class TestEmployeeDetailView:
 
         url = reverse("employees:detail", kwargs={"public_id": approval.user.public_id})
         response = client.get(url)
-        # Check that the page didn't crash
-        assertContains(response, self.APPROVAL_NUMBER_LABEL)
-        assertContains(response, "Informations du salarié")
-        assertContains(response, "Candidatures de ce salarié")
+        assert response.status_code == 404
 
     def test_detail_view_no_approval(self, client):
         company = CompanyFactory(with_membership=True, subject_to_eligibility=True)
@@ -147,8 +144,14 @@ class TestEmployeeDetailView:
         This template is used in approval views but also in many other places.
         Test its content only once.
         """
-        job_application = JobApplicationFactory(
+        # This gives access to the employer
+        accepted_app = JobApplicationFactory(
             job_seeker__public_id="11111111-9999-2222-8888-555555555555",
+            state=JobApplicationState.ACCEPTED,
+        )
+        job_application = JobApplicationFactory(
+            job_seeker=accepted_app.job_seeker,
+            to_company=accepted_app.to_company,
             state=JobApplicationState.PROCESSING,
             with_approval=True,
             approval__id=1,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les autres employeurs n'ont pas de raisons d'y avoir accès.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
