### PR TITLE
Amélioration des méthodes `has_data_changed()`

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -285,15 +285,13 @@ class User(AbstractUser, AddressMixin):
     def __init__(self, *args, _auto_create_job_seeker_profile=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._auto_create_job_seeker_profile = _auto_create_job_seeker_profile
+        self.set_old_values()
 
     def __str__(self):
         return f"{self.get_full_name()} — {self.email}"
 
-    @classmethod
-    def from_db(cls, db, field_names, values):
-        instance = super().from_db(db, field_names, values)
-        instance._old_values = dict(zip(field_names, values))
-        return instance
+    def set_old_values(self):
+        self._old_values = self.__dict__.copy()
 
     def has_data_changed(self, fields):
         if hasattr(self, "_old_values"):
@@ -344,10 +342,12 @@ class User(AbstractUser, AddressMixin):
             if must_create_profile:
                 JobSeekerProfile.objects.create(user=self)
 
-            if self.has_data_changed(["last_name", "first_name"]):
+            if self.has_data_changed(["last_name", "first_name"]) and not self._state.adding:
                 self.jobseeker_profile.pe_obfuscated_nir = None
                 self.jobseeker_profile.pe_last_certification_attempt_at = None
                 self.jobseeker_profile.save(update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at"])
+
+        self.set_old_values()
 
     def get_full_name(self):
         """
@@ -1026,11 +1026,12 @@ class JobSeekerProfile(models.Model):
     def __str__(self):
         return str(self.user)
 
-    @classmethod
-    def from_db(cls, db, field_names, values):
-        instance = super().from_db(db, field_names, values)
-        instance._old_values = dict(zip(field_names, values))
-        return instance
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.set_old_values()
+
+    def set_old_values(self):
+        self._old_values = self.__dict__.copy()
 
     def has_data_changed(self, fields):
         if hasattr(self, "_old_values"):
@@ -1048,12 +1049,14 @@ class JobSeekerProfile(models.Model):
             self.asp_uid = self._default_asp_uid()
             if update_fields is not None:
                 update_fields = set(update_fields) | {"asp_uid"}
-        if self.has_data_changed(["birthdate", "nir"]):
+        if self.has_data_changed(["birthdate", "nir"]) and not self._state.adding:
             self.pe_obfuscated_nir = None
             self.pe_last_certification_attempt_at = None
             if update_fields is not None:
                 update_fields = set(update_fields) | {"pe_obfuscated_nir", "pe_last_certification_attempt_at"}
         super().save(force_insert=force_insert, force_update=force_update, using=using, update_fields=update_fields)
+
+        self.set_old_values()
 
     @staticmethod
     def clean_pole_emploi_fields(cleaned_data):


### PR DESCRIPTION
## :thinking: Pourquoi ?

On a a priori envie que les anciennes valeurs soient mises à jour quand on sauve le modèle.
Typiquement quand on créer le job seeker profile, on fait un create en premier, puis on remplie les valeurs de la même instance. donc on ne détecte pas qu'elles changent.

C'est nécessaire pour que le test `test_apply_as_prescriber_with_pending_authorization` fonctionne dans #4869.

La question que je me pose est si on copie tout `self.__dict__` on si on regarde juste les 2 champs qui nous intéressent en vérifiant juste qu'ils sont présents pour éviter des requêtes supplémentaires en cas de champs "deferred": 
```
def set_old_values(self):
    watched_fields = ["nir", "birthdate"] 
    self._old_values = {
        field: value 
        for field, value in self.__dict__
        if field in watched_fields
    }
```

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
