### PR TITLE
Pilotage : Utilisation du code INSEE enregistré plutôt que de l'inférer depuis le code postal

### DIFF
--- a/clevercloud/crons/populate_metabase_emplois.sh
+++ b/clevercloud/crons/populate_metabase_emplois.sh
@@ -47,7 +47,6 @@ elif [[ "$1" == "--monthly" ]]; then
     django-admin send_slack_message ":rocket: lancement mise à jour de données peu fréquentes C1 -> Metabase"
     django-admin populate_metabase_emplois --mode=rome_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=insee_codes |& tee -a "$OUTPUT_LOG"
-    django-admin populate_metabase_emplois --mode=insee_codes_vs_post_codes |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=departments |& tee -a "$OUTPUT_LOG"
     django-admin populate_metabase_emplois --mode=dbt_daily |& tee -a "$OUTPUT_LOG"
     django-admin send_slack_message ":white_check_mark: succès mise à jour de données peu fréquentes C1 -> Metabase"

--- a/itou/metabase/db.py
+++ b/itou/metabase/db.py
@@ -135,22 +135,6 @@ def create_unversioned_tables_if_needed():
     """
     with MetabaseDatabaseCursor() as (cur, conn):
         create_table_sql_requests = """
-            /* TODO @defajait DROP ASAP - use codes_insee_vs_codes_postaux instead */
-            CREATE TABLE IF NOT EXISTS "commune_gps" (
-                "code_insee" varchar(255),
-                "nom_commune" varchar(255),
-                "code_postal" varchar(255),
-                "latitude" numeric(9,6),
-                "longitude" numeric(9,6)
-            );
-
-            CREATE TABLE IF NOT EXISTS "sa_ept" (
-                "etablissement_public_territorial" varchar(255),
-                "commune" varchar(255),
-                "departement" varchar(255),
-                "code_comm" varchar(25)
-            );
-
             CREATE TABLE IF NOT EXISTS "sa_zones_infradepartementales" (
                 "code_insee" varchar(255),
                 "libelle_commune" varchar(255),
@@ -161,14 +145,6 @@ def create_unversioned_tables_if_needed():
                 "code_commune" varchar,
                 "nom_epci" varchar(255),
                 "type_epci" varchar
-            );
-
-            CREATE TABLE IF NOT EXISTS "code_rome_domaine_professionnel" (
-                "grand_domaine" varchar(255),
-                "domaine_professionnel" varchar(255),
-                "code_rome" varchar,
-                "description_code_rome" varchar,
-                "date_mise_à_jour_metabase" date
             );
 
             CREATE TABLE IF NOT EXISTS "reseau_iae_adherents" (

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -110,7 +110,6 @@ class Command(BaseCommand):
             "memberships": self.populate_memberships,
             "rome_codes": self.populate_rome_codes,
             "insee_codes": self.populate_insee_codes,
-            "insee_codes_vs_post_codes": self.populate_insee_codes_vs_post_codes,
             "departments": self.populate_departments,
             "enums": self.populate_enums,
             "dbt_daily": self.build_dbt_daily,
@@ -463,22 +462,6 @@ class Command(BaseCommand):
         queryset = City.objects.all()
 
         populate_table(insee_codes.TABLE, batch_size=1000, querysets=[queryset])
-
-    def populate_insee_codes_vs_post_codes(self):
-        table_name = "codes_insee_vs_codes_postaux"
-        self.stdout.write(f"Preparing content for {table_name} table...")
-
-        rows = []
-        for city in City.objects.all():
-            for post_code in city.post_codes:
-                row = {
-                    "code_insee": city.code_insee,
-                    "code_postal": post_code,
-                }
-                rows.append(row)
-
-        df = get_df_from_rows(rows)
-        store_df(df=df, table_name=table_name)
 
     def populate_departments(self):
         table_name = "departements"

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -129,9 +129,9 @@ class Command(BaseCommand):
         ONE_MONTH_AGO = timezone.now() - timezone.timedelta(days=30)
         queryset = (
             Company.objects.active()
-            .select_related("convention")
+            .select_related("convention", "insee_city")
             .prefetch_related(
-                "convention__siaes",
+                Prefetch("convention__siaes", queryset=Company.objects.select_related("insee_city")),
                 "job_description_through",
                 "members",
                 Prefetch(
@@ -262,6 +262,7 @@ class Command(BaseCommand):
                 "members",
                 "prescribermembership_set",
             )
+            .select_related("insee_city")
             .annotate(
                 job_applications_count=job_applications_count,
                 accepted_job_applications_count=accepted_job_applications_count,

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -21,7 +21,7 @@ from itou.approvals.enums import Origin, ProlongationReason
 from itou.approvals.models import Approval
 from itou.cities.models import City
 from itou.common_apps.address.departments import DEPARTMENT_TO_REGION, DEPARTMENTS
-from itou.common_apps.address.models import BAN_API_RELIANCE_SCORE
+from itou.common_apps.address.models import BAN_API_RELIANCE_SCORE, AddressMixin
 from itou.companies.models import Company
 from itou.geo.enums import ZRRStatus
 from itou.geo.models import ZRR
@@ -156,8 +156,10 @@ def get_post_code_to_insee_code_map():
 # FIXME @dejafait drop this as soon as data analysts no longer use
 # structures_v0.code_commune nor organisations.code_commune
 # because one post_code can actually have *several* insee_codes (╯°□°)╯︵ ┻━┻
-def convert_post_code_to_insee_code(post_code):
-    return get_post_code_to_insee_code_map().get(post_code)
+def get_code_commune(obj: AddressMixin):
+    if obj.insee_city:
+        return obj.insee_city.code_insee
+    return get_post_code_to_insee_code_map().get(obj.post_code)
 
 
 @functools.cache
@@ -212,7 +214,7 @@ def get_address_columns(name_suffix="", comment_suffix="", custom_fn=lambda o: o
                 "name": f"code_commune{name_suffix}",
                 "type": "varchar",
                 "comment": f"Code commune{comment_suffix}",
-                "fn": lambda o: convert_post_code_to_insee_code(custom_fn(o).post_code),
+                "fn": lambda o: get_code_commune(custom_fn(o)),
             },
             {
                 "name": f"ville{name_suffix}",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car un code postal n'est pas unique et peux donc être assigné à plusieurs ville, on se retrouve donc avec des noms de ville fausses dans les tableaux de bord.

PR associée : https://github.com/gip-inclusion/pilotage-airflow/pull/356