### PR TITLE
UX/UI : Fix la zone cliquable du bouton déconnexion

### DIFF
--- a/itou/templates/layout/_header_user_dropdown_menu.html
+++ b/itou/templates/layout/_header_user_dropdown_menu.html
@@ -38,7 +38,7 @@
         </li>
         <li class="dropdown-divider"></li>
     {% endif %}
-    <li class="dropdown-item">
+    <li class="dropdown-item position-relative">
         <form method="post" action="{% url 'account_logout' %}">
             {% csrf_token %}
             <button class="text-danger stretched-link">Déconnexion</button>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -135,7 +135,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -233,7 +233,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -412,7 +412,7 @@
           </li>
           <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -515,7 +515,7 @@
           </li>
           <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -643,7 +643,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -744,7 +744,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -877,7 +877,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -973,7 +973,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -1124,7 +1124,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -1218,7 +1218,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -1348,7 +1348,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>
@@ -1442,7 +1442,7 @@
       
       <li class="dropdown-divider"></li>
       
-      <li class="dropdown-item">
+      <li class="dropdown-item position-relative">
           <form action="/accounts/logout/" method="post">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button class="text-danger stretched-link">Déconnexion</button>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter les maxclicks.

**Pour infos:**
Le `.stretched-link` ajoute un pseudo element ::after à l'élément HTML afin d'agrandir la zone de click/survol. Ce ::after a pour propriété d'être positionné en absolu et de prendre toute la largeur et la hauteur disponible. Pour limiter la zone de click, il faut bloqué la dimension prise par le ::after en donnant une limite  via la propriété de `position:relative` donner a un élément parent. Sinon la dimension de ::after ne s'arrêtera qu'au premier parent possédant un position:relative 


**Avant**
![capture 2024-09-23 à 09 26 05](https://github.com/user-attachments/assets/02251d74-7885-4fd4-aca9-ead2662fc6a1)




**Apres**
![capture 2024-09-23 à 10 37 18](https://github.com/user-attachments/assets/1457f1ef-72ff-47ea-9cd7-b44704d1482f)
