### PR TITLE
Candidature : API Particulier -> interface

### DIFF
--- a/itou/eligibility/migrations/0001_initial.py
+++ b/itou/eligibility/migrations/0001_initial.py
@@ -149,7 +149,9 @@ class Migration(migrations.Migration):
                 (
                     "eligibility_diagnosis",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="eligibility.eligibilitydiagnosis"
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="selected_administrative_criteria",
+                        to="eligibility.eligibilitydiagnosis",
                     ),
                 ),
             ],
@@ -330,7 +332,9 @@ class Migration(migrations.Migration):
                 (
                     "eligibility_diagnosis",
                     models.ForeignKey(
-                        on_delete=django.db.models.deletion.CASCADE, to="eligibility.geiqeligibilitydiagnosis"
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="selected_administrative_criteria",
+                        to="eligibility.geiqeligibilitydiagnosis",
                     ),
                 ),
             ],

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -74,11 +74,12 @@ class AbstractEligibilityDiagnosisModel(models.Model):
     def is_valid(self):
         return bool(self.expires_at and self.expires_at > timezone.now())
 
+    @property
+    def is_from_employer(self):
+        return self.author_kind in (AuthorKind.GEIQ, AuthorKind.EMPLOYER)
+
     def criteria_can_be_certified(self):
-        return (
-            self.author_kind in (AuthorKind.GEIQ, AuthorKind.EMPLOYER)
-            and self.administrative_criteria.certifiable().exists()
-        )
+        return self.is_from_employer and self.administrative_criteria.certifiable().exists()
 
     def get_author_kind_display(self):
         if self.sender_kind == SenderKind.PRESCRIBER and (
@@ -107,6 +108,9 @@ class AbstractEligibilityDiagnosisModel(models.Model):
                 "certified_at",
             ],
         )
+
+    def get_criteria_display_qs(self, hiring_start_at=None):
+        return self.selected_administrative_criteria.with_is_considered_certified(hiring_start_at=hiring_start_at)
 
 
 class AdministrativeCriteriaQuerySet(models.QuerySet):

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -206,7 +206,7 @@ class SelectedAdministrativeCriteriaQuerySet(models.QuerySet):
 
 
 class AbstractSelectedAdministrativeCriteria(models.Model):
-    CERTIFICATION_GRACE_PERIOD_DAYS = 90
+    CERTIFICATION_GRACE_PERIOD_DAYS = 92
 
     certified = models.BooleanField(blank=True, null=True, verbose_name="certifié par l'API Particulier")
     certified_at = models.DateTimeField(blank=True, null=True, verbose_name="certifié le")

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -160,10 +160,12 @@ class GEIQEligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
     def author_structure(self):
         return self.author_geiq or self.author_prescriber_organization
 
-    @property
-    def administrative_criteria_display(self):
-        # for templates
-        return self.administrative_criteria.exclude(annex=AdministrativeCriteriaAnnex.NO_ANNEX).order_by("ui_rank")
+    def get_criteria_display_qs(self, hiring_start_at=None):
+        return (
+            super()
+            .get_criteria_display_qs(hiring_start_at)
+            .exclude(administrative_criteria__annex=AdministrativeCriteriaAnnex.NO_ANNEX)
+        )
 
     @classmethod
     @transaction.atomic()

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -291,8 +291,7 @@ class GEIQAdministrativeCriteria(AbstractAdministrativeCriteria):
 
 class GEIQSelectedAdministrativeCriteria(AbstractSelectedAdministrativeCriteria):
     eligibility_diagnosis = models.ForeignKey(
-        GEIQEligibilityDiagnosis,
-        on_delete=models.CASCADE,
+        GEIQEligibilityDiagnosis, on_delete=models.CASCADE, related_name="selected_administrative_criteria"
     )
     administrative_criteria = models.ForeignKey(
         GEIQAdministrativeCriteria,

--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -59,7 +59,7 @@ class EligibilityDiagnosisManager(models.Manager):
         """
         return job_seeker.has_valid_approval or bool(self.last_considered_valid(job_seeker, for_siae=for_siae))
 
-    def last_considered_valid(self, job_seeker, for_siae=None):
+    def last_considered_valid(self, job_seeker, for_siae=None, prefetch=None):
         """
         Retrieves the given job seeker's last considered valid diagnosis or None.
 
@@ -77,6 +77,10 @@ class EligibilityDiagnosisManager(models.Manager):
             .annotate(from_prescriber=Case(When(author_kind=AuthorKind.PRESCRIBER, then=1), default=0))
             .order_by("-from_prescriber", "-created_at")
         )
+
+        if prefetch:
+            query = query.prefetch_related(*prefetch)
+
         if not job_seeker.has_valid_approval:
             query = query.valid()
         # Otherwise, a diagnosis is considered valid for the duration of an

--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -269,7 +269,9 @@ class SelectedAdministrativeCriteria(AbstractSelectedAdministrativeCriteria):
     https://docs.djangoproject.com/en/dev/ref/models/relations/
     """
 
-    eligibility_diagnosis = models.ForeignKey(EligibilityDiagnosis, on_delete=models.CASCADE)
+    eligibility_diagnosis = models.ForeignKey(
+        EligibilityDiagnosis, on_delete=models.CASCADE, related_name="selected_administrative_criteria"
+    )
     administrative_criteria = models.ForeignKey(
         AdministrativeCriteria,
         on_delete=models.RESTRICT,

--- a/itou/templates/apply/includes/certification_info_box.html
+++ b/itou/templates/apply/includes/certification_info_box.html
@@ -1,0 +1,18 @@
+{% if diagnosis.criteria_can_be_certified %}
+    <div class="c-box bg-info-lightest my-4 p-0">
+        <button class="has-collapse-caret w-100 text-start d-block d-flex justify-content-between fw-bold text-left p-3 align-items-center"
+                type="button"
+                data-bs-target="#collapse-certif-help-text"
+                data-bs-toggle="collapse"
+                aria-expanded="false"
+                aria-controls="collapse-certif-help-text">
+            <div>
+                <i class="ri-lightbulb-line fw-medium pe-2" aria-hidden="true"></i>
+                <span>Pourquoi certains de mes critères peuvent-ils être certifiés ?</span>
+            </div>
+        </button>
+        <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
+            <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg"></i>
+        </div>
+    </div>
+{% endif %}

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -62,6 +62,23 @@
             {% endwith %}
         {% endif %}
 
+        {% if eligibility_diagnosis.criteria_can_be_certified %}
+            <div class="c-box bg-info-lightest my-4 p-0">
+                <button class="has-collapse-caret w-100 text-start d-block d-flex justify-content-between font-weight-bold text-left p-3 align-items-center"
+                        type="button"
+                        data-bs-target="#collapse-certif-help-text"
+                        data-bs-toggle="collapse"
+                        aria-expanded="false"
+                        aria-controls="collapse-certif-help-text">
+                    <div>
+                        <i class="ri-lightbulb-line font-weight-medium pe-2" aria-hidden="true"></i>
+                        <span>Pourquoi certains de mes critères peuvent-ils être certifiés ?</span>
+                    </div>
+                </button>
+                <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
+                    <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg"></i>
+                </div>
+            </div>
         {% endif %}
 
         <p>

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -1,95 +1,86 @@
 {% if siae.is_subject_to_eligibility_rules or request.user.is_prescriber %}
     {% if eligibility_diagnosis and eligibility_diagnosis.is_considered_valid %}
+        <hr class="my-4">
         {% if is_sent_by_authorized_prescriber %}
-            {% comment %}
-                Les candidatures envoyées par des prescripteurs habilités ne sont pas affichées de manière
-                hiérarchisée afin de ne pas induire les employeurs en erreur.
-                Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critère de niveau 2 par exemple
-            {% endcomment %}
-            <hr class="my-4">
             <h3>Éligibilité à l'IAE</h3>
-            <p>
-                Confirmée par
-                <b>{{ eligibility_diagnosis.author.get_full_name }}</b>
-                {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}){% endif %}
-                {% if eligibility_diagnosis.author_prescriber_organization %}
-                    ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
-                {% endif %}
-            </p>
-
-            {% with eligibility_diagnosis.administrative_criteria.all as administrative_criteria %}
-                {% if administrative_criteria %}
-                    <p>
-                        <span class="badge badge-sm rounded-pill bg-secondary">Situation administrative du candidat</span>
-                    </p>
-                    {# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#regroup #}
-                    {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
-                    <ul>
-                        {% for level in levels %}
-                            {% for criteria in level.list %}<li>{{ criteria.name }}</li>{% endfor %}
-                        {% endfor %}
-                    </ul>
-                {% endif %}
-            {% endwith %}
-
-            <p>
-                <i>
-                    Ce diagnostic est valide du {{ eligibility_diagnosis.created_at|date:"d/m/Y" }} au
-                    {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
-                </i>
-            </p>
         {% else %}
-
-            {% if eligibility_diagnosis is not None %}
-                <hr class="my-4">
-                <h3>Critères d'éligibilité</h3>
-                <p>
-                    Validés par
-                    <b>{{ eligibility_diagnosis.author.get_full_name }}</b>
-                    {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}){% endif %}
-                    {% if eligibility_diagnosis.author_prescriber_organization %}
-                        ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
-                    {% endif %}
-                    le
-                    <b>{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</b>.
-                </p>
-
-                {% with eligibility_diagnosis.administrative_criteria.all as administrative_criteria %}
-                    {% if administrative_criteria %}
-                        <p>
-                            <span class="badge badge-sm rounded-pill bg-secondary">Critères administratifs</span>
-                        </p>
-                        {# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#regroup #}
-                        {% regroup administrative_criteria|dictsort:"level" by get_level_display as levels %}
-                        <ul>
-                            {% for level in levels %}
-                                <li>
-                                    <b>{{ level.grouper }}</b>
-                                    <ul>
-                                        {% for criteria in level.list %}<li>{{ criteria.name }}</li>{% endfor %}
-                                    </ul>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    {% endif %}
-                {% endwith %}
-
-                <p>
-                    <i>
-                        Ce diagnostic expire le
-                        {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
-                    </i>
-                </p>
+            <h3>Critères d'éligibilité</h3>
+        {% endif %}
+        <p>
+            {% if is_sent_by_authorized_prescriber %}
+                Confirmée par
+            {% else %}
+                Validés par
             {% endif %}
+            <strong>{{ eligibility_diagnosis.author.get_full_name }}</strong>
+            {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}){% endif %}
+            {% if eligibility_diagnosis.author_prescriber_organization %}
+                ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
+            {% endif %}
+            le
+            <span class="fw-bold">{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</span>.
+        </p>
 
+        {% if eligibility_diagnosis.criteria_display %}
+            {% with eligibility_diagnosis.criteria_display as selected_administrative_criteria %}
+                <p>
+                    <span class="badge badge-sm rounded-pill bg-secondary">
+                        {% if is_sent_by_authorized_prescriber %}
+                            Situation administrative du candidat
+                        {% else %}
+                            Critères administratifs
+                        {% endif %}
+                    </span>
+                </p>
+                {# https://docs.djangoproject.com/en/dev/ref/templates/builtins/#regroup #}
+                {% regroup selected_administrative_criteria|dictsort:"administrative_criteria.level" by administrative_criteria.get_level_display as levels_list %}
+                <ul>
+                    {% for level, criteria in levels_list %}
+                        <li>
+                            {% comment %}
+                            Les candidatures envoyées par des prescripteurs habilités ne sont pas affichées de manière
+                            hiérarchisée afin de ne pas induire les employeurs en erreur.
+                            Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critères de niveau 2 par exemple.
+                            {% endcomment %}
+                            {% if not is_sent_by_authorized_prescriber %}<b>{{ level }}</b>{% endif %}
+                            <ul>
+                                {% for criterion in criteria %}
+                                    <li>
+                                        <span>{{ criterion.administrative_criteria.name }}</span>
+                                        {% if eligibility_diagnosis.is_from_employer and criterion.is_considered_certified %}
+                                            <span class="badge badge-sm rounded-pill bg-info-lighter text-info ms-3 me-1">
+                                                <i class="ri-verified-badge-fill" aria-hidden="true"></i>
+                                                Certifié
+                                            </span>
+                                        {% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% endwith %}
+        {% endif %}
 
         {% endif %}
+
+        <p>
+            <i>
+                {% if is_sent_by_authorized_prescriber %}
+                    Ce diagnostic est valide du {{ eligibility_diagnosis.created_at|date:"d/m/Y" }} au
+                    {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
+                {% else %}
+                    Ce diagnostic expire le
+                    {{ eligibility_diagnosis.considered_to_expire_at|date:"d/m/Y" }}.
+                {% endif %}
+            </i>
+        </p>
 
     {% elif job_seeker.latest_pe_approval and job_seeker.latest_pe_approval.is_valid %}
         <hr class="my-4">
         <h3>Critères d'éligibilité</h3>
         <p>
-            Validés par <b>France Travail</b>.
+            Validés par <span class="fw-bold">France Travail</span>.
         </p>
 
     {% elif expired_eligibility_diagnosis %}

--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -42,18 +42,10 @@
                             hiérarchisée afin de ne pas induire les employeurs en erreur.
                             Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critères de niveau 2 par exemple.
                             {% endcomment %}
-                            {% if not is_sent_by_authorized_prescriber %}<b>{{ level }}</b>{% endif %}
+                            {% if not is_sent_by_authorized_prescriber %}<span class="fw-bold">{{ level }}</span>{% endif %}
                             <ul>
                                 {% for criterion in criteria %}
-                                    <li>
-                                        <span>{{ criterion.administrative_criteria.name }}</span>
-                                        {% if eligibility_diagnosis.is_from_employer and criterion.is_considered_certified %}
-                                            <span class="badge badge-sm rounded-pill bg-info-lighter text-info ms-3 me-1">
-                                                <i class="ri-verified-badge-fill" aria-hidden="true"></i>
-                                                Certifié
-                                            </span>
-                                        {% endif %}
-                                    </li>
+                                    {% include "apply/includes/selected_administrative_criteria_display.html" with diagnosis=eligibility_diagnosis criterion=criterion %}
                                 {% endfor %}
                             </ul>
                         </li>
@@ -62,24 +54,7 @@
             {% endwith %}
         {% endif %}
 
-        {% if eligibility_diagnosis.criteria_can_be_certified %}
-            <div class="c-box bg-info-lightest my-4 p-0">
-                <button class="has-collapse-caret w-100 text-start d-block d-flex justify-content-between font-weight-bold text-left p-3 align-items-center"
-                        type="button"
-                        data-bs-target="#collapse-certif-help-text"
-                        data-bs-toggle="collapse"
-                        aria-expanded="false"
-                        aria-controls="collapse-certif-help-text">
-                    <div>
-                        <i class="ri-lightbulb-line font-weight-medium pe-2" aria-hidden="true"></i>
-                        <span>Pourquoi certains de mes critères peuvent-ils être certifiés ?</span>
-                    </div>
-                </button>
-                <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
-                    <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg"></i>
-                </div>
-            </div>
-        {% endif %}
+        {% include "apply/includes/certification_info_box.html" with diagnosis=eligibility_diagnosis %}
 
         <p>
             <i>

--- a/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
+++ b/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
@@ -17,14 +17,41 @@
         </p>
     {% endif %}
 
-    {% with criteria=diagnosis.administrative_criteria_display %}
-        {% if criteria %}
-            <h4>Situation administrative du candidat</h4>
-            <ul>
-                {% for c in criteria|dictsort:"ui_rank" %}<li>{{ c.name }}</li>{% endfor %}
-            </ul>
-        {% endif %}
-    {% endwith %}
+    {% if diagnosis.criteria_display %}
+        <h4>Situation administrative du candidat</h4>
+        <ul>
+            {% for criterion in diagnosis.criteria_display|dictsort:"administrative_criteria.ui_rank" %}
+                <li>
+                    {{ criterion.administrative_criteria.name }}
+                    {% if diagnosis.is_from_employer and criterion.is_considered_certified %}
+                        <span class="badge badge-sm rounded-pill bg-info-lighter text-info ms-3 me-1">
+                            <i class="ri-verified-badge-fill" aria-hidden="true"></i>
+                            Certifié
+                        </span>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+    {% if diagnosis.criteria_can_be_certified %}
+        <div class="c-box bg-info-lightest my-4 p-0">
+            <button class="has-collapse-caret w-100 text-start d-block d-flex justify-content-between font-weight-bold text-left p-3 align-items-center"
+                    type="button"
+                    data-bs-target="#collapse-certif-help-text"
+                    data-bs-toggle="collapse"
+                    aria-expanded="false"
+                    aria-controls="collapse-certif-help-text">
+                <div>
+                    <i class="ri-lightbulb-line font-weight-medium pe-2" aria-hidden="true"></i>
+                    <span>Pourquoi certains de mes critères peuvent-ils être certifiés ?</span>
+                </div>
+            </button>
+            <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
+                <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg"></i>
+            </div>
+        </div>
+    {% endif %}
 
     {% if diagnosis.allowance_amount %}
         <p>

--- a/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
+++ b/itou/templates/apply/includes/geiq/geiq_diagnosis_details.html
@@ -21,37 +21,12 @@
         <h4>Situation administrative du candidat</h4>
         <ul>
             {% for criterion in diagnosis.criteria_display|dictsort:"administrative_criteria.ui_rank" %}
-                <li>
-                    {{ criterion.administrative_criteria.name }}
-                    {% if diagnosis.is_from_employer and criterion.is_considered_certified %}
-                        <span class="badge badge-sm rounded-pill bg-info-lighter text-info ms-3 me-1">
-                            <i class="ri-verified-badge-fill" aria-hidden="true"></i>
-                            Certifié
-                        </span>
-                    {% endif %}
-                </li>
+                {% include "apply/includes/selected_administrative_criteria_display.html" with diagnosis=diagnosis criterion=criterion %}
             {% endfor %}
         </ul>
     {% endif %}
 
-    {% if diagnosis.criteria_can_be_certified %}
-        <div class="c-box bg-info-lightest my-4 p-0">
-            <button class="has-collapse-caret w-100 text-start d-block d-flex justify-content-between font-weight-bold text-left p-3 align-items-center"
-                    type="button"
-                    data-bs-target="#collapse-certif-help-text"
-                    data-bs-toggle="collapse"
-                    aria-expanded="false"
-                    aria-controls="collapse-certif-help-text">
-                <div>
-                    <i class="ri-lightbulb-line font-weight-medium pe-2" aria-hidden="true"></i>
-                    <span>Pourquoi certains de mes critères peuvent-ils être certifiés ?</span>
-                </div>
-            </button>
-            <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
-                <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg"></i>
-            </div>
-        </div>
-    {% endif %}
+    {% include "apply/includes/certification_info_box.html" with diagnosis=diagnosis %}
 
     {% if diagnosis.allowance_amount %}
         <p>

--- a/itou/templates/apply/includes/selected_administrative_criteria_display.html
+++ b/itou/templates/apply/includes/selected_administrative_criteria_display.html
@@ -1,0 +1,11 @@
+<li>
+    <div class="d-flex align-items-center">
+        <span>{{ criterion.administrative_criteria.name }}</span>
+        {% if diagnosis.is_from_employer and criterion.is_considered_certified %}
+            <span class="badge badge-sm rounded-pill bg-info-lighter text-info ms-3">
+                <i class="ri-verified-badge-fill" aria-hidden="true"></i>
+                Certifié
+            </span>
+        {% endif %}
+    </div>
+</li>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -39,10 +39,10 @@
                                 {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token SenderKind=SenderKind only %}
                                 {% if job_application.to_company.kind == CompanyKind.GEIQ %}
                                     {# GEIQ eligibility details #}
-                                    {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis request=request %}
+                                    {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis request=request itou_help_center_url=ITOU_HELP_CENTER_URL %}
                                 {% else %}
                                     {# IAE Eligibility ------------------------------------------------------------------------- #}
-                                    {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company %}
+                                    {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company itou_help_center_url=ITOU_HELP_CENTER_URL %}
                                 {% endif %}
                             </div>
 

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -60,10 +60,10 @@
                                 {% include "apply/includes/job_seeker_info.html" with job_seeker=job_application.job_seeker job_application=job_application can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request with_matomo_event=True csrf_token=csrf_token SenderKind=SenderKind only %}
                                 {% if job_application.to_company.kind == CompanyKind.GEIQ %}
                                     {# GEIQ eligibility details #}
-                                    {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis request=request %}
+                                    {% include "apply/includes/geiq/geiq_diagnosis_details.html" with diagnosis=geiq_eligibility_diagnosis request=request itou_help_center_url=ITOU_HELP_CENTER_URL %}
                                 {% else %}
                                     {# Eligibility ------------------------------------------------------------------------- #}
-                                    {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company %}
+                                    {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company itou_help_center_url=ITOU_HELP_CENTER_URL %}
                                 {% endif %}
                             </div>
 

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -13,8 +13,7 @@
         <hr>
         {% include "apply/includes/job_seeker_info.html" with with_matomo_event=False %}
 
-        {% include "apply/includes/eligibility_diagnosis.html" with job_seeker=job_seeker siae=company eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False %}
-
+        {% include "apply/includes/eligibility_diagnosis.html" with job_seeker=job_seeker siae=company eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False itou_help_center_url=ITOU_HELP_CENTER_URL %}
     </div>
     {% include "apply/includes/accept_section.html" %}
 {% endblock %}

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -13,7 +13,8 @@
         <hr>
         {% include "apply/includes/job_seeker_info.html" with with_matomo_event=False %}
 
-        {% include "apply/includes/eligibility_diagnosis.html" with job_seeker=job_seeker siae=company eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False itou_help_center_url=ITOU_HELP_CENTER_URL %}
+        {% include "apply/includes/eligibility_diagnosis.html" with job_seeker=job_seeker siae=company eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False
+        itou_help_center_url=ITOU_HELP_CENTER_URL %}
     </div>
     {% include "apply/includes/accept_section.html" %}
 {% endblock %}

--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -21,7 +21,7 @@
                         {% include "apply/includes/job_seeker_info.html" with job_seeker=job_seeker job_application=job_application with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token SenderKind=SenderKind only %}
                         {# Eligibility ------------------------------------------------------------------------- #}
                         {% if eligibility_diagnosis %}
-                            {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company %}
+                            {% include "apply/includes/eligibility_diagnosis.html" with eligibility_diagnosis=eligibility_diagnosis job_seeker=job_application.job_seeker is_sent_by_authorized_prescriber=job_application.is_sent_by_authorized_prescriber siae=job_application.to_company itou_help_center_url=ITOU_HELP_CENTER_URL %}
                         {% endif %}
                     </div>
 

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -54,10 +54,10 @@
                                         {% include "apply/includes/job_seeker_info.html" with job_seeker=job_seeker job_application=None with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token SenderKind=SenderKind only %}
                                     </div>
                                     {% if iae_eligibility_diagnosis %}
-                                        {% include "job_seekers_views/includes/eligibility_diagnosis.html" with eligibility_diagnosis=iae_eligibility_diagnosis kind="IAE" request=request only %}
+                                        {% include "job_seekers_views/includes/eligibility_diagnosis.html" with eligibility_diagnosis=iae_eligibility_diagnosis kind="IAE" request=request itou_help_center_url=ITOU_HELP_CENTER_URL only %}
                                     {% endif %}
                                     {% if geiq_eligibility_diagnosis %}
-                                        {% include "job_seekers_views/includes/eligibility_diagnosis.html" with eligibility_diagnosis=geiq_eligibility_diagnosis kind="GEIQ" with_allowance=request.user.is_employer request=request only %}
+                                        {% include "job_seekers_views/includes/eligibility_diagnosis.html" with eligibility_diagnosis=geiq_eligibility_diagnosis kind="GEIQ" with_allowance=request.user.is_employer request=request itou_help_center_url=ITOU_HELP_CENTER_URL only %}
                                     {% endif %}
                                 </div>
                                 {% if approval %}

--- a/tests/eligibility/factories.py
+++ b/tests/eligibility/factories.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from itou.companies.enums import CompanyKind
 from itou.eligibility import models
-from itou.eligibility.enums import AuthorKind
+from itou.eligibility.enums import AdministrativeCriteriaAnnex, AuthorKind
 from tests.companies.factories import CompanyFactory, CompanyWith2MembershipsFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import JobSeekerFactory
@@ -45,12 +45,14 @@ def _get_geiq_administrative_criteria(self, create, extracted, **kwargs):
 
 
 def _get_geiq_certifiable_criteria(self, create, extracted, **kwargs):
-    qs = models.GEIQAdministrativeCriteria.objects.certifiable()
+    qs = models.GEIQAdministrativeCriteria.objects.exclude(annex=AdministrativeCriteriaAnnex.NO_ANNEX).certifiable()
     _add_administrative_criteria(self, create, extracted, qs, **kwargs)
 
 
 def _get_geiq_not_certifiable_criteria(self, create, extracted, **kwargs):
-    qs = models.GEIQAdministrativeCriteria.objects.not_certifiable()
+    qs = models.GEIQAdministrativeCriteria.objects.exclude(
+        annex=AdministrativeCriteriaAnnex.NO_ANNEX
+    ).not_certifiable()
     _add_administrative_criteria(self, create, extracted, qs, **kwargs)
 
 

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -644,3 +644,17 @@ def test_with_is_considered_certified():
         days=AbstractSelectedAdministrativeCriteria.CERTIFICATION_GRACE_PERIOD_DAYS + 1
     )
     assert_considered_valid_count(hiring_start_at=hiring_start_at, expected=0)
+
+
+def test_is_from_employer():
+    diagnosis = GEIQEligibilityDiagnosisFactory(from_geiq=True)
+    assert diagnosis.is_from_employer
+
+    diagnosis = GEIQEligibilityDiagnosisFactory(from_prescriber=True)
+    assert not diagnosis.is_from_employer
+
+    diagnosis = IAEEligibilityDiagnosisFactory(from_employer=True)
+    assert diagnosis.is_from_employer
+
+    diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True)
+    assert not diagnosis.is_from_employer

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -896,3109 +896,6 @@
     ]),
   })
 # ---
-# name: ProcessViewsTest.test_details_for_company_from_approval[job application detail for company]
-  dict({
-    'num_queries': 18,
-    'queries': list([
-      dict({
-        'origin': list([
-          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': '''
-          SELECT "django_session"."session_key",
-                 "django_session"."session_data",
-                 "django_session"."expire_date"
-          FROM "django_session"
-          WHERE ("django_session"."expire_date" > %s
-                 AND "django_session"."session_key" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login"
-          FROM "users_user"
-          WHERE "users_user"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_companymembership"."id",
-                 "companies_companymembership"."user_id",
-                 "companies_companymembership"."joined_at",
-                 "companies_companymembership"."is_admin",
-                 "companies_companymembership"."is_active",
-                 "companies_companymembership"."created_at",
-                 "companies_companymembership"."updated_at",
-                 "companies_companymembership"."company_id",
-                 "companies_companymembership"."updated_by_id",
-                 "companies_companymembership"."notifications"
-          FROM "companies_companymembership"
-          WHERE ("companies_companymembership"."user_id" = %s
-                 AND "companies_companymembership"."is_active")
-          ORDER BY "companies_companymembership"."created_at" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_siaeconvention" U0
-             WHERE (U0."deactivated_at" >= %s
-                    AND U0."id" = ("companies_company"."convention_id"))
-             LIMIT 1) AS "has_convention_in_grace_period",
-                 "companies_siaeconvention"."id",
-                 "companies_siaeconvention"."kind",
-                 "companies_siaeconvention"."siret_signature",
-                 "companies_siaeconvention"."is_active",
-                 "companies_siaeconvention"."deactivated_at",
-                 "companies_siaeconvention"."reactivated_by_id",
-                 "companies_siaeconvention"."reactivated_at",
-                 "companies_siaeconvention"."asp_id",
-                 "companies_siaeconvention"."created_at",
-                 "companies_siaeconvention"."updated_at"
-          FROM "companies_company"
-          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
-          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_companymembership"."user_id" = %s
-                 AND "companies_company"."id" IN (%s)
-                 AND (NOT ("companies_company"."kind" IN (%s,
-                                                          %s,
-                                                          %s,
-                                                          %s,
-                                                          %s))
-                      OR "companies_company"."source" = %s
-                      OR EXISTS
-                        (SELECT %s AS "a"
-                         FROM "companies_siaeconvention" U0
-                         WHERE (U0."id" = ("companies_company"."convention_id")
-                                AND U0."is_active")
-                         LIMIT 1)
-                      OR EXISTS
-                        (SELECT %s AS "a"
-                         FROM "companies_siaeconvention" U0
-                         WHERE (U0."deactivated_at" >= %s
-                                AND U0."id" = ("companies_company"."convention_id"))
-                         LIMIT 1)))
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplication"."id",
-                 "job_applications_jobapplication"."job_seeker_id",
-                 "job_applications_jobapplication"."eligibility_diagnosis_id",
-                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
-                 "job_applications_jobapplication"."create_employee_record",
-                 "job_applications_jobapplication"."resume_link",
-                 "job_applications_jobapplication"."sender_id",
-                 "job_applications_jobapplication"."sender_kind",
-                 "job_applications_jobapplication"."sender_company_id",
-                 "job_applications_jobapplication"."sender_prescriber_organization_id",
-                 "job_applications_jobapplication"."to_company_id",
-                 "job_applications_jobapplication"."state",
-                 "job_applications_jobapplication"."archived_at",
-                 "job_applications_jobapplication"."archived_by_id",
-                 "job_applications_jobapplication"."hired_job_id",
-                 "job_applications_jobapplication"."message",
-                 "job_applications_jobapplication"."answer",
-                 "job_applications_jobapplication"."answer_to_prescriber",
-                 "job_applications_jobapplication"."refusal_reason",
-                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
-                 "job_applications_jobapplication"."hiring_start_at",
-                 "job_applications_jobapplication"."hiring_end_at",
-                 "job_applications_jobapplication"."hiring_without_approval",
-                 "job_applications_jobapplication"."origin",
-                 "job_applications_jobapplication"."approval_id",
-                 "job_applications_jobapplication"."approval_delivery_mode",
-                 "job_applications_jobapplication"."approval_number_sent_by_email",
-                 "job_applications_jobapplication"."approval_number_sent_at",
-                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
-                 "job_applications_jobapplication"."approval_manually_refused_by_id",
-                 "job_applications_jobapplication"."approval_manually_refused_at",
-                 "job_applications_jobapplication"."transferred_at",
-                 "job_applications_jobapplication"."transferred_by_id",
-                 "job_applications_jobapplication"."transferred_from_id",
-                 "job_applications_jobapplication"."created_at",
-                 "job_applications_jobapplication"."updated_at",
-                 "job_applications_jobapplication"."processed_at",
-                 "job_applications_jobapplication"."prehiring_guidance_days",
-                 "job_applications_jobapplication"."contract_type",
-                 "job_applications_jobapplication"."nb_hours_per_week",
-                 "job_applications_jobapplication"."contract_type_details",
-                 "job_applications_jobapplication"."qualification_type",
-                 "job_applications_jobapplication"."qualification_level",
-                 "job_applications_jobapplication"."planned_training_hours",
-                 "job_applications_jobapplication"."inverted_vae_contract",
-                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "rdv_insertion_invitationrequest" U0
-             WHERE (U0."company_id" = ("job_applications_jobapplication"."to_company_id")
-                    AND U0."created_at" > %s
-                    AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
-             LIMIT 1) AS "has_pending_rdv_insertion_invitation_request",
-                 COUNT("rdv_insertion_participation"."id") FILTER (
-                                                                   WHERE ("rdv_insertion_appointment"."company_id" = %s
-                                                                          AND "rdv_insertion_appointment"."start_at" > %s
-                                                                          AND "rdv_insertion_participation"."status" = %s)) AS "upcoming_participations_count",
-                 T5."id",
-                 T5."password",
-                 T5."last_login",
-                 T5."is_superuser",
-                 T5."username",
-                 T5."first_name",
-                 T5."last_name",
-                 T5."is_staff",
-                 T5."is_active",
-                 T5."date_joined",
-                 T5."address_line_1",
-                 T5."address_line_2",
-                 T5."post_code",
-                 T5."city",
-                 T5."department",
-                 T5."coords",
-                 T5."geocoding_score",
-                 T5."geocoding_updated_at",
-                 T5."ban_api_resolved_address",
-                 T5."insee_city_id",
-                 T5."title",
-                 T5."email",
-                 T5."phone",
-                 T5."kind",
-                 T5."identity_provider",
-                 T5."has_completed_welcoming_tour",
-                 T5."created_by_id",
-                 T5."external_data_source_history",
-                 T5."last_checked_at",
-                 T5."public_id",
-                 T5."address_filled_at",
-                 T5."first_login",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."ata_allocation_since",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "eligibility_eligibilitydiagnosis"."id",
-                 "eligibility_eligibilitydiagnosis"."author_id",
-                 "eligibility_eligibilitydiagnosis"."author_kind",
-                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
-                 "eligibility_eligibilitydiagnosis"."created_at",
-                 "eligibility_eligibilitydiagnosis"."updated_at",
-                 "eligibility_eligibilitydiagnosis"."expires_at",
-                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
-                 "eligibility_eligibilitydiagnosis"."author_siae_id",
-                 T11."id",
-                 T11."password",
-                 T11."last_login",
-                 T11."is_superuser",
-                 T11."username",
-                 T11."first_name",
-                 T11."last_name",
-                 T11."is_staff",
-                 T11."is_active",
-                 T11."date_joined",
-                 T11."address_line_1",
-                 T11."address_line_2",
-                 T11."post_code",
-                 T11."city",
-                 T11."department",
-                 T11."coords",
-                 T11."geocoding_score",
-                 T11."geocoding_updated_at",
-                 T11."ban_api_resolved_address",
-                 T11."insee_city_id",
-                 T11."title",
-                 T11."email",
-                 T11."phone",
-                 T11."kind",
-                 T11."identity_provider",
-                 T11."has_completed_welcoming_tour",
-                 T11."created_by_id",
-                 T11."external_data_source_history",
-                 T11."last_checked_at",
-                 T11."public_id",
-                 T11."address_filled_at",
-                 T11."first_login",
-                 "prescribers_prescriberorganization"."id",
-                 "prescribers_prescriberorganization"."address_line_1",
-                 "prescribers_prescriberorganization"."address_line_2",
-                 "prescribers_prescriberorganization"."post_code",
-                 "prescribers_prescriberorganization"."city",
-                 "prescribers_prescriberorganization"."department",
-                 "prescribers_prescriberorganization"."coords",
-                 "prescribers_prescriberorganization"."geocoding_score",
-                 "prescribers_prescriberorganization"."geocoding_updated_at",
-                 "prescribers_prescriberorganization"."ban_api_resolved_address",
-                 "prescribers_prescriberorganization"."insee_city_id",
-                 "prescribers_prescriberorganization"."name",
-                 "prescribers_prescriberorganization"."created_at",
-                 "prescribers_prescriberorganization"."updated_at",
-                 "prescribers_prescriberorganization"."uid",
-                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
-                 "prescribers_prescriberorganization"."siret",
-                 "prescribers_prescriberorganization"."is_head_office",
-                 "prescribers_prescriberorganization"."kind",
-                 "prescribers_prescriberorganization"."is_brsa",
-                 "prescribers_prescriberorganization"."phone",
-                 "prescribers_prescriberorganization"."email",
-                 "prescribers_prescriberorganization"."website",
-                 "prescribers_prescriberorganization"."description",
-                 "prescribers_prescriberorganization"."is_authorized",
-                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
-                 "prescribers_prescriberorganization"."created_by_id",
-                 "prescribers_prescriberorganization"."authorization_status",
-                 "prescribers_prescriberorganization"."authorization_updated_at",
-                 "prescribers_prescriberorganization"."authorization_updated_by_id",
-                 T13."id",
-                 T13."password",
-                 T13."last_login",
-                 T13."is_superuser",
-                 T13."username",
-                 T13."first_name",
-                 T13."last_name",
-                 T13."is_staff",
-                 T13."is_active",
-                 T13."date_joined",
-                 T13."address_line_1",
-                 T13."address_line_2",
-                 T13."post_code",
-                 T13."city",
-                 T13."department",
-                 T13."coords",
-                 T13."geocoding_score",
-                 T13."geocoding_updated_at",
-                 T13."ban_api_resolved_address",
-                 T13."insee_city_id",
-                 T13."title",
-                 T13."email",
-                 T13."phone",
-                 T13."kind",
-                 T13."identity_provider",
-                 T13."has_completed_welcoming_tour",
-                 T13."created_by_id",
-                 T13."external_data_source_history",
-                 T13."last_checked_at",
-                 T13."public_id",
-                 T13."address_filled_at",
-                 T13."first_login",
-                 T14."user_id",
-                 T14."birthdate",
-                 T14."birth_place_id",
-                 T14."birth_country_id",
-                 T14."nir",
-                 T14."lack_of_nir_reason",
-                 T14."pole_emploi_id",
-                 T14."lack_of_pole_emploi_id_reason",
-                 T14."asp_uid",
-                 T14."education_level",
-                 T14."resourceless",
-                 T14."rqth_employee",
-                 T14."oeth_employee",
-                 T14."pole_emploi_since",
-                 T14."unemployed_since",
-                 T14."has_rsa_allocation",
-                 T14."rsa_allocation_since",
-                 T14."ass_allocation_since",
-                 T14."aah_allocation_since",
-                 T14."ata_allocation_since",
-                 T14."hexa_lane_number",
-                 T14."hexa_std_extension",
-                 T14."hexa_non_std_extension",
-                 T14."hexa_lane_type",
-                 T14."hexa_lane_name",
-                 T14."hexa_additional_address",
-                 T14."hexa_post_code",
-                 T14."hexa_commune_id",
-                 T14."pe_obfuscated_nir",
-                 T14."pe_last_certification_attempt_at",
-                 T15."id",
-                 T15."address_line_1",
-                 T15."address_line_2",
-                 T15."post_code",
-                 T15."city",
-                 T15."department",
-                 T15."coords",
-                 T15."geocoding_score",
-                 T15."geocoding_updated_at",
-                 T15."ban_api_resolved_address",
-                 T15."insee_city_id",
-                 T15."name",
-                 T15."created_at",
-                 T15."updated_at",
-                 T15."uid",
-                 T15."active_members_email_reminder_last_sent_at",
-                 T15."siret",
-                 T15."naf",
-                 T15."kind",
-                 T15."brand",
-                 T15."phone",
-                 T15."email",
-                 T15."auth_email",
-                 T15."website",
-                 T15."description",
-                 T15."provided_support",
-                 T15."source",
-                 T15."created_by_id",
-                 T15."block_job_applications",
-                 T15."job_applications_blocked_at",
-                 T15."convention_id",
-                 T15."job_app_score",
-                 T15."rdv_solidarites_id",
-                 "eligibility_geiqeligibilitydiagnosis"."id",
-                 "eligibility_geiqeligibilitydiagnosis"."author_id",
-                 "eligibility_geiqeligibilitydiagnosis"."author_kind",
-                 "eligibility_geiqeligibilitydiagnosis"."author_prescriber_organization_id",
-                 "eligibility_geiqeligibilitydiagnosis"."created_at",
-                 "eligibility_geiqeligibilitydiagnosis"."updated_at",
-                 "eligibility_geiqeligibilitydiagnosis"."expires_at",
-                 "eligibility_geiqeligibilitydiagnosis"."job_seeker_id",
-                 "eligibility_geiqeligibilitydiagnosis"."author_geiq_id",
-                 T17."id",
-                 T17."password",
-                 T17."last_login",
-                 T17."is_superuser",
-                 T17."username",
-                 T17."first_name",
-                 T17."last_name",
-                 T17."is_staff",
-                 T17."is_active",
-                 T17."date_joined",
-                 T17."address_line_1",
-                 T17."address_line_2",
-                 T17."post_code",
-                 T17."city",
-                 T17."department",
-                 T17."coords",
-                 T17."geocoding_score",
-                 T17."geocoding_updated_at",
-                 T17."ban_api_resolved_address",
-                 T17."insee_city_id",
-                 T17."title",
-                 T17."email",
-                 T17."phone",
-                 T17."kind",
-                 T17."identity_provider",
-                 T17."has_completed_welcoming_tour",
-                 T17."created_by_id",
-                 T17."external_data_source_history",
-                 T17."last_checked_at",
-                 T17."public_id",
-                 T17."address_filled_at",
-                 T17."first_login",
-                 T18."id",
-                 T18."address_line_1",
-                 T18."address_line_2",
-                 T18."post_code",
-                 T18."city",
-                 T18."department",
-                 T18."coords",
-                 T18."geocoding_score",
-                 T18."geocoding_updated_at",
-                 T18."ban_api_resolved_address",
-                 T18."insee_city_id",
-                 T18."name",
-                 T18."created_at",
-                 T18."updated_at",
-                 T18."uid",
-                 T18."active_members_email_reminder_last_sent_at",
-                 T18."siret",
-                 T18."naf",
-                 T18."kind",
-                 T18."brand",
-                 T18."phone",
-                 T18."email",
-                 T18."auth_email",
-                 T18."website",
-                 T18."description",
-                 T18."provided_support",
-                 T18."source",
-                 T18."created_by_id",
-                 T18."block_job_applications",
-                 T18."job_applications_blocked_at",
-                 T18."convention_id",
-                 T18."job_app_score",
-                 T18."rdv_solidarites_id",
-                 T19."id",
-                 T19."address_line_1",
-                 T19."address_line_2",
-                 T19."post_code",
-                 T19."city",
-                 T19."department",
-                 T19."coords",
-                 T19."geocoding_score",
-                 T19."geocoding_updated_at",
-                 T19."ban_api_resolved_address",
-                 T19."insee_city_id",
-                 T19."name",
-                 T19."created_at",
-                 T19."updated_at",
-                 T19."uid",
-                 T19."active_members_email_reminder_last_sent_at",
-                 T19."siret",
-                 T19."is_head_office",
-                 T19."kind",
-                 T19."is_brsa",
-                 T19."phone",
-                 T19."email",
-                 T19."website",
-                 T19."description",
-                 T19."is_authorized",
-                 T19."code_safir_pole_emploi",
-                 T19."created_by_id",
-                 T19."authorization_status",
-                 T19."authorization_updated_at",
-                 T19."authorization_updated_by_id",
-                 "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."rdv_solidarites_id",
-                 T20."id",
-                 T20."password",
-                 T20."last_login",
-                 T20."is_superuser",
-                 T20."username",
-                 T20."first_name",
-                 T20."last_name",
-                 T20."is_staff",
-                 T20."is_active",
-                 T20."date_joined",
-                 T20."address_line_1",
-                 T20."address_line_2",
-                 T20."post_code",
-                 T20."city",
-                 T20."department",
-                 T20."coords",
-                 T20."geocoding_score",
-                 T20."geocoding_updated_at",
-                 T20."ban_api_resolved_address",
-                 T20."insee_city_id",
-                 T20."title",
-                 T20."email",
-                 T20."phone",
-                 T20."kind",
-                 T20."identity_provider",
-                 T20."has_completed_welcoming_tour",
-                 T20."created_by_id",
-                 T20."external_data_source_history",
-                 T20."last_checked_at",
-                 T20."public_id",
-                 T20."address_filled_at",
-                 T20."first_login",
-                 "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "job_applications_jobapplication"
-          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
-          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
-          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
-          INNER JOIN "users_user" T5 ON ("job_applications_jobapplication"."job_seeker_id" = T5."id")
-          LEFT OUTER JOIN "rdv_insertion_participation" ON (T5."id" = "rdv_insertion_participation"."job_seeker_id")
-          LEFT OUTER JOIN "rdv_insertion_appointment" ON ("rdv_insertion_participation"."appointment_id" = "rdv_insertion_appointment"."id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON (T5."id" = "users_jobseekerprofile"."user_id")
-          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
-          LEFT OUTER JOIN "users_user" T11 ON ("eligibility_eligibilitydiagnosis"."author_id" = T11."id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
-          LEFT OUTER JOIN "users_user" T13 ON ("eligibility_eligibilitydiagnosis"."job_seeker_id" = T13."id")
-          LEFT OUTER JOIN "users_jobseekerprofile" T14 ON (T13."id" = T14."user_id")
-          LEFT OUTER JOIN "companies_company" T15 ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = T15."id")
-          LEFT OUTER JOIN "eligibility_geiqeligibilitydiagnosis" ON ("job_applications_jobapplication"."geiq_eligibility_diagnosis_id" = "eligibility_geiqeligibilitydiagnosis"."id")
-          LEFT OUTER JOIN "users_user" T17 ON ("job_applications_jobapplication"."sender_id" = T17."id")
-          LEFT OUTER JOIN "companies_company" T18 ON ("job_applications_jobapplication"."sender_company_id" = T18."id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" T19 ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = T19."id")
-          LEFT OUTER JOIN "users_user" T20 ON ("job_applications_jobapplication"."archived_by_id" = T20."id")
-          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
-          WHERE ("companies_companymembership"."user_id" = %s
-                 AND "users_user"."is_active"
-                 AND "job_applications_jobapplication"."id" = %s)
-          GROUP BY "job_applications_jobapplication"."id",
-                   T5."id",
-                   "users_jobseekerprofile"."user_id",
-                   "eligibility_eligibilitydiagnosis"."id",
-                   T11."id",
-                   "prescribers_prescriberorganization"."id",
-                   T13."id",
-                   T14."user_id",
-                   T15."id",
-                   "eligibility_geiqeligibilitydiagnosis"."id",
-                   T17."id",
-                   T18."id",
-                   T19."id",
-                   "companies_company"."id",
-                   T20."id",
-                   "approvals_approval"."id"
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
-                 "companies_jobdescription"."id",
-                 "companies_jobdescription"."appellation_id",
-                 "companies_jobdescription"."company_id",
-                 "companies_jobdescription"."created_at",
-                 "companies_jobdescription"."updated_at",
-                 "companies_jobdescription"."is_active",
-                 "companies_jobdescription"."custom_name",
-                 "companies_jobdescription"."description",
-                 "companies_jobdescription"."ui_rank",
-                 "companies_jobdescription"."contract_type",
-                 "companies_jobdescription"."other_contract_type",
-                 "companies_jobdescription"."contract_nature",
-                 "companies_jobdescription"."location_id",
-                 "companies_jobdescription"."hours_per_week",
-                 "companies_jobdescription"."open_positions",
-                 "companies_jobdescription"."profile_description",
-                 "companies_jobdescription"."is_resume_mandatory",
-                 "companies_jobdescription"."is_qpv_mandatory",
-                 "companies_jobdescription"."market_context_description",
-                 "companies_jobdescription"."source_id",
-                 "companies_jobdescription"."source_kind",
-                 "companies_jobdescription"."source_url",
-                 "companies_jobdescription"."field_history",
-                 "companies_jobdescription"."creation_source"
-          FROM "companies_jobdescription"
-          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
-          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
-          ORDER BY "jobs_appellation"."name" ASC,
-                   "companies_jobdescription"."ui_rank" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_admin[common_apps/organizations/models.py]',
-          'Company.convention_can_be_accessed_by[companies/models.py]',
-          'nav[utils/templatetags/nav.py]',
-          'InclusionNode[layout/_header_authenticated.html]',
-          'IncludeNode[layout/base.html]',
-          'IfNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "users_user"
-          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
-          WHERE ("companies_companymembership"."id" IN
-                   (SELECT U0."id"
-                    FROM "companies_companymembership" U0
-                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
-                    WHERE (U0."company_id" = %s
-                           AND U2."is_active"
-                           AND U0."is_active"
-                           AND U0."is_admin"
-                           AND U2."is_active"))
-                 AND "users_user"."id" = %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
-          'VariableNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ForNode[apply/includes/transition_logs.html]',
-          'WithNode[apply/includes/transition_logs.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplicationtransitionlog"."id",
-                 "job_applications_jobapplicationtransitionlog"."transition",
-                 "job_applications_jobapplicationtransitionlog"."from_state",
-                 "job_applications_jobapplicationtransitionlog"."to_state",
-                 "job_applications_jobapplicationtransitionlog"."timestamp",
-                 "job_applications_jobapplicationtransitionlog"."job_application_id",
-                 "job_applications_jobapplicationtransitionlog"."user_id",
-                 "job_applications_jobapplicationtransitionlog"."target_company_id",
-                 "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login"
-          FROM "job_applications_jobapplicationtransitionlog"
-          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplicationtransitionlog"."user_id" = "users_user"."id")
-          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" = %s
-          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'JobApplication.can_be_cancelled[job_applications/models.py]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "employee_record_employeerecord"
-          WHERE "employee_record_employeerecord"."job_application_id" = %s
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': '''
-          UPDATE "django_session"
-          SET "session_data" = %s,
-              "expire_date" = %s
-          WHERE "django_session"."session_key" = %s
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-    ]),
-  })
-# ---
-# name: ProcessViewsTest.test_details_for_company_from_list[job application detail for company]
-  dict({
-    'num_queries': 18,
-    'queries': list([
-      dict({
-        'origin': list([
-          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': '''
-          SELECT "django_session"."session_key",
-                 "django_session"."session_data",
-                 "django_session"."expire_date"
-          FROM "django_session"
-          WHERE ("django_session"."expire_date" > %s
-                 AND "django_session"."session_key" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login"
-          FROM "users_user"
-          WHERE "users_user"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_companymembership"."id",
-                 "companies_companymembership"."user_id",
-                 "companies_companymembership"."joined_at",
-                 "companies_companymembership"."is_admin",
-                 "companies_companymembership"."is_active",
-                 "companies_companymembership"."created_at",
-                 "companies_companymembership"."updated_at",
-                 "companies_companymembership"."company_id",
-                 "companies_companymembership"."updated_by_id",
-                 "companies_companymembership"."notifications"
-          FROM "companies_companymembership"
-          WHERE ("companies_companymembership"."user_id" = %s
-                 AND "companies_companymembership"."is_active")
-          ORDER BY "companies_companymembership"."created_at" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_siaeconvention" U0
-             WHERE (U0."deactivated_at" >= %s
-                    AND U0."id" = ("companies_company"."convention_id"))
-             LIMIT 1) AS "has_convention_in_grace_period",
-                 "companies_siaeconvention"."id",
-                 "companies_siaeconvention"."kind",
-                 "companies_siaeconvention"."siret_signature",
-                 "companies_siaeconvention"."is_active",
-                 "companies_siaeconvention"."deactivated_at",
-                 "companies_siaeconvention"."reactivated_by_id",
-                 "companies_siaeconvention"."reactivated_at",
-                 "companies_siaeconvention"."asp_id",
-                 "companies_siaeconvention"."created_at",
-                 "companies_siaeconvention"."updated_at"
-          FROM "companies_company"
-          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
-          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_companymembership"."user_id" = %s
-                 AND "companies_company"."id" IN (%s)
-                 AND (NOT ("companies_company"."kind" IN (%s,
-                                                          %s,
-                                                          %s,
-                                                          %s,
-                                                          %s))
-                      OR "companies_company"."source" = %s
-                      OR EXISTS
-                        (SELECT %s AS "a"
-                         FROM "companies_siaeconvention" U0
-                         WHERE (U0."id" = ("companies_company"."convention_id")
-                                AND U0."is_active")
-                         LIMIT 1)
-                      OR EXISTS
-                        (SELECT %s AS "a"
-                         FROM "companies_siaeconvention" U0
-                         WHERE (U0."deactivated_at" >= %s
-                                AND U0."id" = ("companies_company"."convention_id"))
-                         LIMIT 1)))
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplication"."id",
-                 "job_applications_jobapplication"."job_seeker_id",
-                 "job_applications_jobapplication"."eligibility_diagnosis_id",
-                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
-                 "job_applications_jobapplication"."create_employee_record",
-                 "job_applications_jobapplication"."resume_link",
-                 "job_applications_jobapplication"."sender_id",
-                 "job_applications_jobapplication"."sender_kind",
-                 "job_applications_jobapplication"."sender_company_id",
-                 "job_applications_jobapplication"."sender_prescriber_organization_id",
-                 "job_applications_jobapplication"."to_company_id",
-                 "job_applications_jobapplication"."state",
-                 "job_applications_jobapplication"."archived_at",
-                 "job_applications_jobapplication"."archived_by_id",
-                 "job_applications_jobapplication"."hired_job_id",
-                 "job_applications_jobapplication"."message",
-                 "job_applications_jobapplication"."answer",
-                 "job_applications_jobapplication"."answer_to_prescriber",
-                 "job_applications_jobapplication"."refusal_reason",
-                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
-                 "job_applications_jobapplication"."hiring_start_at",
-                 "job_applications_jobapplication"."hiring_end_at",
-                 "job_applications_jobapplication"."hiring_without_approval",
-                 "job_applications_jobapplication"."origin",
-                 "job_applications_jobapplication"."approval_id",
-                 "job_applications_jobapplication"."approval_delivery_mode",
-                 "job_applications_jobapplication"."approval_number_sent_by_email",
-                 "job_applications_jobapplication"."approval_number_sent_at",
-                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
-                 "job_applications_jobapplication"."approval_manually_refused_by_id",
-                 "job_applications_jobapplication"."approval_manually_refused_at",
-                 "job_applications_jobapplication"."transferred_at",
-                 "job_applications_jobapplication"."transferred_by_id",
-                 "job_applications_jobapplication"."transferred_from_id",
-                 "job_applications_jobapplication"."created_at",
-                 "job_applications_jobapplication"."updated_at",
-                 "job_applications_jobapplication"."processed_at",
-                 "job_applications_jobapplication"."prehiring_guidance_days",
-                 "job_applications_jobapplication"."contract_type",
-                 "job_applications_jobapplication"."nb_hours_per_week",
-                 "job_applications_jobapplication"."contract_type_details",
-                 "job_applications_jobapplication"."qualification_type",
-                 "job_applications_jobapplication"."qualification_level",
-                 "job_applications_jobapplication"."planned_training_hours",
-                 "job_applications_jobapplication"."inverted_vae_contract",
-                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "rdv_insertion_invitationrequest" U0
-             WHERE (U0."company_id" = ("job_applications_jobapplication"."to_company_id")
-                    AND U0."created_at" > %s
-                    AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
-             LIMIT 1) AS "has_pending_rdv_insertion_invitation_request",
-                 COUNT("rdv_insertion_participation"."id") FILTER (
-                                                                   WHERE ("rdv_insertion_appointment"."company_id" = %s
-                                                                          AND "rdv_insertion_appointment"."start_at" > %s
-                                                                          AND "rdv_insertion_participation"."status" = %s)) AS "upcoming_participations_count",
-                 T5."id",
-                 T5."password",
-                 T5."last_login",
-                 T5."is_superuser",
-                 T5."username",
-                 T5."first_name",
-                 T5."last_name",
-                 T5."is_staff",
-                 T5."is_active",
-                 T5."date_joined",
-                 T5."address_line_1",
-                 T5."address_line_2",
-                 T5."post_code",
-                 T5."city",
-                 T5."department",
-                 T5."coords",
-                 T5."geocoding_score",
-                 T5."geocoding_updated_at",
-                 T5."ban_api_resolved_address",
-                 T5."insee_city_id",
-                 T5."title",
-                 T5."email",
-                 T5."phone",
-                 T5."kind",
-                 T5."identity_provider",
-                 T5."has_completed_welcoming_tour",
-                 T5."created_by_id",
-                 T5."external_data_source_history",
-                 T5."last_checked_at",
-                 T5."public_id",
-                 T5."address_filled_at",
-                 T5."first_login",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."ata_allocation_since",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "eligibility_eligibilitydiagnosis"."id",
-                 "eligibility_eligibilitydiagnosis"."author_id",
-                 "eligibility_eligibilitydiagnosis"."author_kind",
-                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
-                 "eligibility_eligibilitydiagnosis"."created_at",
-                 "eligibility_eligibilitydiagnosis"."updated_at",
-                 "eligibility_eligibilitydiagnosis"."expires_at",
-                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
-                 "eligibility_eligibilitydiagnosis"."author_siae_id",
-                 T11."id",
-                 T11."password",
-                 T11."last_login",
-                 T11."is_superuser",
-                 T11."username",
-                 T11."first_name",
-                 T11."last_name",
-                 T11."is_staff",
-                 T11."is_active",
-                 T11."date_joined",
-                 T11."address_line_1",
-                 T11."address_line_2",
-                 T11."post_code",
-                 T11."city",
-                 T11."department",
-                 T11."coords",
-                 T11."geocoding_score",
-                 T11."geocoding_updated_at",
-                 T11."ban_api_resolved_address",
-                 T11."insee_city_id",
-                 T11."title",
-                 T11."email",
-                 T11."phone",
-                 T11."kind",
-                 T11."identity_provider",
-                 T11."has_completed_welcoming_tour",
-                 T11."created_by_id",
-                 T11."external_data_source_history",
-                 T11."last_checked_at",
-                 T11."public_id",
-                 T11."address_filled_at",
-                 T11."first_login",
-                 "prescribers_prescriberorganization"."id",
-                 "prescribers_prescriberorganization"."address_line_1",
-                 "prescribers_prescriberorganization"."address_line_2",
-                 "prescribers_prescriberorganization"."post_code",
-                 "prescribers_prescriberorganization"."city",
-                 "prescribers_prescriberorganization"."department",
-                 "prescribers_prescriberorganization"."coords",
-                 "prescribers_prescriberorganization"."geocoding_score",
-                 "prescribers_prescriberorganization"."geocoding_updated_at",
-                 "prescribers_prescriberorganization"."ban_api_resolved_address",
-                 "prescribers_prescriberorganization"."insee_city_id",
-                 "prescribers_prescriberorganization"."name",
-                 "prescribers_prescriberorganization"."created_at",
-                 "prescribers_prescriberorganization"."updated_at",
-                 "prescribers_prescriberorganization"."uid",
-                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
-                 "prescribers_prescriberorganization"."siret",
-                 "prescribers_prescriberorganization"."is_head_office",
-                 "prescribers_prescriberorganization"."kind",
-                 "prescribers_prescriberorganization"."is_brsa",
-                 "prescribers_prescriberorganization"."phone",
-                 "prescribers_prescriberorganization"."email",
-                 "prescribers_prescriberorganization"."website",
-                 "prescribers_prescriberorganization"."description",
-                 "prescribers_prescriberorganization"."is_authorized",
-                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
-                 "prescribers_prescriberorganization"."created_by_id",
-                 "prescribers_prescriberorganization"."authorization_status",
-                 "prescribers_prescriberorganization"."authorization_updated_at",
-                 "prescribers_prescriberorganization"."authorization_updated_by_id",
-                 T13."id",
-                 T13."password",
-                 T13."last_login",
-                 T13."is_superuser",
-                 T13."username",
-                 T13."first_name",
-                 T13."last_name",
-                 T13."is_staff",
-                 T13."is_active",
-                 T13."date_joined",
-                 T13."address_line_1",
-                 T13."address_line_2",
-                 T13."post_code",
-                 T13."city",
-                 T13."department",
-                 T13."coords",
-                 T13."geocoding_score",
-                 T13."geocoding_updated_at",
-                 T13."ban_api_resolved_address",
-                 T13."insee_city_id",
-                 T13."title",
-                 T13."email",
-                 T13."phone",
-                 T13."kind",
-                 T13."identity_provider",
-                 T13."has_completed_welcoming_tour",
-                 T13."created_by_id",
-                 T13."external_data_source_history",
-                 T13."last_checked_at",
-                 T13."public_id",
-                 T13."address_filled_at",
-                 T13."first_login",
-                 T14."user_id",
-                 T14."birthdate",
-                 T14."birth_place_id",
-                 T14."birth_country_id",
-                 T14."nir",
-                 T14."lack_of_nir_reason",
-                 T14."pole_emploi_id",
-                 T14."lack_of_pole_emploi_id_reason",
-                 T14."asp_uid",
-                 T14."education_level",
-                 T14."resourceless",
-                 T14."rqth_employee",
-                 T14."oeth_employee",
-                 T14."pole_emploi_since",
-                 T14."unemployed_since",
-                 T14."has_rsa_allocation",
-                 T14."rsa_allocation_since",
-                 T14."ass_allocation_since",
-                 T14."aah_allocation_since",
-                 T14."ata_allocation_since",
-                 T14."hexa_lane_number",
-                 T14."hexa_std_extension",
-                 T14."hexa_non_std_extension",
-                 T14."hexa_lane_type",
-                 T14."hexa_lane_name",
-                 T14."hexa_additional_address",
-                 T14."hexa_post_code",
-                 T14."hexa_commune_id",
-                 T14."pe_obfuscated_nir",
-                 T14."pe_last_certification_attempt_at",
-                 T15."id",
-                 T15."address_line_1",
-                 T15."address_line_2",
-                 T15."post_code",
-                 T15."city",
-                 T15."department",
-                 T15."coords",
-                 T15."geocoding_score",
-                 T15."geocoding_updated_at",
-                 T15."ban_api_resolved_address",
-                 T15."insee_city_id",
-                 T15."name",
-                 T15."created_at",
-                 T15."updated_at",
-                 T15."uid",
-                 T15."active_members_email_reminder_last_sent_at",
-                 T15."siret",
-                 T15."naf",
-                 T15."kind",
-                 T15."brand",
-                 T15."phone",
-                 T15."email",
-                 T15."auth_email",
-                 T15."website",
-                 T15."description",
-                 T15."provided_support",
-                 T15."source",
-                 T15."created_by_id",
-                 T15."block_job_applications",
-                 T15."job_applications_blocked_at",
-                 T15."convention_id",
-                 T15."job_app_score",
-                 T15."rdv_solidarites_id",
-                 "eligibility_geiqeligibilitydiagnosis"."id",
-                 "eligibility_geiqeligibilitydiagnosis"."author_id",
-                 "eligibility_geiqeligibilitydiagnosis"."author_kind",
-                 "eligibility_geiqeligibilitydiagnosis"."author_prescriber_organization_id",
-                 "eligibility_geiqeligibilitydiagnosis"."created_at",
-                 "eligibility_geiqeligibilitydiagnosis"."updated_at",
-                 "eligibility_geiqeligibilitydiagnosis"."expires_at",
-                 "eligibility_geiqeligibilitydiagnosis"."job_seeker_id",
-                 "eligibility_geiqeligibilitydiagnosis"."author_geiq_id",
-                 T17."id",
-                 T17."password",
-                 T17."last_login",
-                 T17."is_superuser",
-                 T17."username",
-                 T17."first_name",
-                 T17."last_name",
-                 T17."is_staff",
-                 T17."is_active",
-                 T17."date_joined",
-                 T17."address_line_1",
-                 T17."address_line_2",
-                 T17."post_code",
-                 T17."city",
-                 T17."department",
-                 T17."coords",
-                 T17."geocoding_score",
-                 T17."geocoding_updated_at",
-                 T17."ban_api_resolved_address",
-                 T17."insee_city_id",
-                 T17."title",
-                 T17."email",
-                 T17."phone",
-                 T17."kind",
-                 T17."identity_provider",
-                 T17."has_completed_welcoming_tour",
-                 T17."created_by_id",
-                 T17."external_data_source_history",
-                 T17."last_checked_at",
-                 T17."public_id",
-                 T17."address_filled_at",
-                 T17."first_login",
-                 T18."id",
-                 T18."address_line_1",
-                 T18."address_line_2",
-                 T18."post_code",
-                 T18."city",
-                 T18."department",
-                 T18."coords",
-                 T18."geocoding_score",
-                 T18."geocoding_updated_at",
-                 T18."ban_api_resolved_address",
-                 T18."insee_city_id",
-                 T18."name",
-                 T18."created_at",
-                 T18."updated_at",
-                 T18."uid",
-                 T18."active_members_email_reminder_last_sent_at",
-                 T18."siret",
-                 T18."naf",
-                 T18."kind",
-                 T18."brand",
-                 T18."phone",
-                 T18."email",
-                 T18."auth_email",
-                 T18."website",
-                 T18."description",
-                 T18."provided_support",
-                 T18."source",
-                 T18."created_by_id",
-                 T18."block_job_applications",
-                 T18."job_applications_blocked_at",
-                 T18."convention_id",
-                 T18."job_app_score",
-                 T18."rdv_solidarites_id",
-                 T19."id",
-                 T19."address_line_1",
-                 T19."address_line_2",
-                 T19."post_code",
-                 T19."city",
-                 T19."department",
-                 T19."coords",
-                 T19."geocoding_score",
-                 T19."geocoding_updated_at",
-                 T19."ban_api_resolved_address",
-                 T19."insee_city_id",
-                 T19."name",
-                 T19."created_at",
-                 T19."updated_at",
-                 T19."uid",
-                 T19."active_members_email_reminder_last_sent_at",
-                 T19."siret",
-                 T19."is_head_office",
-                 T19."kind",
-                 T19."is_brsa",
-                 T19."phone",
-                 T19."email",
-                 T19."website",
-                 T19."description",
-                 T19."is_authorized",
-                 T19."code_safir_pole_emploi",
-                 T19."created_by_id",
-                 T19."authorization_status",
-                 T19."authorization_updated_at",
-                 T19."authorization_updated_by_id",
-                 "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."rdv_solidarites_id",
-                 T20."id",
-                 T20."password",
-                 T20."last_login",
-                 T20."is_superuser",
-                 T20."username",
-                 T20."first_name",
-                 T20."last_name",
-                 T20."is_staff",
-                 T20."is_active",
-                 T20."date_joined",
-                 T20."address_line_1",
-                 T20."address_line_2",
-                 T20."post_code",
-                 T20."city",
-                 T20."department",
-                 T20."coords",
-                 T20."geocoding_score",
-                 T20."geocoding_updated_at",
-                 T20."ban_api_resolved_address",
-                 T20."insee_city_id",
-                 T20."title",
-                 T20."email",
-                 T20."phone",
-                 T20."kind",
-                 T20."identity_provider",
-                 T20."has_completed_welcoming_tour",
-                 T20."created_by_id",
-                 T20."external_data_source_history",
-                 T20."last_checked_at",
-                 T20."public_id",
-                 T20."address_filled_at",
-                 T20."first_login",
-                 "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "job_applications_jobapplication"
-          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
-          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
-          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
-          INNER JOIN "users_user" T5 ON ("job_applications_jobapplication"."job_seeker_id" = T5."id")
-          LEFT OUTER JOIN "rdv_insertion_participation" ON (T5."id" = "rdv_insertion_participation"."job_seeker_id")
-          LEFT OUTER JOIN "rdv_insertion_appointment" ON ("rdv_insertion_participation"."appointment_id" = "rdv_insertion_appointment"."id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON (T5."id" = "users_jobseekerprofile"."user_id")
-          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
-          LEFT OUTER JOIN "users_user" T11 ON ("eligibility_eligibilitydiagnosis"."author_id" = T11."id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
-          LEFT OUTER JOIN "users_user" T13 ON ("eligibility_eligibilitydiagnosis"."job_seeker_id" = T13."id")
-          LEFT OUTER JOIN "users_jobseekerprofile" T14 ON (T13."id" = T14."user_id")
-          LEFT OUTER JOIN "companies_company" T15 ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = T15."id")
-          LEFT OUTER JOIN "eligibility_geiqeligibilitydiagnosis" ON ("job_applications_jobapplication"."geiq_eligibility_diagnosis_id" = "eligibility_geiqeligibilitydiagnosis"."id")
-          LEFT OUTER JOIN "users_user" T17 ON ("job_applications_jobapplication"."sender_id" = T17."id")
-          LEFT OUTER JOIN "companies_company" T18 ON ("job_applications_jobapplication"."sender_company_id" = T18."id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" T19 ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = T19."id")
-          LEFT OUTER JOIN "users_user" T20 ON ("job_applications_jobapplication"."archived_by_id" = T20."id")
-          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
-          WHERE ("companies_companymembership"."user_id" = %s
-                 AND "users_user"."is_active"
-                 AND "job_applications_jobapplication"."id" = %s)
-          GROUP BY "job_applications_jobapplication"."id",
-                   T5."id",
-                   "users_jobseekerprofile"."user_id",
-                   "eligibility_eligibilitydiagnosis"."id",
-                   T11."id",
-                   "prescribers_prescriberorganization"."id",
-                   T13."id",
-                   T14."user_id",
-                   T15."id",
-                   "eligibility_geiqeligibilitydiagnosis"."id",
-                   T17."id",
-                   T18."id",
-                   T19."id",
-                   "companies_company"."id",
-                   T20."id",
-                   "approvals_approval"."id"
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
-                 "companies_jobdescription"."id",
-                 "companies_jobdescription"."appellation_id",
-                 "companies_jobdescription"."company_id",
-                 "companies_jobdescription"."created_at",
-                 "companies_jobdescription"."updated_at",
-                 "companies_jobdescription"."is_active",
-                 "companies_jobdescription"."custom_name",
-                 "companies_jobdescription"."description",
-                 "companies_jobdescription"."ui_rank",
-                 "companies_jobdescription"."contract_type",
-                 "companies_jobdescription"."other_contract_type",
-                 "companies_jobdescription"."contract_nature",
-                 "companies_jobdescription"."location_id",
-                 "companies_jobdescription"."hours_per_week",
-                 "companies_jobdescription"."open_positions",
-                 "companies_jobdescription"."profile_description",
-                 "companies_jobdescription"."is_resume_mandatory",
-                 "companies_jobdescription"."is_qpv_mandatory",
-                 "companies_jobdescription"."market_context_description",
-                 "companies_jobdescription"."source_id",
-                 "companies_jobdescription"."source_kind",
-                 "companies_jobdescription"."source_url",
-                 "companies_jobdescription"."field_history",
-                 "companies_jobdescription"."creation_source"
-          FROM "companies_jobdescription"
-          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
-          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
-          ORDER BY "jobs_appellation"."name" ASC,
-                   "companies_jobdescription"."ui_rank" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_admin[common_apps/organizations/models.py]',
-          'Company.convention_can_be_accessed_by[companies/models.py]',
-          'nav[utils/templatetags/nav.py]',
-          'InclusionNode[layout/_header_authenticated.html]',
-          'IncludeNode[layout/base.html]',
-          'IfNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "users_user"
-          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
-          WHERE ("companies_companymembership"."id" IN
-                   (SELECT U0."id"
-                    FROM "companies_companymembership" U0
-                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
-                    WHERE (U0."company_id" = %s
-                           AND U2."is_active"
-                           AND U0."is_active"
-                           AND U0."is_admin"
-                           AND U2."is_active"))
-                 AND "users_user"."id" = %s)
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
-          'VariableNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ForNode[apply/includes/transition_logs.html]',
-          'WithNode[apply/includes/transition_logs.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplicationtransitionlog"."id",
-                 "job_applications_jobapplicationtransitionlog"."transition",
-                 "job_applications_jobapplicationtransitionlog"."from_state",
-                 "job_applications_jobapplicationtransitionlog"."to_state",
-                 "job_applications_jobapplicationtransitionlog"."timestamp",
-                 "job_applications_jobapplicationtransitionlog"."job_application_id",
-                 "job_applications_jobapplicationtransitionlog"."user_id",
-                 "job_applications_jobapplicationtransitionlog"."target_company_id",
-                 "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login"
-          FROM "job_applications_jobapplicationtransitionlog"
-          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplicationtransitionlog"."user_id" = "users_user"."id")
-          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" = %s
-          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'JobApplication.can_be_cancelled[job_applications/models.py]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "employee_record_employeerecord"
-          WHERE "employee_record_employeerecord"."job_application_id" = %s
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': '''
-          UPDATE "django_session"
-          SET "session_data" = %s,
-              "expire_date" = %s
-          WHERE "django_session"."session_key" = %s
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-    ]),
-  })
-# ---
-# name: ProcessViewsTest.test_details_for_company_transition_logs_hides_hired_by_other
-  '''
-  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
-              <li>
-                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
-                  <span>
-
-                          Passé en "Embauché ailleurs"
-
-
-                  </span>
-              </li>
-
-          <li>
-              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
-              <span>Nouvelle candidature</span>
-          </li>
-
-  </ul>
-  '''
-# ---
-# name: ProcessViewsTest.test_details_for_company_with_transition_logs
-  '''
-  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
-              <li>
-                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
-                  <span>
-
-                          Passé en "Candidature acceptée"
-
-                      par John DOE
-                  </span>
-              </li>
-
-              <li>
-                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
-                  <span>
-
-                          Passé en "Candidature à l'étude"
-
-                      par John DOE
-                  </span>
-              </li>
-
-          <li>
-              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
-              <span>Nouvelle candidature</span>
-          </li>
-
-  </ul>
-  '''
-# ---
-# name: ProcessViewsTest.test_details_for_job_seeker[test_details_for_job_seeker]
-  dict({
-    'num_queries': 17,
-    'queries': list([
-      dict({
-        'origin': list([
-          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': '''
-          SELECT "django_session"."session_key",
-                 "django_session"."session_data",
-                 "django_session"."expire_date"
-          FROM "django_session"
-          WHERE ("django_session"."expire_date" > %s
-                 AND "django_session"."session_key" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login"
-          FROM "users_user"
-          WHERE "users_user"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplication"."id",
-                 "job_applications_jobapplication"."job_seeker_id",
-                 "job_applications_jobapplication"."eligibility_diagnosis_id",
-                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
-                 "job_applications_jobapplication"."create_employee_record",
-                 "job_applications_jobapplication"."resume_link",
-                 "job_applications_jobapplication"."sender_id",
-                 "job_applications_jobapplication"."sender_kind",
-                 "job_applications_jobapplication"."sender_company_id",
-                 "job_applications_jobapplication"."sender_prescriber_organization_id",
-                 "job_applications_jobapplication"."to_company_id",
-                 "job_applications_jobapplication"."state",
-                 "job_applications_jobapplication"."archived_at",
-                 "job_applications_jobapplication"."archived_by_id",
-                 "job_applications_jobapplication"."hired_job_id",
-                 "job_applications_jobapplication"."message",
-                 "job_applications_jobapplication"."answer",
-                 "job_applications_jobapplication"."answer_to_prescriber",
-                 "job_applications_jobapplication"."refusal_reason",
-                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
-                 "job_applications_jobapplication"."hiring_start_at",
-                 "job_applications_jobapplication"."hiring_end_at",
-                 "job_applications_jobapplication"."hiring_without_approval",
-                 "job_applications_jobapplication"."origin",
-                 "job_applications_jobapplication"."approval_id",
-                 "job_applications_jobapplication"."approval_delivery_mode",
-                 "job_applications_jobapplication"."approval_number_sent_by_email",
-                 "job_applications_jobapplication"."approval_number_sent_at",
-                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
-                 "job_applications_jobapplication"."approval_manually_refused_by_id",
-                 "job_applications_jobapplication"."approval_manually_refused_at",
-                 "job_applications_jobapplication"."transferred_at",
-                 "job_applications_jobapplication"."transferred_by_id",
-                 "job_applications_jobapplication"."transferred_from_id",
-                 "job_applications_jobapplication"."created_at",
-                 "job_applications_jobapplication"."updated_at",
-                 "job_applications_jobapplication"."processed_at",
-                 "job_applications_jobapplication"."prehiring_guidance_days",
-                 "job_applications_jobapplication"."contract_type",
-                 "job_applications_jobapplication"."nb_hours_per_week",
-                 "job_applications_jobapplication"."contract_type_details",
-                 "job_applications_jobapplication"."qualification_type",
-                 "job_applications_jobapplication"."qualification_level",
-                 "job_applications_jobapplication"."planned_training_hours",
-                 "job_applications_jobapplication"."inverted_vae_contract",
-                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
-                 "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."ata_allocation_since",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "eligibility_eligibilitydiagnosis"."id",
-                 "eligibility_eligibilitydiagnosis"."author_id",
-                 "eligibility_eligibilitydiagnosis"."author_kind",
-                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
-                 "eligibility_eligibilitydiagnosis"."created_at",
-                 "eligibility_eligibilitydiagnosis"."updated_at",
-                 "eligibility_eligibilitydiagnosis"."expires_at",
-                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
-                 "eligibility_eligibilitydiagnosis"."author_siae_id",
-                 T5."id",
-                 T5."password",
-                 T5."last_login",
-                 T5."is_superuser",
-                 T5."username",
-                 T5."first_name",
-                 T5."last_name",
-                 T5."is_staff",
-                 T5."is_active",
-                 T5."date_joined",
-                 T5."address_line_1",
-                 T5."address_line_2",
-                 T5."post_code",
-                 T5."city",
-                 T5."department",
-                 T5."coords",
-                 T5."geocoding_score",
-                 T5."geocoding_updated_at",
-                 T5."ban_api_resolved_address",
-                 T5."insee_city_id",
-                 T5."title",
-                 T5."email",
-                 T5."phone",
-                 T5."kind",
-                 T5."identity_provider",
-                 T5."has_completed_welcoming_tour",
-                 T5."created_by_id",
-                 T5."external_data_source_history",
-                 T5."last_checked_at",
-                 T5."public_id",
-                 T5."address_filled_at",
-                 T5."first_login",
-                 "prescribers_prescriberorganization"."id",
-                 "prescribers_prescriberorganization"."address_line_1",
-                 "prescribers_prescriberorganization"."address_line_2",
-                 "prescribers_prescriberorganization"."post_code",
-                 "prescribers_prescriberorganization"."city",
-                 "prescribers_prescriberorganization"."department",
-                 "prescribers_prescriberorganization"."coords",
-                 "prescribers_prescriberorganization"."geocoding_score",
-                 "prescribers_prescriberorganization"."geocoding_updated_at",
-                 "prescribers_prescriberorganization"."ban_api_resolved_address",
-                 "prescribers_prescriberorganization"."insee_city_id",
-                 "prescribers_prescriberorganization"."name",
-                 "prescribers_prescriberorganization"."created_at",
-                 "prescribers_prescriberorganization"."updated_at",
-                 "prescribers_prescriberorganization"."uid",
-                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
-                 "prescribers_prescriberorganization"."siret",
-                 "prescribers_prescriberorganization"."is_head_office",
-                 "prescribers_prescriberorganization"."kind",
-                 "prescribers_prescriberorganization"."is_brsa",
-                 "prescribers_prescriberorganization"."phone",
-                 "prescribers_prescriberorganization"."email",
-                 "prescribers_prescriberorganization"."website",
-                 "prescribers_prescriberorganization"."description",
-                 "prescribers_prescriberorganization"."is_authorized",
-                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
-                 "prescribers_prescriberorganization"."created_by_id",
-                 "prescribers_prescriberorganization"."authorization_status",
-                 "prescribers_prescriberorganization"."authorization_updated_at",
-                 "prescribers_prescriberorganization"."authorization_updated_by_id",
-                 T7."id",
-                 T7."password",
-                 T7."last_login",
-                 T7."is_superuser",
-                 T7."username",
-                 T7."first_name",
-                 T7."last_name",
-                 T7."is_staff",
-                 T7."is_active",
-                 T7."date_joined",
-                 T7."address_line_1",
-                 T7."address_line_2",
-                 T7."post_code",
-                 T7."city",
-                 T7."department",
-                 T7."coords",
-                 T7."geocoding_score",
-                 T7."geocoding_updated_at",
-                 T7."ban_api_resolved_address",
-                 T7."insee_city_id",
-                 T7."title",
-                 T7."email",
-                 T7."phone",
-                 T7."kind",
-                 T7."identity_provider",
-                 T7."has_completed_welcoming_tour",
-                 T7."created_by_id",
-                 T7."external_data_source_history",
-                 T7."last_checked_at",
-                 T7."public_id",
-                 T7."address_filled_at",
-                 T7."first_login",
-                 T8."user_id",
-                 T8."birthdate",
-                 T8."birth_place_id",
-                 T8."birth_country_id",
-                 T8."nir",
-                 T8."lack_of_nir_reason",
-                 T8."pole_emploi_id",
-                 T8."lack_of_pole_emploi_id_reason",
-                 T8."asp_uid",
-                 T8."education_level",
-                 T8."resourceless",
-                 T8."rqth_employee",
-                 T8."oeth_employee",
-                 T8."pole_emploi_since",
-                 T8."unemployed_since",
-                 T8."has_rsa_allocation",
-                 T8."rsa_allocation_since",
-                 T8."ass_allocation_since",
-                 T8."aah_allocation_since",
-                 T8."ata_allocation_since",
-                 T8."hexa_lane_number",
-                 T8."hexa_std_extension",
-                 T8."hexa_non_std_extension",
-                 T8."hexa_lane_type",
-                 T8."hexa_lane_name",
-                 T8."hexa_additional_address",
-                 T8."hexa_post_code",
-                 T8."hexa_commune_id",
-                 T8."pe_obfuscated_nir",
-                 T8."pe_last_certification_attempt_at",
-                 "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."rdv_solidarites_id",
-                 T10."id",
-                 T10."password",
-                 T10."last_login",
-                 T10."is_superuser",
-                 T10."username",
-                 T10."first_name",
-                 T10."last_name",
-                 T10."is_staff",
-                 T10."is_active",
-                 T10."date_joined",
-                 T10."address_line_1",
-                 T10."address_line_2",
-                 T10."post_code",
-                 T10."city",
-                 T10."department",
-                 T10."coords",
-                 T10."geocoding_score",
-                 T10."geocoding_updated_at",
-                 T10."ban_api_resolved_address",
-                 T10."insee_city_id",
-                 T10."title",
-                 T10."email",
-                 T10."phone",
-                 T10."kind",
-                 T10."identity_provider",
-                 T10."has_completed_welcoming_tour",
-                 T10."created_by_id",
-                 T10."external_data_source_history",
-                 T10."last_checked_at",
-                 T10."public_id",
-                 T10."address_filled_at",
-                 T10."first_login",
-                 T11."id",
-                 T11."address_line_1",
-                 T11."address_line_2",
-                 T11."post_code",
-                 T11."city",
-                 T11."department",
-                 T11."coords",
-                 T11."geocoding_score",
-                 T11."geocoding_updated_at",
-                 T11."ban_api_resolved_address",
-                 T11."insee_city_id",
-                 T11."name",
-                 T11."created_at",
-                 T11."updated_at",
-                 T11."uid",
-                 T11."active_members_email_reminder_last_sent_at",
-                 T11."siret",
-                 T11."naf",
-                 T11."kind",
-                 T11."brand",
-                 T11."phone",
-                 T11."email",
-                 T11."auth_email",
-                 T11."website",
-                 T11."description",
-                 T11."provided_support",
-                 T11."source",
-                 T11."created_by_id",
-                 T11."block_job_applications",
-                 T11."job_applications_blocked_at",
-                 T11."convention_id",
-                 T11."job_app_score",
-                 T11."rdv_solidarites_id"
-          FROM "job_applications_jobapplication"
-          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
-          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
-          LEFT OUTER JOIN "users_user" T5 ON ("eligibility_eligibilitydiagnosis"."author_id" = T5."id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
-          LEFT OUTER JOIN "users_user" T7 ON ("eligibility_eligibilitydiagnosis"."job_seeker_id" = T7."id")
-          LEFT OUTER JOIN "users_jobseekerprofile" T8 ON (T7."id" = T8."user_id")
-          LEFT OUTER JOIN "companies_company" ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = "companies_company"."id")
-          LEFT OUTER JOIN "users_user" T10 ON ("job_applications_jobapplication"."sender_id" = T10."id")
-          INNER JOIN "companies_company" T11 ON ("job_applications_jobapplication"."to_company_id" = T11."id")
-          WHERE ("job_applications_jobapplication"."id" = %s
-                 AND "job_applications_jobapplication"."job_seeker_id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
-                 "companies_jobdescription"."id",
-                 "companies_jobdescription"."appellation_id",
-                 "companies_jobdescription"."company_id",
-                 "companies_jobdescription"."created_at",
-                 "companies_jobdescription"."updated_at",
-                 "companies_jobdescription"."is_active",
-                 "companies_jobdescription"."custom_name",
-                 "companies_jobdescription"."description",
-                 "companies_jobdescription"."ui_rank",
-                 "companies_jobdescription"."contract_type",
-                 "companies_jobdescription"."other_contract_type",
-                 "companies_jobdescription"."contract_nature",
-                 "companies_jobdescription"."location_id",
-                 "companies_jobdescription"."hours_per_week",
-                 "companies_jobdescription"."open_positions",
-                 "companies_jobdescription"."profile_description",
-                 "companies_jobdescription"."is_resume_mandatory",
-                 "companies_jobdescription"."is_qpv_mandatory",
-                 "companies_jobdescription"."market_context_description",
-                 "companies_jobdescription"."source_id",
-                 "companies_jobdescription"."source_kind",
-                 "companies_jobdescription"."source_url",
-                 "companies_jobdescription"."field_history",
-                 "companies_jobdescription"."creation_source"
-          FROM "companies_jobdescription"
-          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
-          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
-          ORDER BY "jobs_appellation"."name" ASC,
-                   "companies_jobdescription"."ui_rank" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
-          'User.latest_pe_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_poleemploiapproval"."id",
-                 "approvals_poleemploiapproval"."start_at",
-                 "approvals_poleemploiapproval"."end_at",
-                 "approvals_poleemploiapproval"."created_at",
-                 "approvals_poleemploiapproval"."pe_notification_status",
-                 "approvals_poleemploiapproval"."pe_notification_time",
-                 "approvals_poleemploiapproval"."pe_notification_endpoint",
-                 "approvals_poleemploiapproval"."pe_notification_exit_code",
-                 "approvals_poleemploiapproval"."pe_structure_code",
-                 "approvals_poleemploiapproval"."number",
-                 "approvals_poleemploiapproval"."pole_emploi_id",
-                 "approvals_poleemploiapproval"."first_name",
-                 "approvals_poleemploiapproval"."last_name",
-                 "approvals_poleemploiapproval"."birth_name",
-                 "approvals_poleemploiapproval"."birthdate",
-                 "approvals_poleemploiapproval"."nir",
-                 "approvals_poleemploiapproval"."ntt_nia",
-                 "approvals_poleemploiapproval"."siae_siret",
-                 "approvals_poleemploiapproval"."siae_kind"
-          FROM "approvals_poleemploiapproval"
-          WHERE ("approvals_poleemploiapproval"."nir" = %s
-                 AND NOT ("approvals_poleemploiapproval"."number" IN
-                            (SELECT U0."number"
-                             FROM "approvals_approval" U0
-                             WHERE U0."user_id" = %s)))
-          ORDER BY "approvals_poleemploiapproval"."end_at" DESC,
-                   "approvals_poleemploiapproval"."start_at" ASC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EligibilityDiagnosisQuerySet.first[<site-packages>/django/db/models/query.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_considered_valid[eligibility/models/iae.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
-          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_eligibilitydiagnosis"."id",
-                 "eligibility_eligibilitydiagnosis"."author_id",
-                 "eligibility_eligibilitydiagnosis"."author_kind",
-                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
-                 "eligibility_eligibilitydiagnosis"."created_at",
-                 "eligibility_eligibilitydiagnosis"."updated_at",
-                 "eligibility_eligibilitydiagnosis"."expires_at",
-                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
-                 "eligibility_eligibilitydiagnosis"."author_siae_id",
-                 CASE
-                     WHEN "eligibility_eligibilitydiagnosis"."author_kind" = %s THEN %s
-                     ELSE %s
-                 END AS "from_prescriber",
-                 T4."id",
-                 T4."password",
-                 T4."last_login",
-                 T4."is_superuser",
-                 T4."username",
-                 T4."first_name",
-                 T4."last_name",
-                 T4."is_staff",
-                 T4."is_active",
-                 T4."date_joined",
-                 T4."address_line_1",
-                 T4."address_line_2",
-                 T4."post_code",
-                 T4."city",
-                 T4."department",
-                 T4."coords",
-                 T4."geocoding_score",
-                 T4."geocoding_updated_at",
-                 T4."ban_api_resolved_address",
-                 T4."insee_city_id",
-                 T4."title",
-                 T4."email",
-                 T4."phone",
-                 T4."kind",
-                 T4."identity_provider",
-                 T4."has_completed_welcoming_tour",
-                 T4."created_by_id",
-                 T4."external_data_source_history",
-                 T4."last_checked_at",
-                 T4."public_id",
-                 T4."address_filled_at",
-                 T4."first_login",
-                 "prescribers_prescriberorganization"."id",
-                 "prescribers_prescriberorganization"."address_line_1",
-                 "prescribers_prescriberorganization"."address_line_2",
-                 "prescribers_prescriberorganization"."post_code",
-                 "prescribers_prescriberorganization"."city",
-                 "prescribers_prescriberorganization"."department",
-                 "prescribers_prescriberorganization"."coords",
-                 "prescribers_prescriberorganization"."geocoding_score",
-                 "prescribers_prescriberorganization"."geocoding_updated_at",
-                 "prescribers_prescriberorganization"."ban_api_resolved_address",
-                 "prescribers_prescriberorganization"."insee_city_id",
-                 "prescribers_prescriberorganization"."name",
-                 "prescribers_prescriberorganization"."created_at",
-                 "prescribers_prescriberorganization"."updated_at",
-                 "prescribers_prescriberorganization"."uid",
-                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
-                 "prescribers_prescriberorganization"."siret",
-                 "prescribers_prescriberorganization"."is_head_office",
-                 "prescribers_prescriberorganization"."kind",
-                 "prescribers_prescriberorganization"."is_brsa",
-                 "prescribers_prescriberorganization"."phone",
-                 "prescribers_prescriberorganization"."email",
-                 "prescribers_prescriberorganization"."website",
-                 "prescribers_prescriberorganization"."description",
-                 "prescribers_prescriberorganization"."is_authorized",
-                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
-                 "prescribers_prescriberorganization"."created_by_id",
-                 "prescribers_prescriberorganization"."authorization_status",
-                 "prescribers_prescriberorganization"."authorization_updated_at",
-                 "prescribers_prescriberorganization"."authorization_updated_by_id",
-                 "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."rdv_solidarites_id"
-          FROM "eligibility_eligibilitydiagnosis"
-          LEFT OUTER JOIN "companies_company" ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = "companies_company"."id")
-          INNER JOIN "users_user" T4 ON ("eligibility_eligibilitydiagnosis"."author_id" = T4."id")
-          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
-          WHERE (("eligibility_eligibilitydiagnosis"."author_kind" = %s
-                  OR "eligibility_eligibilitydiagnosis"."author_siae_id" = %s)
-                 AND "eligibility_eligibilitydiagnosis"."job_seeker_id" = %s
-                 AND "eligibility_eligibilitydiagnosis"."expires_at" > %s)
-          ORDER BY 10 DESC,
-                   "eligibility_eligibilitydiagnosis"."created_at" DESC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details.html]',
-          'IfNode[apply/process_details.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details.html]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
-          'VariableNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details.html]',
-          'IfNode[apply/process_details.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details.html]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
-          'User.latest_pe_approval[users/models.py]',
-          'User.has_valid_common_approval[users/models.py]',
-          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
-          'VariableNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details.html]',
-          'IfNode[apply/process_details.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details.html]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_poleemploiapproval"."id",
-                 "approvals_poleemploiapproval"."start_at",
-                 "approvals_poleemploiapproval"."end_at",
-                 "approvals_poleemploiapproval"."created_at",
-                 "approvals_poleemploiapproval"."pe_notification_status",
-                 "approvals_poleemploiapproval"."pe_notification_time",
-                 "approvals_poleemploiapproval"."pe_notification_endpoint",
-                 "approvals_poleemploiapproval"."pe_notification_exit_code",
-                 "approvals_poleemploiapproval"."pe_structure_code",
-                 "approvals_poleemploiapproval"."number",
-                 "approvals_poleemploiapproval"."pole_emploi_id",
-                 "approvals_poleemploiapproval"."first_name",
-                 "approvals_poleemploiapproval"."last_name",
-                 "approvals_poleemploiapproval"."birth_name",
-                 "approvals_poleemploiapproval"."birthdate",
-                 "approvals_poleemploiapproval"."nir",
-                 "approvals_poleemploiapproval"."ntt_nia",
-                 "approvals_poleemploiapproval"."siae_siret",
-                 "approvals_poleemploiapproval"."siae_kind"
-          FROM "approvals_poleemploiapproval"
-          WHERE ("approvals_poleemploiapproval"."nir" = %s
-                 AND NOT ("approvals_poleemploiapproval"."number" IN
-                            (SELECT U0."number"
-                             FROM "approvals_approval" U0
-                             WHERE U0."user_id" = %s)))
-          ORDER BY "approvals_poleemploiapproval"."end_at" DESC,
-                   "approvals_poleemploiapproval"."start_at" ASC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'ForNode[apply/includes/transition_logs.html]',
-          'WithNode[apply/includes/transition_logs.html]',
-          'IncludeNode[apply/process_details.html]',
-          'BlockNode[apply/process_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details.html]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplicationtransitionlog"."id",
-                 "job_applications_jobapplicationtransitionlog"."transition",
-                 "job_applications_jobapplicationtransitionlog"."from_state",
-                 "job_applications_jobapplicationtransitionlog"."to_state",
-                 "job_applications_jobapplicationtransitionlog"."timestamp",
-                 "job_applications_jobapplicationtransitionlog"."job_application_id",
-                 "job_applications_jobapplicationtransitionlog"."user_id",
-                 "job_applications_jobapplicationtransitionlog"."target_company_id",
-                 "users_user"."id",
-                 "users_user"."password",
-                 "users_user"."last_login",
-                 "users_user"."is_superuser",
-                 "users_user"."username",
-                 "users_user"."first_name",
-                 "users_user"."last_name",
-                 "users_user"."is_staff",
-                 "users_user"."is_active",
-                 "users_user"."date_joined",
-                 "users_user"."address_line_1",
-                 "users_user"."address_line_2",
-                 "users_user"."post_code",
-                 "users_user"."city",
-                 "users_user"."department",
-                 "users_user"."coords",
-                 "users_user"."geocoding_score",
-                 "users_user"."geocoding_updated_at",
-                 "users_user"."ban_api_resolved_address",
-                 "users_user"."insee_city_id",
-                 "users_user"."title",
-                 "users_user"."email",
-                 "users_user"."phone",
-                 "users_user"."kind",
-                 "users_user"."identity_provider",
-                 "users_user"."has_completed_welcoming_tour",
-                 "users_user"."created_by_id",
-                 "users_user"."external_data_source_history",
-                 "users_user"."last_checked_at",
-                 "users_user"."public_id",
-                 "users_user"."address_filled_at",
-                 "users_user"."first_login"
-          FROM "job_applications_jobapplicationtransitionlog"
-          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplicationtransitionlog"."user_id" = "users_user"."id")
-          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" = %s
-          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': '''
-          UPDATE "django_session"
-          SET "session_data" = %s,
-              "expire_date" = %s
-          WHERE "django_session"."session_key" = %s
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-    ]),
-  })
-# ---
-# name: ProcessViewsTest.test_details_for_job_seeker_with_transition_logs
-  '''
-  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
-              <li>
-                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
-                  <span>
-
-                          Passé en "Candidature acceptée"
-
-                      par John DOE
-                  </span>
-              </li>
-
-              <li>
-                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
-                  <span>
-
-                          Passé en "Candidature à l'étude"
-
-                      par John DOE
-                  </span>
-              </li>
-
-          <li>
-              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
-              <span>Nouvelle candidature</span>
-          </li>
-
-  </ul>
-  '''
-# ---
-# name: ProcessViewsTest.test_details_for_prescriber_with_transition_logs
-  '''
-  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
-              <li>
-                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
-                  <span>
-
-                          Passé en "Candidature acceptée"
-
-                      par John DOE
-                  </span>
-              </li>
-
-              <li>
-                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
-                  <span>
-
-                          Passé en "Candidature à l'étude"
-
-                      par John DOE
-                  </span>
-              </li>
-
-          <li>
-              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
-              <span>Nouvelle candidature</span>
-          </li>
-
-  </ul>
-  '''
-# ---
-# name: ProcessViewsTest.test_external_transfer_log_display
-  '''
-  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
-              <li>
-                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
-                  <span>
-
-                          Candidature transférée à un autre employeur
-
-                      par John DOE
-                  </span>
-              </li>
-
-              <li>
-                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
-                  <span>
-
-                          Passé en "Candidature déclinée"
-
-                      par John DOE
-                  </span>
-              </li>
-
-          <li>
-              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
-              <span>Nouvelle candidature</span>
-          </li>
-
-  </ul>
-  '''
-# ---
-# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_body]
-  '''
-  Bonjour,
-
-  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-
-  Commentaire de l’employeur:
-
-  On vous rappellera.
-
-  ---
-  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
-  Les emplois de l'inclusion
-  http://localhost:8000
-  '''
-# ---
-# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_subject]
-  '[DEV] Votre candidature mise en attente par EI Acme inc.'
-# ---
-# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_proxy_body]
-  '''
-  Bonjour,
-
-  La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
-
-  Commentaire de l’employeur:
-
-  On vous rappellera.
-
-  ---
-  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
-  Les emplois de l'inclusion
-  http://localhost:8000
-  '''
-# ---
-# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_proxy_subject]
-  '[DEV] Candidature de Jane DOE mise en attente par EI Acme inc.'
-# ---
-# name: ProcessViewsTest.test_postpone_from_job_seeker[postpone_email_to_job_seeker_body]
-  '''
-  Bonjour,
-
-  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-
-  Commentaire de l’employeur:
-
-  On vous rappellera.
-
-  ---
-  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
-  Les emplois de l'inclusion
-  http://localhost:8000
-  '''
-# ---
-# name: ProcessViewsTest.test_postpone_from_job_seeker[postpone_email_to_job_seeker_subject]
-  '[DEV] Votre candidature mise en attente par EI Acme inc.'
-# ---
-# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_job_seeker_body]
-  '''
-  Bonjour,
-
-  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-
-  ---
-  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
-  Les emplois de l'inclusion
-  http://localhost:8000
-  '''
-# ---
-# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_job_seeker_subject]
-  '[DEV] Votre candidature mise en attente par EI Acme inc.'
-# ---
-# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_proxy_body]
-  '''
-  Bonjour,
-
-  La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
-
-  ---
-  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
-  Les emplois de l'inclusion
-  http://localhost:8000
-  '''
-# ---
-# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_proxy_subject]
-  '[DEV] Candidature de Jane DOE mise en attente par EI Acme inc.'
-# ---
 # name: TestProcessTransferJobApplication.test_job_application_external_transfer_disabled_for_bad_state
   '''
   <div class="dropdown dropdown-structure">
@@ -4006,15 +903,15 @@
           Transférer cette candidature vers
       </button>
       <div aria-labelledby="transfer_to_button" class="dropdown-menu w-100">
-
-
+          
+          
               <div data-bs-placement="bottom" data-bs-toggle="tooltip" title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur">
                   <div class="dropdown-item disabled">
                       <i class="ri-home-smile-line"></i>
                       <strong>Une autre structure</strong>
                   </div>
               </div>
-
+          
       </div>
   </div>
   '''
@@ -4026,13 +923,13 @@
           Transférer cette candidature vers
       </button>
       <div aria-labelledby="transfer_to_button" class="dropdown-menu w-100">
-
-
+          
+          
               <a class="dropdown-item" href="/apply/[PK of JobApplication]/siae/external-transfer/1">
                   <i class="ri-home-smile-line"></i>
                   <strong>Une autre structure</strong>
               </a>
-
+          
       </div>
   </div>
   '''
@@ -4042,7 +939,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_approval[job application detail for company]
   dict({
-    'num_queries': 17,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -4763,6 +1660,24 @@
           WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
           ORDER BY "jobs_appellation"."name" ASC,
                    "companies_jobdescription"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({
@@ -4829,8 +1744,6 @@
       dict({
         'origin': list([
           'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'WithNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IncludeNode[apply/process_details_company.html]',
@@ -4841,22 +1754,19 @@
           'details_for_company[www/apply/views/process_views.py]',
         ]),
         'sql': '''
-          SELECT "eligibility_administrativecriteria"."id",
-                 "eligibility_administrativecriteria"."kind",
-                 "eligibility_administrativecriteria"."level",
-                 "eligibility_administrativecriteria"."name",
-                 "eligibility_administrativecriteria"."desc",
-                 "eligibility_administrativecriteria"."written_proof",
-                 "eligibility_administrativecriteria"."written_proof_url",
-                 "eligibility_administrativecriteria"."written_proof_validity",
-                 "eligibility_administrativecriteria"."ui_rank",
-                 "eligibility_administrativecriteria"."created_at",
-                 "eligibility_administrativecriteria"."created_by_id"
-          FROM "eligibility_administrativecriteria"
-          INNER JOIN "eligibility_selectedadministrativecriteria" ON ("eligibility_administrativecriteria"."id" = "eligibility_selectedadministrativecriteria"."administrative_criteria_id")
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({
@@ -5010,7 +1920,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_list[job application detail for company]
   dict({
-    'num_queries': 17,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -5735,6 +2645,24 @@
       }),
       dict({
         'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'User.latest_approval[users/models.py]',
           'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
@@ -5797,8 +2725,6 @@
       dict({
         'origin': list([
           'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'WithNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IncludeNode[apply/process_details_company.html]',
@@ -5809,22 +2735,19 @@
           'details_for_company[www/apply/views/process_views.py]',
         ]),
         'sql': '''
-          SELECT "eligibility_administrativecriteria"."id",
-                 "eligibility_administrativecriteria"."kind",
-                 "eligibility_administrativecriteria"."level",
-                 "eligibility_administrativecriteria"."name",
-                 "eligibility_administrativecriteria"."desc",
-                 "eligibility_administrativecriteria"."written_proof",
-                 "eligibility_administrativecriteria"."written_proof_url",
-                 "eligibility_administrativecriteria"."written_proof_validity",
-                 "eligibility_administrativecriteria"."ui_rank",
-                 "eligibility_administrativecriteria"."created_at",
-                 "eligibility_administrativecriteria"."created_by_id"
-          FROM "eligibility_administrativecriteria"
-          INNER JOIN "eligibility_selectedadministrativecriteria" ON ("eligibility_administrativecriteria"."id" = "eligibility_selectedadministrativecriteria"."administrative_criteria_id")
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({
@@ -5979,62 +2902,62 @@
 # name: TestProcessViews.test_details_for_company_transition_logs_hides_hired_by_other
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-
+                      
                           Passé en "Embauché ailleurs"
-
-
+                      
+                      
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_details_for_company_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-
+                      
                           Passé en "Candidature acceptée"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Candidature à l'étude"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_details_for_job_seeker
   dict({
-    'num_queries': 14,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -6498,6 +3421,24 @@
       }),
       dict({
         'origin': list([
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'User.latest_approval[users/models.py]',
           'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
@@ -6661,9 +3602,6 @@
       dict({
         'origin': list([
           'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'WithNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IncludeNode[apply/process_details.html]',
@@ -6674,22 +3612,19 @@
           'details_for_jobseeker[www/apply/views/process_views.py]',
         ]),
         'sql': '''
-          SELECT "eligibility_administrativecriteria"."id",
-                 "eligibility_administrativecriteria"."kind",
-                 "eligibility_administrativecriteria"."level",
-                 "eligibility_administrativecriteria"."name",
-                 "eligibility_administrativecriteria"."desc",
-                 "eligibility_administrativecriteria"."written_proof",
-                 "eligibility_administrativecriteria"."written_proof_url",
-                 "eligibility_administrativecriteria"."written_proof_validity",
-                 "eligibility_administrativecriteria"."ui_rank",
-                 "eligibility_administrativecriteria"."created_at",
-                 "eligibility_administrativecriteria"."created_by_id"
-          FROM "eligibility_administrativecriteria"
-          INNER JOIN "eligibility_selectedadministrativecriteria" ON ("eligibility_administrativecriteria"."id" = "eligibility_selectedadministrativecriteria"."administrative_criteria_id")
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({
@@ -6698,7 +3633,6 @@
           'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
           'VariableNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
@@ -6828,112 +3762,112 @@
 # name: TestProcessViews.test_details_for_job_seeker_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-
+                      
                           Passé en "Candidature acceptée"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Candidature à l'étude"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_details_for_prescriber_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-
+                      
                           Passé en "Candidature acceptée"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Candidature à l'étude"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_external_transfer_log_display
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-
+                      
                           Candidature transférée à un autre employeur
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Candidature déclinée"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_body]
   '''
   Bonjour,
-
+  
   Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-
+  
   Commentaire de l’employeur:
-
+  
   On vous rappellera.
-
+  
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -6946,13 +3880,13 @@
 # name: TestProcessViews.test_postpone_from_employer_orienter[postpone_email_to_proxy_body]
   '''
   Bonjour,
-
+  
   La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
-
+  
   Commentaire de l’employeur:
-
+  
   On vous rappellera.
-
+  
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -6965,13 +3899,13 @@
 # name: TestProcessViews.test_postpone_from_job_seeker[postpone_email_to_job_seeker_body]
   '''
   Bonjour,
-
+  
   Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-
+  
   Commentaire de l’employeur:
-
+  
   On vous rappellera.
-
+  
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -6984,9 +3918,9 @@
 # name: TestProcessViews.test_postpone_from_prescriber[postpone_email_to_job_seeker_body]
   '''
   Bonjour,
-
+  
   Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-
+  
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -6999,9 +3933,9 @@
 # name: TestProcessViews.test_postpone_from_prescriber[postpone_email_to_proxy_body]
   '''
   Bonjour,
-
+  
   La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
-
+  
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -7014,23 +3948,23 @@
 # name: test_add_prior_action_processing
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Action préalable à l’embauche"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:11+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
@@ -7131,239 +4065,239 @@
 # name: test_delete_prior_action[False]
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:40:00+00:00">Le 12 décembre 2023 à 13:40</time>
                   <span>
-
+                      
                           Passé en "Action préalable à l’embauche"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Candidature à l'étude"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:11+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: test_delete_prior_action[True]
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">
-
-
+      
+          
               <li>
                   <time datetime="2023-12-12T12:40:00+00:00">Le 12 décembre 2023 à 13:40</time>
                   <span>
-
+                      
                           Passé en "Action préalable à l’embauche"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-
+                      
                           Passé en "Candidature à l'étude"
-
+                      
                       par John DOE
                   </span>
               </li>
-
+          
           <li>
               <time datetime="2023-12-10T10:11:11+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-
+      
   </ul>
   '''
 # ---
 # name: test_reload_contract_type_and_options[APPRENTICESHIP]
   '''
-
+  
   <div id="geiq_contract_type_and_options_block">
       <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_prehiring_guidance_days">Nombre de jours d’accompagnement avant contrat</label><input type="number" name="prehiring_guidance_days" min="0" class="form-control is-invalid" placeholder="Nombre de jours d’accompagnement avant contrat" required aria-invalid="true" aria-describedby="id_prehiring_guidance_days_helptext" id="id_prehiring_guidance_days">
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
-
+  
   <div class="form-text">Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche</div>
   </div>
       <div class="form-group form-group-required"><label class="form-label" for="id_contract_type">Type de contrat</label><select name="contract_type" hx-trigger="change" hx-post="/apply/10/accept/reload_contract_type_and_options" hx-swap="outerHTML" hx-select="#geiq_contract_type_and_options_block" hx-target="#geiq_contract_type_and_options_block" class="form-select" required id="id_contract_type">
     <option value="">---------</option>
-
+  
     <option value="APPRENTICESHIP" selected>Contrat d&#x27;apprentissage</option>
-
+  
     <option value="PROFESSIONAL_TRAINING">Contrat de professionalisation</option>
-
+  
     <option value="OTHER">Autre type de contrat</option>
-
+  
   </select></div>
       <div class="form-group"><div class="form-check"><input type="checkbox" name="inverted_vae_contract" class="form-check-input" disabled id="id_inverted_vae_contract"><label class="form-check-label" for="id_inverted_vae_contract">Contrat associé à une VAE inversée</label></div></div>
-
+      
       <div class="form-group form-group-required"><label class="form-label" for="id_nb_hours_per_week">Nombre d&#x27;heures par semaine</label><input type="number" name="nb_hours_per_week" min="0" class="form-control" placeholder="Nombre d&#x27;heures par semaine" required id="id_nb_hours_per_week"></div>
   </div>
-
+  
   '''
 # ---
 # name: test_reload_contract_type_and_options[OTHER]
   '''
-
+  
   <div id="geiq_contract_type_and_options_block">
       <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_prehiring_guidance_days">Nombre de jours d’accompagnement avant contrat</label><input type="number" name="prehiring_guidance_days" min="0" class="form-control is-invalid" placeholder="Nombre de jours d’accompagnement avant contrat" required aria-invalid="true" aria-describedby="id_prehiring_guidance_days_helptext" id="id_prehiring_guidance_days">
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
-
+  
   <div class="form-text">Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche</div>
   </div>
       <div class="form-group form-group-required"><label class="form-label" for="id_contract_type">Type de contrat</label><select name="contract_type" hx-trigger="change" hx-post="/apply/10/accept/reload_contract_type_and_options" hx-swap="outerHTML" hx-select="#geiq_contract_type_and_options_block" hx-target="#geiq_contract_type_and_options_block" class="form-select" required id="id_contract_type">
     <option value="">---------</option>
-
+  
     <option value="APPRENTICESHIP">Contrat d&#x27;apprentissage</option>
-
+  
     <option value="PROFESSIONAL_TRAINING">Contrat de professionalisation</option>
-
+  
     <option value="OTHER" selected>Autre type de contrat</option>
-
+  
   </select></div>
       <div class="form-group"><div class="form-check"><input type="checkbox" name="inverted_vae_contract" class="form-check-input" disabled id="id_inverted_vae_contract"><label class="form-check-label" for="id_inverted_vae_contract">Contrat associé à une VAE inversée</label></div></div>
-
+      
           <div id="contractTypeDetails"><div class="form-group"><label class="form-label" for="id_contract_type_details">Précisions sur le type de contrat</label><textarea name="contract_type_details" cols="40" rows="2" class="form-control" placeholder="Précisions sur le type de contrat" aria-describedby="id_contract_type_details_helptext" id="id_contract_type_details">
   </textarea><div class="form-text">Si vous avez choisi un autre type de contrat, merci de bien vouloir fournir plus de précisions</div>
   </div></div>
-
+      
       <div class="form-group form-group-required"><label class="form-label" for="id_nb_hours_per_week">Nombre d&#x27;heures par semaine</label><input type="number" name="nb_hours_per_week" min="0" class="form-control" placeholder="Nombre d&#x27;heures par semaine" required id="id_nb_hours_per_week"></div>
   </div>
-
+  
   '''
 # ---
 # name: test_reload_contract_type_and_options[PROFESSIONAL_TRAINING]
   '''
-
+  
   <div id="geiq_contract_type_and_options_block">
       <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_prehiring_guidance_days">Nombre de jours d’accompagnement avant contrat</label><input type="number" name="prehiring_guidance_days" min="0" class="form-control is-invalid" placeholder="Nombre de jours d’accompagnement avant contrat" required aria-invalid="true" aria-describedby="id_prehiring_guidance_days_helptext" id="id_prehiring_guidance_days">
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
-
+  
   <div class="form-text">Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche</div>
   </div>
       <div class="form-group form-group-required"><label class="form-label" for="id_contract_type">Type de contrat</label><select name="contract_type" hx-trigger="change" hx-post="/apply/10/accept/reload_contract_type_and_options" hx-swap="outerHTML" hx-select="#geiq_contract_type_and_options_block" hx-target="#geiq_contract_type_and_options_block" class="form-select" required id="id_contract_type">
     <option value="">---------</option>
-
+  
     <option value="APPRENTICESHIP">Contrat d&#x27;apprentissage</option>
-
+  
     <option value="PROFESSIONAL_TRAINING" selected>Contrat de professionalisation</option>
-
+  
     <option value="OTHER">Autre type de contrat</option>
-
+  
   </select></div>
       <div class="form-group"><div class="form-check"><input type="checkbox" name="inverted_vae_contract" class="form-check-input" id="id_inverted_vae_contract"><label class="form-check-label" for="id_inverted_vae_contract">Contrat associé à une VAE inversée</label></div></div>
-
+      
       <div class="form-group form-group-required"><label class="form-label" for="id_nb_hours_per_week">Nombre d&#x27;heures par semaine</label><input type="number" name="nb_hours_per_week" min="0" class="form-control" placeholder="Nombre d&#x27;heures par semaine" required id="id_nb_hours_per_week"></div>
   </div>
-
+  
   '''
 # ---
 # name: test_reload_qualification_fields[CCN]
   '''
-
+  
   <div id="geiq_qualification_fields_block">
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-trigger="change" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-select="#geiq_qualification_fields_block" hx-target="#geiq_qualification_fields_block" class="form-select" required id="id_qualification_type">
     <option value="">---------</option>
-
+  
     <option value="STATE_DIPLOMA">Diplôme d&#x27;état ou titre homologué</option>
-
+  
     <option value="CQP">CQP</option>
-
+  
     <option value="CCN" selected>Positionnement de CCN</option>
-
+  
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_level">Niveau de qualification</label><select name="qualification_level" class="form-select" required id="id_qualification_level">
     <option value="" selected>---------</option>
-
+  
     <option value="LEVEL_3">Niveau 3 (CAP, BEP)</option>
-
+  
     <option value="LEVEL_4">Niveau 4 (BP, Bac général, Techno ou Pro, BT)</option>
-
+  
     <option value="LEVEL_5">Niveau 5 ou + (Bac+2 ou +)</option>
-
+  
     <option value="NOT_RELEVANT">Non concerné</option>
-
+  
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_planned_training_hours">Nombre d&#x27;heures de formation prévues</label><input type="number" name="planned_training_hours" value="0" min="0" class="form-control" placeholder="Nombre d&#x27;heures de formation prévues" required id="id_planned_training_hours"></div>
   </div>
-
+  
   '''
 # ---
 # name: test_reload_qualification_fields[CQP]
   '''
-
+  
   <div id="geiq_qualification_fields_block">
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-trigger="change" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-select="#geiq_qualification_fields_block" hx-target="#geiq_qualification_fields_block" class="form-select" required id="id_qualification_type">
     <option value="">---------</option>
-
+  
     <option value="STATE_DIPLOMA">Diplôme d&#x27;état ou titre homologué</option>
-
+  
     <option value="CQP" selected>CQP</option>
-
+  
     <option value="CCN">Positionnement de CCN</option>
-
+  
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_level">Niveau de qualification</label><select name="qualification_level" class="form-select" required id="id_qualification_level">
     <option value="" selected>---------</option>
-
+  
     <option value="LEVEL_3">Niveau 3 (CAP, BEP)</option>
-
+  
     <option value="LEVEL_4">Niveau 4 (BP, Bac général, Techno ou Pro, BT)</option>
-
+  
     <option value="LEVEL_5">Niveau 5 ou + (Bac+2 ou +)</option>
-
+  
     <option value="NOT_RELEVANT">Non concerné</option>
-
+  
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_planned_training_hours">Nombre d&#x27;heures de formation prévues</label><input type="number" name="planned_training_hours" value="0" min="0" class="form-control" placeholder="Nombre d&#x27;heures de formation prévues" required id="id_planned_training_hours"></div>
   </div>
-
+  
   '''
 # ---
 # name: test_reload_qualification_fields[STATE_DIPLOMA]
   '''
-
+  
   <div id="geiq_qualification_fields_block">
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-trigger="change" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-select="#geiq_qualification_fields_block" hx-target="#geiq_qualification_fields_block" class="form-select" required id="id_qualification_type">
     <option value="">---------</option>
-
+  
     <option value="STATE_DIPLOMA" selected>Diplôme d&#x27;état ou titre homologué</option>
-
+  
     <option value="CQP">CQP</option>
-
+  
     <option value="CCN">Positionnement de CCN</option>
-
+  
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_level">Niveau de qualification</label><select name="qualification_level" class="form-select" required id="id_qualification_level">
     <option value="" selected>---------</option>
-
+  
     <option value="LEVEL_3">Niveau 3 (CAP, BEP)</option>
-
+  
     <option value="LEVEL_4">Niveau 4 (BP, Bac général, Techno ou Pro, BT)</option>
-
+  
     <option value="LEVEL_5">Niveau 5 ou + (Bac+2 ou +)</option>
-
+  
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_planned_training_hours">Nombre d&#x27;heures de formation prévues</label><input type="number" name="planned_training_hours" value="0" min="0" class="form-control" placeholder="Nombre d&#x27;heures de formation prévues" required id="id_planned_training_hours"></div>
   </div>
-
+  
   '''
 # ---

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -896,6 +896,3109 @@
     ]),
   })
 # ---
+# name: ProcessViewsTest.test_details_for_company_from_approval[job application detail for company]
+  dict({
+    'num_queries': 18,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "companies_companymembership"."notifications"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "companies_companymembership"."is_active")
+          ORDER BY "companies_companymembership"."created_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_solidarites_id",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_siaeconvention" U0
+             WHERE (U0."deactivated_at" >= %s
+                    AND U0."id" = ("companies_company"."convention_id"))
+             LIMIT 1) AS "has_convention_in_grace_period",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_company"
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND "companies_companymembership"."user_id" = %s
+                 AND "companies_company"."id" IN (%s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."deactivated_at" >= %s
+                                AND U0."id" = ("companies_company"."convention_id"))
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_link",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "rdv_insertion_invitationrequest" U0
+             WHERE (U0."company_id" = ("job_applications_jobapplication"."to_company_id")
+                    AND U0."created_at" > %s
+                    AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
+             LIMIT 1) AS "has_pending_rdv_insertion_invitation_request",
+                 COUNT("rdv_insertion_participation"."id") FILTER (
+                                                                   WHERE ("rdv_insertion_appointment"."company_id" = %s
+                                                                          AND "rdv_insertion_appointment"."start_at" > %s
+                                                                          AND "rdv_insertion_participation"."status" = %s)) AS "upcoming_participations_count",
+                 T5."id",
+                 T5."password",
+                 T5."last_login",
+                 T5."is_superuser",
+                 T5."username",
+                 T5."first_name",
+                 T5."last_name",
+                 T5."is_staff",
+                 T5."is_active",
+                 T5."date_joined",
+                 T5."address_line_1",
+                 T5."address_line_2",
+                 T5."post_code",
+                 T5."city",
+                 T5."department",
+                 T5."coords",
+                 T5."geocoding_score",
+                 T5."geocoding_updated_at",
+                 T5."ban_api_resolved_address",
+                 T5."insee_city_id",
+                 T5."title",
+                 T5."email",
+                 T5."phone",
+                 T5."kind",
+                 T5."identity_provider",
+                 T5."has_completed_welcoming_tour",
+                 T5."created_by_id",
+                 T5."external_data_source_history",
+                 T5."last_checked_at",
+                 T5."public_id",
+                 T5."address_filled_at",
+                 T5."first_login",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."ata_allocation_since",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "eligibility_eligibilitydiagnosis"."id",
+                 "eligibility_eligibilitydiagnosis"."author_id",
+                 "eligibility_eligibilitydiagnosis"."author_kind",
+                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
+                 "eligibility_eligibilitydiagnosis"."created_at",
+                 "eligibility_eligibilitydiagnosis"."updated_at",
+                 "eligibility_eligibilitydiagnosis"."expires_at",
+                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
+                 "eligibility_eligibilitydiagnosis"."author_siae_id",
+                 T11."id",
+                 T11."password",
+                 T11."last_login",
+                 T11."is_superuser",
+                 T11."username",
+                 T11."first_name",
+                 T11."last_name",
+                 T11."is_staff",
+                 T11."is_active",
+                 T11."date_joined",
+                 T11."address_line_1",
+                 T11."address_line_2",
+                 T11."post_code",
+                 T11."city",
+                 T11."department",
+                 T11."coords",
+                 T11."geocoding_score",
+                 T11."geocoding_updated_at",
+                 T11."ban_api_resolved_address",
+                 T11."insee_city_id",
+                 T11."title",
+                 T11."email",
+                 T11."phone",
+                 T11."kind",
+                 T11."identity_provider",
+                 T11."has_completed_welcoming_tour",
+                 T11."created_by_id",
+                 T11."external_data_source_history",
+                 T11."last_checked_at",
+                 T11."public_id",
+                 T11."address_filled_at",
+                 T11."first_login",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."is_head_office",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."is_authorized",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 T13."id",
+                 T13."password",
+                 T13."last_login",
+                 T13."is_superuser",
+                 T13."username",
+                 T13."first_name",
+                 T13."last_name",
+                 T13."is_staff",
+                 T13."is_active",
+                 T13."date_joined",
+                 T13."address_line_1",
+                 T13."address_line_2",
+                 T13."post_code",
+                 T13."city",
+                 T13."department",
+                 T13."coords",
+                 T13."geocoding_score",
+                 T13."geocoding_updated_at",
+                 T13."ban_api_resolved_address",
+                 T13."insee_city_id",
+                 T13."title",
+                 T13."email",
+                 T13."phone",
+                 T13."kind",
+                 T13."identity_provider",
+                 T13."has_completed_welcoming_tour",
+                 T13."created_by_id",
+                 T13."external_data_source_history",
+                 T13."last_checked_at",
+                 T13."public_id",
+                 T13."address_filled_at",
+                 T13."first_login",
+                 T14."user_id",
+                 T14."birthdate",
+                 T14."birth_place_id",
+                 T14."birth_country_id",
+                 T14."nir",
+                 T14."lack_of_nir_reason",
+                 T14."pole_emploi_id",
+                 T14."lack_of_pole_emploi_id_reason",
+                 T14."asp_uid",
+                 T14."education_level",
+                 T14."resourceless",
+                 T14."rqth_employee",
+                 T14."oeth_employee",
+                 T14."pole_emploi_since",
+                 T14."unemployed_since",
+                 T14."has_rsa_allocation",
+                 T14."rsa_allocation_since",
+                 T14."ass_allocation_since",
+                 T14."aah_allocation_since",
+                 T14."ata_allocation_since",
+                 T14."hexa_lane_number",
+                 T14."hexa_std_extension",
+                 T14."hexa_non_std_extension",
+                 T14."hexa_lane_type",
+                 T14."hexa_lane_name",
+                 T14."hexa_additional_address",
+                 T14."hexa_post_code",
+                 T14."hexa_commune_id",
+                 T14."pe_obfuscated_nir",
+                 T14."pe_last_certification_attempt_at",
+                 T15."id",
+                 T15."address_line_1",
+                 T15."address_line_2",
+                 T15."post_code",
+                 T15."city",
+                 T15."department",
+                 T15."coords",
+                 T15."geocoding_score",
+                 T15."geocoding_updated_at",
+                 T15."ban_api_resolved_address",
+                 T15."insee_city_id",
+                 T15."name",
+                 T15."created_at",
+                 T15."updated_at",
+                 T15."uid",
+                 T15."active_members_email_reminder_last_sent_at",
+                 T15."siret",
+                 T15."naf",
+                 T15."kind",
+                 T15."brand",
+                 T15."phone",
+                 T15."email",
+                 T15."auth_email",
+                 T15."website",
+                 T15."description",
+                 T15."provided_support",
+                 T15."source",
+                 T15."created_by_id",
+                 T15."block_job_applications",
+                 T15."job_applications_blocked_at",
+                 T15."convention_id",
+                 T15."job_app_score",
+                 T15."rdv_solidarites_id",
+                 "eligibility_geiqeligibilitydiagnosis"."id",
+                 "eligibility_geiqeligibilitydiagnosis"."author_id",
+                 "eligibility_geiqeligibilitydiagnosis"."author_kind",
+                 "eligibility_geiqeligibilitydiagnosis"."author_prescriber_organization_id",
+                 "eligibility_geiqeligibilitydiagnosis"."created_at",
+                 "eligibility_geiqeligibilitydiagnosis"."updated_at",
+                 "eligibility_geiqeligibilitydiagnosis"."expires_at",
+                 "eligibility_geiqeligibilitydiagnosis"."job_seeker_id",
+                 "eligibility_geiqeligibilitydiagnosis"."author_geiq_id",
+                 T17."id",
+                 T17."password",
+                 T17."last_login",
+                 T17."is_superuser",
+                 T17."username",
+                 T17."first_name",
+                 T17."last_name",
+                 T17."is_staff",
+                 T17."is_active",
+                 T17."date_joined",
+                 T17."address_line_1",
+                 T17."address_line_2",
+                 T17."post_code",
+                 T17."city",
+                 T17."department",
+                 T17."coords",
+                 T17."geocoding_score",
+                 T17."geocoding_updated_at",
+                 T17."ban_api_resolved_address",
+                 T17."insee_city_id",
+                 T17."title",
+                 T17."email",
+                 T17."phone",
+                 T17."kind",
+                 T17."identity_provider",
+                 T17."has_completed_welcoming_tour",
+                 T17."created_by_id",
+                 T17."external_data_source_history",
+                 T17."last_checked_at",
+                 T17."public_id",
+                 T17."address_filled_at",
+                 T17."first_login",
+                 T18."id",
+                 T18."address_line_1",
+                 T18."address_line_2",
+                 T18."post_code",
+                 T18."city",
+                 T18."department",
+                 T18."coords",
+                 T18."geocoding_score",
+                 T18."geocoding_updated_at",
+                 T18."ban_api_resolved_address",
+                 T18."insee_city_id",
+                 T18."name",
+                 T18."created_at",
+                 T18."updated_at",
+                 T18."uid",
+                 T18."active_members_email_reminder_last_sent_at",
+                 T18."siret",
+                 T18."naf",
+                 T18."kind",
+                 T18."brand",
+                 T18."phone",
+                 T18."email",
+                 T18."auth_email",
+                 T18."website",
+                 T18."description",
+                 T18."provided_support",
+                 T18."source",
+                 T18."created_by_id",
+                 T18."block_job_applications",
+                 T18."job_applications_blocked_at",
+                 T18."convention_id",
+                 T18."job_app_score",
+                 T18."rdv_solidarites_id",
+                 T19."id",
+                 T19."address_line_1",
+                 T19."address_line_2",
+                 T19."post_code",
+                 T19."city",
+                 T19."department",
+                 T19."coords",
+                 T19."geocoding_score",
+                 T19."geocoding_updated_at",
+                 T19."ban_api_resolved_address",
+                 T19."insee_city_id",
+                 T19."name",
+                 T19."created_at",
+                 T19."updated_at",
+                 T19."uid",
+                 T19."active_members_email_reminder_last_sent_at",
+                 T19."siret",
+                 T19."is_head_office",
+                 T19."kind",
+                 T19."is_brsa",
+                 T19."phone",
+                 T19."email",
+                 T19."website",
+                 T19."description",
+                 T19."is_authorized",
+                 T19."code_safir_pole_emploi",
+                 T19."created_by_id",
+                 T19."authorization_status",
+                 T19."authorization_updated_at",
+                 T19."authorization_updated_by_id",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_solidarites_id",
+                 T20."id",
+                 T20."password",
+                 T20."last_login",
+                 T20."is_superuser",
+                 T20."username",
+                 T20."first_name",
+                 T20."last_name",
+                 T20."is_staff",
+                 T20."is_active",
+                 T20."date_joined",
+                 T20."address_line_1",
+                 T20."address_line_2",
+                 T20."post_code",
+                 T20."city",
+                 T20."department",
+                 T20."coords",
+                 T20."geocoding_score",
+                 T20."geocoding_updated_at",
+                 T20."ban_api_resolved_address",
+                 T20."insee_city_id",
+                 T20."title",
+                 T20."email",
+                 T20."phone",
+                 T20."kind",
+                 T20."identity_provider",
+                 T20."has_completed_welcoming_tour",
+                 T20."created_by_id",
+                 T20."external_data_source_history",
+                 T20."last_checked_at",
+                 T20."public_id",
+                 T20."address_filled_at",
+                 T20."first_login",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          INNER JOIN "users_user" T5 ON ("job_applications_jobapplication"."job_seeker_id" = T5."id")
+          LEFT OUTER JOIN "rdv_insertion_participation" ON (T5."id" = "rdv_insertion_participation"."job_seeker_id")
+          LEFT OUTER JOIN "rdv_insertion_appointment" ON ("rdv_insertion_participation"."appointment_id" = "rdv_insertion_appointment"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON (T5."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
+          LEFT OUTER JOIN "users_user" T11 ON ("eligibility_eligibilitydiagnosis"."author_id" = T11."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "users_user" T13 ON ("eligibility_eligibilitydiagnosis"."job_seeker_id" = T13."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" T14 ON (T13."id" = T14."user_id")
+          LEFT OUTER JOIN "companies_company" T15 ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = T15."id")
+          LEFT OUTER JOIN "eligibility_geiqeligibilitydiagnosis" ON ("job_applications_jobapplication"."geiq_eligibility_diagnosis_id" = "eligibility_geiqeligibilitydiagnosis"."id")
+          LEFT OUTER JOIN "users_user" T17 ON ("job_applications_jobapplication"."sender_id" = T17."id")
+          LEFT OUTER JOIN "companies_company" T18 ON ("job_applications_jobapplication"."sender_company_id" = T18."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" T19 ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = T19."id")
+          LEFT OUTER JOIN "users_user" T20 ON ("job_applications_jobapplication"."archived_by_id" = T20."id")
+          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "users_user"."is_active"
+                 AND "job_applications_jobapplication"."id" = %s)
+          GROUP BY "job_applications_jobapplication"."id",
+                   T5."id",
+                   "users_jobseekerprofile"."user_id",
+                   "eligibility_eligibilitydiagnosis"."id",
+                   T11."id",
+                   "prescribers_prescriberorganization"."id",
+                   T13."id",
+                   T14."user_id",
+                   T15."id",
+                   "eligibility_geiqeligibilitydiagnosis"."id",
+                   T17."id",
+                   T18."id",
+                   T19."id",
+                   "companies_company"."id",
+                   T20."id",
+                   "approvals_approval"."id"
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
+                 "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."contract_nature",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source"
+          FROM "companies_jobdescription"
+          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          ORDER BY "jobs_appellation"."name" ASC,
+                   "companies_jobdescription"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'User.latest_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.has_admin[common_apps/organizations/models.py]',
+          'Company.convention_can_be_accessed_by[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE ("companies_companymembership"."id" IN
+                   (SELECT U0."id"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = %s
+                           AND U2."is_active"
+                           AND U0."is_active"
+                           AND U0."is_admin"
+                           AND U2."is_active"))
+                 AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details_company.html]',
+          'IfNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'User.latest_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
+          'VariableNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details_company.html]',
+          'IfNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ForNode[apply/includes/transition_logs.html]',
+          'WithNode[apply/includes/transition_logs.html]',
+          'IncludeNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplicationtransitionlog"."id",
+                 "job_applications_jobapplicationtransitionlog"."transition",
+                 "job_applications_jobapplicationtransitionlog"."from_state",
+                 "job_applications_jobapplicationtransitionlog"."to_state",
+                 "job_applications_jobapplicationtransitionlog"."timestamp",
+                 "job_applications_jobapplicationtransitionlog"."job_application_id",
+                 "job_applications_jobapplicationtransitionlog"."user_id",
+                 "job_applications_jobapplicationtransitionlog"."target_company_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "job_applications_jobapplicationtransitionlog"
+          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplicationtransitionlog"."user_id" = "users_user"."id")
+          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" = %s
+          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobApplication.can_be_cancelled[job_applications/models.py]',
+          'IfNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "employee_record_employeerecord"
+          WHERE "employee_record_employeerecord"."job_application_id" = %s
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          UPDATE "django_session"
+          SET "session_data" = %s,
+              "expire_date" = %s
+          WHERE "django_session"."session_key" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: ProcessViewsTest.test_details_for_company_from_list[job application detail for company]
+  dict({
+    'num_queries': 18,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "companies_companymembership"."notifications"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "companies_companymembership"."is_active")
+          ORDER BY "companies_companymembership"."created_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_solidarites_id",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_siaeconvention" U0
+             WHERE (U0."deactivated_at" >= %s
+                    AND U0."id" = ("companies_company"."convention_id"))
+             LIMIT 1) AS "has_convention_in_grace_period",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_company"
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND "companies_companymembership"."user_id" = %s
+                 AND "companies_company"."id" IN (%s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."deactivated_at" >= %s
+                                AND U0."id" = ("companies_company"."convention_id"))
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_link",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "rdv_insertion_invitationrequest" U0
+             WHERE (U0."company_id" = ("job_applications_jobapplication"."to_company_id")
+                    AND U0."created_at" > %s
+                    AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
+             LIMIT 1) AS "has_pending_rdv_insertion_invitation_request",
+                 COUNT("rdv_insertion_participation"."id") FILTER (
+                                                                   WHERE ("rdv_insertion_appointment"."company_id" = %s
+                                                                          AND "rdv_insertion_appointment"."start_at" > %s
+                                                                          AND "rdv_insertion_participation"."status" = %s)) AS "upcoming_participations_count",
+                 T5."id",
+                 T5."password",
+                 T5."last_login",
+                 T5."is_superuser",
+                 T5."username",
+                 T5."first_name",
+                 T5."last_name",
+                 T5."is_staff",
+                 T5."is_active",
+                 T5."date_joined",
+                 T5."address_line_1",
+                 T5."address_line_2",
+                 T5."post_code",
+                 T5."city",
+                 T5."department",
+                 T5."coords",
+                 T5."geocoding_score",
+                 T5."geocoding_updated_at",
+                 T5."ban_api_resolved_address",
+                 T5."insee_city_id",
+                 T5."title",
+                 T5."email",
+                 T5."phone",
+                 T5."kind",
+                 T5."identity_provider",
+                 T5."has_completed_welcoming_tour",
+                 T5."created_by_id",
+                 T5."external_data_source_history",
+                 T5."last_checked_at",
+                 T5."public_id",
+                 T5."address_filled_at",
+                 T5."first_login",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."ata_allocation_since",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "eligibility_eligibilitydiagnosis"."id",
+                 "eligibility_eligibilitydiagnosis"."author_id",
+                 "eligibility_eligibilitydiagnosis"."author_kind",
+                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
+                 "eligibility_eligibilitydiagnosis"."created_at",
+                 "eligibility_eligibilitydiagnosis"."updated_at",
+                 "eligibility_eligibilitydiagnosis"."expires_at",
+                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
+                 "eligibility_eligibilitydiagnosis"."author_siae_id",
+                 T11."id",
+                 T11."password",
+                 T11."last_login",
+                 T11."is_superuser",
+                 T11."username",
+                 T11."first_name",
+                 T11."last_name",
+                 T11."is_staff",
+                 T11."is_active",
+                 T11."date_joined",
+                 T11."address_line_1",
+                 T11."address_line_2",
+                 T11."post_code",
+                 T11."city",
+                 T11."department",
+                 T11."coords",
+                 T11."geocoding_score",
+                 T11."geocoding_updated_at",
+                 T11."ban_api_resolved_address",
+                 T11."insee_city_id",
+                 T11."title",
+                 T11."email",
+                 T11."phone",
+                 T11."kind",
+                 T11."identity_provider",
+                 T11."has_completed_welcoming_tour",
+                 T11."created_by_id",
+                 T11."external_data_source_history",
+                 T11."last_checked_at",
+                 T11."public_id",
+                 T11."address_filled_at",
+                 T11."first_login",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."is_head_office",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."is_authorized",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 T13."id",
+                 T13."password",
+                 T13."last_login",
+                 T13."is_superuser",
+                 T13."username",
+                 T13."first_name",
+                 T13."last_name",
+                 T13."is_staff",
+                 T13."is_active",
+                 T13."date_joined",
+                 T13."address_line_1",
+                 T13."address_line_2",
+                 T13."post_code",
+                 T13."city",
+                 T13."department",
+                 T13."coords",
+                 T13."geocoding_score",
+                 T13."geocoding_updated_at",
+                 T13."ban_api_resolved_address",
+                 T13."insee_city_id",
+                 T13."title",
+                 T13."email",
+                 T13."phone",
+                 T13."kind",
+                 T13."identity_provider",
+                 T13."has_completed_welcoming_tour",
+                 T13."created_by_id",
+                 T13."external_data_source_history",
+                 T13."last_checked_at",
+                 T13."public_id",
+                 T13."address_filled_at",
+                 T13."first_login",
+                 T14."user_id",
+                 T14."birthdate",
+                 T14."birth_place_id",
+                 T14."birth_country_id",
+                 T14."nir",
+                 T14."lack_of_nir_reason",
+                 T14."pole_emploi_id",
+                 T14."lack_of_pole_emploi_id_reason",
+                 T14."asp_uid",
+                 T14."education_level",
+                 T14."resourceless",
+                 T14."rqth_employee",
+                 T14."oeth_employee",
+                 T14."pole_emploi_since",
+                 T14."unemployed_since",
+                 T14."has_rsa_allocation",
+                 T14."rsa_allocation_since",
+                 T14."ass_allocation_since",
+                 T14."aah_allocation_since",
+                 T14."ata_allocation_since",
+                 T14."hexa_lane_number",
+                 T14."hexa_std_extension",
+                 T14."hexa_non_std_extension",
+                 T14."hexa_lane_type",
+                 T14."hexa_lane_name",
+                 T14."hexa_additional_address",
+                 T14."hexa_post_code",
+                 T14."hexa_commune_id",
+                 T14."pe_obfuscated_nir",
+                 T14."pe_last_certification_attempt_at",
+                 T15."id",
+                 T15."address_line_1",
+                 T15."address_line_2",
+                 T15."post_code",
+                 T15."city",
+                 T15."department",
+                 T15."coords",
+                 T15."geocoding_score",
+                 T15."geocoding_updated_at",
+                 T15."ban_api_resolved_address",
+                 T15."insee_city_id",
+                 T15."name",
+                 T15."created_at",
+                 T15."updated_at",
+                 T15."uid",
+                 T15."active_members_email_reminder_last_sent_at",
+                 T15."siret",
+                 T15."naf",
+                 T15."kind",
+                 T15."brand",
+                 T15."phone",
+                 T15."email",
+                 T15."auth_email",
+                 T15."website",
+                 T15."description",
+                 T15."provided_support",
+                 T15."source",
+                 T15."created_by_id",
+                 T15."block_job_applications",
+                 T15."job_applications_blocked_at",
+                 T15."convention_id",
+                 T15."job_app_score",
+                 T15."rdv_solidarites_id",
+                 "eligibility_geiqeligibilitydiagnosis"."id",
+                 "eligibility_geiqeligibilitydiagnosis"."author_id",
+                 "eligibility_geiqeligibilitydiagnosis"."author_kind",
+                 "eligibility_geiqeligibilitydiagnosis"."author_prescriber_organization_id",
+                 "eligibility_geiqeligibilitydiagnosis"."created_at",
+                 "eligibility_geiqeligibilitydiagnosis"."updated_at",
+                 "eligibility_geiqeligibilitydiagnosis"."expires_at",
+                 "eligibility_geiqeligibilitydiagnosis"."job_seeker_id",
+                 "eligibility_geiqeligibilitydiagnosis"."author_geiq_id",
+                 T17."id",
+                 T17."password",
+                 T17."last_login",
+                 T17."is_superuser",
+                 T17."username",
+                 T17."first_name",
+                 T17."last_name",
+                 T17."is_staff",
+                 T17."is_active",
+                 T17."date_joined",
+                 T17."address_line_1",
+                 T17."address_line_2",
+                 T17."post_code",
+                 T17."city",
+                 T17."department",
+                 T17."coords",
+                 T17."geocoding_score",
+                 T17."geocoding_updated_at",
+                 T17."ban_api_resolved_address",
+                 T17."insee_city_id",
+                 T17."title",
+                 T17."email",
+                 T17."phone",
+                 T17."kind",
+                 T17."identity_provider",
+                 T17."has_completed_welcoming_tour",
+                 T17."created_by_id",
+                 T17."external_data_source_history",
+                 T17."last_checked_at",
+                 T17."public_id",
+                 T17."address_filled_at",
+                 T17."first_login",
+                 T18."id",
+                 T18."address_line_1",
+                 T18."address_line_2",
+                 T18."post_code",
+                 T18."city",
+                 T18."department",
+                 T18."coords",
+                 T18."geocoding_score",
+                 T18."geocoding_updated_at",
+                 T18."ban_api_resolved_address",
+                 T18."insee_city_id",
+                 T18."name",
+                 T18."created_at",
+                 T18."updated_at",
+                 T18."uid",
+                 T18."active_members_email_reminder_last_sent_at",
+                 T18."siret",
+                 T18."naf",
+                 T18."kind",
+                 T18."brand",
+                 T18."phone",
+                 T18."email",
+                 T18."auth_email",
+                 T18."website",
+                 T18."description",
+                 T18."provided_support",
+                 T18."source",
+                 T18."created_by_id",
+                 T18."block_job_applications",
+                 T18."job_applications_blocked_at",
+                 T18."convention_id",
+                 T18."job_app_score",
+                 T18."rdv_solidarites_id",
+                 T19."id",
+                 T19."address_line_1",
+                 T19."address_line_2",
+                 T19."post_code",
+                 T19."city",
+                 T19."department",
+                 T19."coords",
+                 T19."geocoding_score",
+                 T19."geocoding_updated_at",
+                 T19."ban_api_resolved_address",
+                 T19."insee_city_id",
+                 T19."name",
+                 T19."created_at",
+                 T19."updated_at",
+                 T19."uid",
+                 T19."active_members_email_reminder_last_sent_at",
+                 T19."siret",
+                 T19."is_head_office",
+                 T19."kind",
+                 T19."is_brsa",
+                 T19."phone",
+                 T19."email",
+                 T19."website",
+                 T19."description",
+                 T19."is_authorized",
+                 T19."code_safir_pole_emploi",
+                 T19."created_by_id",
+                 T19."authorization_status",
+                 T19."authorization_updated_at",
+                 T19."authorization_updated_by_id",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_solidarites_id",
+                 T20."id",
+                 T20."password",
+                 T20."last_login",
+                 T20."is_superuser",
+                 T20."username",
+                 T20."first_name",
+                 T20."last_name",
+                 T20."is_staff",
+                 T20."is_active",
+                 T20."date_joined",
+                 T20."address_line_1",
+                 T20."address_line_2",
+                 T20."post_code",
+                 T20."city",
+                 T20."department",
+                 T20."coords",
+                 T20."geocoding_score",
+                 T20."geocoding_updated_at",
+                 T20."ban_api_resolved_address",
+                 T20."insee_city_id",
+                 T20."title",
+                 T20."email",
+                 T20."phone",
+                 T20."kind",
+                 T20."identity_provider",
+                 T20."has_completed_welcoming_tour",
+                 T20."created_by_id",
+                 T20."external_data_source_history",
+                 T20."last_checked_at",
+                 T20."public_id",
+                 T20."address_filled_at",
+                 T20."first_login",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          INNER JOIN "users_user" T5 ON ("job_applications_jobapplication"."job_seeker_id" = T5."id")
+          LEFT OUTER JOIN "rdv_insertion_participation" ON (T5."id" = "rdv_insertion_participation"."job_seeker_id")
+          LEFT OUTER JOIN "rdv_insertion_appointment" ON ("rdv_insertion_participation"."appointment_id" = "rdv_insertion_appointment"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON (T5."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
+          LEFT OUTER JOIN "users_user" T11 ON ("eligibility_eligibilitydiagnosis"."author_id" = T11."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "users_user" T13 ON ("eligibility_eligibilitydiagnosis"."job_seeker_id" = T13."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" T14 ON (T13."id" = T14."user_id")
+          LEFT OUTER JOIN "companies_company" T15 ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = T15."id")
+          LEFT OUTER JOIN "eligibility_geiqeligibilitydiagnosis" ON ("job_applications_jobapplication"."geiq_eligibility_diagnosis_id" = "eligibility_geiqeligibilitydiagnosis"."id")
+          LEFT OUTER JOIN "users_user" T17 ON ("job_applications_jobapplication"."sender_id" = T17."id")
+          LEFT OUTER JOIN "companies_company" T18 ON ("job_applications_jobapplication"."sender_company_id" = T18."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" T19 ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = T19."id")
+          LEFT OUTER JOIN "users_user" T20 ON ("job_applications_jobapplication"."archived_by_id" = T20."id")
+          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          WHERE ("companies_companymembership"."user_id" = %s
+                 AND "users_user"."is_active"
+                 AND "job_applications_jobapplication"."id" = %s)
+          GROUP BY "job_applications_jobapplication"."id",
+                   T5."id",
+                   "users_jobseekerprofile"."user_id",
+                   "eligibility_eligibilitydiagnosis"."id",
+                   T11."id",
+                   "prescribers_prescriberorganization"."id",
+                   T13."id",
+                   T14."user_id",
+                   T15."id",
+                   "eligibility_geiqeligibilitydiagnosis"."id",
+                   T17."id",
+                   T18."id",
+                   T19."id",
+                   "companies_company"."id",
+                   T20."id",
+                   "approvals_approval"."id"
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
+                 "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."contract_nature",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source"
+          FROM "companies_jobdescription"
+          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          ORDER BY "jobs_appellation"."name" ASC,
+                   "companies_jobdescription"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'User.latest_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Company.has_admin[common_apps/organizations/models.py]',
+          'Company.convention_can_be_accessed_by[companies/models.py]',
+          'nav[utils/templatetags/nav.py]',
+          'InclusionNode[layout/_header_authenticated.html]',
+          'IncludeNode[layout/base.html]',
+          'IfNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE ("companies_companymembership"."id" IN
+                   (SELECT U0."id"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = %s
+                           AND U2."is_active"
+                           AND U0."is_active"
+                           AND U0."is_admin"
+                           AND U2."is_active"))
+                 AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details_company.html]',
+          'IfNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'User.latest_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
+          'VariableNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details_company.html]',
+          'IfNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ForNode[apply/includes/transition_logs.html]',
+          'WithNode[apply/includes/transition_logs.html]',
+          'IncludeNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplicationtransitionlog"."id",
+                 "job_applications_jobapplicationtransitionlog"."transition",
+                 "job_applications_jobapplicationtransitionlog"."from_state",
+                 "job_applications_jobapplicationtransitionlog"."to_state",
+                 "job_applications_jobapplicationtransitionlog"."timestamp",
+                 "job_applications_jobapplicationtransitionlog"."job_application_id",
+                 "job_applications_jobapplicationtransitionlog"."user_id",
+                 "job_applications_jobapplicationtransitionlog"."target_company_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "job_applications_jobapplicationtransitionlog"
+          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplicationtransitionlog"."user_id" = "users_user"."id")
+          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" = %s
+          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobApplication.can_be_cancelled[job_applications/models.py]',
+          'IfNode[apply/process_details_company.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details_company.html]',
+          'details_for_company[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "employee_record_employeerecord"
+          WHERE "employee_record_employeerecord"."job_application_id" = %s
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          UPDATE "django_session"
+          SET "session_data" = %s,
+              "expire_date" = %s
+          WHERE "django_session"."session_key" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: ProcessViewsTest.test_details_for_company_transition_logs_hides_hired_by_other
+  '''
+  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
+
+
+              <li>
+                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
+                  <span>
+
+                          Passé en "Embauché ailleurs"
+
+
+                  </span>
+              </li>
+
+          <li>
+              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
+              <span>Nouvelle candidature</span>
+          </li>
+
+  </ul>
+  '''
+# ---
+# name: ProcessViewsTest.test_details_for_company_with_transition_logs
+  '''
+  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
+
+
+              <li>
+                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
+                  <span>
+
+                          Passé en "Candidature acceptée"
+
+                      par John DOE
+                  </span>
+              </li>
+
+              <li>
+                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
+                  <span>
+
+                          Passé en "Candidature à l'étude"
+
+                      par John DOE
+                  </span>
+              </li>
+
+          <li>
+              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
+              <span>Nouvelle candidature</span>
+          </li>
+
+  </ul>
+  '''
+# ---
+# name: ProcessViewsTest.test_details_for_job_seeker[test_details_for_job_seeker]
+  dict({
+    'num_queries': 17,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_link",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."ata_allocation_since",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "eligibility_eligibilitydiagnosis"."id",
+                 "eligibility_eligibilitydiagnosis"."author_id",
+                 "eligibility_eligibilitydiagnosis"."author_kind",
+                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
+                 "eligibility_eligibilitydiagnosis"."created_at",
+                 "eligibility_eligibilitydiagnosis"."updated_at",
+                 "eligibility_eligibilitydiagnosis"."expires_at",
+                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
+                 "eligibility_eligibilitydiagnosis"."author_siae_id",
+                 T5."id",
+                 T5."password",
+                 T5."last_login",
+                 T5."is_superuser",
+                 T5."username",
+                 T5."first_name",
+                 T5."last_name",
+                 T5."is_staff",
+                 T5."is_active",
+                 T5."date_joined",
+                 T5."address_line_1",
+                 T5."address_line_2",
+                 T5."post_code",
+                 T5."city",
+                 T5."department",
+                 T5."coords",
+                 T5."geocoding_score",
+                 T5."geocoding_updated_at",
+                 T5."ban_api_resolved_address",
+                 T5."insee_city_id",
+                 T5."title",
+                 T5."email",
+                 T5."phone",
+                 T5."kind",
+                 T5."identity_provider",
+                 T5."has_completed_welcoming_tour",
+                 T5."created_by_id",
+                 T5."external_data_source_history",
+                 T5."last_checked_at",
+                 T5."public_id",
+                 T5."address_filled_at",
+                 T5."first_login",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."is_head_office",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."is_authorized",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 T7."id",
+                 T7."password",
+                 T7."last_login",
+                 T7."is_superuser",
+                 T7."username",
+                 T7."first_name",
+                 T7."last_name",
+                 T7."is_staff",
+                 T7."is_active",
+                 T7."date_joined",
+                 T7."address_line_1",
+                 T7."address_line_2",
+                 T7."post_code",
+                 T7."city",
+                 T7."department",
+                 T7."coords",
+                 T7."geocoding_score",
+                 T7."geocoding_updated_at",
+                 T7."ban_api_resolved_address",
+                 T7."insee_city_id",
+                 T7."title",
+                 T7."email",
+                 T7."phone",
+                 T7."kind",
+                 T7."identity_provider",
+                 T7."has_completed_welcoming_tour",
+                 T7."created_by_id",
+                 T7."external_data_source_history",
+                 T7."last_checked_at",
+                 T7."public_id",
+                 T7."address_filled_at",
+                 T7."first_login",
+                 T8."user_id",
+                 T8."birthdate",
+                 T8."birth_place_id",
+                 T8."birth_country_id",
+                 T8."nir",
+                 T8."lack_of_nir_reason",
+                 T8."pole_emploi_id",
+                 T8."lack_of_pole_emploi_id_reason",
+                 T8."asp_uid",
+                 T8."education_level",
+                 T8."resourceless",
+                 T8."rqth_employee",
+                 T8."oeth_employee",
+                 T8."pole_emploi_since",
+                 T8."unemployed_since",
+                 T8."has_rsa_allocation",
+                 T8."rsa_allocation_since",
+                 T8."ass_allocation_since",
+                 T8."aah_allocation_since",
+                 T8."ata_allocation_since",
+                 T8."hexa_lane_number",
+                 T8."hexa_std_extension",
+                 T8."hexa_non_std_extension",
+                 T8."hexa_lane_type",
+                 T8."hexa_lane_name",
+                 T8."hexa_additional_address",
+                 T8."hexa_post_code",
+                 T8."hexa_commune_id",
+                 T8."pe_obfuscated_nir",
+                 T8."pe_last_certification_attempt_at",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_solidarites_id",
+                 T10."id",
+                 T10."password",
+                 T10."last_login",
+                 T10."is_superuser",
+                 T10."username",
+                 T10."first_name",
+                 T10."last_name",
+                 T10."is_staff",
+                 T10."is_active",
+                 T10."date_joined",
+                 T10."address_line_1",
+                 T10."address_line_2",
+                 T10."post_code",
+                 T10."city",
+                 T10."department",
+                 T10."coords",
+                 T10."geocoding_score",
+                 T10."geocoding_updated_at",
+                 T10."ban_api_resolved_address",
+                 T10."insee_city_id",
+                 T10."title",
+                 T10."email",
+                 T10."phone",
+                 T10."kind",
+                 T10."identity_provider",
+                 T10."has_completed_welcoming_tour",
+                 T10."created_by_id",
+                 T10."external_data_source_history",
+                 T10."last_checked_at",
+                 T10."public_id",
+                 T10."address_filled_at",
+                 T10."first_login",
+                 T11."id",
+                 T11."address_line_1",
+                 T11."address_line_2",
+                 T11."post_code",
+                 T11."city",
+                 T11."department",
+                 T11."coords",
+                 T11."geocoding_score",
+                 T11."geocoding_updated_at",
+                 T11."ban_api_resolved_address",
+                 T11."insee_city_id",
+                 T11."name",
+                 T11."created_at",
+                 T11."updated_at",
+                 T11."uid",
+                 T11."active_members_email_reminder_last_sent_at",
+                 T11."siret",
+                 T11."naf",
+                 T11."kind",
+                 T11."brand",
+                 T11."phone",
+                 T11."email",
+                 T11."auth_email",
+                 T11."website",
+                 T11."description",
+                 T11."provided_support",
+                 T11."source",
+                 T11."created_by_id",
+                 T11."block_job_applications",
+                 T11."job_applications_blocked_at",
+                 T11."convention_id",
+                 T11."job_app_score",
+                 T11."rdv_solidarites_id"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("job_applications_jobapplication"."eligibility_diagnosis_id" = "eligibility_eligibilitydiagnosis"."id")
+          LEFT OUTER JOIN "users_user" T5 ON ("eligibility_eligibilitydiagnosis"."author_id" = T5."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "users_user" T7 ON ("eligibility_eligibilitydiagnosis"."job_seeker_id" = T7."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" T8 ON (T7."id" = T8."user_id")
+          LEFT OUTER JOIN "companies_company" ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = "companies_company"."id")
+          LEFT OUTER JOIN "users_user" T10 ON ("job_applications_jobapplication"."sender_id" = T10."id")
+          INNER JOIN "companies_company" T11 ON ("job_applications_jobapplication"."to_company_id" = T11."id")
+          WHERE ("job_applications_jobapplication"."id" = %s
+                 AND "job_applications_jobapplication"."job_seeker_id" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
+                 "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."contract_nature",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source"
+          FROM "companies_jobdescription"
+          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          ORDER BY "jobs_appellation"."name" ASC,
+                   "companies_jobdescription"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'User.latest_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'User.latest_pe_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_poleemploiapproval"."id",
+                 "approvals_poleemploiapproval"."start_at",
+                 "approvals_poleemploiapproval"."end_at",
+                 "approvals_poleemploiapproval"."created_at",
+                 "approvals_poleemploiapproval"."pe_notification_status",
+                 "approvals_poleemploiapproval"."pe_notification_time",
+                 "approvals_poleemploiapproval"."pe_notification_endpoint",
+                 "approvals_poleemploiapproval"."pe_notification_exit_code",
+                 "approvals_poleemploiapproval"."pe_structure_code",
+                 "approvals_poleemploiapproval"."number",
+                 "approvals_poleemploiapproval"."pole_emploi_id",
+                 "approvals_poleemploiapproval"."first_name",
+                 "approvals_poleemploiapproval"."last_name",
+                 "approvals_poleemploiapproval"."birth_name",
+                 "approvals_poleemploiapproval"."birthdate",
+                 "approvals_poleemploiapproval"."nir",
+                 "approvals_poleemploiapproval"."ntt_nia",
+                 "approvals_poleemploiapproval"."siae_siret",
+                 "approvals_poleemploiapproval"."siae_kind"
+          FROM "approvals_poleemploiapproval"
+          WHERE ("approvals_poleemploiapproval"."nir" = %s
+                 AND NOT ("approvals_poleemploiapproval"."number" IN
+                            (SELECT U0."number"
+                             FROM "approvals_approval" U0
+                             WHERE U0."user_id" = %s)))
+          ORDER BY "approvals_poleemploiapproval"."end_at" DESC,
+                   "approvals_poleemploiapproval"."start_at" ASC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EligibilityDiagnosisQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_considered_valid[eligibility/models/iae.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.has_considered_valid[eligibility/models/iae.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_expired[eligibility/models/iae.py]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_eligibilitydiagnosis"."id",
+                 "eligibility_eligibilitydiagnosis"."author_id",
+                 "eligibility_eligibilitydiagnosis"."author_kind",
+                 "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id",
+                 "eligibility_eligibilitydiagnosis"."created_at",
+                 "eligibility_eligibilitydiagnosis"."updated_at",
+                 "eligibility_eligibilitydiagnosis"."expires_at",
+                 "eligibility_eligibilitydiagnosis"."job_seeker_id",
+                 "eligibility_eligibilitydiagnosis"."author_siae_id",
+                 CASE
+                     WHEN "eligibility_eligibilitydiagnosis"."author_kind" = %s THEN %s
+                     ELSE %s
+                 END AS "from_prescriber",
+                 T4."id",
+                 T4."password",
+                 T4."last_login",
+                 T4."is_superuser",
+                 T4."username",
+                 T4."first_name",
+                 T4."last_name",
+                 T4."is_staff",
+                 T4."is_active",
+                 T4."date_joined",
+                 T4."address_line_1",
+                 T4."address_line_2",
+                 T4."post_code",
+                 T4."city",
+                 T4."department",
+                 T4."coords",
+                 T4."geocoding_score",
+                 T4."geocoding_updated_at",
+                 T4."ban_api_resolved_address",
+                 T4."insee_city_id",
+                 T4."title",
+                 T4."email",
+                 T4."phone",
+                 T4."kind",
+                 T4."identity_provider",
+                 T4."has_completed_welcoming_tour",
+                 T4."created_by_id",
+                 T4."external_data_source_history",
+                 T4."last_checked_at",
+                 T4."public_id",
+                 T4."address_filled_at",
+                 T4."first_login",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."is_head_office",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."is_authorized",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "eligibility_eligibilitydiagnosis"
+          LEFT OUTER JOIN "companies_company" ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = "companies_company"."id")
+          INNER JOIN "users_user" T4 ON ("eligibility_eligibilitydiagnosis"."author_id" = T4."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE (("eligibility_eligibilitydiagnosis"."author_kind" = %s
+                  OR "eligibility_eligibilitydiagnosis"."author_siae_id" = %s)
+                 AND "eligibility_eligibilitydiagnosis"."job_seeker_id" = %s
+                 AND "eligibility_eligibilitydiagnosis"."expires_at" > %s)
+          ORDER BY 10 DESC,
+                   "eligibility_eligibilitydiagnosis"."created_at" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details.html]',
+          'IfNode[apply/process_details.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details.html]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'User.latest_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
+          'VariableNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details.html]',
+          'IfNode[apply/process_details.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details.html]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'User.latest_pe_approval[users/models.py]',
+          'User.has_valid_common_approval[users/models.py]',
+          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
+          'VariableNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/process_details.html]',
+          'IfNode[apply/process_details.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details.html]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_poleemploiapproval"."id",
+                 "approvals_poleemploiapproval"."start_at",
+                 "approvals_poleemploiapproval"."end_at",
+                 "approvals_poleemploiapproval"."created_at",
+                 "approvals_poleemploiapproval"."pe_notification_status",
+                 "approvals_poleemploiapproval"."pe_notification_time",
+                 "approvals_poleemploiapproval"."pe_notification_endpoint",
+                 "approvals_poleemploiapproval"."pe_notification_exit_code",
+                 "approvals_poleemploiapproval"."pe_structure_code",
+                 "approvals_poleemploiapproval"."number",
+                 "approvals_poleemploiapproval"."pole_emploi_id",
+                 "approvals_poleemploiapproval"."first_name",
+                 "approvals_poleemploiapproval"."last_name",
+                 "approvals_poleemploiapproval"."birth_name",
+                 "approvals_poleemploiapproval"."birthdate",
+                 "approvals_poleemploiapproval"."nir",
+                 "approvals_poleemploiapproval"."ntt_nia",
+                 "approvals_poleemploiapproval"."siae_siret",
+                 "approvals_poleemploiapproval"."siae_kind"
+          FROM "approvals_poleemploiapproval"
+          WHERE ("approvals_poleemploiapproval"."nir" = %s
+                 AND NOT ("approvals_poleemploiapproval"."number" IN
+                            (SELECT U0."number"
+                             FROM "approvals_approval" U0
+                             WHERE U0."user_id" = %s)))
+          ORDER BY "approvals_poleemploiapproval"."end_at" DESC,
+                   "approvals_poleemploiapproval"."start_at" ASC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ForNode[apply/includes/transition_logs.html]',
+          'WithNode[apply/includes/transition_logs.html]',
+          'IncludeNode[apply/process_details.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_details.html]',
+          'details_for_jobseeker[www/apply/views/process_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplicationtransitionlog"."id",
+                 "job_applications_jobapplicationtransitionlog"."transition",
+                 "job_applications_jobapplicationtransitionlog"."from_state",
+                 "job_applications_jobapplicationtransitionlog"."to_state",
+                 "job_applications_jobapplicationtransitionlog"."timestamp",
+                 "job_applications_jobapplicationtransitionlog"."job_application_id",
+                 "job_applications_jobapplicationtransitionlog"."user_id",
+                 "job_applications_jobapplicationtransitionlog"."target_company_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "job_applications_jobapplicationtransitionlog"
+          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplicationtransitionlog"."user_id" = "users_user"."id")
+          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" = %s
+          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          UPDATE "django_session"
+          SET "session_data" = %s,
+              "expire_date" = %s
+          WHERE "django_session"."session_key" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'SessionStore.save[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: ProcessViewsTest.test_details_for_job_seeker_with_transition_logs
+  '''
+  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
+
+
+              <li>
+                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
+                  <span>
+
+                          Passé en "Candidature acceptée"
+
+                      par John DOE
+                  </span>
+              </li>
+
+              <li>
+                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
+                  <span>
+
+                          Passé en "Candidature à l'étude"
+
+                      par John DOE
+                  </span>
+              </li>
+
+          <li>
+              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
+              <span>Nouvelle candidature</span>
+          </li>
+
+  </ul>
+  '''
+# ---
+# name: ProcessViewsTest.test_details_for_prescriber_with_transition_logs
+  '''
+  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
+
+
+              <li>
+                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
+                  <span>
+
+                          Passé en "Candidature acceptée"
+
+                      par John DOE
+                  </span>
+              </li>
+
+              <li>
+                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
+                  <span>
+
+                          Passé en "Candidature à l'étude"
+
+                      par John DOE
+                  </span>
+              </li>
+
+          <li>
+              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
+              <span>Nouvelle candidature</span>
+          </li>
+
+  </ul>
+  '''
+# ---
+# name: ProcessViewsTest.test_external_transfer_log_display
+  '''
+  <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
+
+
+              <li>
+                  <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
+                  <span>
+
+                          Candidature transférée à un autre employeur
+
+                      par John DOE
+                  </span>
+              </li>
+
+              <li>
+                  <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
+                  <span>
+
+                          Passé en "Candidature déclinée"
+
+                      par John DOE
+                  </span>
+              </li>
+
+          <li>
+              <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
+              <span>Nouvelle candidature</span>
+          </li>
+
+  </ul>
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_body]
+  '''
+  Bonjour,
+
+  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
+
+  Commentaire de l’employeur:
+
+  On vous rappellera.
+
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_subject]
+  '[DEV] Votre candidature mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_proxy_body]
+  '''
+  Bonjour,
+
+  La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
+
+  Commentaire de l’employeur:
+
+  On vous rappellera.
+
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_employer_orienter[postpone_email_to_proxy_subject]
+  '[DEV] Candidature de Jane DOE mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_job_seeker[postpone_email_to_job_seeker_body]
+  '''
+  Bonjour,
+
+  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
+
+  Commentaire de l’employeur:
+
+  On vous rappellera.
+
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_job_seeker[postpone_email_to_job_seeker_subject]
+  '[DEV] Votre candidature mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_job_seeker_body]
+  '''
+  Bonjour,
+
+  Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
+
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_job_seeker_subject]
+  '[DEV] Votre candidature mise en attente par EI Acme inc.'
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_proxy_body]
+  '''
+  Bonjour,
+
+  La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
+
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: ProcessViewsTest.test_postpone_from_prescriber[postpone_email_to_proxy_subject]
+  '[DEV] Candidature de Jane DOE mise en attente par EI Acme inc.'
+# ---
 # name: TestProcessTransferJobApplication.test_job_application_external_transfer_disabled_for_bad_state
   '''
   <div class="dropdown dropdown-structure">
@@ -903,15 +4006,15 @@
           Transférer cette candidature vers
       </button>
       <div aria-labelledby="transfer_to_button" class="dropdown-menu w-100">
-          
-          
+
+
               <div data-bs-placement="bottom" data-bs-toggle="tooltip" title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur">
                   <div class="dropdown-item disabled">
                       <i class="ri-home-smile-line"></i>
                       <strong>Une autre structure</strong>
                   </div>
               </div>
-          
+
       </div>
   </div>
   '''
@@ -923,13 +4026,13 @@
           Transférer cette candidature vers
       </button>
       <div aria-labelledby="transfer_to_button" class="dropdown-menu w-100">
-          
-          
+
+
               <a class="dropdown-item" href="/apply/[PK of JobApplication]/siae/external-transfer/1">
                   <i class="ri-home-smile-line"></i>
                   <strong>Une autre structure</strong>
               </a>
-          
+
       </div>
   </div>
   '''
@@ -2876,56 +5979,56 @@
 # name: TestProcessViews.test_details_for_company_transition_logs_hides_hired_by_other
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-                      
+
                           Passé en "Embauché ailleurs"
-                      
-                      
+
+
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_details_for_company_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-                      
+
                           Passé en "Candidature acceptée"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Candidature à l'étude"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
@@ -3725,112 +6828,112 @@
 # name: TestProcessViews.test_details_for_job_seeker_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-                      
+
                           Passé en "Candidature acceptée"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Candidature à l'étude"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_details_for_prescriber_with_transition_logs
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-                      
+
                           Passé en "Candidature acceptée"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Candidature à l'étude"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_external_transfer_log_display
   '''
   <ul class="list-step" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:38:00+00:00">Le 12 décembre 2023 à 13:38</time>
                   <span>
-                      
+
                           Candidature transférée à un autre employeur
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Candidature déclinée"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:00+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_body]
   '''
   Bonjour,
-  
+
   Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-  
+
   Commentaire de l’employeur:
-  
+
   On vous rappellera.
-  
+
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -3843,13 +6946,13 @@
 # name: TestProcessViews.test_postpone_from_employer_orienter[postpone_email_to_proxy_body]
   '''
   Bonjour,
-  
+
   La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
-  
+
   Commentaire de l’employeur:
-  
+
   On vous rappellera.
-  
+
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -3862,13 +6965,13 @@
 # name: TestProcessViews.test_postpone_from_job_seeker[postpone_email_to_job_seeker_body]
   '''
   Bonjour,
-  
+
   Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-  
+
   Commentaire de l’employeur:
-  
+
   On vous rappellera.
-  
+
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -3881,9 +6984,9 @@
 # name: TestProcessViews.test_postpone_from_prescriber[postpone_email_to_job_seeker_body]
   '''
   Bonjour,
-  
+
   Suite à votre candidature au sein de la structure EI Acme inc., l’employeur a mis votre candidature en attente.
-  
+
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -3896,9 +6999,9 @@
 # name: TestProcessViews.test_postpone_from_prescriber[postpone_email_to_proxy_body]
   '''
   Bonjour,
-  
+
   La candidature de Jane DOE au sein de la structure EI Acme inc. a été mise en attente par l’employeur.
-  
+
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
@@ -3911,23 +7014,23 @@
 # name: test_add_prior_action_processing
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Action préalable à l’embauche"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:11+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
@@ -4028,239 +7131,239 @@
 # name: test_delete_prior_action[False]
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:40:00+00:00">Le 12 décembre 2023 à 13:40</time>
                   <span>
-                      
+
                           Passé en "Action préalable à l’embauche"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Candidature à l'étude"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:11+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
 # name: test_delete_prior_action[True]
   '''
   <ul class="list-step" hx-swap-oob="true" id="transition_logs_11111111-1111-1111-1111-111111111111">
-      
-          
+
+
               <li>
                   <time datetime="2023-12-12T12:40:00+00:00">Le 12 décembre 2023 à 13:40</time>
                   <span>
-                      
+
                           Passé en "Action préalable à l’embauche"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
               <li>
                   <time datetime="2023-12-12T12:37:00+00:00">Le 12 décembre 2023 à 13:37</time>
                   <span>
-                      
+
                           Passé en "Candidature à l'étude"
-                      
+
                       par John DOE
                   </span>
               </li>
-          
+
           <li>
               <time datetime="2023-12-10T10:11:11+00:00">Le 10 décembre 2023 à 11:11</time>
               <span>Nouvelle candidature</span>
           </li>
-      
+
   </ul>
   '''
 # ---
 # name: test_reload_contract_type_and_options[APPRENTICESHIP]
   '''
-  
+
   <div id="geiq_contract_type_and_options_block">
       <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_prehiring_guidance_days">Nombre de jours d’accompagnement avant contrat</label><input type="number" name="prehiring_guidance_days" min="0" class="form-control is-invalid" placeholder="Nombre de jours d’accompagnement avant contrat" required aria-invalid="true" aria-describedby="id_prehiring_guidance_days_helptext" id="id_prehiring_guidance_days">
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
-  
+
   <div class="form-text">Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche</div>
   </div>
       <div class="form-group form-group-required"><label class="form-label" for="id_contract_type">Type de contrat</label><select name="contract_type" hx-trigger="change" hx-post="/apply/10/accept/reload_contract_type_and_options" hx-swap="outerHTML" hx-select="#geiq_contract_type_and_options_block" hx-target="#geiq_contract_type_and_options_block" class="form-select" required id="id_contract_type">
     <option value="">---------</option>
-  
+
     <option value="APPRENTICESHIP" selected>Contrat d&#x27;apprentissage</option>
-  
+
     <option value="PROFESSIONAL_TRAINING">Contrat de professionalisation</option>
-  
+
     <option value="OTHER">Autre type de contrat</option>
-  
+
   </select></div>
       <div class="form-group"><div class="form-check"><input type="checkbox" name="inverted_vae_contract" class="form-check-input" disabled id="id_inverted_vae_contract"><label class="form-check-label" for="id_inverted_vae_contract">Contrat associé à une VAE inversée</label></div></div>
-      
+
       <div class="form-group form-group-required"><label class="form-label" for="id_nb_hours_per_week">Nombre d&#x27;heures par semaine</label><input type="number" name="nb_hours_per_week" min="0" class="form-control" placeholder="Nombre d&#x27;heures par semaine" required id="id_nb_hours_per_week"></div>
   </div>
-  
+
   '''
 # ---
 # name: test_reload_contract_type_and_options[OTHER]
   '''
-  
+
   <div id="geiq_contract_type_and_options_block">
       <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_prehiring_guidance_days">Nombre de jours d’accompagnement avant contrat</label><input type="number" name="prehiring_guidance_days" min="0" class="form-control is-invalid" placeholder="Nombre de jours d’accompagnement avant contrat" required aria-invalid="true" aria-describedby="id_prehiring_guidance_days_helptext" id="id_prehiring_guidance_days">
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
-  
+
   <div class="form-text">Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche</div>
   </div>
       <div class="form-group form-group-required"><label class="form-label" for="id_contract_type">Type de contrat</label><select name="contract_type" hx-trigger="change" hx-post="/apply/10/accept/reload_contract_type_and_options" hx-swap="outerHTML" hx-select="#geiq_contract_type_and_options_block" hx-target="#geiq_contract_type_and_options_block" class="form-select" required id="id_contract_type">
     <option value="">---------</option>
-  
+
     <option value="APPRENTICESHIP">Contrat d&#x27;apprentissage</option>
-  
+
     <option value="PROFESSIONAL_TRAINING">Contrat de professionalisation</option>
-  
+
     <option value="OTHER" selected>Autre type de contrat</option>
-  
+
   </select></div>
       <div class="form-group"><div class="form-check"><input type="checkbox" name="inverted_vae_contract" class="form-check-input" disabled id="id_inverted_vae_contract"><label class="form-check-label" for="id_inverted_vae_contract">Contrat associé à une VAE inversée</label></div></div>
-      
+
           <div id="contractTypeDetails"><div class="form-group"><label class="form-label" for="id_contract_type_details">Précisions sur le type de contrat</label><textarea name="contract_type_details" cols="40" rows="2" class="form-control" placeholder="Précisions sur le type de contrat" aria-describedby="id_contract_type_details_helptext" id="id_contract_type_details">
   </textarea><div class="form-text">Si vous avez choisi un autre type de contrat, merci de bien vouloir fournir plus de précisions</div>
   </div></div>
-      
+
       <div class="form-group form-group-required"><label class="form-label" for="id_nb_hours_per_week">Nombre d&#x27;heures par semaine</label><input type="number" name="nb_hours_per_week" min="0" class="form-control" placeholder="Nombre d&#x27;heures par semaine" required id="id_nb_hours_per_week"></div>
   </div>
-  
+
   '''
 # ---
 # name: test_reload_contract_type_and_options[PROFESSIONAL_TRAINING]
   '''
-  
+
   <div id="geiq_contract_type_and_options_block">
       <div class="form-group is-invalid form-group-required"><label class="form-label" for="id_prehiring_guidance_days">Nombre de jours d’accompagnement avant contrat</label><input type="number" name="prehiring_guidance_days" min="0" class="form-control is-invalid" placeholder="Nombre de jours d’accompagnement avant contrat" required aria-invalid="true" aria-describedby="id_prehiring_guidance_days_helptext" id="id_prehiring_guidance_days">
       <div class="invalid-feedback">Ce champ est obligatoire.</div>
-  
+
   <div class="form-text">Laissez "0" si vous n'avez pas accompagné le candidat avant son embauche</div>
   </div>
       <div class="form-group form-group-required"><label class="form-label" for="id_contract_type">Type de contrat</label><select name="contract_type" hx-trigger="change" hx-post="/apply/10/accept/reload_contract_type_and_options" hx-swap="outerHTML" hx-select="#geiq_contract_type_and_options_block" hx-target="#geiq_contract_type_and_options_block" class="form-select" required id="id_contract_type">
     <option value="">---------</option>
-  
+
     <option value="APPRENTICESHIP">Contrat d&#x27;apprentissage</option>
-  
+
     <option value="PROFESSIONAL_TRAINING" selected>Contrat de professionalisation</option>
-  
+
     <option value="OTHER">Autre type de contrat</option>
-  
+
   </select></div>
       <div class="form-group"><div class="form-check"><input type="checkbox" name="inverted_vae_contract" class="form-check-input" id="id_inverted_vae_contract"><label class="form-check-label" for="id_inverted_vae_contract">Contrat associé à une VAE inversée</label></div></div>
-      
+
       <div class="form-group form-group-required"><label class="form-label" for="id_nb_hours_per_week">Nombre d&#x27;heures par semaine</label><input type="number" name="nb_hours_per_week" min="0" class="form-control" placeholder="Nombre d&#x27;heures par semaine" required id="id_nb_hours_per_week"></div>
   </div>
-  
+
   '''
 # ---
 # name: test_reload_qualification_fields[CCN]
   '''
-  
+
   <div id="geiq_qualification_fields_block">
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-trigger="change" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-select="#geiq_qualification_fields_block" hx-target="#geiq_qualification_fields_block" class="form-select" required id="id_qualification_type">
     <option value="">---------</option>
-  
+
     <option value="STATE_DIPLOMA">Diplôme d&#x27;état ou titre homologué</option>
-  
+
     <option value="CQP">CQP</option>
-  
+
     <option value="CCN" selected>Positionnement de CCN</option>
-  
+
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_level">Niveau de qualification</label><select name="qualification_level" class="form-select" required id="id_qualification_level">
     <option value="" selected>---------</option>
-  
+
     <option value="LEVEL_3">Niveau 3 (CAP, BEP)</option>
-  
+
     <option value="LEVEL_4">Niveau 4 (BP, Bac général, Techno ou Pro, BT)</option>
-  
+
     <option value="LEVEL_5">Niveau 5 ou + (Bac+2 ou +)</option>
-  
+
     <option value="NOT_RELEVANT">Non concerné</option>
-  
+
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_planned_training_hours">Nombre d&#x27;heures de formation prévues</label><input type="number" name="planned_training_hours" value="0" min="0" class="form-control" placeholder="Nombre d&#x27;heures de formation prévues" required id="id_planned_training_hours"></div>
   </div>
-  
+
   '''
 # ---
 # name: test_reload_qualification_fields[CQP]
   '''
-  
+
   <div id="geiq_qualification_fields_block">
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-trigger="change" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-select="#geiq_qualification_fields_block" hx-target="#geiq_qualification_fields_block" class="form-select" required id="id_qualification_type">
     <option value="">---------</option>
-  
+
     <option value="STATE_DIPLOMA">Diplôme d&#x27;état ou titre homologué</option>
-  
+
     <option value="CQP" selected>CQP</option>
-  
+
     <option value="CCN">Positionnement de CCN</option>
-  
+
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_level">Niveau de qualification</label><select name="qualification_level" class="form-select" required id="id_qualification_level">
     <option value="" selected>---------</option>
-  
+
     <option value="LEVEL_3">Niveau 3 (CAP, BEP)</option>
-  
+
     <option value="LEVEL_4">Niveau 4 (BP, Bac général, Techno ou Pro, BT)</option>
-  
+
     <option value="LEVEL_5">Niveau 5 ou + (Bac+2 ou +)</option>
-  
+
     <option value="NOT_RELEVANT">Non concerné</option>
-  
+
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_planned_training_hours">Nombre d&#x27;heures de formation prévues</label><input type="number" name="planned_training_hours" value="0" min="0" class="form-control" placeholder="Nombre d&#x27;heures de formation prévues" required id="id_planned_training_hours"></div>
   </div>
-  
+
   '''
 # ---
 # name: test_reload_qualification_fields[STATE_DIPLOMA]
   '''
-  
+
   <div id="geiq_qualification_fields_block">
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_type">Type de qualification visé</label><select name="qualification_type" hx-trigger="change" hx-post="/apply/10/accept/reload_qualification_fields" hx-swap="outerHTML" hx-select="#geiq_qualification_fields_block" hx-target="#geiq_qualification_fields_block" class="form-select" required id="id_qualification_type">
     <option value="">---------</option>
-  
+
     <option value="STATE_DIPLOMA" selected>Diplôme d&#x27;état ou titre homologué</option>
-  
+
     <option value="CQP">CQP</option>
-  
+
     <option value="CCN">Positionnement de CCN</option>
-  
+
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_qualification_level">Niveau de qualification</label><select name="qualification_level" class="form-select" required id="id_qualification_level">
     <option value="" selected>---------</option>
-  
+
     <option value="LEVEL_3">Niveau 3 (CAP, BEP)</option>
-  
+
     <option value="LEVEL_4">Niveau 4 (BP, Bac général, Techno ou Pro, BT)</option>
-  
+
     <option value="LEVEL_5">Niveau 5 ou + (Bac+2 ou +)</option>
-  
+
   </select></div>
       <div class="form-group form-group-required"><label class="form-label" for="id_planned_training_hours">Nombre d&#x27;heures de formation prévues</label><input type="number" name="planned_training_hours" value="0" min="0" class="form-control" placeholder="Nombre d&#x27;heures de formation prévues" required id="id_planned_training_hours"></div>
   </div>
-  
+
   '''
 # ---

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestHireConfirmation.test_as_company[view queries]
   dict({
-    'num_queries': 20,
+    'num_queries': 19,
     'queries': list([
       dict({
         'origin': list([
@@ -854,34 +854,6 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/submit/hire_confirmation.html]',
-          'BlockNode[apply/submit_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/submit_base.html]',
-          'ExtendsNode[apply/submit/hire_confirmation.html]',
-          '_accept[www/apply/views/common.py]',
-          'hire_confirmation[www/apply/views/submit_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 %s AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -629,6 +629,26 @@
         'origin': list([
           'EligibilityDiagnosisQuerySet.first[<site-packages>/django/db/models/query.py]',
           'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_considered_valid[eligibility/models/iae.py]',
+          'hire_confirmation[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EligibilityDiagnosisQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_considered_valid[eligibility/models/iae.py]',
           '_accept[www/apply/views/common.py]',
           'hire_confirmation[www/apply/views/submit_views.py]',
         ]),
@@ -834,41 +854,6 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'WithNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/submit/hire_confirmation.html]',
-          'BlockNode[apply/submit_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/submit_base.html]',
-          'ExtendsNode[apply/submit/hire_confirmation.html]',
-          '_accept[www/apply/views/common.py]',
-          'hire_confirmation[www/apply/views/submit_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_administrativecriteria"."id",
-                 "eligibility_administrativecriteria"."kind",
-                 "eligibility_administrativecriteria"."level",
-                 "eligibility_administrativecriteria"."name",
-                 "eligibility_administrativecriteria"."desc",
-                 "eligibility_administrativecriteria"."written_proof",
-                 "eligibility_administrativecriteria"."written_proof_url",
-                 "eligibility_administrativecriteria"."written_proof_validity",
-                 "eligibility_administrativecriteria"."ui_rank",
-                 "eligibility_administrativecriteria"."created_at",
-                 "eligibility_administrativecriteria"."created_by_id"
-          FROM "eligibility_administrativecriteria"
-          INNER JOIN "eligibility_selectedadministrativecriteria" ON ("eligibility_administrativecriteria"."id" = "eligibility_selectedadministrativecriteria"."administrative_criteria_id")
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestHireConfirmation.test_as_company[view queries]
   dict({
-    'num_queries': 19,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -854,6 +854,34 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/submit/hire_confirmation.html]',
+          'BlockNode[apply/submit_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit_base.html]',
+          'ExtendsNode[apply/submit/hire_confirmation.html]',
+          '_accept[www/apply/views/common.py]',
+          'hire_confirmation[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 %s AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_templates.ambr
+++ b/tests/www/apply/__snapshots__/test_templates.ambr
@@ -1,0 +1,34 @@
+# serializer version: 1
+# name: test_certified_badge__geiq
+  '''
+  
+      
+          <hr class="my-4">
+          <h3>Éligibilité public prioritaire GEIQ validée</h3>
+      
+  
+      
+          <p>
+              Éligibilité GEIQ confirmée par <b>Karen MOSES (Carlier)</b>
+          </p>
+      
+  
+      
+          
+              <h4>Situation administrative du candidat</h4>
+              <ul>
+                  <li>Bénéficiaire du Revenu de Solidarité Active (RSA)</li>
+              </ul>
+          
+      
+  
+      
+          <p>
+              <b>Durée de validité du diagnostic :</b> du 19/09/2024 au 19/03/2025.
+          </p>
+          
+      
+  
+  
+  '''
+# ---

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -1,14 +1,24 @@
+import datetime
+
 import pytest
 from django.template import Context
 from django.test.client import RequestFactory
 from django.utils.html import escape
+from freezegun import freeze_time
 from pytest_django.asserts import assertInHTML
 
+from itou.eligibility.enums import AdministrativeCriteriaLevel
 from itou.job_applications.enums import Origin
 from itou.jobs.models import Appellation
 from itou.utils.context_processors import expose_enums
+from itou.utils.mocks.api_particulier import rsa_certified_mocker
 from itou.www.apply.views.list_views import JobApplicationsListKind
-from tests.job_applications.factories import JobApplicationSentByCompanyFactory, JobApplicationSentByJobSeekerFactory
+from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
+from tests.job_applications.factories import (
+    JobApplicationFactory,
+    JobApplicationSentByCompanyFactory,
+    JobApplicationSentByJobSeekerFactory,
+)
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import EmployerFactory, JobSeekerFactory
 from tests.utils.test import load_template
@@ -165,3 +175,284 @@ def test_known_criteria_template_with_partial_zrr_criterion():
     assert "est classée en ZRR" not in rendered
     assert "est partiellement classée en ZRR" in rendered
     assert escape(job_seeker.city) in rendered
+
+
+class TestCertifiedBadgeIae:
+    CERTIFIED_BADGE_TEXT = "Certifié"
+    ELIGIBILITY_TITLE_FROM_PRESCRIBER = "Situation administrative du candidat"
+    ELIGIBILITY_TITLE_FROM_EMPLOYER = "Critères administratifs"
+
+    @property
+    def template(self):
+        return load_template("apply/includes/eligibility_diagnosis.html")
+
+    def default_params(self, diagnosis):
+        job_application = JobApplicationFactory(
+            eligibility_diagnosis=diagnosis,
+            hiring_start_at=datetime.date(2024, 8, 3),
+        )
+        if diagnosis.is_from_employer:
+            job_application.to_company = diagnosis.author_siae
+            job_application.save()
+        # This is the way it's set in views.
+        diagnosis.criteria_display = diagnosis.get_criteria_display_qs(hiring_start_at=job_application.hiring_start_at)
+        return {
+            "eligibility_diagnosis": diagnosis,
+            "request": RequestFactory(),
+            "siae": job_application.to_company,
+            "job_seeker": diagnosis.job_seeker,
+            "itou_help_center_url": "https://help.com",
+            "is_sent_by_authorized_prescriber": True,
+        }
+
+    def assert_criteria_name_in_rendered(self, diagnosis, rendered):
+        for criterion in diagnosis.administrative_criteria.all():
+            assert escape(criterion.name) in rendered
+
+    def test_nominal_case(self, mocker):
+        # Eligibility diagnosis made by an employer and job application not sent by an authorized prescriber.
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_employer=True)
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(
+            Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": False})
+        )
+
+        assert "Critères administratifs" in rendered
+        assert AdministrativeCriteriaLevel.LEVEL_1.label in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT in rendered
+
+        # Eligibility diagnosis made by an employer but job application sent by an authorized prescriber.
+        rendered = self.template.render(
+            Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": True})
+        )
+        assert self.ELIGIBILITY_TITLE_FROM_PRESCRIBER in rendered
+        assert AdministrativeCriteriaLevel.LEVEL_1.label not in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT in rendered
+
+    def test_diag_from_prescriber(self, mocker):
+        # Diagnosis from prescriber but job application not sent by an authorized prescriber.
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_prescriber=True)
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(
+            Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": False})
+        )
+
+        assert self.ELIGIBILITY_TITLE_FROM_EMPLOYER in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+        assert AdministrativeCriteriaLevel.LEVEL_1.label in rendered
+
+        # Diagnosis from prescriber and application sent by an authorized prescriber.
+        rendered = self.template.render(
+            Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": True})
+        )
+        assert self.ELIGIBILITY_TITLE_FROM_PRESCRIBER in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+        assert AdministrativeCriteriaLevel.LEVEL_1.label not in rendered
+
+    def test_no_certifiable_criteria(self):
+        # No certifiable criteria
+        diagnosis = IAEEligibilityDiagnosisFactory(with_not_certifiable_criteria=True, from_employer=True)
+
+        rendered = self.template.render(Context(self.default_params(diagnosis)))
+        assert self.ELIGIBILITY_TITLE_FROM_PRESCRIBER in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+
+    def test_expired_diagnosis(self):
+        # Expired Eligibility Diagnosis
+        diagnosis = IAEEligibilityDiagnosisFactory(expired=True, from_prescriber=True)
+        rendered = self.template.render(
+            Context(
+                self.default_params(diagnosis)
+                | {
+                    "expired_eligibility_diagnosis": diagnosis,
+                }
+            )
+        )
+        assert self.ELIGIBILITY_TITLE_FROM_PRESCRIBER not in rendered
+        assert AdministrativeCriteriaLevel.LEVEL_1.label not in rendered
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+        assert "Le diagnostic d'éligibilité IAE de ce candidat a expiré" in rendered
+
+    def test_info_box(self, mocker):
+        """Information box about why some criteria are certifiable."""
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        certified_help_text = "Pourquoi certains de mes critères peuvent-ils être certifiés"
+        # No certifiable criteria
+        diagnosis = IAEEligibilityDiagnosisFactory(with_not_certifiable_criteria=True, from_employer=True)
+        rendered = self.template.render(Context(self.default_params(diagnosis)))
+        assert certified_help_text not in rendered
+
+        # Certifiable criteria, even if not certified.
+        diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_employer=True)
+        rendered = self.template.render(Context(self.default_params(diagnosis)))
+        assert certified_help_text in rendered
+
+        # Certifiable and certified.
+        diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_employer=True)
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(Context(self.default_params(diagnosis)))
+        assert certified_help_text in rendered
+
+
+class TestCertifiedBadgeGEIQ:
+    CERTIFIED_BADGE_TEXT = "Certifié"
+    ELIGIBILITY_TITLE = "Situation administrative du candidat"
+
+    @property
+    def template(self):
+        return load_template("apply/includes/geiq/geiq_diagnosis_details.html")
+
+    def default_params_geiq(self, diagnosis, job_application):
+        diagnosis.criteria_display = diagnosis.get_criteria_display_qs(hiring_start_at=job_application.hiring_start_at)
+        return {
+            "request": RequestFactory(),
+            "diagnosis": diagnosis,
+            "itou_help_center_url": "https://help.com",
+        }
+
+    def assert_criteria_name_in_rendered(self, diagnosis, rendered):
+        for criterion in diagnosis.administrative_criteria.all():
+            assert escape(criterion.name) in rendered
+
+    def create_job_application(self, diagnosis, hiring_start_at=None):
+        if not hiring_start_at:
+            hiring_start_at = datetime.date(2024, 8, 3)
+        job_application = JobApplicationFactory(
+            with_geiq_eligibility_diagnosis=True,
+            geiq_eligibility_diagnosis=diagnosis,
+            hiring_start_at=hiring_start_at,
+        )
+        if diagnosis.is_from_employer:
+            job_application.to_company = diagnosis.author_geiq
+            job_application.save()
+        return job_application
+
+    @pytest.mark.ignore_unknown_variable_template_error("request")
+    def test_diag_from_prescriber(self):
+        """
+        Nominal case
+        Eligibility diagnosis is from a prescriber.
+        Don't display a "certified" badge.
+        """
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_certifiable_criteria=True,
+            from_prescriber=True,
+        )
+        job_application = self.create_job_application(diagnosis)
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert self.ELIGIBILITY_TITLE in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+
+    @freeze_time("2024-10-04")
+    def test_nominal_case(self, mocker):
+        """
+        Eligibility diagnosis is from an employer.
+        Display a "certified" badge.
+        """
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_certifiable_criteria=True,
+            from_geiq=True,
+        )
+        job_application_with_certified_criteria = self.create_job_application(diagnosis)
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(
+            Context(self.default_params_geiq(diagnosis, job_application_with_certified_criteria))
+        )
+        assert self.ELIGIBILITY_TITLE in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT in rendered
+
+    @freeze_time("2024-10-04")
+    def test_hiring_date_nearly_out_of_boundaries(self, mocker):
+        # Hiring start at starts 20 days after the certification period ending.
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_certifiable_criteria=True,
+            from_geiq=True,
+        )
+        job_application = self.create_job_application(diagnosis, hiring_start_at=datetime.date(2024, 11, 30))
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert self.ELIGIBILITY_TITLE in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT in rendered
+
+    @freeze_time("2024-10-04")
+    def test_hiring_date_out_of_boundaries(self, mocker):
+        # Hiring start at starts more than 90 days after the certification period ending.
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_certifiable_criteria=True,
+            from_geiq=True,
+        )
+        job_application = self.create_job_application(diagnosis, hiring_start_at=datetime.date(2025, 2, 28))
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert self.ELIGIBILITY_TITLE in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+
+    def test_no_certified_criteria(self):
+        # No certified criteria
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_not_certifiable_criteria=True,
+            from_geiq=True,
+        )
+        job_application = self.create_job_application(diagnosis)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert self.ELIGIBILITY_TITLE in rendered
+        self.assert_criteria_name_in_rendered(diagnosis, rendered)
+        assert self.CERTIFIED_BADGE_TEXT not in rendered
+
+    def test_info_box(self, mocker):
+        """Information box about why some criteria are certifiable."""
+        certified_help_text = "Pourquoi certains de mes critères peuvent-ils être certifiés"
+        diagnosis = GEIQEligibilityDiagnosisFactory(with_not_certifiable_criteria=True, from_geiq=True)
+        # No certifiable criteria
+        job_application = self.create_job_application(diagnosis)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert certified_help_text not in rendered
+
+        # Certifiable criteria but not certified.
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_certifiable_criteria=True,
+            from_geiq=True,
+        )
+        job_application = self.create_job_application(diagnosis)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert certified_help_text in rendered
+
+        # Certifiable and certified.
+        mocker.patch(
+            "itou.utils.apis.api_particulier.APIParticulierClient._request", return_value=rsa_certified_mocker()
+        )
+        diagnosis = GEIQEligibilityDiagnosisFactory(
+            with_certifiable_criteria=True,
+            from_geiq=True,
+        )
+        diagnosis.selected_administrative_criteria.first().certify(save=True)
+        job_application = self.create_job_application(diagnosis)
+        rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
+        assert certified_help_text in rendered

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEmployeeDetailView.test_detail_view[employee detail view]
   dict({
-    'num_queries': 24,
+    'num_queries': 25,
     'queries': list([
       dict({
         'origin': list([
@@ -553,6 +553,26 @@
           FROM "approvals_suspension"
           WHERE "approvals_suspension"."approval_id" IN (%s)
           ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobApplicationQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'EmployeeDetailView.get_job_application[www/employees_views/views.py]',
+          'EmployeeDetailView.get_context_data[www/employees_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -866,7 +866,6 @@
           'VariableNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IncludeNode[employees/detail.html]',
           'IfNode[employees/detail.html]',
           'BlockNode[layout/base.html]',
@@ -913,8 +912,6 @@
       dict({
         'origin': list([
           'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'WithNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
           'IncludeNode[employees/detail.html]',
@@ -923,22 +920,19 @@
           'ExtendsNode[employees/detail.html]',
         ]),
         'sql': '''
-          SELECT "eligibility_administrativecriteria"."id",
-                 "eligibility_administrativecriteria"."kind",
-                 "eligibility_administrativecriteria"."level",
-                 "eligibility_administrativecriteria"."name",
-                 "eligibility_administrativecriteria"."desc",
-                 "eligibility_administrativecriteria"."written_proof",
-                 "eligibility_administrativecriteria"."written_proof_url",
-                 "eligibility_administrativecriteria"."written_proof_validity",
-                 "eligibility_administrativecriteria"."ui_rank",
-                 "eligibility_administrativecriteria"."created_at",
-                 "eligibility_administrativecriteria"."created_by_id"
-          FROM "eligibility_administrativecriteria"
-          INNER JOIN "eligibility_selectedadministrativecriteria" ON ("eligibility_administrativecriteria"."id" = "eligibility_selectedadministrativecriteria"."administrative_criteria_id")
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
+                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
+          FROM "eligibility_selectedadministrativecriteria"
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -954,7 +954,7 @@
 # ---
 # name: test_job_application_tab[job seeker details view with sent job applications]
   dict({
-    'num_queries': 17,
+    'num_queries': 18,
     'queries': list([
       dict({
         'origin': list([
@@ -1451,6 +1451,26 @@
           ORDER BY 10 DESC,
                    "eligibility_eligibilitydiagnosis"."created_at" DESC
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EligibilityDiagnosisQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'EligibilityDiagnosisManagerFromEligibilityDiagnosisQuerySet.last_considered_valid[eligibility/models/iae.py]',
+          'JobSeekerDetailView.get_context_data[www/job_seekers_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_selectedadministrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY RANDOM() ASC
         ''',
       }),
       dict({

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -648,7 +648,7 @@ class TestSiaeSelectCriteriaView:
     def test_post(self, client):
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
 
         url = reverse(
@@ -673,7 +673,7 @@ class TestSiaeSelectCriteriaView:
     def test_post_with_submission_freezed_at(self, client):
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
         # Freeze submission
         evaluated_job_application.evaluated_siae.evaluation_campaign.freeze(timezone.now())
@@ -715,7 +715,7 @@ class TestSiaeSelectCriteriaView:
 
         # preselected criteria
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
         EvaluatedAdministrativeCriteria.objects.create(
             evaluated_job_application=evaluated_job_application,
@@ -758,7 +758,7 @@ class TestSiaeUploadDocsView:
         siae = membership.company
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(siae, user)
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteria.objects.create(
             evaluated_job_application=evaluated_job_application,
@@ -799,7 +799,7 @@ class TestSiaeUploadDocsView:
 
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteria.objects.create(
             evaluated_job_application=evaluated_job_application,
@@ -830,7 +830,7 @@ class TestSiaeUploadDocsView:
 
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteria.objects.create(
             evaluated_job_application=evaluated_job_application,
@@ -875,7 +875,7 @@ class TestSiaeUploadDocsView:
 
         evaluated_job_application = create_evaluated_siae_with_consistent_datas(self.siae, self.user)
         criterion = (
-            evaluated_job_application.job_application.eligibility_diagnosis.selectedadministrativecriteria_set.first()
+            evaluated_job_application.job_application.eligibility_diagnosis.selected_administrative_criteria.first()
         )
         proof = FileFactory()
         evaluated_administrative_criteria = EvaluatedAdministrativeCriteria.objects.create(


### PR DESCRIPTION
:warning:  Je recommande une relecture commit par commit.

## :thinking: Pourquoi ?

En tant qu'employeur (SIAE ou GEIQ) ayant embauché un candidat pour lequel j'ai réalisé moi-même le diagnostic d’éligibilité, je souhaite voir les critères qui ont été certifiés par l'API Particulier dans la page du diagnostic.

> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

- Réorganisation du gabarit qui affiche les critères.
- Calcul de la validité de la certification dans une Queryset pour qu'il soit réutilisable ailleurs (dans le contrôle a posteriori par exemple).

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester ?

En tant qu'employeur (SIAE ou GEIQ), réaliser une auto-prescription pour un candidat connu de l'API Particulier avec le critère BRSA.
Dans la page de candidature, un macaron « certifié » devrait apparaître au-dessus de l'encart informatif.
Réaliser un test pour un candidat n'ayant aucun critère ou n'était pas connu de l'API.
Pour aller plus vite, il est possible de modifier directement dans l'admin Django les valeurs retournées par l'API Particulier. C'est pratique pour vérifier la période de grâce (les critères certifiés même si la date de candidature n'entre pas parfaitement dans leur date de validité).