### PR TITLE
Autoriser test+cap@inclusion.beta.gouv.fr à se logger via Django

### DIFF
--- a/itou/fixtures/django/05_test_users.json
+++ b/itou/fixtures/django/05_test_users.json
@@ -993,7 +993,7 @@
       "geocoding_updated_at": null,
       "groups": [],
       "has_completed_welcoming_tour": true,
-      "identity_provider": "IC",
+      "identity_provider": "DJANGO",
       "insee_city": null,
       "is_active": true,
       "is_staff": false,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Facilement contrôler cet utilisateur en local.
