### PR TITLE
Admin: amélioration de la recherche des PASS IAE par numéro

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -315,7 +315,9 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
                 # Handle partial numbers not starting with the prefix (migrated PEApproval)
                 search_fields.append("number__contains")
 
-        if search_term.isdecimal() and len(search_term) <= 15:
+        if search_term.isdecimal() and 13 <= len(search_term) <= 15:
+            # Searching by NIR is much more expensive than by number
+            # so only do so for long numbers
             if len(search_term) == 15:  # Complete NIR
                 search_fields.append("user__jobseeker_profile__nir__exact")
             else:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si le terme de recherche est un nombre de 12 chiffres ou moins, la recherche ne se fera plus que sur le numéro du PASS et non plus sur le NIR du candidat pour un gain de performance substantiel: 45 ms vs 450 ms en local.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
