### PR TITLE
Employeur : le champ `email` est facultatif dans les formulaires d'édition et de création de SIAE

### DIFF
--- a/itou/www/companies_views/forms.py
+++ b/itou/www/companies_views/forms.py
@@ -122,7 +122,7 @@ class EditCompanyForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        required_fields = ["brand", "address_line_1", "post_code", "city", "phone", "email"]
+        required_fields = ["brand", "address_line_1", "post_code", "city", "phone"]
         for required_field in required_fields:
             self.fields[required_field].required = True
 

--- a/tests/www/companies_views/test_edit_company_views.py
+++ b/tests/www/companies_views/test_edit_company_views.py
@@ -24,8 +24,8 @@ class EditCompanyViewTest(TestCase):
 
         post_data = {
             "brand": "NEW FAMOUS COMPANY BRAND NAME",
-            "phone": "0610203050",
-            "email": "",
+            "phone": "",
+            "email": "toto@titi.fr",
             "website": "https://famous-company.com",
             "address_line_1": "1 Rue Jeanne d'Arc",
             "address_line_2": "",
@@ -38,7 +38,7 @@ class EditCompanyViewTest(TestCase):
         self.assertContains(response, "Ce champ est obligatoire")
 
         # Go to next step: description
-        post_data["email"] = "toto@titi.fr"
+        post_data["phone"] = "0610203050"
         response = self.client.post(url, data=post_data)
         self.assertRedirects(response, reverse("companies_views:edit_company_step_description"))
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le champ `email` était obligatoire dans le formulaire **d'édition** d'une SIAE, mais pas dans le formulaire **de création**.
On veut harmoniser, et il semble préférable d'avoir un **champ facultatif** : une structure peut ne pas vouloir recevoir d'emails.

Dans pas mal de jobboards, l'entreprise a le choix de ne pas exposer ce champ au public.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

