### PR TITLE
github : Notifier automatiquement le pilotage quand une PR est fusionnée

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,7 +21,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[*.js]
+[*.{js,yml,yaml}]
 indent_style = space
 indent_size = 2
 

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -22,3 +22,13 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MEP_C1_WEBHOOK_URL }}
+      - name: "📢 Notify the #mep-c2 channel"
+        if: contains(github.event.pull_request.labels.*.name, 'pilotage')
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload: |
+            {
+              "text": ${{ toJSON(format('<{0}|{1}>', github.event.pull_request.html_url, github.event.pull_request.title)) }}
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_MEP_C2_WEBHOOK_URL }}


### PR DESCRIPTION
## :thinking: Pourquoi ?

[[Notifs sur slack] - Mettre en place les notifs de mep C2 pour qu’elles aient la même tête que dans mep c1](https://www.notion.so/gip-inclusion/Notifs-sur-slack-Mettre-en-place-les-notifs-de-mep-C2-pour-qu-elles-aient-la-m-me-t-te-que-dans-m-9b52111e165548929273f848efb3ec3f?pvs=4)

RàF :
- [x] Créer le label "pilotage"
- [x] Enregistrer `SLACK_MEP_C2_WEBHOOK_URL` dans les secrets 