### PR TITLE
UX/UI: l'input de recherche dépasse du viewport en mobile

### DIFF
--- a/itou/templates/search/includes/prescribers_search_form.html
+++ b/itou/templates/search/includes/prescribers_search_form.html
@@ -13,7 +13,7 @@
             <div class="input-group-text bg-white p-0">
                 <button class="btn btn-ico {% if is_home %}btn-primary{% else %}btn-link{% endif %} js-search-button" aria-label="Rechercher un prescripteur">
                     <i class="ri-search-line font-weight-bold" aria-hidden="true"></i>
-                    <span {% if is_home %}class="d-none d-sm-inline-flex me-0 me-sm-1"{% endif %}>Rechercher</span>
+                    <span class="d-none d-sm-inline-flex me-0 me-sm-1">Rechercher</span>
                 </button>
             </div>
         </div>

--- a/itou/templates/search/includes/siaes_search_form.html
+++ b/itou/templates/search/includes/siaes_search_form.html
@@ -14,7 +14,7 @@
             <div class="input-group-text bg-white p-0">
                 <button class="btn btn-ico {% if is_home %}btn-primary{% else %}btn-link{% endif %}" aria-label="Rechercher un emploi inclusif">
                     <i class="ri-search-line font-weight-bold" aria-hidden="true"></i>
-                    <span {% if is_home %}class="d-none d-sm-inline-flex me-0 me-sm-1"{% endif %}>Rechercher</span>
+                    <span class="d-none d-sm-inline-flex me-0 me-sm-1">Rechercher</span>
                 </button>
             </div>
         </div>

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -19,7 +19,7 @@
               <div class="input-group-text bg-white p-0">
                   <button aria-label="Rechercher un emploi inclusif" class="btn btn-ico btn-link">
                       <i aria-hidden="true" class="ri-search-line font-weight-bold"></i>
-                      <span>Rechercher</span>
+                      <span class="d-none d-sm-inline-flex me-0 me-sm-1">Rechercher</span>
                   </button>
               </div>
           </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pacque des classes responsives n'étaient plus utilisées que sur la home
