### PR TITLE
Renommer la variable siae de la vue _accept en company

### DIFF
--- a/itou/templates/apply/includes/accept_section.html
+++ b/itou/templates/apply/includes/accept_section.html
@@ -12,7 +12,7 @@
                 <p>
                     Êtes-vous sûr(e) de vouloir confirmer l’embauche de <strong>{{ job_seeker.get_full_name }}</strong> dans la structure suivante ?
                 </p>
-                {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
+                {% include "companies/includes/_company_info.html" with company=company extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -49,7 +49,7 @@
         {% bootstrap_form_errors form_accept type="non_fields" %}
 
         {# reloadable contract type and options for GEIQ #}
-        {% if siae.kind == CompanyKind.GEIQ %}
+        {% if company.kind == CompanyKind.GEIQ %}
             {% include "apply/includes/geiq/geiq_contract_type_and_options.html" %}
         {% endif %}
 
@@ -59,7 +59,7 @@
         {% bootstrap_field form_accept.hiring_start_at %}
 
         {# reloadable training and qualification for GEIQ #}
-        {% if siae.kind == CompanyKind.GEIQ %}
+        {% if company.kind == CompanyKind.GEIQ %}
             {% include "apply/includes/geiq/geiq_qualification_fields.html" %}
         {% endif %}
 

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -13,7 +13,7 @@
         <hr>
         {% include "apply/includes/job_seeker_info.html" with with_matomo_event=False %}
 
-        {% include "apply/includes/eligibility_diagnosis.html" with job_seeker=job_seeker siae=siae eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False %}
+        {% include "apply/includes/eligibility_diagnosis.html" with job_seeker=job_seeker siae=company eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False %}
 
     </div>
     {% include "apply/includes/accept_section.html" %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

La vue est appelée pour les SIAE et les GEIQ. La condition `siae.kind == CompanyKind.GEIQ` est perturbante.
