### PR TITLE
Contrôle a posteriori: amélioration de l'admin pour afficher l'état d'une auto-prescription au sein d'une entreprise contrôlée

### DIFF
--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -45,7 +45,7 @@ class EvaluatedJobApplicationsInline(ItouTabularInline):
         return super().get_queryset(request).prefetch_related("evaluated_administrative_criteria")
 
     def state(self, obj):
-        return obj.state
+        return obj.compute_state()
 
     @admin.display(description="lien vers les candidatures évaluées")
     def id_link(self, obj):

--- a/tests/siae_evaluations/test_admin.py
+++ b/tests/siae_evaluations/test_admin.py
@@ -263,3 +263,27 @@ def test_evaluated_job_application_state_display(admin_client):
         html=True,
         count=1,
     )
+
+
+def test_evaluated_job_application_state_display_in_evaluated_siae_admin(admin_client):
+    evaluated_job_app = EvaluatedJobApplicationFactory(
+        complete=True,
+        evaluated_siae__evaluation_campaign__evaluations_asked_at=timezone.now() - timedelta(days=60),
+    )
+    response = admin_client.get(
+        reverse(
+            "admin:siae_evaluations_evaluatedsiae_change",
+            kwargs={"object_id": evaluated_job_app.evaluated_siae.pk},
+        )
+    )
+    # Check evaluated job app state is properly displayed in its inline table
+    assertContains(
+        response,
+        """
+        <td class="field-state">
+          <p>SUBMITTED</p>
+        </td>
+        """,
+        html=True,
+        count=1,
+    )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour accéder plus facilement aux informations.
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
