### PR TITLE
Connexion : Empêcher les utilisateurs de remplacer leur SSO une fois ils sont inscrit [GEN-2115]

### DIFF
--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -22,8 +22,8 @@ class FranceConnectUserData(OIDConnectUserData):
     city: str | None = None
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.FRANCE_CONNECT
-    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.JOB_SEEKER]
-    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]
+    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.JOB_SEEKER,)
+    allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()
 
     @staticmethod
     def user_info_mapping_dict(user_info: dict):

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -22,8 +22,8 @@ class InclusionConnectState(OIDConnectState):
 class InclusionConnectPrescriberData(OIDConnectUserData):
     kind: UserKind = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
-    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
-    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]
+    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.PRESCRIBER, UserKind.EMPLOYER)
+    allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = (IdentityProvider.DJANGO,)
 
     def join_org(self, user: User, safir: str):
         try:
@@ -39,5 +39,5 @@ class InclusionConnectPrescriberData(OIDConnectUserData):
 class InclusionConnectEmployerData(OIDConnectUserData):
     kind: UserKind = UserKind.EMPLOYER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
-    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.PRESCRIBER, UserKind.EMPLOYER]
-    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]
+    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.PRESCRIBER, UserKind.EMPLOYER)
+    allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = (IdentityProvider.DJANGO,)

--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -105,8 +105,8 @@ class OIDConnectUserData:
     username: str
     identity_provider: IdentityProvider
     kind: UserKind
-    login_allowed_user_kinds: ClassVar[list[UserKind]]
-    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = dataclasses.field(default=list)
+    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = ()
+    allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()
 
     def check_valid_kind(self, user, user_data_dict, is_login):
         if user.kind not in self.login_allowed_user_kinds or (user.kind != user_data_dict["kind"] and not is_login):
@@ -138,6 +138,7 @@ class OIDConnectUserData:
                 # A different user has already claimed this email address (we require emails to be unique)
                 user = User.objects.get(email=self.email)
                 if user.identity_provider not in self.allowed_identity_provider_migration:
+                    self.check_valid_kind(user, user_data_dict, is_login)
                     raise EmailInUseException(user)
             except User.DoesNotExist:
                 # User.objects.create_user does the following:

--- a/itou/openid_connect/pe_connect/models.py
+++ b/itou/openid_connect/pe_connect/models.py
@@ -16,5 +16,5 @@ class PoleEmploiConnectUserData(OIDConnectUserData):
     # Mapping is made in self.user_info_mapping_dict.
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.PE_CONNECT
-    login_allowed_user_kinds: ClassVar[list[UserKind]] = [UserKind.JOB_SEEKER]
-    allowed_identity_provider_migration: ClassVar[list[IdentityProvider]] = [IdentityProvider.DJANGO]
+    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.JOB_SEEKER,)
+    allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -216,21 +216,6 @@ class FranceConnectTest(TestCase):
         with pytest.raises(ValidationError):
             fc_user_data.create_or_update_user()
 
-    def test_create_django_user_with_already_existing_fc_email_django(self):
-        """
-        If there already is an existing user from Django with email FranceConnect sent us
-        we use it and we update it
-        """
-        fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
-        JobSeekerFactory(email=fc_user_data.email, identity_provider=IdentityProvider.DJANGO)
-        user, created = fc_user_data.create_or_update_user()
-        assert not created
-        assert user.last_name == FC_USERINFO["family_name"]
-        assert user.first_name == FC_USERINFO["given_name"]
-        assert user.username == FC_USERINFO["sub"]
-        assert user.identity_provider == IdentityProvider.FRANCE_CONNECT
-        assert user.external_data_source_history != {}
-
     def test_create_or_update_user_raise_invalid_kind_exception(self):
         fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
 
@@ -317,8 +302,10 @@ class FranceConnectTest(TestCase):
         assert not auth.get_user(self.client).is_authenticated
 
 
-@pytest.mark.parametrize("identity_provider", [IdentityProvider.PE_CONNECT, IdentityProvider.FRANCE_CONNECT])
-def test_create_django_user_with_already_existing_fc_email(identity_provider):
+@pytest.mark.parametrize(
+    "identity_provider", [IdentityProvider.DJANGO, IdentityProvider.PE_CONNECT, IdentityProvider.FRANCE_CONNECT]
+)
+def test_create_django_user_with_already_existing_fc_email_fails(identity_provider):
     fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
     JobSeekerFactory(
         username="another_username",

--- a/tests/openid_connect/pe_connect/tests.py
+++ b/tests/openid_connect/pe_connect/tests.py
@@ -181,21 +181,6 @@ class TestPoleEmploiConnect:
         with pytest.raises(ValidationError):
             peamu_user_data.create_or_update_user()
 
-    def test_create_django_user_with_already_existing_peamu_email_django(self):
-        """
-        If there already is an existing user from Django with email PEAMU sent us
-        we use it and we update it
-        """
-        peamu_user_data = PoleEmploiConnectUserData.from_user_info(PEAMU_USERINFO)
-        JobSeekerFactory(email=peamu_user_data.email, identity_provider=IdentityProvider.DJANGO)
-        user, created = peamu_user_data.create_or_update_user()
-        assert not created
-        assert user.last_name == PEAMU_USERINFO["family_name"]
-        assert user.first_name == PEAMU_USERINFO["given_name"]
-        assert user.username == PEAMU_USERINFO["sub"]
-        assert user.identity_provider == IdentityProvider.PE_CONNECT
-        assert user.external_data_source_history != {}
-
     def test_create_or_update_user_raise_invalid_kind_exception(self):
         peamu_user_data = PoleEmploiConnectUserData.from_user_info(PEAMU_USERINFO)
 
@@ -323,8 +308,10 @@ class TestPoleEmploiConnect:
         assert not auth.get_user(client).is_authenticated
 
 
-@pytest.mark.parametrize("identity_provider", [IdentityProvider.PE_CONNECT, IdentityProvider.FRANCE_CONNECT])
-def test_create_user_with_already_existing_peamu_email(identity_provider):
+@pytest.mark.parametrize(
+    "identity_provider", [IdentityProvider.DJANGO, IdentityProvider.PE_CONNECT, IdentityProvider.FRANCE_CONNECT]
+)
+def test_create_user_with_already_existing_peamu_email_fails(identity_provider):
     """
     In OIDC, SSO provider + username represents unicity.
     However, we require that emails are unique as well.


### PR DESCRIPTION
## :thinking: Pourquoi ?

Désormais quand l'utilisateur se connecte aux emplois avec un SSO (InclusionConnect, PEConnect, FranceConnect) et le compte n'existe pas mais le courriel est utilisé par un autre SSO, on va montrer en erreur. Précédemment on a laissé l'utilisateur à écraser son compte, et ça a causé des problèmes pour les utilisateurs qui partagent une adresse e-mail.

On permet toujours les utilisateurs à remplacer leur compte Django avec un compte SSO.

## :cake: Comment ?

Sur un prochain ticket on va remplacer les alertes / modales affichées avec des alertes qui rédirigent vers le connexion. Je les ai laissé dans l'état actuel pour l'instant pour simiplifier cette étape ci.

Extension de https://github.com/gip-inclusion/les-emplois/pull/4810

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
