### PR TITLE
UX/UI: forcer la position .dropdown-menu sur les menu "mon espace" et "besoin d'aide"

### DIFF
--- a/itou/templates/layout/_header.html
+++ b/itou/templates/layout/_header.html
@@ -88,7 +88,7 @@
                     <i class="ri-user-add-line" aria-hidden="true"></i>
                     <span>S’inscrire</span>
                 </a>
-                <div class="dropdown">
+                <div class="dropup dropup-center">
                     <button type="button" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="helpDropdownMobile" aria-expanded="false">
                         Besoin d’aide ?
                     </button>

--- a/itou/templates/layout/_header_authenticated.html
+++ b/itou/templates/layout/_header_authenticated.html
@@ -143,7 +143,7 @@
             <nav class="flex-grow-1" role="navigation" aria-label="Navigation principale">
                 {% nav request %}
             </nav>
-            <div class="dropdown d-sm-none d-xl-inline-block">
+            <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                 <button type="button"
                         class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3"
                         data-bs-toggle="dropdown"
@@ -157,7 +157,7 @@
                     {% include "layout/_header_user_dropdown_menu.html" with request=request user=user mobile=True csrf_token=csrf_token only %}
                 </div>
             </div>
-            <div class="dropdown">
+            <div class="dropup dropup-center">
                 <button type="button" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="helpDropdownMobile" aria-expanded="false">
                     Besoin d'aide ?
                 </button>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -190,11 +190,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.2.3.zip",
-            "sha256": "ca0c6edff6cfdd2848c9a7e1e49e263ce83422ff94f3fcf751c4eba0956cfcba",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.2.4.zip",
+            "sha256": "0da5e56a31f4ab53aeff49466aca6d33442aa4373aeb650c45b4730d6dc60603",
         },
         "extract": {
-            "origin": "itou-theme-2.2.3/dist",
+            "origin": "itou-theme-2.2.4/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -101,7 +101,7 @@
   </ul>
   
               </nav>
-              <div class="dropdown d-sm-none d-xl-inline-block">
+              <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                   <button aria-controls="dashboardUserDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3" data-bs-toggle="dropdown" type="button">
                       <i aria-hidden="true" class="ri-account-circle-line"></i>
                       <span class="ms-2">Mon espace</span>
@@ -145,7 +145,7 @@
   
                   </div>
               </div>
-              <div class="dropdown">
+              <div class="dropup dropup-center">
                   <button aria-controls="helpDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" type="button">
                       Besoin d'aide ?
                   </button>
@@ -373,7 +373,7 @@
   </ul>
   
               </nav>
-              <div class="dropdown d-sm-none d-xl-inline-block">
+              <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                   <button aria-controls="dashboardUserDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3" data-bs-toggle="dropdown" type="button">
                       <i aria-hidden="true" class="ri-account-circle-line"></i>
                       <span class="ms-2">Mon espace</span>
@@ -422,7 +422,7 @@
   
                   </div>
               </div>
-              <div class="dropdown">
+              <div class="dropup dropup-center">
                   <button aria-controls="helpDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" type="button">
                       Besoin d'aide ?
                   </button>
@@ -602,7 +602,7 @@
   </ul>
   
               </nav>
-              <div class="dropdown d-sm-none d-xl-inline-block">
+              <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                   <button aria-controls="dashboardUserDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3" data-bs-toggle="dropdown" type="button">
                       <i aria-hidden="true" class="ri-account-circle-line"></i>
                       <span class="ms-2">Mon espace</span>
@@ -653,7 +653,7 @@
   
                   </div>
               </div>
-              <div class="dropdown">
+              <div class="dropup dropup-center">
                   <button aria-controls="helpDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" type="button">
                       Besoin d'aide ?
                   </button>
@@ -841,7 +841,7 @@
   </ul>
   
               </nav>
-              <div class="dropdown d-sm-none d-xl-inline-block">
+              <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                   <button aria-controls="dashboardUserDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3" data-bs-toggle="dropdown" type="button">
                       <i aria-hidden="true" class="ri-account-circle-line"></i>
                       <span class="ms-2">Mon espace</span>
@@ -887,7 +887,7 @@
   
                   </div>
               </div>
-              <div class="dropdown">
+              <div class="dropup dropup-center">
                   <button aria-controls="helpDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" type="button">
                       Besoin d'aide ?
                   </button>
@@ -1090,7 +1090,7 @@
   </ul>
   
               </nav>
-              <div class="dropdown d-sm-none d-xl-inline-block">
+              <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                   <button aria-controls="dashboardUserDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3" data-bs-toggle="dropdown" type="button">
                       <i aria-hidden="true" class="ri-account-circle-line"></i>
                       <span class="ms-2">Mon espace</span>
@@ -1134,7 +1134,7 @@
   
                   </div>
               </div>
-              <div class="dropdown">
+              <div class="dropup dropup-center">
                   <button aria-controls="helpDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" type="button">
                       Besoin d'aide ?
                   </button>
@@ -1314,7 +1314,7 @@
   </ul>
   
               </nav>
-              <div class="dropdown d-sm-none d-xl-inline-block">
+              <div class="dropup dropup-center d-sm-none d-xl-inline-block">
                   <button aria-controls="dashboardUserDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico btn-block bg-white dropdown-toggle my-3" data-bs-toggle="dropdown" type="button">
                       <i aria-hidden="true" class="ri-account-circle-line"></i>
                       <span class="ms-2">Mon espace</span>
@@ -1358,7 +1358,7 @@
   
                   </div>
               </div>
-              <div class="dropdown">
+              <div class="dropup dropup-center">
                   <button aria-controls="helpDropdownMobile" aria-expanded="false" aria-haspopup="true" class="btn btn-link btn-block dropdown-toggle p-0" data-bs-toggle="dropdown" type="button">
                       Besoin d'aide ?
                   </button>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin que ces deux menus s'ouvrent toujours par le haut 

