### PR TITLE
Candidature : le bouton Annuler renvoie vers la fiche de poste ou l'entreprise

### DIFF
--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -238,6 +238,6 @@
     {% if auto_prescription_process %}
         {% itou_buttons_form primary_label="Enregistrer" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_employer" %}
     {% else %}
-        {% itou_buttons_form primary_label="Envoyer la candidature" secondary_url=back_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_"|add:request.user.get_kind_display %}
+        {% itou_buttons_form primary_label="Envoyer la candidature" secondary_url=back_url reset_url=reset_url matomo_category="candidature" matomo_action="submit" matomo_name="candidature_"|add:request.user.get_kind_display %}
     {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -76,7 +76,7 @@
                 </div>
             {% endif %}
             {# Reload this page and show a modal containing more information about the job seeker. #}
-            {% itou_buttons_form primary_label="Suivant" primary_name="preview" primary_value="1" %}
+            {% itou_buttons_form primary_label="Suivant" primary_name="preview" primary_value="1" reset_url=reset_url %}
         </div>
         {% if preview_mode %}
             <!-- Modal -->

--- a/itou/templates/apply/submit_step_job_seeker.html
+++ b/itou/templates/apply/submit_step_job_seeker.html
@@ -39,7 +39,7 @@
                 {% include "signup/includes/no_email_link.html" with link_text="Le candidat n'a pas d'e-mail ?" only %}
             </div>
 
-            {% itou_buttons_form primary_label="Suivant" secondary_url=back_url primary_name="preview" primary_value="1" %}
+            {% itou_buttons_form primary_label="Suivant" secondary_url=back_url primary_name="preview" primary_value="1" reset_url=reset_url %}
         </div>
         {% if preview_mode %}
             <!-- Modal -->

--- a/itou/templates/apply/submit_step_job_seeker_check_info.html
+++ b/itou/templates/apply/submit_step_job_seeker_check_info.html
@@ -12,7 +12,7 @@
 
         {% bootstrap_form form alert_error_type="all" %}
 
-        {% itou_buttons_form primary_label="Continuer" %}
+        {% itou_buttons_form primary_label="Continuer" reset_url=reset_url %}
     </form>
 
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand on rentre dans le parcours “postuler” et qu’on fait annuler, on revient sur l’accueil, on s’attend à revenir sur la fiche de poste sur laquelle on était (à priori ce fonctionnement s’applique partout → lorsqu’on annule on revient à la racine du parcours.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
