### PR TITLE
Connexion: Ajout d'un vérification du paramètre `next_url` lors d'une connexion via un SSO

### DIFF
--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -29,19 +29,10 @@ def _redirect_to_job_seeker_login_on_error(error_msg, request=None, extra_tags="
     return HttpResponseRedirect(reverse("login:job_seeker"))
 
 
-def get_callback_redirect_uri(request) -> str:
-    redirect_uri = get_absolute_url(reverse("france_connect:callback"))
-    next_url = request.GET.get("next")
-    if next_url:
-        redirect_uri += f"?next={next_url}"
-
+def france_connect_authorize(request):
     # The redirect_uri should be defined in the FC settings to be allowed
     # NB: the integration platform allows "http://127.0.0.1:8000/franceconnect/callback"
-    return redirect_uri
-
-
-def france_connect_authorize(request):
-    redirect_uri = get_callback_redirect_uri(request)
+    redirect_uri = get_absolute_url(reverse("france_connect:callback"))
     state = FranceConnectState.save_state()
     data = {
         "response_type": "code",
@@ -70,8 +61,7 @@ def france_connect_callback(request):
         )
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
-    redirect_uri = get_callback_redirect_uri(request)
-
+    redirect_uri = get_absolute_url(reverse("france_connect:callback"))
     data = {
         "client_id": settings.FRANCE_CONNECT_CLIENT_ID,
         "client_secret": settings.FRANCE_CONNECT_CLIENT_SECRET,

--- a/tests/openid_connect/inclusion_connect/tests.py
+++ b/tests/openid_connect/inclusion_connect/tests.py
@@ -363,6 +363,13 @@ class InclusionConnectAuthorizeViewTest(InclusionConnectBaseTestCase):
                 response = self.client.get(url)
                 self.assertRedirects(response, reverse("search:employers_home"))
 
+    def test_next_url(self):
+        url = f"{reverse('inclusion_connect:authorize')}?{urlencode({'next_url': 'https://external.url.com'})}"
+        with self.assertLogs() as cm:
+            response = self.client.get(url, follow=False)
+        self.assertRedirects(response, reverse("search:employers_home"))
+        assert cm.records[0].message == "Forbidden external url"
+
 
 class InclusionConnectCallbackViewTest(MessagesTestMixin, InclusionConnectBaseTestCase):
     @respx.mock


### PR DESCRIPTION
## :thinking: Pourquoi ?

Extrait de #4080
Voir https://github.com/gip-inclusion/les-emplois/pull/4080#discussion_r1752096446 et https://github.com/gip-inclusion/les-emplois/pull/4080#discussion_r1752128117

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
