### PR TITLE
Candidature : vérifier la cohérence du NIR avec la date de naissance et la civilité

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -159,6 +159,9 @@ class CheckJobSeekerInfoForm(JobSeekerProfileFieldsMixin, forms.ModelForm):
     def clean(self):
         super().clean()
         JobSeekerProfile.clean_pole_emploi_fields(self.cleaned_data)
+        JobSeekerProfile.clean_nir_title_birthdate_fields(
+            self.cleaned_data | {"nir": self.instance.jobseeker_profile.nir}, remind_nir_in_error=True
+        )
 
 
 class CreateOrUpdateJobSeekerStep1Form(
@@ -194,6 +197,10 @@ class CreateOrUpdateJobSeekerStep1Form(
                 "class": "js-period-date-input",
             }
         )
+
+    def clean(self):
+        super().clean()
+        JobSeekerProfile.clean_nir_title_birthdate_fields(self.cleaned_data)
 
 
 class CreateOrUpdateJobSeekerStep2Form(JobSeekerAddressForm, forms.ModelForm):

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -91,6 +91,7 @@ class EditJobSeekerInfoForm(
     def clean(self):
         super().clean()
         JobSeekerProfile.clean_pole_emploi_fields(self.cleaned_data)
+        JobSeekerProfile.clean_nir_title_birthdate_fields(self.cleaned_data)
 
     def save(self, commit=True):
         self.instance.last_checked_at = timezone.now()

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -347,7 +347,7 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
 
     @factory.lazy_attribute
     def nir(self):
-        gender = random.choice([1, 2])
+        gender = "1" if self.user.title == Title.M else "2"
         if self.birthdate:
             year = self.birthdate.strftime("%y")
             month = self.birthdate.strftime("%m")

--- a/tests/www/dashboard/test_edit_job_seeker_info.py
+++ b/tests/www/dashboard/test_edit_job_seeker_info.py
@@ -67,7 +67,7 @@ class EditJobSeekerInfo(TestCase):
         side_effect=mock_get_geocoding_data_by_ban_api_resolved,
     )
     def test_edit_by_company_with_nir(self, _mock):
-        job_application = JobApplicationSentByPrescriberFactory()
+        job_application = JobApplicationSentByPrescriberFactory(job_seeker__jobseeker_profile__nir="178122978200508")
         user = job_application.to_company.members.first()
 
         # Ensure that the job seeker is not autonomous (i.e. he did not register by himself).
@@ -158,7 +158,7 @@ class EditJobSeekerInfo(TestCase):
         self.assertNotContains(response, self.NIR_UPDATE_TALLY_LINK_LABEL, html=True)
         self.assertContains(response, "Pour ajouter le numéro de sécurité sociale, veuillez décocher la case")
 
-        NEW_NIR = "1 970 13625838386"
+        NEW_NIR = "1 781 22978200508"
         post_data = {
             "email": "bob@saintclar.net",
             "title": "M",
@@ -257,7 +257,7 @@ class EditJobSeekerInfo(TestCase):
             "Le numéro de sécurité sociale est trop court (15 caractères autorisés).",
         )
 
-        NEW_NIR = "1 970 13625838386"
+        NEW_NIR = "1 781 22978200508"
         post_data["nir"] = NEW_NIR
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, expected_url=back_url)
@@ -388,7 +388,9 @@ class EditJobSeekerInfo(TestCase):
         new_email = "bidou@yopmail.com"
         company = CompanyFactory(with_membership=True)
         user = company.members.first()
-        job_application = JobApplicationSentByPrescriberFactory(to_company=company, job_seeker__created_by=user)
+        job_application = JobApplicationSentByPrescriberFactory(
+            to_company=company, job_seeker__created_by=user, job_seeker__jobseeker_profile__nir="178122978200508"
+        )
 
         self.client.force_login(user)
 
@@ -435,7 +437,7 @@ class EditJobSeekerInfo(TestCase):
     )
     def test_edit_email_when_confirmed(self, _mock):
         new_email = "bidou@yopmail.com"
-        job_application = JobApplicationSentByPrescriberFactory()
+        job_application = JobApplicationSentByPrescriberFactory(job_seeker__jobseeker_profile__nir="178122978200508")
         user = job_application.to_company.members.first()
 
         # Ensure that the job seeker is not autonomous (i.e. he did not register by himself).


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une nouvelle vérification pour être sûr que les données entrées soient cohérentes.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
