### PR TITLE
Réparation du script `create-fast-machine.sh` suite au passage à `clever-deploy`

### DIFF
--- a/scripts/clever-deploy
+++ b/scripts/clever-deploy
@@ -48,7 +48,7 @@ esac
         f.close()
         os.chmod(f.name, stat.S_IRUSR | stat.S_IXUSR)
         subprocess.check_call(
-            ["git", "push", deploy_url, f"{branch}:master", "--force", "--progress"],
+            ["git", "push", deploy_url, f"{branch}:refs/heads/master", "--force", "--progress"],
             env={
                 "CLEVER_TOKEN": os.environ["CLEVER_TOKEN"],
                 "CLEVER_SECRET": os.environ["CLEVER_SECRET"],

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -49,7 +49,7 @@ Vous pouvez maintenant:
  - 🔨 Jouer les scripts d’import, par exemple:
     cd ~/app_* && scripts/import-iae.sh
  - 🍺 Supprimer la machine:
-    clever delete --alias $APP_NAME --yes && git remote remove "$APP_NAME"
+    clever delete --alias $APP_NAME --yes
 EOF
 
 exit 0


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter les refs ambigües.

```
error: The destination you provided is not a full refname (i.e.,
starting with "refs/"). We tried to guess what you meant by:

- Looking for a ref that matches 'master' on the remote side.
- Checking if the <src> being pushed ('refs/remotes/origin/master')
  is a ref in "refs/{heads,tags}/". If so we add a corresponding
  refs/{heads,tags}/ prefix on the remote side.

Neither worked, so we gave up. You must fully qualify the ref.
hint: The <src> part of the refspec is a commit object.
hint: Did you mean to create a new branch by pushing to
hint: 'refs/remotes/origin/master:refs/heads/master'?
error: failed to push some refs to 'https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_3b692b2d-6045-4713-a18b-2708cdee4e88.git'
Traceback (most recent call last):
  File "/home/freitafr/dev/itou/./scripts/clever-deploy", line 87, in <module>
    deploy()
  File "/home/freitafr/dev/itou/./scripts/clever-deploy", line 50, in deploy
    subprocess.check_call(
  File "/usr/lib/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'push', 'https://push-n3-par-clevercloud-customers.services.clever-cloud.com/app_3b692b2d-6045-4713-a18b-2708cdee4e88.git', 'origin/master:master', '--force', '--progress']' returned non-zero exit status 1.
```
