### PR TITLE
Employeur : saut de ligne automatique en markdown

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -556,7 +556,12 @@ REQUESTS_TIMEOUT = 5  # in seconds
 
 # Markdownify settings
 # ------------------------------------------------------------------------------
-MARKDOWNIFY = {"default": {"WHITELIST_TAGS": ["a", "p", "ul", "li", "em", "strong"]}}
+MARKDOWNIFY = {
+    "default": {
+        "WHITELIST_TAGS": ["a", "p", "ul", "li", "em", "strong", "br"],
+        "MARKDOWN_EXTENSIONS": ["nl2br"],
+    }
+}
 
 # ASP SFTP connection
 # ------------------------------------------------------------------------------

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -378,7 +378,7 @@ class EditJobDescriptionViewTest(JobDescriptionAbstractTest):
 
         # Step 3: preview and validation
         response = self.client.get(self.edit_preview_url)
-        self.assertContains(response, "<strong>Lorem ipsum</strong>\nSpan")
+        self.assertContains(response, "<strong>Lorem ipsum</strong><br>\nSpan")
         self.assertContains(response, "profile_<em>description</em>")
         self.assertContains(response, "Whatever market description")
         self.assertContains(response, "Curriculum Vitae")


### PR DESCRIPTION
## :thinking: Pourquoi ?

On veut qu'un saut de ligne en markdown génère un saut de ligne (`<br>`) en HTML.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+
