### PR TITLE
UX/UI : réparer la modale de confirmation d'embauche GEIQ sans aide

### DIFF
--- a/itou/templates/apply/includes/buttons/accept.html
+++ b/itou/templates/apply/includes/buttons/accept.html
@@ -7,11 +7,9 @@
         <span>Accepter</span>
     </a>
 {% else %}
-    {# GEIQ SIAE without valid geiq_eligibility_diagnosis #}
+    {# GEIQ SIAE without valid geiq_eligibility_diagnosis, modal in apply/process_details_company.html #}
     <button class="btn btn-lg btn-white btn-block btn-ico" data-bs-toggle="modal" data-bs-target="#confirm_no_allowance_modal">
         <i class="ri-check-line font-weight-medium" aria-hidden="true"></i>
         <span>Accepter</span>
     </button>
-    {# Confirmation modal for hiring #}
-    {% include "apply/includes/geiq/no_allowance_modal.html" with next_url=accept_url %}
 {% endif %}

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -150,9 +150,7 @@
 
 {% block modals %}
     {{ block.super }}
-    {% comment %}
-    Job application transfer modals triggered by apply/includes/transfer_job_application.html
-    {% endcomment %}
+    {# Job application transfer modals triggered by apply/includes/transfer_job_application.html #}
     {% if job_application.is_in_transferable_state %}
         {% for siae in request.organizations %}
             {% if siae != request.current_organization %}
@@ -183,5 +181,11 @@
                 </div>
             {% endif %}
         {% endfor %}
+    {% endif %}
+
+    {# GEIQ SIAE without valid geiq_eligibility_diagnosis. Modal triggered by apply/includes/buttons/accept.html #}
+    {% if job_application.to_company.kind == CompanyKind.GEIQ and not geiq_eligibility_diagnosis.is_valid %}
+        {% url 'apply:accept' job_application_id=job_application.pk as accept_url %}
+        {% include "apply/includes/geiq/no_allowance_modal.html" with next_url=accept_url %}
     {% endif %}
 {% endblock %}

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -23,6 +23,7 @@ class TestJobApplicationGEIQEligibilityDetails:
     )
     NO_VALID_DIAGNOSIS = "Éligibilité public prioritaire GEIQ non confirmée"
     EXPIRED_DIAGNOSIS_EXPLANATION = "Le diagnostic du candidat a expiré"
+    CONFIRMATION_MODAL = "Êtes-vous sûr de vouloir continuer sans bénéficier d’une aide financière de l’État ?"
 
     def get_response(self, client, job_application, user):
         client.force_login(user)
@@ -48,12 +49,14 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertContains(response, self.VALID_DIAGNOSIS)
         assertContains(response, self.ALLOWANCE_AND_COMPANY)
         assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
         # as job seeker, I see the prescriber diagnosis
         response = self.get_response(client, job_application, job_application.job_seeker)
         assertContains(response, self.VALID_DIAGNOSIS)
         assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
         assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
         # as a prescriber, I see my diagnosis
         assert diagnosis.author.is_prescriber
@@ -61,6 +64,7 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertContains(response, self.VALID_DIAGNOSIS)
         assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
         assertNotContains(response, self.NO_ALLOWANCE)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
     def test_with_expired_diagnosis(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True, expired=True)
@@ -76,12 +80,14 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertContains(response, self.NO_VALID_DIAGNOSIS)
         assertNotContains(response, self.NO_ALLOWANCE)
         assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        assertContains(response, self.CONFIRMATION_MODAL)
 
         # as job seeker, I see the prescriber diagnosis isn't valid anymore without further details
         response = self.get_response(client, job_application, job_application.job_seeker)
         assertContains(response, self.NO_VALID_DIAGNOSIS)
         assertNotContains(response, self.VALID_DIAGNOSIS)
         assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
         # as a prescriber, I see the prescriber diagnosis isn't valid anymore
         assert diagnosis.author.is_prescriber
@@ -89,6 +95,7 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertContains(response, self.NO_VALID_DIAGNOSIS)
         assertNotContains(response, self.NO_ALLOWANCE)
         assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
     def test_without_diagnosis(self, client):
         # No GEIQ diagnosis for this job seeker / job application
@@ -97,15 +104,18 @@ class TestJobApplicationGEIQEligibilityDetails:
         # as employer, I see there's no diagnosis
         response = self.get_response(client, job_application, job_application.to_company.members.first())
         assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertContains(response, self.CONFIRMATION_MODAL)
 
         # as job seeker, I see there's no diagnosis
         response = self.get_response(client, job_application, job_application.job_seeker)
         assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
         # as a prescriber, I don't see anything
         assert job_application.sender.is_prescriber
         response = self.get_response(client, job_application, job_application.sender)
         assertContains(response, self.NO_VALID_DIAGNOSIS)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
     def test_accepted_job_app_with_valid_diagnosis(self, client):
         diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
@@ -209,6 +219,7 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertNotContains(response, self.NO_ALLOWANCE)
         assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
         assertContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        assertContains(response, self.CONFIRMATION_MODAL)
 
         # as job seeker, I see the prescriber diagnosis
         response = self.get_response(client, job_application, job_application.job_seeker)
@@ -216,6 +227,7 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertNotContains(response, self.NO_ALLOWANCE)
         assertNotContains(response, self.ALLOWANCE_AND_COMPANY)
         assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
+        assertNotContains(response, self.CONFIRMATION_MODAL)
 
 
 def test_get_geiq_eligibility_diagnosis(subtests):


### PR DESCRIPTION
## :thinking: Pourquoi ?

En tant que GEIQ, la modale de confirmation d'embauche d'un candidat sans aide est cachée derrière le backdrop.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

On réutilise le block `{% block modals %}` dans `process_details_company.html`

## :desert_island: Comment tester

STR :

1. Se connecter en tant que GEIQ
2. Créer une candidature pour le GEIQ
3. Étudier la candidature
4. Cliquer sur Accepter
