### PR TITLE
Inscription : Parcours initialisation de mot de passe pour les candidats créés par un tiers [GEN-235]

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -39,6 +39,12 @@ urlpatterns = [
     # Avoid user enumeration via password reset page.
     re_path(r"^accounts/password/reset/$", signup_views.ItouPasswordResetView.as_view()),
     # --------------------------------------------------------------------------------------
+    # Override allauth `account_reset_password_from_key` URL.
+    re_path(
+        r"^accounts/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$",
+        signup_views.ItouPasswordResetFromKeyView.as_view(),
+    ),
+    # --------------------------------------------------------------------------------------
     # Other allauth URLs.
     path("accounts/", include("allauth.urls")),
     # --------------------------------------------------------------------------------------

--- a/itou/communications/__init__.py
+++ b/itou/communications/__init__.py
@@ -10,6 +10,7 @@ class NotificationCategory(StrEnum):
     MEMBERS_MANAGEMENT = "Gestion des collaborateurs"
     JOB_APPLICATION = "Candidature"
     GEIQ_IMPLEMENTATION_ASSESSMENT = "Bilan d’exécution GEIQ"
+    REGISTRATION = "Inscription"
 
 
 class NotificationRegistry:

--- a/itou/templates/account/email/email_jobseeker_created_by_third_party_body.txt
+++ b/itou/templates/account/email/email_jobseeker_created_by_third_party_body.txt
@@ -1,0 +1,23 @@
+{% extends "layout/base_email_text_body.txt" %}
+
+{#
+    Context
+
+    job_seeker (created account user)
+    creator (creator of the account - prescriber)
+    creator_org (the creating organization if one exists)
+    account_activation_link
+#}
+
+{% block body %}
+
+Bonjour {% if job_seeker.title %}{{ job_seeker.get_title_display }} {% endif %}{{ job_seeker.get_full_name }},
+
+Votre compte candidat vient d’être créé sur les Emplois de l’inclusion par {{ creator.get_full_name }}{% if creator_org %} de {{ creator_org.display_name }}{% endif %}.
+
+Pour finaliser votre inscription, merci de cliquer sur le lien suivant : {{ account_activation_link }}. Ce lien expirera dans 14 jours.
+Dès votre arrivée sur le site des Emplois de l’inclusion, vous serez invité à définir un mot de passe pour votre compte candidat.
+
+Cet e-mail a été généré et envoyé automatiquement, merci de ne pas y répondre.
+
+{% endblock body %}

--- a/itou/templates/account/email/email_jobseeker_created_by_third_party_subject.txt
+++ b/itou/templates/account/email/email_jobseeker_created_by_third_party_subject.txt
@@ -1,0 +1,1 @@
+Création de votre compte candidat

--- a/itou/templates/account/password_reset_from_key.html
+++ b/itou/templates/account/password_reset_from_key.html
@@ -7,8 +7,10 @@
 
 {% block title_content %}
     <h1>
-        {% if token_fail %}
-            Mauvais jeton d'identification
+        {% if token_fail|default:False %}
+            Le lien de réinitialisation n'est pas valide
+        {% elif user_is_new %}
+            Création de votre mot de passe
         {% else %}
             Modification de votre mot de passe
         {% endif %}
@@ -20,11 +22,11 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12 col-lg-8">
-                    {% if token_fail %}
+                    {% if token_fail|default:False %}
 
                         {% url 'account_reset_password' as passwd_reset_url %}
                         <p>
-                            Le lien de réinitialisation du mot de passe est invalide. Il a peut être déjà été utilisé. Veuillez faire une nouvelle <a href="{{ passwd_reset_url }}">demande de réinitialisation de mot de passe</a>.
+                            Il a peut être déjà été utilisé, ou expiré. Veuillez faire une nouvelle <a href="{{ passwd_reset_url }}">demande de réinitialisation de mot de passe</a>.
                         </p>
 
                     {% else %}
@@ -41,7 +43,7 @@
                                 {% bootstrap_field form.password2 %}
 
                                 {% url 'home:hp' as reset_url %}
-                                {% itou_buttons_form primary_label="Modifier le mot de passe" reset_url=reset_url %}
+                                {% itou_buttons_form primary_label=action_text reset_url=reset_url %}
 
                             </form>
 

--- a/itou/users/notifications.py
+++ b/itou/users/notifications.py
@@ -16,3 +16,12 @@ class OrganizationActiveMembersReminderNotification(
         context = super().get_context()
         context["structure"] = self.structure
         return context
+
+
+@notifications_registry.register
+class JobSeekerCreatedByProxyNotification(EmailNotification):
+    name = "Invitation à accéder au compte d'un nouvel utilisateur créé par un tiers"
+    category = NotificationCategory.REGISTRATION
+    subject_template = "account/email/email_jobseeker_created_by_third_party_subject.txt"
+    body_template = "account/email/email_jobseeker_created_by_third_party_body.txt"
+    can_be_disabled = False

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -736,7 +736,9 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
     def post(self, request, *args, **kwargs):
         try:
             with transaction.atomic():
-                user = User.create_job_seeker_by_proxy(self.sender, **self._get_user_data_from_session())
+                user = User.create_job_seeker_by_proxy(
+                    self.sender, **self._get_user_data_from_session(), acting_organization=request.current_organization
+                )
                 self.profile = user.jobseeker_profile
                 for k, v in self._get_profile_data_from_session().items():
                     setattr(self.profile, k, v)

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -75,6 +75,7 @@ class ItouPasswordResetFromKeyView(PasswordResetFromKeyView):
         if self.user_is_new():
             # clear any pre-existing session and login the user
             self.request.session.clear()
+            self.reset_user.emailaddress_set.filter(email=self.reset_user.email).update(verified=True)
             login(self.request, self.reset_user, backend="django.contrib.auth.backends.ModelBackend")
             return reverse("welcoming_tour:index")
         return super().get_success_url()

--- a/tests/users/__snapshots__/test_models.ambr
+++ b/tests/users/__snapshots__/test_models.ambr
@@ -1,0 +1,18 @@
+# serializer version: 1
+# name: TestModel.test_create_job_seeker_by_proxy[email jobseeker created by proxy]
+  '''
+  Bonjour Monsieur John DOE,
+  
+  Votre compte candidat vient d’être créé sur les Emplois de l’inclusion par Pierre DUPONT de Pres. Org..
+  
+  Pour finaliser votre inscription, merci de cliquer sur le lien suivant : [RESET PASSWORD LINK REMOVED]. Ce lien expirera dans 14 jours.
+  Dès votre arrivée sur le site des Emplois de l’inclusion, vous serez invité à définir un mot de passe pour votre compte candidat.
+  
+  Cet e-mail a été généré et envoyé automatiquement, merci de ne pas y répondre.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -175,6 +175,7 @@ class TestModel:
         post_data = {"password1": "newPassword1%", "password2": "newPassword1%"}
         response = client.post(password_change_url_with_hidden_key, data=post_data)
         assertRedirects(response, reverse("welcoming_tour:index"))
+        assert user.has_verified_email
         client.logout()
 
         # E-mail already exists, this should raise an error.

--- a/tests/www/signup/__snapshots__/test_password.ambr
+++ b/tests/www/signup/__snapshots__/test_password.ambr
@@ -1,0 +1,163 @@
+# serializer version: 1
+# name: TestPasswordReset.test_password_reset_token_invalid_content
+  '''
+  <main class="s-main" id="main" role="main">
+              <div aria-atomic="true" aria-live="polite" class="toast-container">
+  
+  </div>
+  
+              <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
+      <h1>
+          
+              Le lien de réinitialisation n'est pas valide
+          
+      </h1>
+  
+                              
+                                  
+  
+  
+                              
+                              
+                          </div>
+                      </div>
+                  </div>
+              </section>
+  
+              
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      
+  
+                          
+                          <p>
+                              Il a peut être déjà été utilisé, ou expiré. Veuillez faire une nouvelle <a href="/accounts/password/reset/">demande de réinitialisation de mot de passe</a>.
+                          </p>
+  
+                      
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+          </main>
+  '''
+# ---
+# name: TestPasswordReset.test_password_reset_user_creation
+  '''
+  <main class="s-main" id="main" role="main">
+              <div aria-atomic="true" aria-live="polite" class="toast-container">
+  
+  </div>
+  
+              <section class="s-title-02">
+                  <div class="s-title-02__container container">
+                      <div class="s-title-02__row row">
+                          <div class="s-title-02__col col-12">
+                              
+                              
+      <h1>
+          
+              Création de votre mot de passe
+          
+      </h1>
+  
+                              
+                                  
+  
+  
+                              
+                              
+                          </div>
+                      </div>
+                  </div>
+              </section>
+  
+              
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-lg-8">
+                      
+  
+                          
+  
+                              <form action="[change password form url]" class="js-prevent-multiple-submit" method="post">
+  
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+  
+                                  
+  
+                                  <div class="form-group form-group-required"><label class="form-label" for="id_password1">Nouveau mot de passe</label><div class="input-group">
+      <input aria-describedby="id_password1_helptext" autocomplete="new-password" class="form-control" id="id_password1" name="password1" placeholder="Nouveau mot de passe" required="" type="password"/>
+  
+      <div class="input-group-text p-0">
+          <button class="btn btn-sm btn-link btn-ico" data-it-password="toggle" type="button">
+              <i aria-hidden="true" class="ri-eye-line"></i>
+              <span>Afficher</span>
+          </button>
+      </div>
+  </div><div class="form-text"><ul><li>Votre mot de passe ne peut pas trop ressembler à vos autres informations personnelles.</li><li>Votre mot de passe doit contenir au minimum 12 caractères.</li><li>Votre mot de passe ne peut pas être un mot de passe couramment utilisé.</li><li>Votre mot de passe ne peut pas être entièrement numérique.</li><li>Le mot de passe doit contenir au moins 3 des 4 types suivants : majuscules, minuscules, chiffres, caractères spéciaux.</li></ul></div>
+  </div>
+                                  <div class="form-group form-group-required"><label class="form-label" for="id_password2">Nouveau mot de passe (confirmation)</label><div class="input-group">
+      <input class="form-control" id="id_password2" name="password2" placeholder="Nouveau mot de passe (confirmation)" required="" type="password"/>
+  
+      <div class="input-group-text p-0">
+          <button class="btn btn-sm btn-link btn-ico" data-it-password="toggle" type="button">
+              <i aria-hidden="true" class="ri-eye-line"></i>
+              <span>Afficher</span>
+          </button>
+      </div>
+  </div></div>
+  
+                                  
+                                  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
+                  
+                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                          <span>Enregistrer le mot de passe</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  
+  
+  
+                              </form>
+  
+                          
+  
+                      
+                  </div>
+              </div>
+          </div>
+      </section>
+  
+          </main>
+  '''
+# ---

--- a/tests/www/signup/test_password.py
+++ b/tests/www/signup/test_password.py
@@ -3,15 +3,22 @@ from allauth.account.utils import user_pk_to_url_str
 from django.conf import settings
 from django.core import mail
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.http import urlencode
 from pytest_django.asserts import assertRedirects
 
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory
+from tests.utils.test import parse_response_to_soup
 
 
 class TestPasswordReset:
+    def _get_password_change_from_key_url(self, user):
+        uidb36 = user_pk_to_url_str(user)
+        key = default_token_generator.make_token(user)
+        return reverse("account_reset_password_from_key", kwargs={"uidb36": uidb36, "key": key})
+
     def test_password_reset_flow(self, client):
-        user = JobSeekerFactory()
+        user = JobSeekerFactory(last_login=timezone.now(), password="somethingElse%")
 
         # Ask for password reset.
         url = reverse("account_reset_password")
@@ -37,16 +44,14 @@ class TestPasswordReset:
         assert email.to[0] == user.email
 
         # Change forgotten password.
-        uidb36 = user_pk_to_url_str(user)
-        key = default_token_generator.make_token(user)
-        password_change_url = reverse("account_reset_password_from_key", kwargs={"uidb36": uidb36, "key": key})
+        password_change_url = self._get_password_change_from_key_url(user)
         response = client.get(password_change_url)
         password_change_url_with_hidden_key = response.url
         post_data = {"password1": DEFAULT_PASSWORD, "password2": DEFAULT_PASSWORD}
         response = client.post(password_change_url_with_hidden_key, data=post_data)
         assertRedirects(response, reverse("account_reset_password_from_key_done"))
 
-        # User can log in with his new password.
+        # User can log in with their new password.
         assert client.login(username=user.email, password=DEFAULT_PASSWORD)
         client.logout()
 
@@ -62,6 +67,49 @@ class TestPasswordReset:
         args = urlencode({"email": post_data["email"]})
         next_url = reverse("account_reset_password_done")
         assert response.url == f"{next_url}?{args}"
+
+    def test_password_reset_user_creation(self, client, snapshot):
+        # user creation differs because they are logged in and redirected to the welcoming tour on creation
+        user = JobSeekerFactory(last_login=None)
+
+        password_change_url = self._get_password_change_from_key_url(user)
+        response = client.get(password_change_url)
+        password_change_url_with_hidden_key = response.url
+
+        response = client.get(password_change_url_with_hidden_key)
+        assert (
+            str(
+                parse_response_to_soup(
+                    response,
+                    "#main",
+                    replace_in_attr=[
+                        (
+                            "action",
+                            password_change_url_with_hidden_key,
+                            "[change password form url]",
+                        )
+                    ],
+                )
+            )
+            == snapshot
+        )
+
+        post_data = {"password1": DEFAULT_PASSWORD, "password2": DEFAULT_PASSWORD}
+        response = client.post(password_change_url_with_hidden_key, data=post_data)
+        assertRedirects(response, reverse("welcoming_tour:index"))
+        assert response.context["request"].user.is_authenticated
+
+        # User can log in with their new password.
+        client.logout()
+        assert client.login(username=user.email, password=DEFAULT_PASSWORD)
+
+    def test_password_reset_token_invalid_content(self, client, snapshot):
+        # user creation differs because they are logged in and redirected to the welcoming tour on creation
+        password_change_url = reverse(
+            "account_reset_password_from_key", kwargs={"uidb36": "something", "key": "invalid"}
+        )
+        response = client.get(password_change_url)
+        assert str(parse_response_to_soup(response, "#main")) == snapshot
 
 
 class TestPasswordChange:
@@ -84,6 +132,6 @@ class TestPasswordChange:
         assert response.status_code == 302
         assertRedirects(response, reverse("dashboard:index"))
 
-        # User can log in with his new password.
+        # User can log in with their new password.
         client.logout()
         assert client.login(username=user.email, password=new_password)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand un candidat est créé par un tier, on devrait lui notifier avec un lien qui lui permet définir son mot de passe

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran

<img width="958" alt="Screenshot 2024-09-19 at 13 39 37" src="https://github.com/user-attachments/assets/3200828d-567b-4ace-9f7a-8c5e0940dc2d">

<img width="902" alt="Screenshot 2024-09-25 at 12 19 16" src="https://github.com/user-attachments/assets/9cbe3958-2362-4a47-ae6a-0a1a6f7f0cf0">
