### PR TITLE
Admin : Lecture seule pour les champs `siret`, `convention` et `auth_email` quand l'entreprise vient du flux IAE

### DIFF
--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -200,6 +200,8 @@ class CompanyAdmin(ItouGISMixin, OrganizationAdmin):
         ]
         if obj:
             readonly_fields.append("kind")
+            if obj.source == models.Company.SOURCE_ASP:
+                readonly_fields.extend(["siret", "convention", "auth_email"])
         return readonly_fields
 
     def save_model(self, request, obj, form, change):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter des erreurs humaines et les grains de sable dans la machinerie.

`siret` : Utiliser par l'import IAE comme valeur identifiant
`convention` : Je ne vois pas de raison pour laisser modifier la convention par autre chose que l'import IAE vu que c'est la source de donnée
`auth_email` : Moins critique mais vu que c'est l'email utilisé pour la première inscription c'est pas plus mal de ne pas autoriser sa modification pour rester aligné avec les données du flux