### PR TITLE
Candidature: Prévenir dans la candidature que la personne a quitté l’organisation

### DIFF
--- a/itou/communications/dispatch/base.py
+++ b/itou/communications/dispatch/base.py
@@ -3,9 +3,10 @@ class BaseNotification:
 
     can_be_disabled = True
 
-    def __init__(self, user, structure=None, /, **kwargs):
+    def __init__(self, user, structure=None, forward_from_user=None, /, **kwargs):
         self.user = user
         self.structure = structure
+        self.forward_from_user = forward_from_user
         self.context = kwargs
 
     def __repr__(self):
@@ -29,7 +30,11 @@ class BaseNotification:
         return True
 
     def get_context(self):
-        return self.validate_context()
+        return self.validate_context() | {
+            "user": self.user,
+            "structure": self.structure,
+            "forward_from_user": self.forward_from_user,
+        }
 
     def validate_context(self):
         return self.context

--- a/itou/communications/dispatch/email.py
+++ b/itou/communications/dispatch/email.py
@@ -13,15 +13,6 @@ class EmailNotification(BaseNotification):
     REQUIRED = BaseNotification.REQUIRED + ["subject_template", "body_template"]
 
     def build(self):
-        # TODO: Temporary log for analysis : remove by the end of November 2024
-        if self.user.is_prescriber and self.structure:
-            memberships = (
-                PrescriberMembership.objects.active().filter(organization=self.structure).select_related("user")
-            )
-            members = [m.user for m in memberships]
-            if self.user not in members:
-                admin_count = len([m for m in memberships if m.is_admin])
-                logger.info("Estimate new email sent to admin_count=%d", admin_count)
         return get_email_message(
             [self.user.email],
             self.get_context(),
@@ -30,5 +21,23 @@ class EmailNotification(BaseNotification):
         )
 
     def send(self):
+        if (
+            # If it is already a forwarded notification, do not check if the user is still a member of the organization
+            not self.forward_from_user
+            # Don't use should_send() if the user left the org because we don't want to use his settings
+            and self.is_applicable()
+            and self.user.is_prescriber
+            and self.structure
+        ):
+            memberships = (
+                PrescriberMembership.objects.active().filter(organization=self.structure).select_related("user")
+            )
+            members = [m.user for m in memberships]
+            if self.user not in members:
+                admins = [m.user for m in memberships if m.is_admin]
+                logger.info("Send email copy to admin, admin_count=%d", len(admins))
+                for admin in admins:
+                    self.__class__(admin, self.structure, self.user, **self.context).send()
+                return
         if self.should_send():
-            return self.build().send()
+            self.build().send()

--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -1,6 +1,21 @@
 {% load format_filters %}
 {% load matomo %}
 
+{% if job_application_sender_left_org %}
+    <div class="alert alert-warning alert-dismissible fade show" role="status">
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+        <div class="row">
+            <div class="col-auto pe-0">
+                <i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>
+            </div>
+            <div class="col">
+                <p class="mb-0">L’émetteur de cette candidature ne fait plus partie de l’organisation émettrice</p>
+            </div>
+        </div>
+    </div>
+
+
+{% endif %}
 <ul class="list-data list-data__two-column-md mb-3">
     <li>
         <small>Émetteur</small>
@@ -14,6 +29,8 @@
         <small>Adresse e-mail</small>
         {% if request.user.is_job_seeker and job_application.sender_kind != SenderKind.JOB_SEEKER %}
             <strong>Non communiquée</strong>
+        {% elif job_application_sender_left_org %}
+            <div class="text-warning fst-italic">Les réponses seront transmises aux administrateurs de l’organisation</div>
         {% else %}
             <strong>{{ job_application.sender.email }}</strong>
             {% matomo_event "candidature" "clic" "copied_sender_email" as matomo_event_attrs %}

--- a/itou/templates/layout/base_email_text_body.txt
+++ b/itou/templates/layout/base_email_text_body.txt
@@ -1,7 +1,7 @@
 {% autoescape off %}
 
 {% if forward_from_user|default:False %}
-Vous recevez cet e-mail parce que l'utilisateur {{ forward_from_user.get_full_name }} ({{ forward_from_user.email}}) ne fait plus partie de votre organisation.
+Vous recevez cet e-mail parce que l'utilisateur {{ forward_from_user.get_full_name }} ({{ forward_from_user.email}}) ne fait plus partie de votre {{ forward_from_user.is_employer|yesno:"structure,organisation" }}.
 
 -----
 {% endif %}

--- a/itou/templates/layout/base_email_text_body.txt
+++ b/itou/templates/layout/base_email_text_body.txt
@@ -1,5 +1,11 @@
 {% autoescape off %}
 
+{% if forward_from_user|default:False %}
+Vous recevez cet e-mail parce que l'utilisateur {{ forward_from_user.get_full_name }} ({{ forward_from_user.email}}) ne fait plus partie de votre organisation.
+
+-----
+{% endif %}
+
 {% block body %}{% endblock %}
 
 {% include "layout/base_email_signature.txt" %}

--- a/itou/users/notifications.py
+++ b/itou/users/notifications.py
@@ -12,11 +12,6 @@ class OrganizationActiveMembersReminderNotification(
     body_template = "users/emails/check_authorized_members_email_body.txt"
     can_be_disabled = False
 
-    def get_context(self):
-        context = super().get_context()
-        context["structure"] = self.structure
-        return context
-
 
 @notifications_registry.register
 class JobSeekerCreatedByProxyNotification(EmailNotification):

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -83,6 +83,14 @@ def _get_geiq_eligibility_diagnosis(job_application, only_prescriber):
     ).first()
 
 
+def job_application_sender_left_org(job_app):
+    if org_id := job_app.sender_prescriber_organization_id:
+        return not job_app.sender.prescribermembership_set.active().filter(organization_id=org_id).exists()
+    if company_id := job_app.sender_company_id:
+        return not job_app.sender.companymembership_set.active().filter(company_id=company_id).exists()
+    return False
+
+
 @login_required
 def details_for_jobseeker(request, job_application_id, template_name="apply/process_details.html"):
     """
@@ -156,6 +164,7 @@ def details_for_jobseeker(request, job_application_id, template_name="apply/proc
         "transition_logs": transition_logs,
         "back_url": back_url,
         "matomo_custom_title": "Candidature",
+        "job_application_sender_left_org": job_application_sender_left_org(job_application),
     }
 
     return render(request, template_name, context)
@@ -267,6 +276,7 @@ def details_for_company(request, job_application_id, template_name="apply/proces
             PriorActionForm(action_only=True) if job_application.can_change_prior_actions else None
         ),
         "matomo_custom_title": "Candidature",
+        "job_application_sender_left_org": job_application_sender_left_org(job_application),
     }
 
     return render(request, template_name, context)
@@ -349,6 +359,7 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
         "refused_by": refused_by,
         "refusal_contact_email": refusal_contact_email,
         "with_job_seeker_detail_url": True,
+        "job_application_sender_left_org": job_application_sender_left_org(job_application),
     }
 
     return render(request, template_name, context)

--- a/tests/job_applications/__snapshots__/test_transfer.ambr
+++ b/tests/job_applications/__snapshots__/test_transfer.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_model_fields
   dict({
-    'num_queries': 14,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -144,6 +144,62 @@
                WHERE (U0."company_id" = %s
                       AND U2."is_active"
                       AND U0."is_active"))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobApplicationTransferredForEmployerNotification.send[communications/dispatch/email.py]',
+          'JobApplication.transfer[job_applications/models.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id",
+                 "companies_companymembership"."notifications",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."company_id" = %s)
           ORDER BY RANDOM() ASC
         ''',
       }),

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -976,7 +976,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_approval[job application detail for company]
   dict({
-    'num_queries': 21,
+    'num_queries': 22,
     'queries': list([
       dict({
         'origin': list([
@@ -1793,6 +1793,23 @@
           SELECT %s AS "a"
           FROM "employee_record_employeerecord"
           WHERE "employee_record_employeerecord"."job_application_id" = %s
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'job_application_sender_left_org[www/apply/views/process_views.py]',
+          'details_for_company[www/apply/views/process_views.py]',
+          '_check_user_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("prescribers_prescribermembership"."user_id" = %s
+                 AND "users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" = %s)
           LIMIT 1
         ''',
       }),
@@ -2110,7 +2127,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_list[job application detail for company]
   dict({
-    'num_queries': 21,
+    'num_queries': 22,
     'queries': list([
       dict({
         'origin': list([
@@ -2927,6 +2944,23 @@
           SELECT %s AS "a"
           FROM "employee_record_employeerecord"
           WHERE "employee_record_employeerecord"."job_application_id" = %s
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'job_application_sender_left_org[www/apply/views/process_views.py]',
+          'details_for_company[www/apply/views/process_views.py]',
+          '_check_user_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("prescribers_prescribermembership"."user_id" = %s
+                 AND "users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" = %s)
           LIMIT 1
         ''',
       }),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Simplifier la prise de contact avec le référent.
Il faut mettre en place l'envoi des réponses aux administrateurs avant ce ticket en revanche

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
