### PR TITLE
Candidature: Amélioration de la validation du NIR

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1094,7 +1094,15 @@ class JobSeekerProfile(models.Model):
             if cleaned_birthdate := cleaned_data.get("birthdate"):
                 nir_year_month = cleaned_nir[1:5]
                 birthdate_year_month = cleaned_birthdate.strftime("%y%m")
-                if nir_year_month != birthdate_year_month:
+                birthdate_inconsistency = False
+                if 1 <= int(nir_year_month[2:4]) <= 12:
+                    birthdate_inconsistency = nir_year_month != birthdate_year_month
+                else:
+                    # NIR month may be between 20 and 42 or 50 and 99 ¯\_(ツ)_/¯
+                    # https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_s%C3%A9curit%C3%A9_sociale_en_France#cite_note-B
+                    # just check for the year
+                    birthdate_inconsistency = nir_year_month[:2] != birthdate_year_month[:2]
+                if birthdate_inconsistency:
                     raise ValidationError(
                         JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_BIRTHDATE
                         % (f" {cleaned_nir}" if remind_nir_in_error else "")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand le mois 'est pas une valeur entre 1 et 12, on ne peut pas comparer avec le mois de naissance renseigné.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
