### PR TITLE
Pilotage : Ajouter un encart sur les TDB afin d’annoncer l’enquête utilisateurs

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -36,7 +36,7 @@
                     <p class="mb-0">{{ banner.description }}</p>
                 </div>
                 <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                    <a class="btn btn-sm btn-primary btn-block btn-ico" href="{{ banner.url }}" target="_blank" rel="noopener"><span>Je m’inscris</span> <i class="ri-external-link-line font-weight-medium" aria-hidden="true"></i></a>
+                    <a class="btn btn-sm btn-primary btn-block btn-ico" href="{{ banner.url }}" target="_blank" rel="noopener"><span>{{ banner.call_to_action|default:"Je m’inscris" }}</span> <i class="ri-external-link-line font-weight-medium" aria-hidden="true"></i></a>
                 </div>
             </div>
         </div>

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -27,7 +27,7 @@
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
             <div class="row">
                 <div class="col-auto pe-0">
-                    <i class="ri-information-line ri-xl text-important" aria-hidden="true"></i>
+                    <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
                 </div>
                 <div class="col">
                     <p class="mb-2">

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -135,10 +135,11 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
     if "pilotage_webinar_banners" not in base_context:
         base_context["pilotage_webinar_banners"] = [
             {
-                "title": "Des questions sur l’utilisation de vos tableaux de bord ?",
-                "description": "Nous y répondons lors d’un webinaire questions / réponses animé chaque mois. Inscrivez-vous à la prochaine session prévu jeudi 29 août de 14h à 14h45.",  # noqa: E501
-                "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-de-liae-questions-reponses-sur-les-tableaux-de-bord-1?s=67c316de-9dc5-4ec7-a469-6698507fa312",  # noqa: E501
-                "is_displayable": lambda: timezone.localdate() <= datetime.date(2024, 8, 29),
+                "title": "Enquête utilisateur : votre avis est précieux pour nous aider à améliorer nos tableaux de bord !",  # noqa: E501
+                "description": "Jusqu’au 20 octobre, prenez part à notre enquête sur l'usage des tableaux de bord dans vos missions et partagez vos suggestions d'amélioration.",  # noqa: E501
+                "call_to_action": "Je participe à l’enquête",
+                "url": "https://tally.so/r/nPYGJd",
+                "is_displayable": lambda: timezone.localdate() <= datetime.date(2024, 10, 20),
             }
         ]
     base_context["pilotage_webinar_banners"] = [

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -343,36 +343,12 @@ def stats_cd_iae(request):
 
 @login_required
 def stats_cd_hiring(request):
-    context = {
-        "pilotage_webinar_banners": [
-            {
-                "title": "Des questions sur la prise en main de ce nouveau tableau de bord ?",
-                "description": "Nous y répondons en direct lors d’un webinaire de questions / réponses, dédiés aux Conseils départementaux, organisés le mardi 17 septembre à 14h",  # noqa: E501
-                "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-webinaire-questions-and-reponses-pour-les-conseils-departementaux?s=f83e62e2-42a3-4cc1-9772-c963d2be2c00",  # noqa: E501
-                "is_displayable": lambda: timezone.localdate() <= datetime.date(2024, 9, 17),
-            }
-        ]
-    }
-    return render_stats_cd(request=request, page_title="Facilitation des embauches en IAE", extra_context=context)
+    return render_stats_cd(request=request, page_title="Facilitation des embauches en IAE")
 
 
 @login_required
 def stats_cd_brsa(request):
-    context = {
-        "pilotage_webinar_banners": [
-            {
-                "title": "Des questions sur la prise en main de ce nouveau tableau de bord ?",
-                "description": "Nous y répondons en direct lors d’un webinaire de questions / réponses, dédiés aux Conseils départementaux, organisés le mardi 17 septembre à 14h",  # noqa: E501
-                "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-webinaire-questions-and-reponses-pour-les-conseils-departementaux?s=f83e62e2-42a3-4cc1-9772-c963d2be2c00",  # noqa: E501
-                "is_displayable": lambda: timezone.localdate() <= datetime.date(2024, 9, 17),
-            }
-        ]
-    }
-    return render_stats_cd(
-        request=request,
-        page_title="Suivi des prescriptions des accompagnateurs des publics bRSA",
-        extra_context=context,
-    )
+    return render_stats_cd(request=request, page_title="Suivi des prescriptions des accompagnateurs des publics bRSA")
 
 
 @login_required


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/enqu-te-utilisateur-Ajouter-un-encart-sur-les-TDB-afin-d-annoncer-l-enqu-te-utilisateurs-6d9f60a98d7840ce9cc3d52ee1119cbd?pvs=4

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/b50b8818-5d08-4723-92a7-1b0fe43194ad)
