### PR TITLE
Tech: correction des formulaires de création de suspension & fiche salarié

### DIFF
--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -81,7 +81,7 @@
                                 <p>
                                     En confirmant cette demande je certifie sur l'honneur que le motif de suspension choisi correspond à la situation du salarié.
                                 </p>
-                                {% itou_buttons_form primary_label="Confirmer la suspension" primary_aria_label="Confirmer la suspension du PASS IAE de "|add:approval.user.get_full_name primary_name="save" primary_value=1 secondary_url=request.path|add:"?back_url="|add:back_url secondary_name="edit" secondary_value="1" reset_url=back_url show_mandatory_fields_mention=False %}
+                                {% itou_buttons_form primary_label="Confirmer la suspension" primary_aria_label="Confirmer la suspension du PASS IAE de "|add:approval.user.get_full_name primary_name="save" primary_value=1 secondary_name="edit" secondary_value="1" reset_url=back_url show_mandatory_fields_mention=False %}
 
                             </form>
                         </div>

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -59,7 +59,7 @@
                             {% url "employee_record_views:list" as reset_url %}
                             {% if wizard.steps.prev %}
                                 {% url 'employee_record_views:add' as secondary_url %}
-                                {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" secondary_url=secondary_url|add:wizard.steps.prev secondary_name="wizard_goto_step" secondary_value=wizard.steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_name="création" %}
+                                {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" secondary_name="wizard_goto_step" secondary_value=wizard.steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_name="création" %}
                             {% else %}
                                 {% itou_buttons_form primary_label=wizard.steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url|add:"?status=NEW" %}
                             {% endif %}

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -6,7 +6,8 @@
         {% if show_mandatory_fields_mention %}<small class="d-inline-block mb-3">* champs obligatoires</small>{% endif %}
         <div class="form-row align-items-center justify-content-end gx-3">
             <div class="form-group col-12 col-lg order-3 order-lg-1">
-                {% if secondary_url %}
+                {% if secondary_name and secondary_value or secondary_url %}
+                    {# If there is a previous step - which is what most secondaries link to - we want a confirmation before resetting everything #}
                     <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
                         <i class="ri-close-line ri-lg" aria-hidden="true"></i>
                         <span>Annuler</span>
@@ -18,14 +19,17 @@
                     </a>
                 {% endif %}
             </div>
-            {% if secondary_url %}
+            {% if secondary_name and secondary_value or secondary_url %}
                 <div class="form-group col col-lg-auto order-1 order-lg-2">
-                    <a href="{{ secondary_url }}"
-                       class="btn btn-block btn-outline-primary"
-                       aria-label="{{ secondary_aria_label }}"
-                       {% if secondary_name and secondary_value %}name="{{ secondary_name }}" value="{{ secondary_value }}"{% endif %}>
-                        <span>Retour</span>
-                    </a>
+                    {% if secondary_name and secondary_value %}
+                        <button type="submit" class="btn btn-block btn-outline-primary" aria-label="{{ secondary_aria_label }}" name="{{ secondary_name }}" value="{{ secondary_value }}">
+                            <span>Retour</span>
+                        </button>
+                    {% else %}
+                        <a href="{{ secondary_url }}" class="btn btn-block btn-outline-primary" aria-label="{{ secondary_aria_label }}">
+                            <span>Retour</span>
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
             <div class="form-group col col-lg-auto order-2 order-lg-3">
@@ -55,7 +59,7 @@
     </div>
 </div>
 
-{% if secondary_url %}
+{% if secondary_name and secondary_value or secondary_url %}
     <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -55,21 +55,23 @@
     </div>
 </div>
 
-<div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-            </div>
-            <div class="modal-body">
-                Les informations renseignées ne seront pas enregistrées.
-                <br>
-                Cette action est irréversible.
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+{% if secondary_url %}
+    <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                </div>
+                <div class="modal-body">
+                    Les informations renseignées ne seront pas enregistrées.
+                    <br>
+                    Cette action est irréversible.
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                    <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                </div>
             </div>
         </div>
     </div>
-</div>
+{% endif %}

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -41,7 +41,6 @@
                     <a href="{{ primary_url }}"
                        class="btn btn-block btn-primary"
                        aria-label="{{ primary_aria_label }}"
-                       {% if primary_name and primary_value %}name="{{ primary_name }}" value="{{ primary_value }}"{% endif %}
                        {% if matomo_category and matomo_action and matomo_name %}{% matomo_event matomo_category matomo_action matomo_name %}{% endif %}>
                         <span>{{ primary_label }}</span>
                     </a>

--- a/itou/templates/utils/templatetags/buttons_form.html
+++ b/itou/templates/utils/templatetags/buttons_form.html
@@ -58,33 +58,18 @@
 <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
-            {% if modal_content_save_and_quit %}
-                <div class="modal-header">
-                    <h3 class="modal-title">Enregistrer et quitter ?</h3>
-                </div>
-                <div class="modal-body">
-                    Les informations renseignées seront enregistrées.
-                    <br>
-                    Vous pourrez terminer de les compléter plus tard.
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                    <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Enregistrer et quitter</a>
-                </div>
-            {% else %}
-                <div class="modal-header">
-                    <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                </div>
-                <div class="modal-body">
-                    Les informations renseignées ne seront pas enregistrées.
-                    <br>
-                    Cette action est irréversible.
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                    <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                </div>
-            {% endif %}
+            <div class="modal-header">
+                <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+            </div>
+            <div class="modal-body">
+                Les informations renseignées ne seront pas enregistrées.
+                <br>
+                Cette action est irréversible.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                <a href="{{ reset_url }}" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+            </div>
         </div>
     </div>
 </div>

--- a/itou/utils/templatetags/buttons_form.py
+++ b/itou/utils/templatetags/buttons_form.py
@@ -23,7 +23,6 @@ def itou_buttons_form(
     matomo_category=None,
     matomo_action=None,
     matomo_name=None,
-    modal_content_save_and_quit=False,
 ):
     """
     Render buttons on forms.
@@ -67,9 +66,6 @@ def itou_buttons_form(
         secondary_name & secondary_value
             If set together, the name and value for the secondary button.
 
-        modal_content_save_and_quit
-            If set, force alternate modal content for the save and quit button.
-
     **Usage**::
 
         {% itou_buttons_form  %}
@@ -99,5 +95,4 @@ def itou_buttons_form(
         "matomo_category": matomo_category,
         "matomo_action": matomo_action,
         "matomo_name": matomo_name,
-        "modal_content_save_and_quit": modal_content_save_and_quit,
     }

--- a/itou/utils/templatetags/buttons_form.py
+++ b/itou/utils/templatetags/buttons_form.py
@@ -79,6 +79,18 @@ def itou_buttons_form(
     if any(matomo_values) and not all(matomo_values):
         raise ValueError("Matomo values are all or nothing")
 
+    if (primary_name is None) != (primary_value is None):
+        raise ValueError("primary_name & primary_value must be used together")
+
+    if primary_name and primary_url:
+        raise ValueError("primary_url cannot be used with primary_name/value")
+
+    if (secondary_name is None) != (secondary_value is None):
+        raise ValueError("secondary_name & secondary_value must be used together")
+
+    if secondary_name and secondary_url:
+        raise ValueError("secondary_url cannot be used with secondary_name/value")
+
     return {
         "show_mandatory_fields_mention": show_mandatory_fields_mention,
         "primary_aria_label": primary_aria_label,

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -376,6 +376,7 @@
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
                   
+                      
                       <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
                           <i class="ri-close-line ri-lg" aria-hidden="true"></i>
                           <span>Annuler</span>
@@ -384,12 +385,11 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a href="/prev"
-                         class="btn btn-block btn-outline-primary"
-                         aria-label="label"
-                         >
-                          <span>Retour</span>
-                      </a>
+                      
+                          <a href="/prev" class="btn btn-block btn-outline-primary" aria-label="label">
+                              <span>Retour</span>
+                          </a>
+                      
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
@@ -441,6 +441,7 @@
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
                   
+                      
                       <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
                           <i class="ri-close-line ri-lg" aria-hidden="true"></i>
                           <span>Annuler</span>
@@ -449,12 +450,11 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a href="/do"
-                         class="btn btn-block btn-outline-primary"
-                         aria-label="Retourner à l’étape précédente"
-                         name="name" value="1">
-                          <span>Retour</span>
-                      </a>
+                      
+                          <button type="submit" class="btn btn-block btn-outline-primary" aria-label="Retourner à l’étape précédente" name="name" value="1">
+                              <span>Retour</span>
+                          </button>
+                      
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">
@@ -506,6 +506,7 @@
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
                   
+                      
                       <button type="button" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire" data-bs-toggle="modal" data-bs-target="#confirm_reset_modal">
                           <i class="ri-close-line ri-lg" aria-hidden="true"></i>
                           <span>Annuler</span>
@@ -514,12 +515,11 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a href="/do"
-                         class="btn btn-block btn-outline-primary"
-                         aria-label="Retourner à l’étape précédente"
-                         >
-                          <span>Retour</span>
-                      </a>
+                      
+                          <a href="/do" class="btn btn-block btn-outline-primary" aria-label="Retourner à l’étape précédente">
+                              <span>Retour</span>
+                          </a>
+                      
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -314,7 +314,6 @@
                       <a href="/next"
                          class="btn btn-block btn-primary"
                          aria-label="Passer à l’étape suivante"
-                         
                          >
                           <span>Suivant</span>
                       </a>
@@ -351,7 +350,6 @@
                       <a href="/next"
                          class="btn btn-block btn-primary"
                          aria-label="label"
-                         name="name" value="1"
                          data-matomo-event="true" data-matomo-category="category" data-matomo-action="action" data-matomo-option="name">
                           <span>Suivant</span>
                       </a>

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -291,6 +291,43 @@
   
   '''
 # ---
+# name: TestButtonsForm.test_itou_buttons_with_primary_name_value_aria_label_and_matomo_tags[with_primary_name_value_aria_label_and_matomo_tags]
+  '''
+  
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3">
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
+                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
+                  
+                      <button type="submit"
+                              class="btn btn-block btn-primary"
+                              aria-label="label"
+                              name="name" value="1"
+                              data-matomo-event="true" data-matomo-category="category" data-matomo-action="action" data-matomo-option="name">
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  
+  
+  '''
+# ---
 # name: TestButtonsForm.test_itou_buttons_with_primary_url[with_primary_url]
   '''
   
@@ -315,42 +352,6 @@
                          class="btn btn-block btn-primary"
                          aria-label="Passer à l’étape suivante"
                          >
-                          <span>Suivant</span>
-                      </a>
-                  
-              </div>
-          </div>
-      </div>
-  </div>
-  
-  
-  
-  '''
-# ---
-# name: TestButtonsForm.test_itou_buttons_with_primary_url_name_value_aria_label_and_matomo_tags[with_primary_url_name_value_aria_label_and_matomo_tags]
-  '''
-  
-  
-  <div class="row">
-      <div class="col-12">
-          <hr class="mb-3">
-          <small class="d-inline-block mb-3">* champs obligatoires</small>
-          <div class="form-row align-items-center justify-content-end gx-3">
-              <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  
-                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
-                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
-                          <span>Annuler</span>
-                      </a>
-                  
-              </div>
-              
-              <div class="form-group col col-lg-auto order-2 order-lg-3">
-                  
-                      <a href="/next"
-                         class="btn btn-block btn-primary"
-                         aria-label="label"
-                         data-matomo-event="true" data-matomo-category="category" data-matomo-action="action" data-matomo-option="name">
                           <span>Suivant</span>
                       </a>
                   

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -32,24 +32,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -86,24 +69,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -140,24 +106,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/reset" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -194,24 +143,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -248,24 +180,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -302,24 +217,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -352,24 +250,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -406,24 +287,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -460,24 +324,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -514,24 +361,7 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   '''
 # ---
@@ -577,24 +407,26 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+  
+      <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
               </div>
           </div>
       </div>
-  </div>
+  
   
   '''
 # ---
@@ -640,24 +472,26 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+  
+      <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
               </div>
           </div>
       </div>
-  </div>
+  
   
   '''
 # ---
@@ -703,24 +537,26 @@
       </div>
   </div>
   
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+  
+      <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+                  </div>
               </div>
           </div>
       </div>
-  </div>
+  
   
   '''
 # ---

--- a/tests/utils/__snapshots__/test_templatetags.ambr
+++ b/tests/utils/__snapshots__/test_templatetags.ambr
@@ -35,20 +35,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -91,20 +89,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -147,20 +143,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/reset" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/reset" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -203,20 +197,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -259,20 +251,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -315,20 +305,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -367,20 +355,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -423,20 +409,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -479,20 +463,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -535,20 +517,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -600,20 +580,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -665,20 +643,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>
@@ -730,76 +706,18 @@
   <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
-                  </div>
-              
-          </div>
-      </div>
-  </div>
-  
-  '''
-# ---
-# name: TestButtonsForm.test_save_and_quit_modal_content[save_and_quit_modal_content]
-  '''
-  
-  
-  <div class="row">
-      <div class="col-12">
-          <hr class="mb-3">
-          <small class="d-inline-block mb-3">* champs obligatoires</small>
-          <div class="form-row align-items-center justify-content-end gx-3">
-              <div class="form-group col-12 col-lg order-3 order-lg-1">
-                  
-                      <a href="/dashboard/" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" aria-label="Annuler la saisie de ce formulaire">
-                          <i class="ri-close-line ri-lg" aria-hidden="true"></i>
-                          <span>Annuler</span>
-                      </a>
-                  
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
               </div>
-              
-              <div class="form-group col col-lg-auto order-2 order-lg-3">
-                  
-                      <button type="submit"
-                              class="btn btn-block btn-primary"
-                              aria-label="Passer à l’étape suivante"
-                              
-                              >
-                          <span>Suivant</span>
-                      </button>
-                  
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br>
+                  Cette action est irréversible.
               </div>
-          </div>
-      </div>
-  </div>
-  
-  <div id="confirm_reset_modal" class="modal fade" tabindex="-1" aria-hidden="true">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Enregistrer et quitter ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées seront enregistrées.
-                      <br>
-                      Vous pourrez terminer de les compléter plus tard.
-                  </div>
-                  <div class="modal-footer">
-                      <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                      <a href="/dashboard/" class="btn btn-sm btn-danger">Enregistrer et quitter</a>
-                  </div>
-              
+              <div class="modal-footer">
+                  <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                  <a href="/dashboard/" class="btn btn-sm btn-danger">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -38,14 +38,14 @@ class TestButtonsForm:
         template = Template('{% load buttons_form %}{% itou_buttons_form primary_url="/next" %}')
         assert template.render(Context({})) == snapshot(name="with_primary_url")
 
-    def test_itou_buttons_with_primary_url_name_value_aria_label_and_matomo_tags(self, snapshot):
+    def test_itou_buttons_with_primary_name_value_aria_label_and_matomo_tags(self, snapshot):
         template = Template(
             "{% load buttons_form %}"
-            '{% itou_buttons_form primary_url="/next" primary_name="name" primary_value="1" '
+            '{% itou_buttons_form primary_name="name" primary_value="1" '
             'primary_aria_label="label" '
             'matomo_category="category" matomo_action="action" matomo_name="name" %}'
         )
-        assert template.render(Context({})) == snapshot(name="with_primary_url_name_value_aria_label_and_matomo_tags")
+        assert template.render(Context({})) == snapshot(name="with_primary_name_value_aria_label_and_matomo_tags")
 
     def test_itou_buttons_with_primary_disabled(self, snapshot):
         template = Template("{% load buttons_form %}{% itou_buttons_form primary_disabled=True %}")
@@ -62,10 +62,7 @@ class TestButtonsForm:
         assert template.render(Context({})) == snapshot(name="no_form_title")
 
     def test_itou_buttons_with_secondary_name_and_value(self, snapshot):
-        template = Template(
-            '{% load buttons_form %}{% itou_buttons_form secondary_url="/do" '
-            'secondary_name="name" secondary_value="1" %}'
-        )
+        template = Template('{% load buttons_form %}{% itou_buttons_form secondary_name="name" secondary_value="1" %}')
         assert template.render(Context({})) == snapshot(name="with_secondary_name_and_value")
 
     def test_itou_buttons_matomo_event(self, snapshot):

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -79,10 +79,6 @@ class TestButtonsForm:
         template = Template("{% load buttons_form %}{% itou_buttons_form show_mandatory_fields_mention=False %}")
         assert template.render(Context({})) == snapshot(name="no_mandatory_fields_mention")
 
-    def test_save_and_quit_modal_content(self, snapshot):
-        template = Template("{% load buttons_form %}{% itou_buttons_form modal_content_save_and_quit=True %}")
-        assert template.render(Context({})) == snapshot(name="save_and_quit_modal_content")
-
 
 class TestNav:
     def test_active_view_names(self):

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -813,6 +813,7 @@
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
                   
+                      
                       <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
                           <i aria-hidden="true" class="ri-close-line ri-lg"></i>
                           <span>Annuler</span>
@@ -821,9 +822,11 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
-                          <span>Retour</span>
-                      </a>
+                      
+                          <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/approvals/suspension/[PK of Suspension]/action/">
+                              <span>Retour</span>
+                          </a>
+                      
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -837,24 +837,26 @@
       </div>
   </div>
   
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/approvals/detail/[public_id of User]">Confirmer l'annulation</a>
+  
+      <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/approvals/detail/[public_id of User]">Confirmer l'annulation</a>
+                  </div>
               </div>
           </div>
       </div>
-  </div>
+  
   
                           </form>
                       </div>

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -840,20 +840,18 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/approvals/detail/[public_id of User]">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/approvals/detail/[public_id of User]">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -87,20 +87,18 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/employee_record/list?status=NEW">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/employee_record/list?status=NEW">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -84,24 +84,26 @@
       </div>
   </div>
   
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/employee_record/list?status=NEW">Confirmer l'annulation</a>
+  
+      <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/employee_record/list?status=NEW">Confirmer l'annulation</a>
+                  </div>
               </div>
           </div>
       </div>
-  </div>
+  
   
                               
                           </form>

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -60,6 +60,7 @@
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
                   
+                      
                       <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
                           <i aria-hidden="true" class="ri-close-line ri-lg"></i>
                           <span>Annuler</span>
@@ -68,9 +69,11 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/add/choose-employee" name="wizard_goto_step" value="choose-employee">
-                          <span>Retour</span>
-                      </a>
+                      
+                          <button aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" name="wizard_goto_step" type="submit" value="choose-employee">
+                              <span>Retour</span>
+                          </button>
+                      
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -311,24 +311,26 @@
       </div>
   </div>
   
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/employee_record/list">Confirmer l'annulation</a>
+  
+      <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content">
+                  <div class="modal-header">
+                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+                  </div>
+                  <div class="modal-body">
+                      Les informations renseignées ne seront pas enregistrées.
+                      <br/>
+                      Cette action est irréversible.
+                  </div>
+                  <div class="modal-footer">
+                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                      <a class="btn btn-sm btn-danger" href="/employee_record/list">Confirmer l'annulation</a>
+                  </div>
               </div>
           </div>
       </div>
-  </div>
+  
   
                           
                       </div>

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -287,6 +287,7 @@
           <div class="form-row align-items-center justify-content-end gx-3">
               <div class="form-group col-12 col-lg order-3 order-lg-1">
                   
+                      
                       <button aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" data-bs-target="#confirm_reset_modal" data-bs-toggle="modal" type="button">
                           <i aria-hidden="true" class="ri-close-line ri-lg"></i>
                           <span>Annuler</span>
@@ -295,9 +296,11 @@
               </div>
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
-                      <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/create/[PK of JobApplication]">
-                          <span>Retour</span>
-                      </a>
+                      
+                          <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/create/[PK of JobApplication]">
+                              <span>Retour</span>
+                          </a>
+                      
                   </div>
               
               <div class="form-group col col-lg-auto order-2 order-lg-3">

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -314,20 +314,18 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/employee_record/list">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/employee_record/list">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>

--- a/tests/www/prescribers_views/__snapshots__/test_edit.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_edit.ambr
@@ -258,24 +258,7 @@
       </div>
   </div>
   
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
                           </form>
   '''

--- a/tests/www/prescribers_views/__snapshots__/test_edit.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_edit.ambr
@@ -261,20 +261,18 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -133,20 +133,18 @@
   <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
           <div class="modal-content">
-              
-                  <div class="modal-header">
-                      <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-                  </div>
-                  <div class="modal-body">
-                      Les informations renseignées ne seront pas enregistrées.
-                      <br/>
-                      Cette action est irréversible.
-                  </div>
-                  <div class="modal-footer">
-                      <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                      <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
-                  </div>
-              
+              <div class="modal-header">
+                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
+              </div>
+              <div class="modal-body">
+                  Les informations renseignées ne seront pas enregistrées.
+                  <br/>
+                  Cette action est irréversible.
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
+                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
+              </div>
           </div>
       </div>
   </div>

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -130,24 +130,7 @@
       </div>
   </div>
   
-  <div aria-hidden="true" class="modal fade" id="confirm_reset_modal" tabindex="-1">
-      <div class="modal-dialog modal-dialog-centered">
-          <div class="modal-content">
-              <div class="modal-header">
-                  <h3 class="modal-title">Êtes-vous sûr de vouloir annuler ?</h3>
-              </div>
-              <div class="modal-body">
-                  Les informations renseignées ne seront pas enregistrées.
-                  <br/>
-                  Cette action est irréversible.
-              </div>
-              <div class="modal-footer">
-                  <button class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal" type="button">Retour</button>
-                  <a class="btn btn-sm btn-danger" href="/dashboard/">Confirmer l'annulation</a>
-              </div>
-          </div>
-      </div>
-  </div>
+  
   
   
   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour que le tag fasse ce qu'on pense qu'il fait.

Dans le formulaire de création de suspension, cela permet de conserver ce que l'on avait saisi dans la première étape lorsqu'on clique sur `Retour`.
Dans le formulaire de création de fiche salarié, cela ne semble pas avoir d'impact.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
