### PR TITLE
Vérifier l’existence d’une `apply_session` après ApplicationJobsView

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -725,6 +725,16 @@ class JobApplicationExternalTransferStep3View(ApplicationOverrideMixin, Applicat
     template_name = "apply/process_external_transfer_resume.html"
     form_class = TransferJobApplicationForm
 
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated and not self.apply_session.exists():
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:job_application_external_transfer_step_2",
+                    kwargs={"job_application_id": self.job_application.pk, "company_pk": self.company.pk},
+                )
+            )
+        return super().dispatch(request, *args, **kwargs)
+
     def get_initial(self):
         sender_display = self.job_application.sender.get_full_name()
         if self.job_application.sender_company:

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -318,6 +318,9 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
         job_application = JobApplicationFactory(job_seeker=job_seeker, to_company=diagnosis.author_geiq)
         url = reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
         client.force_login(diagnosis.author_geiq.members.first())
+        session = client.session
+        session[f"job_application-{job_application.to_company_id}"] = {"selected_jobs": []}
+        session.save()
         response = client.get(url)
 
         assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
@@ -328,6 +331,9 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
         geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
         prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.get()
         client.force_login(prescriber)
+        session = client.session
+        session[f"job_application-{geiq.pk}"] = {"selected_jobs": []}
+        session.save()
         response = client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -345,6 +351,9 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
         url = reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
 
         client.force_login(diagnosis.author_geiq.members.first())
+        session = client.session
+        session[f"job_application-{job_application.to_company_id}"] = {"selected_jobs": []}
+        session.save()
         response = client.get(url)
 
         assertTemplateUsed(response, "apply/includes/known_criteria.html")
@@ -354,8 +363,11 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
         # Check QPV fragment is displayed for prescriber:
         job_seeker_in_qpv = JobSeekerFactory(with_address_in_qpv=True)
         prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.get()
-        client.force_login(prescriber)
         geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
+        client.force_login(prescriber)
+        session = client.session
+        session[f"job_application-{geiq.pk}"] = {"selected_jobs": []}
+        session.save()
         response = client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -374,6 +386,9 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
         url = reverse("apply:geiq_eligibility_criteria", kwargs={"job_application_id": job_application.pk})
 
         client.force_login(diagnosis.author_geiq.members.first())
+        session = client.session
+        session[f"job_application-{job_application.to_company_id}"] = {"selected_jobs": []}
+        session.save()
         response = client.get(url)
 
         assertTemplateUsed(response, "apply/includes/known_criteria.html")
@@ -385,6 +400,9 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
         geiq = CompanyWithMembershipAndJobsFactory(kind=CompanyKind.GEIQ, with_jobs=True)
         prescriber = PrescriberOrganizationWithMembershipFactory(authorized=True).members.get()
         client.force_login(prescriber)
+        session = client.session
+        session[f"job_application-{geiq.pk}"] = {"selected_jobs": []}
+        session.save()
         response = client.get(
             reverse(
                 "apply:application_geiq_eligibility",
@@ -398,6 +416,9 @@ class TestJobSeekerGeoDetailsForGEIQDiagnosis:
     def test_jobseeker_cannot_create_geiq_diagnosis(self, client):
         job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ)
         client.force_login(job_application.job_seeker)
+        session = client.session
+        session[f"job_application-{job_application.to_company_id}"] = {"selected_jobs": []}
+        session.save()
         # Needed to setup session
         response = client.get(reverse("apply:geiq_eligibility", kwargs={"job_application_id": job_application.pk}))
         assert response.status_code == 404

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -287,6 +287,9 @@ def test_step_3(client, snapshot):
     employer = job_application.to_company.members.get()
     other_company = CompanyFactory(with_membership=True)
     client.force_login(employer)
+    session = client.session
+    session[f"job_application-{other_company.pk}"] = {"selected_jobs": []}
+    session.save()
 
     transfer_step_2_url = reverse(
         "apply:job_application_external_transfer_step_2",
@@ -328,6 +331,9 @@ def test_step_3_no_previous_CV(client, mocker, pdf_file):
     employer = job_application.to_company.members.get()
     other_company = CompanyFactory(with_membership=True)
     client.force_login(employer)
+    session = client.session
+    session[f"job_application-{other_company.pk}"] = {"selected_jobs": []}
+    session.save()
 
     transfer_step_2_url = reverse(
         "apply:job_application_external_transfer_step_2",
@@ -370,6 +376,9 @@ def test_step_3_remove_previous_CV(client):
     employer = job_application.to_company.members.get()
     other_company = CompanyFactory(with_membership=True)
     client.force_login(employer)
+    session = client.session
+    session[f"job_application-{other_company.pk}"] = {"selected_jobs": []}
+    session.save()
 
     transfer_step_2_url = reverse(
         "apply:job_application_external_transfer_step_2",
@@ -408,6 +417,9 @@ def test_step_3_replace_previous_CV(client, mocker, pdf_file):
     employer = job_application.to_company.members.get()
     other_company = CompanyFactory(with_membership=True)
     client.force_login(employer)
+    session = client.session
+    session[f"job_application-{other_company.pk}"] = {"selected_jobs": []}
+    session.save()
 
     transfer_step_2_url = reverse(
         "apply:job_application_external_transfer_step_2",
@@ -444,6 +456,26 @@ def test_step_3_replace_previous_CV(client, mocker, pdf_file):
         f"/resume/11111111-1111-1111-1111-111111111111.pdf"
     )
     assert new_job_application.state == JobApplicationState.NEW
+
+
+def test_access_step_3_without_session(client):
+    job_application = JobApplicationFactory(state=JobApplicationState.REFUSED, for_snapshot=True, resume_link="")
+    employer = job_application.to_company.members.get()
+    other_company = CompanyFactory(with_membership=True)
+    client.force_login(employer)
+    response = client.get(
+        reverse(
+            "apply:job_application_external_transfer_step_3",
+            kwargs={"job_application_id": job_application.pk, "company_pk": other_company.pk},
+        )
+    )
+    assertRedirects(
+        response,
+        reverse(
+            "apply:job_application_external_transfer_step_2",
+            kwargs={"job_application_id": job_application.pk, "company_pk": other_company.pk},
+        ),
+    )
 
 
 def test_full_process(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Clarifier le cycle de vie de `apply_session`.


Correction d’une perte de données dans un cas rarissime (voir message de commit).
