### PR TITLE
Permettre à RDV-I d'envoyer une invitation pour les structures ayant plusieurs catégories de motif

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -1099,6 +1099,11 @@ def rdv_insertion_invite(request, job_application_id, for_detail=False):
                         else None
                     ),
                     "address": job_application.job_seeker.address_on_one_line,
+                    "invitation": {
+                        "motif_category": {
+                            "name": "Entretien SIAE",
+                        },
+                    },
                 }
 
                 response = httpx.post(url=url, headers=headers, json=data, timeout=10)


### PR DESCRIPTION
Actuellement erreur 422 car la catégorie n'est pas spécifiée et que certaines structures participant à l'expérimentation ont plusieurs catégories de motif actives.

## :thinking: Pourquoi ?

Nous ne devions pas rencontrer de structure avec plusieurs catégories à ce stade car actuellement impossible de soumettre la catégorie de manière "stable" (ID, slug).


## :cake: Comment ? <!-- optionnel -->

En attendant le support d'un slug côté API RDV-I, on peut sélectionner la catégorie en la soumettant par son label.
