### PR TITLE
Statistiques : Correction du filtre des structures pour le TB 440

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -266,7 +266,7 @@ def stats_siae_orga_etp(request):
         request=request,
         context=context,
         params={
-            mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [str(current_org.convention.asp_id)],
+            mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [org.convention.asp_id for org in request.organizations],
         },
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon l'utilisateur ne peux pas choisir une autre de ses structures directement depuis le filtre Metabase.

Se base sur #4775.