### PR TITLE
Employeur : ajouter un éditeur de texte markdown sur les grands champs de saisie

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,6 +11,7 @@ import warnings
 from dotenv import load_dotenv
 
 from itou.utils.enums import ItouEnvironment
+from itou.utils.urls import markdown_url_set_protocol, markdown_url_set_target_blank
 
 from ..sentry import sentry_init
 
@@ -50,8 +51,10 @@ INSTALLED_APPS = [
     "citext",
     "django_bootstrap5",
     "django_select2",
+    "easymde",
     "formtools",
     "huey.contrib.djhuey",
+    "markdownify",
     "rest_framework",
     "rest_framework.authtoken",
     "drf_spectacular",
@@ -550,6 +553,19 @@ SPECTACULAR_SETTINGS = {
 # requests.get(timeout=settings.REQUESTS_TIMEOUT)
 REQUESTS_TIMEOUT = 5  # in seconds
 
+# Markdownify settings
+# ------------------------------------------------------------------------------
+MARKDOWNIFY = {
+    "default": {
+        "WHITELIST_TAGS": ["a", "p", "ul", "ol", "li", "em", "strong", "br"],
+        "MARKDOWN_EXTENSIONS": ["nl2br", "sane_lists"],
+        "LINKIFY_TEXT": {
+            "PARSE_URLS": True,
+            "CALLBACKS": [markdown_url_set_target_blank, markdown_url_set_protocol],
+            "PARSE_EMAIL": True,
+        },
+    }
+}
 # ASP SFTP connection
 # ------------------------------------------------------------------------------
 ASP_SFTP_HOST = os.getenv("ASP_SFTP_HOST")

--- a/itou/static/js/easymde_config.js
+++ b/itou/static/js/easymde_config.js
@@ -1,0 +1,43 @@
+
+let textareas = document.querySelectorAll(".easymde-box");
+
+textareas.forEach((textarea) => {
+  const easyMDE = new EasyMDE({
+    element: textarea,
+    autoDownloadFontAwesome: true,
+    toolbar: [
+      {
+        name: "bold",
+        action: EasyMDE.toggleBold,
+        className: "ri ri-bold ri-lg",
+        title: "Gras",
+      },
+      {
+        name: "italic",
+        action: EasyMDE.toggleItalic,
+        className: "ri ri-italic ri-lg",
+        title: "Italique",
+      },
+      {
+        name: "unordered-list",
+        action: EasyMDE.toggleUnorderedList,
+        className: "ri ri-list-unordered ri-lg",
+        title: "Liste à puces",
+      },
+      {
+        name: "ordered-list",
+        action: EasyMDE.toggleOrderedList,
+        className: "ri ri-list-ordered ri-lg",
+        title: "Liste numérotée",
+      },
+      {
+        name: "link",
+        action: EasyMDE.drawLink,
+        className: "ri ri-link ri-lg",
+        title: "Lien",
+      },
+    ],
+    spellChecker: false,
+    status: [],
+  });
+});

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load str_filters %}
 {% load matomo %}
+{% load markdownify %}
 
 {% block title %}{{ siae.display_name }} {{ block.super }}{% endblock %}
 
@@ -79,14 +80,14 @@
                         {% if siae.description %}
                             <article class="mb-3 mb-lg-5">
                                 <h2 class="h3">Son activité</h2>
-                                {{ siae.description | linebreaks }}
+                                {{ siae.description|markdownify }}
                             </article>
                         {% endif %}
 
                         {% if siae.provided_support %}
                             <article>
                                 <h2 class="h3">L'accompagnement proposé</h2>
-                                {{ siae.provided_support | linebreaks }}
+                                {{ siae.provided_support|markdownify }}
                             </article>
                         {% endif %}
 

--- a/itou/templates/companies/create_siae.html
+++ b/itou/templates/companies/create_siae.html
@@ -4,6 +4,8 @@
 
 {% block title %}Créer une nouvelle structure {{ block.super }}{% endblock %}
 
+{% block extra_head %}{{ block.super }}{{ form.media.css }}{% endblock %}
+
 {% block title_content %}
     <h1>Créer/rejoindre une nouvelle structure</h1>
     <p>Vous souhaitez rejoindre une structure :</p>
@@ -63,4 +65,9 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media.js }}
 {% endblock %}

--- a/itou/templates/companies/edit_job_description_details.html
+++ b/itou/templates/companies/edit_job_description_details.html
@@ -5,6 +5,8 @@
 
 {% block title %}Modifier les détails de la fiche de poste {{ block.super }}{% endblock %}
 
+{% block extra_head %}{{ block.super }}{{ form.media.css }}{% endblock %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
@@ -89,4 +91,9 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media.js }}
 {% endblock %}

--- a/itou/templates/companies/edit_siae_description.html
+++ b/itou/templates/companies/edit_siae_description.html
@@ -6,6 +6,8 @@
 
 {% block title %}Modifier les coordonnées de votre structure {{ block.super }}{% endblock %}
 
+{% block extra_head %}{{ block.super }}{{ form.media.css }}{% endblock %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
@@ -75,4 +77,9 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media.js }}
 {% endblock %}

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -4,6 +4,7 @@
 {% load static %}
 {% load theme_inclusion %}
 {% load buttons_form %}
+{% load markdownify %}
 
 {% block title %}Modifier les coordonnées de votre structure {{ block.super }}{% endblock %}
 
@@ -42,14 +43,14 @@
                             {% if siae.description %}
                                 <div class="my-3 my-lg-5">
                                     <h3>Son activité</h3>
-                                    {{ form_data.description | linebreaks }}
+                                    {{ form_data.description|markdownify }}
                                 </div>
                             {% endif %}
 
                             {% if siae.provided_support %}
                                 <div class="my-3 my-lg-5">
                                     <h3>L'accompagnement proposé</h3>
-                                    {{ form_data.provided_support | linebreaks }}
+                                    {{ form_data.provided_support|markdownify }}
                                 </div>
                             {% endif %}
 

--- a/itou/templates/companies/includes/_job_description_details.html
+++ b/itou/templates/companies/includes/_job_description_details.html
@@ -1,4 +1,5 @@
 {% load str_filters %}
+{% load markdownify %}
 
 <h3>Informations générales</h3>
 <ul class="list-unstyled mb-5">
@@ -29,10 +30,10 @@
 {% with no_content_message="La structure n'a pas encore renseigné cette rubrique" %}
     <hr>
     <h3>Description du poste</h3>
-    <div class="mb-5">{{ job.description|default:no_content_message|linebreaks }}</div>
+    <div class="mb-5">{{ job.description|markdownify|default:no_content_message }}</div>
     <hr>
     <h3>Profil recherché et prérequis</h3>
-    <div class="mb-5">{{ job.profile_description|default:no_content_message|linebreaks }}</div>
+    <div class="mb-5">{{ job.profile_description|markdownify|default:no_content_message }}</div>
 {% endwith %}
 
 {% if job.is_resume_mandatory %}

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load format_filters %}
+{% load markdownify %}
 
 {% block title %}{{ prescriber_org.display_name }} {{ block.super }}{% endblock %}
 
@@ -25,7 +26,7 @@
 
                     {% if prescriber_org.description %}
                         <hr>
-                        <div>{{ prescriber_org.description|linebreaks }}</div>
+                        <div>{{ prescriber_org.description|markdownify }}</div>
                     {% endif %}
 
                     {% if user.is_authenticated and prescriber_org.email %}

--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -4,6 +4,8 @@
 
 {% block title %}Modifier cette organisation {{ block.super }}{% endblock %}
 
+{% block extra_head %}{{ block.super }}{{ form.media.css }}{% endblock %}
+
 {% block title_prevstep %}
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
@@ -43,4 +45,9 @@
             </div>
         </div>
     </section>
+{% endblock %}
+
+{% block script %}
+    {{ block.super }}
+    {{ form.media.js }}
 {% endblock %}

--- a/itou/utils/urls.py
+++ b/itou/utils/urls.py
@@ -121,3 +121,17 @@ def get_tally_form_url(form_id, **kwargs):
         url += "?" + urlencode(kwargs)
 
     return mark_safe(url)
+
+
+def markdown_url_set_target_blank(attrs, new=False):
+    attrs[(None, "target")] = "_blank"
+    attrs[(None, "rel")] = "noopener"
+    attrs[(None, "aria-label")] = "Ouverture dans un nouvel onglet"
+    return attrs
+
+
+def markdown_url_set_protocol(attrs, new=False):
+    if href := attrs.get((None, "href")):
+        if not (href.startswith("http") or href.startswith("mailto")):
+            attrs[(None, "href")] = "https://" + href
+    return attrs

--- a/itou/utils/widgets.py
+++ b/itou/utils/widgets.py
@@ -11,6 +11,7 @@ from django.contrib.gis.forms import widgets as gis_widgets
 from django.db.models import Q
 from django.forms.models import ModelChoiceIterator
 from django_select2.forms import Select2Widget
+from easymde.widgets import EasyMDEEditor
 
 from itou.utils.validators import get_max_birthdate, get_min_birthdate
 
@@ -193,3 +194,10 @@ class RadioSelectWithDisabledChoices(forms.RadioSelect):
         if value in self.disabled_values:
             option["attrs"]["disabled"] = True
         return option
+
+
+class EasyMDEEditorWithConfig(EasyMDEEditor):
+    class Media:
+        extend = False
+        js = ("easymde/easymde.min.js", "js/easymde_config.js")
+        css = {"all": ("easymde/easymde.min.css",)}

--- a/itou/www/companies_views/forms.py
+++ b/itou/www/companies_views/forms.py
@@ -10,7 +10,7 @@ from itou.companies.enums import CompanyKind, ContractType
 from itou.companies.models import Company, CompanyMembership, JobDescription
 from itou.jobs.models import Appellation
 from itou.utils.urls import get_external_link_markup
-from itou.utils.widgets import RemoteAutocompleteSelect2Widget
+from itou.utils.widgets import EasyMDEEditorWithConfig, RemoteAutocompleteSelect2Widget
 
 
 class CreateCompanyForm(forms.ModelForm):
@@ -37,6 +37,9 @@ class CreateCompanyForm(forms.ModelForm):
             "brand": "Si ce champ est renseigné, il sera utilisé en tant que nom sur la fiche.",
             "website": "Votre site web doit commencer par http:// ou https://",
             "description": "Texte de présentation de votre structure.",
+        }
+        widgets = {
+            "description": EasyMDEEditorWithConfig,
         }
 
     def __init__(self, current_company, current_user, *args, **kwargs):
@@ -145,6 +148,11 @@ class EditSiaeDescriptionForm(forms.ModelForm):
         labels = {
             "description": "Description générale de l'activité",
             "provided_support": "Type d'accompagnement proposé",
+        }
+
+        widgets = {
+            "description": EasyMDEEditorWithConfig,
+            "provided_support": EasyMDEEditorWithConfig,
         }
 
     def __init__(self, *args, **kwargs):
@@ -343,6 +351,10 @@ class EditJobDescriptionDetailsForm(forms.ModelForm):
             "is_resume_mandatory": "Le CV est nécessaire pour le traitement de la candidature",
             "is_qpv_mandatory": "Le marché s’inscrit dans le cadre du NPNRU et ces clauses sociales doivent "
             "bénéficier en priorité aux publics résidant en Quartier Prioritaire de la Ville.",
+        }
+        widgets = {
+            "description": EasyMDEEditorWithConfig,
+            "profile_description": EasyMDEEditorWithConfig,
         }
 
     def __init__(self, current_company: Company, *args, **kwargs):

--- a/itou/www/prescribers_views/forms.py
+++ b/itou/www/prescribers_views/forms.py
@@ -2,6 +2,7 @@ from django import forms
 
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
+from itou.utils.widgets import EasyMDEEditorWithConfig
 
 
 class EditPrescriberOrganizationForm(forms.ModelForm):
@@ -54,6 +55,8 @@ class EditPrescriberOrganizationForm(forms.ModelForm):
         if self.instance.kind == PrescriberOrganizationKind.PE:
             for field in self.fields.values():
                 field.disabled = True
+        else:
+            self.fields["description"].widget = EasyMDEEditorWithConfig()
 
     def clean_siret(self):
         siret = self.cleaned_data["siret"]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -51,6 +51,12 @@ django-datadog-logger
 # django-redis (full featured cache backend)
 django-redis  # https://github.com/jazzband/django-redis
 
+# django-markdownify (to render only a set of HTML tags)
+django-markdownify  # https://github.com/erwinmatijsen/django-markdownify
+
+# Markdown editor
+django-easymde  # https://github.com/WPI-LNL/django-easymde
+
 # Pillow (image manipulation)
 pillow  # https://python-pillow.org/
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,6 +45,10 @@ bcrypt==4.2.0 \
     --hash=sha256:cf69eaf5185fd58f268f805b505ce31f9b9fc2d64b376642164e9244540c1221 \
     --hash=sha256:f4f4acf526fcd1c34e7ce851147deedd4e26e6402369304220250598b26448db
     # via paramiko
+bleach[css]==6.1.0 \
+    --hash=sha256:0a31f1837963c41d46bbf1331b8778e1308ea0791db03cc4e7357b97cf42a8fe \
+    --hash=sha256:3225f354cfc436b9789c66c4ee030194bee0568fbf9cbdad3bc8b5c26c5f12b6
+    # via django-markdownify
 boto3==1.35.24 \
     --hash=sha256:97fcc1a14cbc759e4ba9535ced703a99fcf652c9c4b8dfcd06f292c80551684b \
     --hash=sha256:be7807f30f26d6c0057e45cfd09dad5968e664488bf4f9138d0bb7a0f6d8ed40
@@ -272,6 +276,7 @@ django==5.0.9 \
     #   django-formtools
     #   django-hijack
     #   django-htmx
+    #   django-markdownify
     #   django-pgtrigger
     #   django-redis
     #   django-select2
@@ -306,6 +311,10 @@ django-datadog-logger==0.7.2 \
     --hash=sha256:0659f0e243152589ef3d9d6b452494b914fcf1b84c2ea7e1e25d214d945b9407 \
     --hash=sha256:c5107b7e189bc541c1c8f4ad2810dc94227fb5632be8973eb226f83d20f86e32
     # via -r requirements/base.in
+django-easymde==1.0.4 \
+    --hash=sha256:0690902bde591461138e174e47f58363f1f7b7fb637ebae7401e7a6449177e26 \
+    --hash=sha256:5b2fd94953b76cb69aebd5d6169056084188e079609bee1300174ad54cfa346a
+    # via -r requirements/base.in
 django-filter==24.3 \
     --hash=sha256:c4852822928ce17fb699bcfccd644b3574f1a2d80aeb2b4ff4f16b02dd49dc64 \
     --hash=sha256:d8ccaf6732afd21ca0542f6733b11591030fa98669f8d15599b358e24a2cd9c3
@@ -321,6 +330,10 @@ django-hijack==3.6.0 \
 django-htmx==1.19.0 \
     --hash=sha256:875a642814e52278c1728842436beda2001847a493ab79fd82da3fb46ead140f \
     --hash=sha256:e7e17304e78e07f96eca0affc3ce1806edfdf3538bb7cb1912452b101f3e627d
+    # via -r requirements/base.in
+django-markdownify==0.9.5 \
+    --hash=sha256:2c4ae44e386c209453caf5e9ea1b74f64535985d338ad2d5ad5e7089cc94be86 \
+    --hash=sha256:34c34eba4a797282a5c5bd97b13cec84d6a4c0673ad47ce1c1d000d74dd8d4ab
     # via -r requirements/base.in
 django-pgtrigger==4.12.2 \
     --hash=sha256:1e1f6bf448997ee02a5af07d62a23b10085055e3b7e21062c8480c0b3b56f475 \
@@ -643,7 +656,9 @@ lxml==5.3.0 \
 markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   django-markdownify
 numpy==2.1.1 \
     --hash=sha256:046356b19d7ad1890c751b99acad5e82dc4a02232013bd9a9a712fddf8eb60f5 \
     --hash=sha256:0b8cc2715a84b7c3b161f9ebbd942740aaed913584cae9cdc7f8ad5ad41943d0 \
@@ -1161,10 +1176,15 @@ sentry-sdk==2.14.0 \
     --hash=sha256:1e0e2eaf6dad918c7d1e0edac868a7bf20017b177f242cefe2a6bcd47955961d \
     --hash=sha256:b8bc3dc51d06590df1291b7519b85c75e2ced4f28d9ea655b6d54033503b5bf4
     # via -r requirements/base.in
+setuptools==75.1.0 \
+    --hash=sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2 \
+    --hash=sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538
+    # via django-easymde
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
+    #   bleach
     #   html5lib
     #   python-dateutil
 sniffio==1.3.1 \
@@ -1181,6 +1201,10 @@ tenacity==9.0.0 \
     --hash=sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b \
     --hash=sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539
     # via -r requirements/base.in
+tinycss2==1.2.1 \
+    --hash=sha256:2b80a96d41e7c3914b8cda8bc7f705a4d9c49275616e886103dd839dfc847847 \
+    --hash=sha256:8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627
+    # via bleach
 tqdm==4.66.5 \
     --hash=sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd \
     --hash=sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad
@@ -1214,7 +1238,10 @@ urllib3==2.2.3 \
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-    # via html5lib
+    # via
+    #   bleach
+    #   html5lib
+    #   tinycss2
 xlrd==2.0.1 \
     --hash=sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd \
     --hash=sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,6 +60,12 @@ beautifulsoup4==4.12.3 \
     --hash=sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051 \
     --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
     # via -r requirements/test.txt
+bleach[css]==6.1.0 \
+    --hash=sha256:0a31f1837963c41d46bbf1331b8778e1308ea0791db03cc4e7357b97cf42a8fe \
+    --hash=sha256:3225f354cfc436b9789c66c4ee030194bee0568fbf9cbdad3bc8b5c26c5f12b6
+    # via
+    #   -r requirements/test.txt
+    #   django-markdownify
 boto3==1.35.24 \
     --hash=sha256:97fcc1a14cbc759e4ba9535ced703a99fcf652c9c4b8dfcd06f292c80551684b \
     --hash=sha256:be7807f30f26d6c0057e45cfd09dad5968e664488bf4f9138d0bb7a0f6d8ed40
@@ -326,6 +332,7 @@ django==5.0.9 \
     #   django-formtools
     #   django-hijack
     #   django-htmx
+    #   django-markdownify
     #   django-pgtrigger
     #   django-redis
     #   django-select2
@@ -366,6 +373,10 @@ django-debug-toolbar==4.4.6 \
     --hash=sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044 \
     --hash=sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45
     # via -r requirements/dev.in
+django-easymde==1.0.4 \
+    --hash=sha256:0690902bde591461138e174e47f58363f1f7b7fb637ebae7401e7a6449177e26 \
+    --hash=sha256:5b2fd94953b76cb69aebd5d6169056084188e079609bee1300174ad54cfa346a
+    # via -r requirements/test.txt
 django-extensions==3.2.3 \
     --hash=sha256:44d27919d04e23b3f40231c4ab7af4e61ce832ef46d610cc650d53e68328410a \
     --hash=sha256:9600b7562f79a92cbf1fde6403c04fee314608fefbb595502e34383ae8203401
@@ -385,6 +396,10 @@ django-hijack==3.6.0 \
 django-htmx==1.19.0 \
     --hash=sha256:875a642814e52278c1728842436beda2001847a493ab79fd82da3fb46ead140f \
     --hash=sha256:e7e17304e78e07f96eca0affc3ce1806edfdf3538bb7cb1912452b101f3e627d
+    # via -r requirements/test.txt
+django-markdownify==0.9.5 \
+    --hash=sha256:2c4ae44e386c209453caf5e9ea1b74f64535985d338ad2d5ad5e7089cc94be86 \
+    --hash=sha256:34c34eba4a797282a5c5bd97b13cec84d6a4c0673ad47ce1c1d000d74dd8d4ab
     # via -r requirements/test.txt
 django-pgtrigger==4.12.2 \
     --hash=sha256:1e1f6bf448997ee02a5af07d62a23b10085055e3b7e21062c8480c0b3b56f475 \
@@ -809,7 +824,9 @@ lxml==5.3.0 \
 markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   django-markdownify
 matplotlib-inline==0.1.7 \
     --hash=sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90 \
     --hash=sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca
@@ -1572,6 +1589,12 @@ sentry-sdk==2.14.0 \
     --hash=sha256:1e0e2eaf6dad918c7d1e0edac868a7bf20017b177f242cefe2a6bcd47955961d \
     --hash=sha256:b8bc3dc51d06590df1291b7519b85c75e2ced4f28d9ea655b6d54033503b5bf4
     # via -r requirements/test.txt
+setuptools==75.1.0 \
+    --hash=sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2 \
+    --hash=sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538
+    # via
+    #   -r requirements/test.txt
+    #   django-easymde
 shellcheck-py==0.10.0.1 \
     --hash=sha256:390826b340b8c19173922b0da5ef7b66ef34d4d087dc48aad3e01f7e77e164d9 \
     --hash=sha256:48f08965cafbb3363b265c4ef40628ffced19cb6fc7c4bb5ce72d32cbcfb4bb9 \
@@ -1585,6 +1608,7 @@ six==1.16.0 \
     # via
     #   -r requirements/test.txt
     #   asttokens
+    #   bleach
     #   cssbeautifier
     #   html5lib
     #   jsbeautifier
@@ -1621,6 +1645,12 @@ tenacity==9.0.0 \
     --hash=sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b \
     --hash=sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539
     # via -r requirements/test.txt
+tinycss2==1.2.1 \
+    --hash=sha256:2b80a96d41e7c3914b8cda8bc7f705a4d9c49275616e886103dd839dfc847847 \
+    --hash=sha256:8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627
+    # via
+    #   -r requirements/test.txt
+    #   bleach
 tqdm==4.66.5 \
     --hash=sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd \
     --hash=sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad
@@ -1702,7 +1732,9 @@ webencodings==0.5.1 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
     # via
     #   -r requirements/test.txt
+    #   bleach
     #   html5lib
+    #   tinycss2
 xlrd==2.0.1 \
     --hash=sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd \
     --hash=sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -56,6 +56,12 @@ beautifulsoup4==4.12.3 \
     --hash=sha256:74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051 \
     --hash=sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
     # via -r requirements/test.in
+bleach[css]==6.1.0 \
+    --hash=sha256:0a31f1837963c41d46bbf1331b8778e1308ea0791db03cc4e7357b97cf42a8fe \
+    --hash=sha256:3225f354cfc436b9789c66c4ee030194bee0568fbf9cbdad3bc8b5c26c5f12b6
+    # via
+    #   -r requirements/base.txt
+    #   django-markdownify
 boto3==1.35.24 \
     --hash=sha256:97fcc1a14cbc759e4ba9535ced703a99fcf652c9c4b8dfcd06f292c80551684b \
     --hash=sha256:be7807f30f26d6c0057e45cfd09dad5968e664488bf4f9138d0bb7a0f6d8ed40
@@ -300,6 +306,7 @@ django==5.0.9 \
     #   django-formtools
     #   django-hijack
     #   django-htmx
+    #   django-markdownify
     #   django-pgtrigger
     #   django-redis
     #   django-select2
@@ -336,6 +343,10 @@ django-datadog-logger==0.7.2 \
     --hash=sha256:0659f0e243152589ef3d9d6b452494b914fcf1b84c2ea7e1e25d214d945b9407 \
     --hash=sha256:c5107b7e189bc541c1c8f4ad2810dc94227fb5632be8973eb226f83d20f86e32
     # via -r requirements/base.txt
+django-easymde==1.0.4 \
+    --hash=sha256:0690902bde591461138e174e47f58363f1f7b7fb637ebae7401e7a6449177e26 \
+    --hash=sha256:5b2fd94953b76cb69aebd5d6169056084188e079609bee1300174ad54cfa346a
+    # via -r requirements/base.txt
 django-filter==24.3 \
     --hash=sha256:c4852822928ce17fb699bcfccd644b3574f1a2d80aeb2b4ff4f16b02dd49dc64 \
     --hash=sha256:d8ccaf6732afd21ca0542f6733b11591030fa98669f8d15599b358e24a2cd9c3
@@ -351,6 +362,10 @@ django-hijack==3.6.0 \
 django-htmx==1.19.0 \
     --hash=sha256:875a642814e52278c1728842436beda2001847a493ab79fd82da3fb46ead140f \
     --hash=sha256:e7e17304e78e07f96eca0affc3ce1806edfdf3538bb7cb1912452b101f3e627d
+    # via -r requirements/base.txt
+django-markdownify==0.9.5 \
+    --hash=sha256:2c4ae44e386c209453caf5e9ea1b74f64535985d338ad2d5ad5e7089cc94be86 \
+    --hash=sha256:34c34eba4a797282a5c5bd97b13cec84d6a4c0673ad47ce1c1d000d74dd8d4ab
     # via -r requirements/base.txt
 django-pgtrigger==4.12.2 \
     --hash=sha256:1e1f6bf448997ee02a5af07d62a23b10085055e3b7e21062c8480c0b3b56f475 \
@@ -737,7 +752,9 @@ lxml==5.3.0 \
 markdown==3.7 \
     --hash=sha256:2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2 \
     --hash=sha256:7eb6df5690b81a1d7942992c97fad2938e956e79df20cbc6186e9c3a77b1c803
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   django-markdownify
 numpy==2.1.1 \
     --hash=sha256:046356b19d7ad1890c751b99acad5e82dc4a02232013bd9a9a712fddf8eb60f5 \
     --hash=sha256:0b8cc2715a84b7c3b161f9ebbd942740aaed913584cae9cdc7f8ad5ad41943d0 \
@@ -1451,6 +1468,12 @@ sentry-sdk==2.14.0 \
     --hash=sha256:1e0e2eaf6dad918c7d1e0edac868a7bf20017b177f242cefe2a6bcd47955961d \
     --hash=sha256:b8bc3dc51d06590df1291b7519b85c75e2ced4f28d9ea655b6d54033503b5bf4
     # via -r requirements/base.txt
+setuptools==75.1.0 \
+    --hash=sha256:35ab7fd3bcd95e6b7fd704e4a1539513edad446c097797f2985e0e4b960772f2 \
+    --hash=sha256:d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538
+    # via
+    #   -r requirements/base.txt
+    #   django-easymde
 shellcheck-py==0.10.0.1 \
     --hash=sha256:390826b340b8c19173922b0da5ef7b66ef34d4d087dc48aad3e01f7e77e164d9 \
     --hash=sha256:48f08965cafbb3363b265c4ef40628ffced19cb6fc7c4bb5ce72d32cbcfb4bb9 \
@@ -1463,6 +1486,7 @@ six==1.16.0 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
     # via
     #   -r requirements/base.txt
+    #   bleach
     #   cssbeautifier
     #   html5lib
     #   jsbeautifier
@@ -1493,6 +1517,12 @@ tenacity==9.0.0 \
     --hash=sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b \
     --hash=sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539
     # via -r requirements/base.txt
+tinycss2==1.2.1 \
+    --hash=sha256:2b80a96d41e7c3914b8cda8bc7f705a4d9c49275616e886103dd839dfc847847 \
+    --hash=sha256:8cff3a8f066c2ec677c06dbc7b45619804a6938478d9d73c284b29d14ecb0627
+    # via
+    #   -r requirements/base.txt
+    #   bleach
 tqdm==4.66.5 \
     --hash=sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd \
     --hash=sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad
@@ -1559,7 +1589,9 @@ webencodings==0.5.1 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
     # via
     #   -r requirements/base.txt
+    #   bleach
     #   html5lib
+    #   tinycss2
 xlrd==2.0.1 \
     --hash=sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd \
     --hash=sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -358,10 +358,10 @@ class EditJobDescriptionViewTest(JobDescriptionAbstractTest):
             with self.subTest(k):
                 assert v == session_data.get(k)
 
-        # Step 2: edit job description details
+        # Step 2: edit job description details and check the rendered markdown
         post_data = {
-            "description": "description",
-            "profile_description": "profile_description",
+            "description": "**Lorem ipsum**\n<span>Span</span>",  # HTML tags should be ignored
+            "profile_description": "profile_*description*",
             "is_resume_mandatory": True,
             "is_qpv_mandatory": True,
         }
@@ -378,9 +378,8 @@ class EditJobDescriptionViewTest(JobDescriptionAbstractTest):
 
         # Step 3: preview and validation
         response = self.client.get(self.edit_preview_url)
-
-        self.assertContains(response, "description")
-        self.assertContains(response, "profile_description")
+        self.assertContains(response, "<strong>Lorem ipsum</strong><br>\nSpan")
+        self.assertContains(response, "profile_<em>description</em>")
         self.assertContains(response, "Whatever market description")
         self.assertContains(response, "Curriculum Vitae")
         # Rendering of `is_qpv_mandatory`


### PR DESCRIPTION
:warning:  Nouvelle PR suite au retour métier (j'avais fusionné trop vite 😵‍💫). Les ajouts/modifications de code, par rapport à la PR initiale relue, sont indiqués ci-après.
PR initiale : https://github.com/gip-inclusion/les-emplois/pull/4816
PR de revert : https://github.com/gip-inclusion/les-emplois/pull/4833

## :thinking: Pourquoi ?

Inciter les utilisateurs à renseigner plus d’infos dans leurs descriptions de fiche structure et fiche de poste.
On a observé de très bons résultats sur le marché depuis qu’ils l’ont fait.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

- utiliser `django-easymde`, qui importe `EasyMDE` (js et css) dans les formulaires, via `{{ form.media }}`.
Malheureusement la version actuelle du `django-easymde` ne permet pas de configuration "dynamique" (mentionner une fonction JS, comme `toggleBold` par exemple), donc on doit configurer l'éditeur avec un fichier JS (`itou/static/js/easymde_config.js`) pour le moment. On enregistre en base de données un texte au format markdown.

- `django-markdownify`: pour convertir le markdown enregistré en HTML. On préfère `markdownify` à `markdown` ici pour pouvoir choisir un sous-ensemble de balises HTML dans le rendu (`<em>`, `<bold>`, `<a>`…).

Les tests vérifient qu'on traduit les balises désirées, et qu'on ne traduit pas les autres balises.
On ne teste pas le bon chargement de l'éditeur EasyMDE (ça ferait partie de tests fronts ?).

**Nouveautés avec cette nouvelle PR** :
- rajouté les listes numérotées
- une nouvelle ligne en markdown génère une nouvelle ligne (`br`) en HTML.
- cliquer sur un lien ouvre un nouvel onglet
- les liens sont mieux gérés (par exemple `[test](www.test.com)` => on rajoute `https://`)


## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester + captures d'écran
### En tant qu'employeur
Se connecter en tant qu'employeur et créer une nouvelle structure
![image](https://github.com/user-attachments/assets/779a1c6a-2b98-4eb1-9d90-72b05679845b)


Aller voir la fiche publique
![image](https://github.com/user-attachments/assets/79d4a060-3119-491b-afef-2c5ef2a45985)


Modifier les informations
![image](https://github.com/user-attachments/assets/760550d6-9d3d-40e3-b7a4-2e3d5656f831)

Prévisualiser
![image](https://github.com/user-attachments/assets/30bcde51-4037-4077-8ce8-04e4cb25034a)


### En tant que prescripteur

Se connecter en tant qu'Orienteur (prescripteur non habilité) et "Modifier cette organisation"
![image](https://github.com/user-attachments/assets/e75096cd-0666-4921-a8f2-6f1a75495478)


Cas particulier pour France Travail (se connecter en tant que Prescripteur habilité), les champs sont en lecture seule : 
![image](https://github.com/user-attachments/assets/72a1a90b-4d46-4b17-a015-137eea640e30)

