### PR TITLE
Candidature: Correction de la sélection de commune quand le code insee a changé depuis la naissance du candidat

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -166,7 +166,7 @@ class CheckJobSeekerInfoForm(JobSeekerProfileFieldsMixin, forms.ModelForm):
 
 
 class CreateOrUpdateJobSeekerStep1Form(
-    JobSeekerNIRUpdateMixin, JobSeekerProfileFieldsMixin, BirthPlaceAndCountryMixin, forms.ModelForm
+    JobSeekerNIRUpdateMixin, BirthPlaceAndCountryMixin, JobSeekerProfileFieldsMixin, forms.ModelForm
 ):
     REQUIRED_FIELDS = [
         "title",

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -455,3 +455,9 @@ class CertifiedCriteriaInfoRequiredFormTest(TestCase):
             f"Le code INSEE {birth_place.code} n'est pas référencé par l'ASP en date du {early_date:%d/%m/%Y}"
         )
         assert form.errors["birth_place"] == [expected_msg]
+
+
+class TestCreateOrUpdateJobSeekerStep1Form:
+    def test_commune_birthdate_dependency(self):
+        form = apply_forms.CreateOrUpdateJobSeekerStep1Form()
+        assert form.with_birthdate_field


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à une remontée utilisateur : https://plateforme-inclusion.zendesk.com/agent/tickets/20239


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
