### PR TITLE
Connexion: Amélioration technique autour de la mise à jour de SSO

### DIFF
--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+from typing import ClassVar
 
 from itou.users.enums import IdentityProvider, UserKind
 
@@ -19,9 +20,9 @@ class FranceConnectUserData(OIDConnectUserData):
     address_line_1: str | None = None
     post_code: str | None = None
     city: str | None = None
-    kind: str = UserKind.JOB_SEEKER
+    kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.FRANCE_CONNECT
-    login_allowed_user_kinds = [UserKind.JOB_SEEKER]
+    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.JOB_SEEKER]
 
     @staticmethod
     def user_info_mapping_dict(user_info: dict):

--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -23,6 +23,7 @@ class FranceConnectUserData(OIDConnectUserData):
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.FRANCE_CONNECT
     login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.JOB_SEEKER]
+    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]
 
     @staticmethod
     def user_info_mapping_dict(user_info: dict):

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+from typing import ClassVar
 
 from django.db import models
 
@@ -16,15 +17,12 @@ logger = logging.getLogger(__name__)
 class InclusionConnectState(OIDConnectState):
     data = models.JSONField(verbose_name="données de session", default=dict, blank=True)
 
-    class Meta:
-        abstract = False
-
 
 @dataclasses.dataclass
 class InclusionConnectPrescriberData(OIDConnectUserData):
-    kind: str = UserKind.PRESCRIBER
+    kind: UserKind = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
-    login_allowed_user_kinds = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
+    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
 
     def join_org(self, user: User, safir: str):
         try:
@@ -38,6 +36,6 @@ class InclusionConnectPrescriberData(OIDConnectUserData):
 
 @dataclasses.dataclass
 class InclusionConnectEmployerData(OIDConnectUserData):
-    kind: str = UserKind.EMPLOYER
+    kind: UserKind = UserKind.EMPLOYER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
-    login_allowed_user_kinds = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
+    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.PRESCRIBER, UserKind.EMPLOYER]

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -23,6 +23,7 @@ class InclusionConnectPrescriberData(OIDConnectUserData):
     kind: UserKind = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
     login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
+    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]
 
     def join_org(self, user: User, safir: str):
         try:
@@ -39,3 +40,4 @@ class InclusionConnectEmployerData(OIDConnectUserData):
     kind: UserKind = UserKind.EMPLOYER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
     login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
+    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]

--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -268,9 +268,8 @@ def inclusion_connect_callback(request):
         messages.error(request, error)
         is_successful = False
 
-    user_created = False
     try:
-        user, user_created = ic_user_data.create_or_update_user(is_login=ic_state.data.get("is_login"))
+        user, _ = ic_user_data.create_or_update_user(is_login=ic_state.data.get("is_login"))
     except InvalidKindException:
         existing_user = User.objects.get(email=user_data["email"])
         _add_user_kind_error_message(request, existing_user, user_kind)

--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import ClassVar
 from urllib.parse import unquote
 
 from django.core import signing
@@ -103,8 +104,8 @@ class OIDConnectUserData:
     last_name: str
     username: str
     identity_provider: IdentityProvider
-    kind: str
-    login_allowed_user_kinds = [UserKind]
+    kind: UserKind
+    login_allowed_user_kinds: ClassVar[list[UserKind]]
 
     def check_valid_kind(self, user, user_data_dict, is_login):
         if user.kind not in self.login_allowed_user_kinds or (user.kind != user_data_dict["kind"] and not is_login):

--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -106,6 +106,7 @@ class OIDConnectUserData:
     identity_provider: IdentityProvider
     kind: UserKind
     login_allowed_user_kinds: ClassVar[list[UserKind]]
+    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = dataclasses.field(default=list)
 
     def check_valid_kind(self, user, user_data_dict, is_login):
         if user.kind not in self.login_allowed_user_kinds or (user.kind != user_data_dict["kind"] and not is_login):
@@ -128,23 +129,24 @@ class OIDConnectUserData:
         birthdate = user_data_dict.pop(
             "birthdate", _no_birthdate
         )  # This field is stored on JobSeekerProfile and not User
+        update_user_info = True
+        created = False
         try:
             # Look if a user with the given sub (username) exists for this identity_provider
             # We can't use a get_or_create here because we have to set the provider data for each field.
             user = User.objects.get(username=self.username, identity_provider=self.identity_provider)
-            created = False
         except User.DoesNotExist:
             try:
                 # A different user has already claimed this email address (we require emails to be unique)
                 user = User.objects.get(email=self.email)
-                created = False
                 if user.identity_provider == self.identity_provider:
                     raise EmailInUseException(user)
-                # It is possible to "upgrade" a Django account to an SSO, but not to replace an SSO
-                if user.identity_provider != IdentityProvider.DJANGO:
-                    self.check_valid_kind(user, user_data_dict, is_login)
-                    # Don't update a user handled by another SSO provider.
-                    return user, created
+                # if it can, do we update the account -> if not don't update user info
+                if user.identity_provider not in self.allowed_identity_provider_migration:
+                    # Updating a user info also changes the identity_provider
+                    update_user_info = False
+                    # If we want to prevent the user to login if the account is handled by another provider
+                    # don't change update_user_info and just raise a new error here.
             except User.DoesNotExist:
                 # User.objects.create_user does the following:
                 # - set User.is_active to true,
@@ -154,11 +156,11 @@ class OIDConnectUserData:
                 # provider the code will break here. We know it but since it's highly unlikely we just added a test
                 # on this behaviour. No need to do a fancy bypass if it's never used.
                 user = User.objects.create_user(**user_data_dict)
+                update_user_info = False
                 created = True
                 if birthdate is not _no_birthdate and user_data_dict["kind"] == UserKind.JOB_SEEKER:
                     user.jobseeker_profile.birthdate = birthdate
                     user.jobseeker_profile.save(update_fields={"birthdate"})
-
         else:
             other_user = User.objects.exclude(pk=user.pk).filter(email=self.email).first()
             if other_user:
@@ -168,7 +170,7 @@ class OIDConnectUserData:
 
         self.check_valid_kind(user, user_data_dict, is_login)
 
-        if not created:
+        if update_user_info:
             for key, value in user_data_dict.items():
                 # Don't update kind on login, it allows prescribers to log through employer form
                 # which happens a lot...
@@ -179,9 +181,11 @@ class OIDConnectUserData:
                 user.jobseeker_profile.birthdate = birthdate
                 user.jobseeker_profile.save(update_fields={"birthdate"})
 
-        for key, value in user_data_dict.items():
-            user.update_external_data_source_history_field(provider=self.identity_provider, field=key, value=value)
-        user.save()
+        if created or update_user_info:
+            for key, value in user_data_dict.items():
+                user.update_external_data_source_history_field(provider=self.identity_provider, field=key, value=value)
+            user.save()
+
         return user, created
 
     @staticmethod

--- a/itou/openid_connect/pe_connect/models.py
+++ b/itou/openid_connect/pe_connect/models.py
@@ -17,3 +17,4 @@ class PoleEmploiConnectUserData(OIDConnectUserData):
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.PE_CONNECT
     login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.JOB_SEEKER]
+    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]

--- a/itou/openid_connect/pe_connect/models.py
+++ b/itou/openid_connect/pe_connect/models.py
@@ -1,4 +1,5 @@
 import dataclasses
+from typing import ClassVar
 
 from itou.users.enums import IdentityProvider, UserKind
 
@@ -6,14 +7,13 @@ from ..models import OIDConnectState, OIDConnectUserData
 
 
 class PoleEmploiConnectState(OIDConnectState):
-    class Meta:
-        abstract = False
+    pass
 
 
 @dataclasses.dataclass
 class PoleEmploiConnectUserData(OIDConnectUserData):
     # Attributes are User model ones.
     # Mapping is made in self.user_info_mapping_dict.
-    kind: str = UserKind.JOB_SEEKER
+    kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.PE_CONNECT
-    login_allowed_user_kinds = [UserKind.JOB_SEEKER]
+    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.JOB_SEEKER]


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'idée est de sortir une partie de la PR ProConnect pour permettre à Calum de l'utliser dans une autre PR où l'on va empêcher FranceConnect et PEConnect de convertir des comptes Django, et de se connecter depuis un compte de l'autre SSO  

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
