### PR TITLE
Statistiques: Amélioration du suivi des refus de candidatures [GEN-2117]

### DIFF
--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -127,9 +127,9 @@
 
                             {% url 'apply:details_for_company' job_application_id=job_application.id as reset_url %}
                             {% if wizard.steps.prev %}
-                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" secondary_url=wizard.steps.prev matomo_category="candidature" matomo_action="submit" matomo_name="refuse_application_submit" %}
+                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" secondary_url=wizard.steps.prev matomo_category="candidature" matomo_action="submit" matomo_name=matomo_event_name %}
                             {% else %}
-                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" matomo_category="candidature" matomo_action="submit" matomo_name="refuse_application_submit" %}
+                                {% itou_buttons_form reset_url=reset_url primary_label=wizard.steps.next|yesno:"Suivant,Confirmer le refus" matomo_category="candidature" matomo_action="submit" matomo_name=matomo_event_name %}
                             {% endif %}
                         </form>
                     </div>

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -403,6 +403,7 @@ class JobApplicationRefuseView(LoginRequiredMixin, NamedUrlSessionWizardView):
             "job_application": self.job_application,
             "can_view_personal_information": True,  # SIAE members have access to personal info
             "matomo_custom_title": "Candidature refusée",
+            "matomo_event_name": f"refuse-application-{self.steps.current}-submit",
             "primary_button_label": "Suivant" if context["wizard"]["steps"].next else "Confirmer le refus",
             "secondary_button_label": "Précédent" if context["wizard"]["steps"].prev else "Annuler",
         }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour suivre le taux de conversion à chaque étape du refus (choix de la raison, message pour le candidat, message pour le prescripteur)

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
