### PR TITLE
assertSnapshotQueries: gestion d'une origine manquante

### DIFF
--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -292,7 +292,10 @@ def _detect_origin(debug=False):
                         pass
                     else:
                         class_name = type(frame_self).__name__
-                        template_origin = f"{class_name}[{frame_self.origin.template_name}]"
+                        if hasattr(frame_self, "origin"):
+                            template_origin = f"{class_name}[{frame_self.origin.template_name}]"
+                        else:
+                            template_origin = class_name
                         # This requires the engine to be in debug mode
                         if debug:
                             template_debug_info = get_template_source_from_exception_info(frame_self, frame_context)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parfois, le noeud n'a pas d'attribut `origin` et :boom: .

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
