### PR TITLE
GEIQ : Masquer les diagnostics d’éligibilité employeurs aux prescripteurs [GEN-1975]

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -167,7 +167,7 @@ class ApplicationBaseView(ApplyStepBaseView):
         _check_job_seeker_approval(request, self.job_seeker, self.company)
         if self.company.kind == CompanyKind.GEIQ:
             self.geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(
-                self.job_seeker, self.company
+                self.job_seeker, self.company if self.request.user.is_employer else None
             ).first()
         elif self.company.is_subject_to_eligibility_rules:
             self.eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -16,6 +16,7 @@ from pytest_django.asserts import assertContains, assertRedirects
 
 from itou.asp.models import AllocationDuration, EducationLevel, RSAAllocation
 from itou.companies.enums import CompanyKind, ContractType
+from itou.eligibility.enums import AuthorKind
 from itou.eligibility.models import (
     AdministrativeCriteria,
     EligibilityDiagnosis,
@@ -3653,6 +3654,9 @@ def test_detect_existing_job_seeker(client):
 
 
 class ApplicationGEIQEligibilityViewTest(TestCase):
+    DIAG_VALIDITY_TXT = "Date de fin de validité du diagnostic"
+    UPDATE_ELIGIBILITY = "Mettre à jour l’éligibilité"
+
     @classmethod
     def setUpTestData(cls):
         cls.geiq = CompanyFactory(with_membership=True, with_jobs=True, kind=CompanyKind.GEIQ)
@@ -3780,6 +3784,55 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
         )
         self.assertContains(response, geiq_eligibility_url)
 
+    def test_authorized_prescriber_can_see_other_authorized_prescriber_eligibility_diagnosis(self):
+        job_seeker = JobSeekerFactory()
+        GEIQEligibilityDiagnosisFactory(from_prescriber=True, job_seeker=job_seeker)
+
+        self.client.force_login(self.prescriber_org.members.get())
+        self._setup_session()
+        response = self.client.get(
+            reverse(
+                "apply:application_geiq_eligibility",
+                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": job_seeker.public_id},
+            )
+        )
+        self.assertContains(response, "Éligibilité GEIQ confirmée")
+        self.assertContains(response, self.DIAG_VALIDITY_TXT)
+        self.assertContains(response, self.UPDATE_ELIGIBILITY)
+
+    def test_authorized_prescriber_do_not_see_company_eligibility_diagnosis(self):
+        job_seeker = JobSeekerFactory()
+        GEIQEligibilityDiagnosisFactory(from_geiq=True, author_geiq=self.geiq, job_seeker=job_seeker)
+        url = reverse(
+            "apply:application_geiq_eligibility",
+            kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": job_seeker.public_id},
+        )
+        prescriber = self.prescriber_org.members.get()
+
+        self.client.force_login(prescriber)
+        self._setup_session()
+        response = self.client.get(url)
+        self.assertContains(response, "Éligibilité GEIQ non confirmée")
+        self.assertNotContains(response, self.DIAG_VALIDITY_TXT)
+        self.assertNotContains(response, self.UPDATE_ELIGIBILITY)
+
+        response = self.client.post(url, {"not": "empty"})
+        assertRedirects(
+            response,
+            reverse(
+                "apply:application_resume",
+                kwargs={"company_pk": self.geiq.pk, "job_seeker_public_id": job_seeker.public_id},
+            ),
+        )
+        prescriber_diag, _company_diag = GEIQEligibilityDiagnosis.objects.filter(job_seeker=job_seeker).order_by(
+            "-created_at"
+        )
+        assert prescriber_diag.author_kind == AuthorKind.PRESCRIBER
+        assert prescriber_diag.author == prescriber
+        assert prescriber_diag.author_prescriber_organization == self.prescriber_org
+        assert prescriber_diag.job_seeker == job_seeker
+        assert prescriber_diag.author_geiq is None
+
     def test_geiq_eligibility_badge(self):
         self.client.force_login(self.prescriber_org.members.first())
 
@@ -3798,6 +3851,7 @@ class ApplicationGEIQEligibilityViewTest(TestCase):
 
         self.assertContains(response, "Éligibilité GEIQ confirmée")
         self.assertTemplateUsed(response, "apply/includes/geiq/geiq_administrative_criteria_form.html")
+        self.assertContains(response, self.DIAG_VALIDITY_TXT)
 
         # Badge KO if job seeker has no diagnosis
         job_seeker_without_diagnosis = JobSeekerFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Auparavant, les prescripteurs voyaient les diagnostics d’éligibilité établis par les employeurs lors du processus de prescription.

- Si le prescripteur ne mettait pas à jour le diagnostic, le candidat n’obtenait pas de diagnostic d’un prescripteur habilité qui permet aux GEIQ d’obtenir l’aide au poste maximal. C’était néfaste pour le candidat.
- Si le prescripteur mettait à jour le diagnostic, le système effectuait par erreur une mise à jour du diagnostic employeur, au lieu d’établir un diagnostic d’un prescripteur habilité.

## :desert_island: Comment tester

1. Se connecter en tant que GEIQ
2. Enregistrer une candidature pour un nouveau candidat
3. Dans le process, établir un diagnostic d’éligibilité
4. Se connecter en tant que prescripteur
5. Effectuer un prescription pour le candidat de l’étape 2.
6. Durant le process, le diagnostic d’éligibilité employeur ne doit jamais apparaître pour le prescripteur
7. À l’issue de la prescription, il y a deux diagnostics d’éligibilité, et l’éligibilité du candidat est confirmée.
