### PR TITLE
Admin : Correction de l’affichage de l’état des candidatures contrôlée a posteriori

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -264,7 +264,7 @@ class EvaluatedJobApplicationAdmin(ItouModelAdmin):
         return super().get_queryset(request).prefetch_related("evaluated_administrative_criteria")
 
     def state(self, obj):
-        return obj.state
+        return obj.compute_state()
 
     def approval(self, obj):
         if obj.job_application.approval:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Affichait `State: -`.

## :cake: Comment ? <!-- optionnel -->

L’attribut `state` n’existe pas sur les instances.
Django masque ces erreurs pour afficher un `-`:
https://github.com/django/django/blob/8e68f938f376cf2ca22a7e8ff0bcbe1b7a5832d1/django/contrib/admin/helpers.py#L269-L272
