### PR TITLE
Connexion : Nouvelle page pour se connecter à un compte existant suite à un conflit d'email lors de l'enregistrement [GEN-1569]

### DIFF
--- a/itou/openid_connect/errors.py
+++ b/itou/openid_connect/errors.py
@@ -1,0 +1,45 @@
+from urllib.parse import quote
+
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.html import format_html
+
+from itou.utils.emails import redact_email_address
+
+
+def format_error_modal_content(message_body, action_url, action_text):
+    return format_html(
+        '<div class="modal-body">'
+        "{}"
+        "</div>"
+        '<div class="modal-footer">'
+        '<button type="button" class="btn btn-sm btn-link" data-bs-dismiss="modal">Retour</button>'
+        '<a href="{}" class="btn btn-sm btn-primary">{}</a>'
+        "</div>",
+        message_body,
+        action_url,
+        action_text,
+    )
+
+
+def redirect_with_error_sso_email_conflict_on_registration(request, user, sso_name):
+    redirect_url = reverse("signup:choose_user_kind")
+    messages.error(
+        request,
+        format_error_modal_content(
+            format_html(
+                "<p>L’inscription via {} a échoué car un compte existe déjà avec l’adresse email "
+                "{} mais avec un mode de connexion différent.</p><p>Pour accéder à votre compte "
+                "cliquez sur le bouton <strong>“Je me connecte avec ce compte”</strong>.</p>"
+                '<p>Si ce compte n’est pas le vôtre, cliquez sur <strong>"Retour"</strong> et utilisez une autre '
+                "adresse email pour vous inscrire.</p>",
+                sso_name,
+                redact_email_address(user.email),
+            ),
+            f'{reverse("login:existing_user", args=(user.public_id,))}?back_url={quote(redirect_url)}',
+            "Je me connecte avec ce compte",
+        ),
+        extra_tags="modal sso_email_conflict_registration_failure",
+    )
+    return HttpResponseRedirect(redirect_url)

--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -22,7 +22,6 @@ class FranceConnectUserData(OIDConnectUserData):
     city: str | None = None
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.FRANCE_CONNECT
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.JOB_SEEKER,)
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()
 
     @staticmethod

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -11,7 +11,7 @@ from django.utils import crypto
 from django.utils.html import format_html
 from django.utils.http import urlencode
 
-from itou.users.enums import UserKind
+from itou.users.enums import IdentityProvider, UserKind
 from itou.utils import constants as global_constants
 from itou.utils.urls import get_absolute_url
 
@@ -119,12 +119,7 @@ def france_connect_callback(request):
         user, _ = fc_user_data.create_or_update_user()
     except InvalidKindException as e:
         messages.info(request, "Ce compte existe déjà, veuillez vous connecter.")
-        url = {
-            UserKind.PRESCRIBER: reverse("login:prescriber"),
-            UserKind.EMPLOYER: reverse("login:employer"),
-            UserKind.LABOR_INSPECTOR: reverse("login:labor_inspector"),
-        }[e.user.kind]
-        return HttpResponseRedirect(url)
+        return HttpResponseRedirect(UserKind.get_login_url(e.user.kind))
     except EmailInUseException as e:
         redacted_name = e.user.get_redacted_full_name()
         msg_who = (

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -44,5 +44,4 @@ class InclusionConnectPrescriberData(InclusionConnectUserData):
 class InclusionConnectEmployerData(InclusionConnectUserData):
     kind: UserKind = UserKind.EMPLOYER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.PRESCRIBER, UserKind.EMPLOYER)
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = (IdentityProvider.DJANGO,)

--- a/itou/openid_connect/inclusion_connect/models.py
+++ b/itou/openid_connect/inclusion_connect/models.py
@@ -36,7 +36,6 @@ class InclusionConnectUserData(OIDConnectUserData):
 class InclusionConnectPrescriberData(InclusionConnectUserData):
     kind: UserKind = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.INCLUSION_CONNECT
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.PRESCRIBER, UserKind.EMPLOYER)
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = (IdentityProvider.DJANGO,)
 
 

--- a/itou/openid_connect/models.py
+++ b/itou/openid_connect/models.py
@@ -105,8 +105,11 @@ class OIDConnectUserData:
     username: str
     identity_provider: IdentityProvider
     kind: UserKind
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = ()
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()
+
+    @property
+    def login_allowed_user_kinds(self) -> tuple[UserKind]:
+        return IdentityProvider.supported_user_kinds[self.identity_provider]
 
     def check_valid_kind(self, user, user_data_dict, is_login):
         if user.kind not in self.login_allowed_user_kinds or (user.kind != user_data_dict["kind"] and not is_login):

--- a/itou/openid_connect/pe_connect/models.py
+++ b/itou/openid_connect/pe_connect/models.py
@@ -16,5 +16,4 @@ class PoleEmploiConnectUserData(OIDConnectUserData):
     # Mapping is made in self.user_info_mapping_dict.
     kind: UserKind = UserKind.JOB_SEEKER
     identity_provider: IdentityProvider = IdentityProvider.PE_CONNECT
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.JOB_SEEKER,)
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()

--- a/itou/openid_connect/pe_connect/views.py
+++ b/itou/openid_connect/pe_connect/views.py
@@ -18,6 +18,7 @@ from itou.users.enums import IdentityProvider, UserKind
 from itou.utils import constants as global_constants
 from itou.utils.urls import add_url_params, get_absolute_url
 
+from ..errors import redirect_with_error_sso_email_conflict_on_registration
 from ..models import EmailInUseException, InvalidKindException, MultipleUsersFoundException
 from . import constants
 from .models import PoleEmploiConnectState, PoleEmploiConnectUserData
@@ -144,26 +145,8 @@ def pe_connect_callback(request):
             request=request,
         )
     except EmailInUseException as e:
-        redacted_name = e.user.get_redacted_full_name()
-        msg_who = (
-            format_html(
-                " au nom de <strong>{}</strong>",
-                redacted_name,
-            )
-            if redacted_name
-            else ""
-        )
-
-        return _redirect_to_job_seeker_login_on_error(
-            format_html(
-                "Vous avez essayé de vous connecter avec un compte France Travail, mais un compte"
-                "{} a déjà été créé avec cette adresse e-mail. Vous pouvez néanmoins"
-                " vous inscrire en utilisant une autre adresse e-mail et un mot de passe"
-                ' en cliquant sur <strong>"Inscription"</strong>.',
-                msg_who,
-            ),
-            request=request,
-            extra_tags="modal sso_email_conflict_registration_failure",
+        return redirect_with_error_sso_email_conflict_on_registration(
+            request, e.user, IdentityProvider.PE_CONNECT.label
         )
 
     nir = request.session.get(global_constants.ITOU_SESSION_NIR_KEY)

--- a/itou/openid_connect/pe_connect/views.py
+++ b/itou/openid_connect/pe_connect/views.py
@@ -14,7 +14,7 @@ from django.utils.http import urlencode
 
 from itou.external_data.models import ExternalDataImport
 from itou.external_data.tasks import huey_import_user_pe_data
-from itou.users.enums import UserKind
+from itou.users.enums import IdentityProvider, UserKind
 from itou.utils import constants as global_constants
 from itou.utils.urls import add_url_params, get_absolute_url
 
@@ -129,15 +129,7 @@ def pe_connect_callback(request):
         user, _ = pe_user_data.create_or_update_user()
     except InvalidKindException as e:
         messages.info(request, "Ce compte existe déjà, veuillez vous connecter.")
-        url = {
-            UserKind.PRESCRIBER: reverse("login:prescriber"),
-            UserKind.EMPLOYER: reverse("login:employer"),
-            UserKind.LABOR_INSPECTOR: reverse("login:labor_inspector"),
-            # Staff members may have created a job seeker account with the same email
-            # as their staff email on the platform for troubleshooting.
-            UserKind.ITOU_STAFF: reverse("login:job_seeker"),
-        }[e.user.kind]
-        return HttpResponseRedirect(url)
+        return HttpResponseRedirect(UserKind.get_login_url(e.user.kind))
     except MultipleUsersFoundException as e:
         return _redirect_to_job_seeker_login_on_error(
             format_html(

--- a/itou/openid_connect/pro_connect/models.py
+++ b/itou/openid_connect/pro_connect/models.py
@@ -45,7 +45,6 @@ class ProConnectUserData(OIDConnectUserData):
 class ProConnectPrescriberData(ProConnectUserData):
     kind: UserKind = UserKind.PRESCRIBER
     identity_provider: IdentityProvider = IdentityProvider.PRO_CONNECT
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.PRESCRIBER, UserKind.EMPLOYER)
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = (
         IdentityProvider.DJANGO,
         IdentityProvider.INCLUSION_CONNECT,
@@ -56,7 +55,6 @@ class ProConnectPrescriberData(ProConnectUserData):
 class ProConnectEmployerData(ProConnectUserData):
     kind: UserKind = UserKind.EMPLOYER
     identity_provider: IdentityProvider = IdentityProvider.PRO_CONNECT
-    login_allowed_user_kinds: ClassVar[tuple[UserKind]] = (UserKind.PRESCRIBER, UserKind.EMPLOYER)
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = (
         IdentityProvider.DJANGO,
         IdentityProvider.INCLUSION_CONNECT,

--- a/itou/templates/account/includes/login_inclusion_connect.html
+++ b/itou/templates/account/includes/login_inclusion_connect.html
@@ -1,0 +1,23 @@
+{% load static %}
+{% load theme_inclusion %}
+{% load matomo %}
+
+{% if inclusion_connect_url %}
+    <div class="text-center">
+        <a href="{{ inclusion_connect_url }}" class="btn-inclusion-connect" {% matomo_event "connexion "|add:matomo_account_type "clic" "se-connecter-avec-inclusion-connect" %}>
+            <picture>
+                <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
+                <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" alt="Se connecter avec Inclusion Connect">
+            </picture>
+        </a>
+    </div>
+{% else %}
+    <div class="alert alert-info" role="status">
+        <p class="mb-2">
+            <strong>Inclusion Connect est momentanément désactivé.</strong>
+        </p>
+        <p class="mb-0">
+            Afin de demander un PASS IAE en urgence, <a href="https://tally.so/r/nrj0V5" target="_blank" class="has-external-link">remplissez ce formulaire.</a>
+        </p>
+    </div>
+{% endif %}

--- a/itou/templates/account/includes/login_pro_connect.html
+++ b/itou/templates/account/includes/login_pro_connect.html
@@ -1,0 +1,24 @@
+{% load static %}
+{% load theme_inclusion %}
+{% load matomo %}
+
+{% if pro_connect_url %}
+    <div class="text-center">
+        <a href="{{ pro_connect_url }}" class="proconnect-button" {% matomo_event "connexion "|add:matomo_account_type "clic" "se-connecter-avec-pro-connect" %}>
+        </a>
+        <p>
+            <a href="https://proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
+                Qu’est-ce que ProConnect ?
+            </a>
+        </p>
+    </div>
+{% else %}
+    <div class="alert alert-info" role="status">
+        <p class="mb-2">
+            <strong>ProConnect est momentanément désactivé.</strong>
+        </p>
+        <p class="mb-0">
+            Afin de demander un PASS IAE en urgence, <a href="https://tally.so/r/nrj0V5" target="_blank" class="has-external-link">remplissez ce formulaire.</a>
+        </p>
+    </div>
+{% endif %}

--- a/itou/templates/account/login_existing_user.html
+++ b/itou/templates/account/login_existing_user.html
@@ -1,0 +1,52 @@
+{# django-allauth template override. #}
+{% extends "layout/base.html" %}
+
+{% block title %}Connexion {{ block.super }}{% endblock %}
+
+{% block title_prevstep %}
+    {% include "layout/previous_step.html" with back_url=back_url|default:None only %}
+{% endblock %}
+
+{% block title_content %}<h1>Se connecter</h1>{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-lg-6">
+                    <div class="c-form mb-5">
+                        {% if login_provider == "IC" %}
+                            {% include "account/includes/login_inclusion_connect.html" %}
+                        {% elif login_provider == "PC" %}
+                            {% include "account/includes/login_pro_connect.html" %}
+                        {% elif login_provider == "FC" %}
+                            <p class="h4">Se connecter avec FranceConnect</p>
+                            {% if show_france_connect %}
+                                <div class="mt-4">{% include "signup/includes/france_connect_button.html" %}</div>
+                            {% else %}
+                                <div class="alert alert-info" role="status">
+                                    <p class="mb-0">FranceConnect est désactivé.</p>
+                                </div>
+                            {% endif %}
+                        {% elif login_provider == "PEC" %}
+                            <p class="h4">Se connecter avec France Travail</p>
+                            {% if show_peamu %}
+                                <div class="mt-4 text-center">{% include "signup/includes/peamu_button.html" %}</div>
+                            {% else %}
+                                <div class="alert alert-info" role="status">
+                                    <p class="mb-0">France Travail est désactivé.</p>
+                                </div>
+                            {% endif %}
+                        {% elif login_provider == "DJANGO" %}
+                            {% include "account/includes/login_form.html" %}
+                        {% else %}
+                            <div class="alert alert-info" role="status">
+                                <p class="mb-0">Le mode de connexion associé à ce compte est désactivé. Veuillez contacter le support.</p>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -1,9 +1,5 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
-{% load redirection_fields %}
-{% load static %}
-{% load theme_inclusion %}
-{% load matomo %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
@@ -22,34 +18,9 @@
                     <div class="c-form mb-5">
                         {% if uses_inclusion_connect %}
                             {% if pro_connect_url %}
-                                <div class="text-center">
-                                    <a href="{{ pro_connect_url }}" class="proconnect-button" {% matomo_event "connexion "|add:matomo_account_type "clic" "se-connecter-avec-pro-connect" %}>
-                                    </a>
-                                    <p>
-                                        <a href="https://proconnect.gouv.fr/" target="_blank" rel="noopener noreferrer" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
-                                            Qu’est-ce que ProConnect ?
-                                        </a>
-                                    </p>
-                                </div>
-
-                            {% elif inclusion_connect_url %}
-                                <div class="text-center">
-                                    <a href="{{ inclusion_connect_url }}" class="btn-inclusion-connect" {% matomo_event "connexion "|add:matomo_account_type "clic" "se-connecter-avec-inclusion-connect" %}>
-                                        <picture>
-                                            <source srcset="{% static_theme_images 'logo-inclusion-connect-one-line.svg' %}" height="14" width="286" type="image/svg+xml" media="(min-width: 30em)">
-                                            <img src="{% static_theme_images 'logo-inclusion-connect-two-lines.svg' %}" height="37" width="142" alt="Se connecter avec Inclusion Connect">
-                                        </picture>
-                                    </a>
-                                </div>
+                                {% include "account/includes/login_pro_connect.html" %}
                             {% else %}
-                                <div class="alert alert-info" role="status">
-                                    <p class="mb-2">
-                                        <strong>Inclusion Connect est momentanément désactivé.</strong>
-                                    </p>
-                                    <p class="mb-0">
-                                        Afin de demander un PASS IAE en urgence, <a href="https://tally.so/r/nrj0V5" target="_blank" class="has-external-link">remplissez ce formulaire.</a>
-                                    </p>
-                                </div>
+                                {% include "account/includes/login_inclusion_connect.html" %}
                             {% endif %}
                             <hr class="my-5" data-it-text="ou">
                             <div class="text-center">

--- a/itou/templates/utils/modal_includes/sso_email_conflict_registration_failure.html
+++ b/itou/templates/utils/modal_includes/sso_email_conflict_registration_failure.html
@@ -11,12 +11,6 @@
             </h3>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
         </div>
-        <div class="row modal-body">
-            <p>{{ message }}</p>
-        </div>
-        <div class="modal-footer">
-            <button type="button" class="btn" data-bs-dismiss="modal">Retour</button>
-            <a href="{% url 'signup:job_seeker' %}" class="btn btn-primary">Inscription</a>
-        </div>
+        {{ message }}
     </div>
 </div>

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -38,6 +38,16 @@ class IdentityProvider(models.TextChoices):
     PRO_CONNECT = "PC", "ProConnect"
     PE_CONNECT = "PEC", "Pôle emploi Connect"
 
+    @classmethod
+    @property
+    def supported_user_kinds(cls):
+        return {
+            cls.DJANGO: tuple(UserKind.values),
+            cls.FRANCE_CONNECT: (UserKind.JOB_SEEKER,),
+            cls.INCLUSION_CONNECT: (UserKind.PRESCRIBER, UserKind.EMPLOYER),
+            cls.PE_CONNECT: (UserKind.JOB_SEEKER,),
+        }
+
 
 class LackOfNIRReason(models.TextChoices):
     TEMPORARY_NUMBER = "TEMPORARY_NUMBER", "Numéro temporaire (NIA/NTT)"

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -3,6 +3,7 @@ Enums fields used in User models.
 """
 
 from django.db import models
+from django.urls import reverse
 
 
 KIND_JOB_SEEKER = "job_seeker"
@@ -18,6 +19,17 @@ class UserKind(models.TextChoices):
     EMPLOYER = KIND_EMPLOYER, "employeur"
     LABOR_INSPECTOR = KIND_LABOR_INSPECTOR, "inspecteur du travail"
     ITOU_STAFF = KIND_ITOU_STAFF, "administrateur"
+
+    @classmethod
+    def get_login_url(cls, user_kind, default="login:job_seeker"):
+        url_lookup = {
+            UserKind.JOB_SEEKER: "login:job_seeker",
+            UserKind.PRESCRIBER: "login:prescriber",
+            UserKind.EMPLOYER: "login:employer",
+            UserKind.LABOR_INSPECTOR: "login:labor_inspector",
+            UserKind.ITOU_STAFF: "login:job_seeker",
+        }
+        return reverse(url_lookup[user_kind]) if user_kind in url_lookup else reverse(default)
 
 
 MATOMO_ACCOUNT_TYPE = {

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -46,6 +46,7 @@ class IdentityProvider(models.TextChoices):
             cls.FRANCE_CONNECT: (UserKind.JOB_SEEKER,),
             cls.INCLUSION_CONNECT: (UserKind.PRESCRIBER, UserKind.EMPLOYER),
             cls.PE_CONNECT: (UserKind.JOB_SEEKER,),
+            cls.PRO_CONNECT: (UserKind.PRESCRIBER, UserKind.EMPLOYER),
         }
 
 

--- a/itou/utils/perms/middleware.py
+++ b/itou/utils/perms/middleware.py
@@ -8,7 +8,6 @@ from django.utils.safestring import mark_safe
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.enums import IdentityProvider, UserKind
 from itou.utils import constants as global_constants
-from itou.www.login import urls as login_urls
 
 
 def extract_membership_infos_and_update_session(memberships, org_through_field, session):
@@ -152,14 +151,13 @@ class ItouCurrentOrganizationMiddleware:
         # - View two: user is added to the group.
         # In view two, the user is authenticated but he does not belong to any group.
         # This raises an error so we skip the middleware only in this case.
-        login_routes = [reverse(f"login:{url.name}") for url in login_urls.urlpatterns] + [reverse("account_login")]
         skip_middleware_conditions = [
-            request.path in login_routes,
+            request.path.startswith("/login/"),
             request.path.startswith("/invitations/") and not request.path.startswith("/invitations/invite"),
             request.path.startswith("/signup/siae/join"),  # employer about to join a company
             request.path.startswith("/signup/facilitator/join"),  # facilitator about to join a company
             request.path.startswith("/signup/prescriber/join"),  # prescriber about to join a organization
-            request.path == reverse("account_logout"),
+            request.path in [reverse("account_login"), reverse("account_logout")],
             request.path.startswith("/hijack/release"),  # Allow to release hijack
             request.path.startswith("/api"),  # APIs should handle those errors
         ]

--- a/itou/www/login/urls.py
+++ b/itou/www/login/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path("employer", views.EmployerLoginView.as_view(), name="employer"),
     path("labor_inspector", views.LaborInspectorLoginView.as_view(), name="labor_inspector"),
     path("job_seeker", views.JobSeekerLoginView.as_view(), name="job_seeker"),
+    path("existing/<uuid:user_public_id>", views.ExistingUserLoginView.as_view(), name="existing_user"),
 ]

--- a/tests/openid_connect/france_connect/__snapshots__/tests.ambr
+++ b/tests/openid_connect/france_connect/__snapshots__/tests.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: TestFranceConnect.test_callback_redirect_on_email_in_use_exception
+  '<div class="modal-body"><p>L’inscription via FranceConnect a échoué car un compte existe déjà avec l’adresse email w**************@y******.c** mais avec un mode de connexion différent.</p><p>Pour accéder à votre compte cliquez sur le bouton <strong>“Je me connecte avec ce compte”</strong>.</p><p>Si ce compte n’est pas le vôtre, cliquez sur <strong>"Retour"</strong> et utilisez une autre adresse email pour vous inscrire.</p></div><div class="modal-footer"><button type="button" class="btn btn-sm btn-link" data-bs-dismiss="modal">Retour</button><a href="/login/existing/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/signup/" class="btn btn-sm btn-primary">Je me connecte avec ce compte</a></div>'
+# ---

--- a/tests/openid_connect/pe_connect/__snapshots__/tests.ambr
+++ b/tests/openid_connect/pe_connect/__snapshots__/tests.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: TestPoleEmploiConnect.test_callback_redirect_on_email_in_use_exception
+  '<div class="modal-body"><p>L’inscription via Pôle emploi Connect a échoué car un compte existe déjà avec l’adresse email w**************@y******.c** mais avec un mode de connexion différent.</p><p>Pour accéder à votre compte cliquez sur le bouton <strong>“Je me connecte avec ce compte”</strong>.</p><p>Si ce compte n’est pas le vôtre, cliquez sur <strong>"Retour"</strong> et utilisez une autre adresse email pour vous inscrire.</p></div><div class="modal-footer"><button type="button" class="btn btn-sm btn-link" data-bs-dismiss="modal">Retour</button><a href="/login/existing/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/signup/" class="btn btn-sm btn-primary">Je me connecte avec ce compte</a></div>'
+# ---

--- a/tests/openid_connect/pro_connect/__snapshots__/tests.ambr
+++ b/tests/openid_connect/pro_connect/__snapshots__/tests.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: TestProConnectCallbackView.test_callback_redirect_on_email_in_use_exception
+  '<div class="modal-body"><p>L’inscription via ProConnect a échoué car un compte existe déjà avec l’adresse email m*****@l*********.f* mais avec un mode de connexion différent.</p><p>Pour accéder à votre compte cliquez sur le bouton <strong>“Je me connecte avec ce compte”</strong>.</p><p>Si ce compte n’est pas le vôtre, cliquez sur <strong>"Retour"</strong> et utilisez une autre adresse email pour vous inscrire.</p></div><div class="modal-footer"><button type="button" class="btn btn-sm btn-link" data-bs-dismiss="modal">Retour</button><a href="/login/existing/03580247-b036-4578-bf9d-f92c9c2f68cd?back_url=/signup/" class="btn btn-sm btn-primary">Je me connecte avec ce compte</a></div>'
+# ---

--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -499,6 +499,18 @@ class TestProConnectCallbackView:
             user.delete()
 
     @respx.mock
+    def test_callback_redirect_on_email_in_use_exception(self, client, snapshot):
+        # EmailInUseException raised by the email conflict
+        oidc_user_data = ProConnectPrescriberData.from_user_info(OIDC_USERINFO)
+        PrescriberFactory(
+            email=oidc_user_data.email, identity_provider=IdentityProvider.PRO_CONNECT, for_snapshot=True
+        )
+
+        # Test redirection and modal content
+        response = mock_oauth_dance(client, UserKind.PRESCRIBER, next_url=reverse("signup:choose_user_kind"))
+        assertMessages(response, [messages.Message(messages.ERROR, snapshot)])
+
+    @respx.mock
     def test_callback_updating_email_collision(self, client):
         PrescriberFactory(
             first_name="Bernard",

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -63,6 +63,7 @@ class UserFactory(factory.django.DjangoModelFactory):
             last_name="Doe",
             email="john.doe@test.local",
             phone="0606060606",
+            public_id="c0fee70e-cf34-4d37-919d-a1ae3e3bf7e5",
         )
 
     username = factory.Sequence("user_name{}".format)

--- a/tests/users/test_enums.py
+++ b/tests/users/test_enums.py
@@ -1,0 +1,7 @@
+from itou.users.enums import IdentityProvider
+
+
+def test_identity_provider_configures_allowed_user_kinds():
+    for identity_provider in IdentityProvider.values:
+        # will raise a KeyError if an implementation is missing for the IdentityProvider
+        assert len(IdentityProvider.supported_user_kinds[identity_provider]) > 0

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -6,6 +6,7 @@ import os.path
 import random
 import re
 from contextlib import contextmanager
+from itertools import chain
 
 import openpyxl
 import sqlparse
@@ -68,8 +69,12 @@ def parse_response_to_soup(response, selector=None, no_html_body=False, replace_
         soup["nonce"] = "NORMALIZED_CSP_NONCE"
     for csp_nonce_script in soup.find_all("script", {"nonce": True}):
         csp_nonce_script["nonce"] = "NORMALIZED_CSP_NONCE"
-    for img in soup.find_all("img", attrs={"src": True}):
+    for img in chain(
+        soup.find_all("img", attrs={"src": True}), soup.find_all("input", attrs={"type": "image", "src": True})
+    ):
         img["src"] = remove_static_hash(img["src"])
+    for img in soup.find_all("source", attrs={"srcset": True}):
+        img["srcset"] = remove_static_hash(img["srcset"])
     if replace_in_attr:
         replacements = [
             (

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -169,6 +169,7 @@ def test_both_diag_from_company(client, snapshot):
         company__subject_to_eligibility=True,
         company__for_snapshot=True,
         user__for_snapshot=True,
+        user__public_id=uuid.uuid4(),
         user__email="un@autre.email",
     )
     IAEEligibilityDiagnosisFactory(

--- a/tests/www/login/__snapshots__/tests.ambr
+++ b/tests/www/login/__snapshots__/tests.ambr
@@ -1,0 +1,232 @@
+# serializer version: 1
+# name: TestExistingUserLogin.test_login[DJANGO]
+  '''
+  <div class="c-form mb-5">
+                          
+                              
+  
+  
+  
+  <form class="js-prevent-multiple-submit" method="post">
+      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+      <fieldset>
+          <p class="h4">Se connecter avec vos identifiants</p>
+          
+          
+          <div class="form-group form-group-required"><label class="form-label" for="id_login">Adresse e-mail</label><input autocomplete="email" autofocus="" class="form-control" id="id_login" maxlength="320" name="login" placeholder="adresse@email.fr" required="" type="email"/></div>
+          <div class="mb-3 form-group-required"><label class="form-label" for="id_password">Mot de passe</label><div class="input-group">
+      <input aria-describedby="id_password_helptext" autocomplete="current-password" class="form-control" id="id_password" name="password" placeholder="**********" required="" type="password"/>
+  
+      <div class="input-group-text p-0">
+          <button class="btn btn-sm btn-link btn-ico" data-it-password="toggle" type="button">
+              <i aria-hidden="true" class="ri-eye-line"></i>
+              <span>Afficher</span>
+          </button>
+      </div>
+  </div><div class="form-text"><a class="btn-link fs-sm" href="/accounts/password/reset/">Mot de passe oublié ?</a></div>
+  </div>
+      </fieldset>
+      
+      
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
+                  
+                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
+                          <span>Se connecter</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  
+  
+  </form>
+  
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login[FC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              <p class="h4">Se connecter avec FranceConnect</p>
+                              
+                                  <div class="mt-4">
+  
+  
+  <p class="mb-0">
+      <strong>Utilisez FranceConnect pour vous connecter ou créer un compte</strong>.
+  </p>
+  <p>
+      FranceConnect est la solution proposée par l’État pour sécuriser et simplifier la connexion à vos services en ligne.
+  </p>
+  <div class="text-center">
+      <a aria-label="S'identifier avec FranceConnect" data-matomo-action="clic" data-matomo-category="inscription-candidat" data-matomo-event="true" data-matomo-option="se-connecter-avec-france-connect" href="/franceconnect/authorize">
+          <img alt="" class="img-fluid mb-1 itou-france-connect"/>
+      </a>
+      <br/>
+      <a class="btn btn-link" href="https://app.franceconnect.gouv.fr/en-savoir-plus">Qu’est-ce que FranceConnect ?</a>
+  </div>
+  </div>
+                              
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login[IC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              
+  
+  
+  
+  
+      <div class="text-center">
+          <a class="btn-inclusion-connect" data-matomo-action="clic" data-matomo-category="connexion prescripteur" data-matomo-event="true" data-matomo-option="se-connecter-avec-inclusion-connect" href="/inclusion_connect/authorize?user_kind=prescriber&amp;previous_url=%2Flogin%2Fexisting%2Fc0fee70e-cf34-4d37-919d-a1ae3e3bf7e5%3Fback_url%3D%2Fsignup%2F">
+              <picture>
+                  <source height="14" media="(min-width: 30em)" srcset="/static/vendor/theme-inclusion/images/logo-inclusion-connect-one-line.svg" type="image/svg+xml" width="286"/>
+                  <img alt="Se connecter avec Inclusion Connect" height="37" src="/static/vendor/theme-inclusion/images/logo-inclusion-connect-two-lines.svg" width="142"/>
+              </picture>
+          </a>
+      </div>
+  
+  
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login[PC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              
+  
+  
+  
+  
+      <div class="text-center">
+          <a class="proconnect-button" data-matomo-action="clic" data-matomo-category="connexion prescripteur" data-matomo-event="true" data-matomo-option="se-connecter-avec-pro-connect" href="/pro_connect/authorize?user_kind=prescriber&amp;previous_url=%2Flogin%2Fexisting%2Fc0fee70e-cf34-4d37-919d-a1ae3e3bf7e5%3Fback_url%3D%2Fsignup%2F">
+          </a>
+          <p>
+              <a href="https://proconnect.gouv.fr/" rel="noopener noreferrer" target="_blank" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
+                  Qu’est-ce que ProConnect ?
+              </a>
+          </p>
+      </div>
+  
+  
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login[PEC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              <p class="h4">Se connecter avec France Travail</p>
+                              
+                                  <div class="mt-4 text-center">
+  
+  
+  <form action="/pe_connect/authorize" method="post">
+      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+      <input alt="Se connecter avec votre compte France Travail" data-matomo-action="clic" data-matomo-category="inscription-candidat" data-matomo-event="true" data-matomo-option="se-connecter-avec-pe" src="/static/img/peamu_btn.svg" type="image"/>
+  </form>
+  </div>
+                              
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login_disabled_provider[FC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              <p class="h4">Se connecter avec FranceConnect</p>
+                              
+                                  <div class="alert alert-info" role="status">
+                                      <p class="mb-0">FranceConnect est désactivé.</p>
+                                  </div>
+                              
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login_disabled_provider[IC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              
+  
+  
+  
+  
+      <div class="alert alert-info" role="status">
+          <p class="mb-2">
+              <strong>Inclusion Connect est momentanément désactivé.</strong>
+          </p>
+          <p class="mb-0">
+              Afin de demander un PASS IAE en urgence, <a class="has-external-link" href="https://tally.so/r/nrj0V5" target="_blank">remplissez ce formulaire.</a>
+          </p>
+      </div>
+  
+  
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login_disabled_provider[PC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              
+  
+  
+  
+  
+      <div class="alert alert-info" role="status">
+          <p class="mb-2">
+              <strong>ProConnect est momentanément désactivé.</strong>
+          </p>
+          <p class="mb-0">
+              Afin de demander un PASS IAE en urgence, <a class="has-external-link" href="https://tally.so/r/nrj0V5" target="_blank">remplissez ce formulaire.</a>
+          </p>
+      </div>
+  
+  
+                          
+                      </div>
+  '''
+# ---
+# name: TestExistingUserLogin.test_login_disabled_provider[PEC]
+  '''
+  <div class="c-form mb-5">
+                          
+                              <p class="h4">Se connecter avec France Travail</p>
+                              
+                                  <div class="alert alert-info" role="status">
+                                      <p class="mb-0">France Travail est désactivé.</p>
+                                  </div>
+                              
+                          
+                      </div>
+  '''
+# ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans le cadre de la refonte de parcours d'inscription, quand les utilisateurs se connecte avec un nouveau compte qui partage un email avec un autre compte, on affiche un erreur. Dans ce PR on affiche un erreur standardisé, qui permet l'utilisateur à se connecter au compte existant (via une page dédiée) ou de s'inscrire avec un email différent depuis la page signup.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran

Example :

<img width="783" alt="Screenshot 2024-10-02 at 11 30 50" src="https://github.com/user-attachments/assets/0b579bdc-2709-4d45-8d4d-0a0cea9fd0be">

En cliquant sur « se connecter avec ce compte » :

<img width="702" alt="Screenshot 2024-10-02 at 11 31 24" src="https://github.com/user-attachments/assets/8d667f56-2ef1-4a07-be29-73894f0061cb">

En cliquant sur « retour » :

<img width="1035" alt="Screenshot 2024-10-02 at 11 38 41" src="https://github.com/user-attachments/assets/5fd5884a-6584-418f-9c7c-b841662b6706">