### PR TITLE
tests: Préchauffer le cache de ContentType de manière globale

### DIFF
--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -1,12 +1,10 @@
 import pytest
 from django.contrib.admin import helpers
-from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertNumQueries, assertRedirects
 
 from itou.companies.enums import CompanyKind
-from itou.companies.models import Company
 from tests.common_apps.organizations.tests import assert_set_admin_role__creation, assert_set_admin_role__removal
 from tests.companies.factories import CompanyFactory
 from tests.users.factories import EmployerFactory, ItouStaffFactory
@@ -18,8 +16,6 @@ class TestCompanyAdmin:
     @pytest.mark.ignore_unknown_variable_template_error("show_change_form_export")
     def test_display_for_new_company(self, admin_client, snapshot):
         """Does not search approvals with company IS NULL"""
-        # prewarm ContentType cache if needed to avoid extra query
-        ContentType.objects.get_for_model(Company)
         with assertNumQueries(9):
             # 1. SELECT django session
             # 2. SELECT user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,15 @@ def preload_spatial_reference(django_db_setup, django_db_blocker):
 
 
 @pytest.fixture(autouse=True, scope="session")
+def preload_contenttype_cache(django_db_setup, django_db_blocker):
+    from django.apps import apps
+    from django.contrib.contenttypes.models import ContentType
+
+    with django_db_blocker.unblock():
+        ContentType.objects.get_for_models(*apps.get_models())
+
+
+@pytest.fixture(autouse=True, scope="session")
 def test_bucket():
     # TODO: Remove this code block once we stop using a models.URLField() to store a S3 link (ie. `resume_link`)
     from django.core.validators import URLValidator

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -1,6 +1,5 @@
 import pytest
 import xworkflows
-from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -172,8 +171,6 @@ def test_model_fields():
     assert job_application.transferred_from is None
     assert job_application.transferred_at is None
 
-    # prewarm ContentType cache if needed to avoid extra query
-    ContentType.objects.get_for_model(target_company)
     with assertNumQueries(
         2  # Check user is in both origin and dest siae
         + 1  # Update job application to dereference eligibility diagnosis

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -305,8 +305,6 @@ def test_num_queries(admin_client):
         sender=prescriber,
         sender_kind=SenderKind.PRESCRIBER,
     )
-    # prewarm ContentType cache if needed to avoid extra query
-    ContentType.objects.get_for_model(prescriber)
     with assertNumQueries(
         BASE_NUM_QUERIES
         + 1  # Load Django session

--- a/tests/www/dashboard/test_edit_user_notifications.py
+++ b/tests/www/dashboard/test_edit_user_notifications.py
@@ -4,8 +4,6 @@ from django.urls import reverse
 
 from itou.communications import registry as notifications_registry
 from itou.communications.models import DisabledNotification, NotificationSettings
-from itou.companies.models import Company
-from itou.prescribers.models import PrescriberOrganization
 from tests.institutions.factories import LaborInspectorFactory
 from tests.users.factories import (
     EmployerFactory,
@@ -35,8 +33,6 @@ class EditUserNotificationsTest(TestCase):
         employer = EmployerFactory(with_company=True)
         self.client.force_login(employer)
         url = reverse("dashboard:edit_user_notifications")
-        # prewarm ContentType cache if needed to avoid extra query
-        ContentType.objects.get_for_model(Company)
         # 1.  SELECT django_session
         # 2.  SELECT users_user
         # 3.  SELECT companies_companymembership
@@ -58,8 +54,6 @@ class EditUserNotificationsTest(TestCase):
         prescriber = PrescriberFactory(membership=True)
         self.client.force_login(prescriber)
         url = reverse("dashboard:edit_user_notifications")
-        # prewarm ContentType cache if needed to avoid extra query
-        ContentType.objects.get_for_model(PrescriberOrganization)
         with self.assertNumQueries(
             1  # Load django session
             + 1  # Load current user
@@ -76,8 +70,6 @@ class EditUserNotificationsTest(TestCase):
         solo_adviser = PrescriberFactory(membership=False)
         self.client.force_login(solo_adviser)
         url = reverse("dashboard:edit_user_notifications")
-        # prewarm ContentType cache if needed to avoid extra query
-        ContentType.objects.get_for_model(PrescriberOrganization)
         with self.assertNumQueries(
             1  # Load django session
             + 1  # Load current user
@@ -116,9 +108,6 @@ class EditUserNotificationsTest(TestCase):
             for notification in notifications_registry
             if notification(employer, company).is_manageable_by_user()
         ]
-
-        # prewarm ContentType cache if needed to avoid extra query
-        ContentType.objects.get_for_model(Company)
 
         # No notification settings defined by default
         assert not NotificationSettings.objects.exists()
@@ -198,9 +187,6 @@ class EditUserNotificationsTest(TestCase):
             for notification in notifications_registry
             if notification(prescriber, organization).is_manageable_by_user()
         ]
-
-        # prewarm ContentType cache if needed to avoid extra query
-        ContentType.objects.get_for_model(PrescriberOrganization)
 
         # No notification settings defined by default
         assert not NotificationSettings.objects.exists()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Plus de stabilité, moins de requêtes, moins de surprises.
