### PR TITLE
Corriger la hauteur minimale de l'iframe livestorm

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -178,7 +178,6 @@
             /* beautify ignore:end */
 
             // livestorm
-            const tablet_width = 750;
             tarteaucitron.services.livestorm = {
                 "key": "livestorm",
                 "type": "video",
@@ -190,15 +189,9 @@
                     "use strict";
                     tarteaucitron.fallback(['js-tac-livestorm'], function(x) {
                         var frame_title = tarteaucitron.fixSelfXSS(x.getAttribute("title") || 'livestorm iframe'),
-                            width = x.getAttribute("width"),
-                            height = x.getAttribute("height"),
-                            url = x.getAttribute("data-url");
-
-                        // Poor attempt to make the Livestorm iframe responsive.
-                        if (document.body.clientWidth > tablet_width) {
-                            height = "365px";
-                        }
-                        return '<iframe title="' + frame_title + '" src="' + url + '" style="min-height:' + height + ';" allowtransparency allowfullscreen></iframe>';
+                            height = tarteaucitron.fixSelfXSS(x.getAttribute("height") || '365'),
+                            url = tarteaucitron.fixSelfXSS(x.getAttribute("data-url"));
+                        return '<iframe title="' + frame_title + '" src="' + url + '" style="min-height:' + height + 'px;" allowtransparency allowfullscreen></iframe>';
                     });
                 },
                 "fallback": function() {
@@ -206,11 +199,7 @@
                     var id = 'livestorm';
                     tarteaucitron.fallback(['js-tac-livestorm'], function(elem) {
                         elem.style.width = elem.getAttribute('width');
-                        if (document.body.clientWidth > tablet_width) {
-                            elem.style.height = "310px";
-                        } else {
-                            elem.style.height = elem.getAttribute('height');
-                        }
+                        elem.style.height = "365px";
                         return tarteaucitron.engage(id);
                     });
                 }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le script ne fonctionnait que sur la homepage (pb avec `document.body.clientWidth`) et gérait une hauteur pour le mobile inutile

