### PR TITLE
Connexion : Empêcher les utilisateurs de se connecter à un autre compte du SSO partageant un courriel existant

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -18,7 +18,7 @@ from itou.utils import constants as global_constants
 from itou.utils.constants import ITOU_HELP_CENTER_URL
 from itou.utils.urls import add_url_params, get_absolute_url
 
-from ..models import InvalidKindException, MultipleUsersFoundException
+from ..models import EmailInUseException, InvalidKindException, MultipleUsersFoundException
 from . import constants
 from .enums import InclusionConnectChannel
 from .models import (
@@ -274,6 +274,27 @@ def inclusion_connect_callback(request):
     except InvalidKindException:
         existing_user = User.objects.get(email=user_data["email"])
         _add_user_kind_error_message(request, existing_user, user_kind)
+        is_successful = False
+    except EmailInUseException as e:
+        redacted_name = e.user.get_redacted_full_name()
+        msg_who = (
+            format_html(
+                " au nom de <strong>{}</strong>",
+                redacted_name,
+            )
+            if redacted_name
+            else ""
+        )
+
+        error = format_html(
+            "Vous avez essayé de vous connecter avec un compte Inclusion Connect, mais un compte"
+            "{} a déjà été créé avec cette adresse e-mail. "
+            "Veuillez vous rapprocher du support pour débloquer la situation en suivant "
+            "<a href='{}'>ce lien</a>.",
+            msg_who,
+            global_constants.ITOU_HELP_CENTER_URL,
+        )
+        messages.error(request, error)
         is_successful = False
     except MultipleUsersFoundException as e:
         # Here we have a user trying to update his email, but with an already existing email

--- a/itou/openid_connect/pe_connect/views.py
+++ b/itou/openid_connect/pe_connect/views.py
@@ -153,7 +153,14 @@ def pe_connect_callback(request):
         )
     except EmailInUseException as e:
         redacted_name = e.user.get_redacted_full_name()
-        msg_who = f" au nom de <strong>{redacted_name}</strong>" if redacted_name else ""
+        msg_who = (
+            format_html(
+                " au nom de <strong>{}</strong>",
+                redacted_name,
+            )
+            if redacted_name
+            else ""
+        )
 
         return _redirect_to_job_seeker_login_on_error(
             format_html(
@@ -164,7 +171,7 @@ def pe_connect_callback(request):
                 msg_who,
             ),
             request=request,
-            extra_tags="modal france_travail_registration_failure",
+            extra_tags="modal sso_email_conflict_registration_failure",
         )
 
     nir = request.session.get(global_constants.ITOU_SESSION_NIR_KEY)

--- a/itou/templates/utils/modal_includes/sso_email_conflict_registration_failure.html
+++ b/itou/templates/utils/modal_includes/sso_email_conflict_registration_failure.html
@@ -12,7 +12,6 @@
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
         </div>
         <div class="row modal-body">
-            <h2 class="h4">L'inscription via France Travail a échoué</h2>
             <p>{{ message }}</p>
         </div>
         <div class="modal-footer">

--- a/itou/templates/utils/modals.html
+++ b/itou/templates/utils/modals.html
@@ -5,8 +5,8 @@
 {% for message in messages %}
     {% if "modal" in message.extra_tags %}
         <div class="modal fade" id="message-modal-{{ forloop.counter }}" data-bs-backdrop="static" tabindex="-1" role="dialog" aria-labelledby="message-modal-{{ forloop.counter }}-label" aria-modal="true">
-            {% if "france_travail_registration_failure" in message.extra_tags %}
-                {% include "utils/modal_includes/france_travail_registration_failure.html" %}
+            {% if "sso_email_conflict_registration_failure" in message.extra_tags %}
+                {% include "utils/modal_includes/sso_email_conflict_registration_failure.html" %}
             {% endif %}
         </div>
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sur OIDConnect, les nom d’utilisateurs (sub) sont uniques, mais non les e-mails. Les SSOs permettent donc la réutilisation des emails entre comptes, qui est invalide sur notre service. Désormais on a permis la modification de nom d'utilisateur quand il arrive du même SSO avec un autre `sub`. Cela cause des problèmes intransients pour nos utilisateurs, et ce PR remplace ce comportement avec les erreurs explicite sur le login. C'est une étape intermediare, où après on va enforcer qu'un email peut utiliser seulement un SSO.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## Captures d'écran

<img width="800" alt="Screenshot 2024-09-24 at 15 04 37" src="https://github.com/user-attachments/assets/f242cb75-4cc5-49ad-b383-35bef6aac3e8">

FranceConnect

<img width="1021" alt="Screenshot 2024-09-24 at 15 29 39" src="https://github.com/user-attachments/assets/3b81d568-c272-4a13-9213-41cdf852c08c">

InclusionConnect