### PR TITLE
Pilotage : Publier le TB 440/485 en Occitanie et en Bretagne pour les SIAE, les DDETS, les DREETS, les CD, et la DGEFP

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -347,6 +347,12 @@
                                 <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                 <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                             </a>
+                        </li>
+                        <li class="d-flex justify-content-between align-items-center mb-3">
+                            <a href="{% url 'stats:stats_dgefp_iae_orga_etp' %}" class="btn-link btn-ico">
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
+                            </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
                         </li>
                     {% endif %}

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -210,6 +210,15 @@
                                 </a>
                             </li>
                         {% endif %}
+                        {% if can_view_stats_ddets_iae_orga_etp %}
+                            <li class="d-flex justify-content-between align-items-center mb-3">
+                                <a href="{% url 'stats:stats_ddets_iae_orga_etp' %}" class="btn-link btn-ico">
+                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                    <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
+                                </a>
+                                {% include "dashboard/includes/stats_new_badge.html" %}
+                            </li>
+                        {% endif %}
                     {% endif %}
                     {% if can_view_stats_ddets_log %}
                         <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -97,6 +97,15 @@
                             </a>
                         </li>
                     {% endif %}
+                    {% if can_view_stats_cd_orga_etp %}
+                        <li class="d-flex justify-content-between align-items-center mb-3">
+                            <a href="{% url 'stats:stats_cd_orga_etp' %}" class="btn-link btn-ico">
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
+                            </a>
+                            {% include "dashboard/includes/stats_new_badge.html" %}
+                        </li>
+                    {% endif %}
                     {% if can_view_stats_ft %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9"

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -281,6 +281,15 @@
                             </a>
                         </li>
                     {% endif %}
+                    {% if can_view_stats_dreets_iae_orga_etp %}
+                        <li class="d-flex justify-content-between align-items-center mb-3">
+                            <a href="{% url 'stats:stats_dreets_iae_orga_etp' %}" class="btn-link btn-ico">
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <span>Suivre les effectifs annuels et mensuels en ETP des structures de ma région</span>
+                            </a>
+                            {% include "dashboard/includes/stats_new_badge.html" %}
+                        </li>
+                    {% endif %}
                     {% if can_view_stats_dgefp_iae %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_auto_prescription' %}" class="btn-link btn-ico">

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -173,6 +173,9 @@ METABASE_DASHBOARDS = {
     "stats_ddets_iae_aci": {
         "dashboard_id": 327,
     },
+    "stats_ddets_iae_orga_etp": {
+        "dashboard_id": 485,
+    },
     #
     # Institution stats - DDETS LOG - department level.
     #

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -221,6 +221,9 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "w2az2j",
         "tally_embed_form_id": "3Nlvzl",
     },
+    "stats_dreets_iae_orga_etp": {
+        "dashboard_id": 485,
+    },
     #
     # Institution stats - DRIHL - region level - IDF only.
     #

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -83,6 +83,9 @@ METABASE_DASHBOARDS = {
     "stats_cd_aci": {
         "dashboard_id": 327,
     },
+    "stats_cd_orga_etp": {
+        "dashboard_id": 485,
+    },
     #
     # Prescriber stats - FT.
     #

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -271,6 +271,9 @@ METABASE_DASHBOARDS = {
     "stats_dgefp_iae_af": {
         "dashboard_id": 142,
     },
+    "stats_dgefp_iae_orga_etp": {
+        "dashboard_id": 485,
+    },
     #
     # Institution stats - DIHAL - nation level.
     #

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -204,6 +204,7 @@ def dashboard_stats(request, template_name="dashboard/dashboard_stats.html"):
         "can_view_stats_ddets_iae_orga_etp": stats_utils.can_view_stats_ddets_iae_orga_etp(request),
         "can_view_stats_ddets_log": stats_utils.can_view_stats_ddets_log(request),
         "can_view_stats_dreets_iae": stats_utils.can_view_stats_dreets_iae(request),
+        "can_view_stats_dreets_iae_orga_etp": stats_utils.can_view_stats_dreets_iae_orga_etp(request),
         "can_view_stats_dgefp_iae": stats_utils.can_view_stats_dgefp_iae(request),
         "can_view_stats_dihal": stats_utils.can_view_stats_dihal(request),
         "can_view_stats_drihl": stats_utils.can_view_stats_drihl(request),

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -201,6 +201,7 @@ def dashboard_stats(request, template_name="dashboard/dashboard_stats.html"):
         "can_view_stats_ph": stats_utils.can_view_stats_ph(request),
         "can_view_stats_ddets_iae": stats_utils.can_view_stats_ddets_iae(request),
         "can_view_stats_ddets_iae_aci": stats_utils.can_view_stats_ddets_iae_aci(request),
+        "can_view_stats_ddets_iae_orga_etp": stats_utils.can_view_stats_ddets_iae_orga_etp(request),
         "can_view_stats_ddets_log": stats_utils.can_view_stats_ddets_log(request),
         "can_view_stats_dreets_iae": stats_utils.can_view_stats_dreets_iae(request),
         "can_view_stats_dgefp_iae": stats_utils.can_view_stats_dgefp_iae(request),

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -196,6 +196,7 @@ def dashboard_stats(request, template_name="dashboard/dashboard_stats.html"):
         "can_view_stats_siae_orga_etp": stats_utils.can_view_stats_siae_orga_etp(request),
         "can_view_stats_cd": stats_utils.can_view_stats_cd(request),
         "can_view_stats_cd_aci": stats_utils.can_view_stats_cd_aci(request),
+        "can_view_stats_cd_orga_etp": stats_utils.can_view_stats_cd_orga_etp(request),
         "can_view_stats_ft": stats_utils.can_view_stats_ft(request),
         "can_view_stats_ph": stats_utils.can_view_stats_ph(request),
         "can_view_stats_ddets_iae": stats_utils.can_view_stats_ddets_iae(request),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path("cd/hiring", views.stats_cd_hiring, name="stats_cd_hiring"),
     path("cd/brsa", views.stats_cd_brsa, name="stats_cd_brsa"),
     path("cd/aci", views.stats_cd_aci, name="stats_cd_aci"),
+    path("cd/orga_etp", views.stats_cd_orga_etp, name="stats_cd_orga_etp"),
     # Prescriber stats - FT.
     # Legacy `pe` term is used in URLs for retroactivity in Matomo stats but in fact it means `ft`.
     path("pe/delay/main", views.stats_ft_delay_main, name="stats_ft_delay_main"),

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -71,6 +71,7 @@ urlpatterns = [
     path("ddets/hiring", views.stats_ddets_iae_hiring, name="stats_ddets_iae_hiring"),
     path("ddets/state", views.stats_ddets_iae_state, name="stats_ddets_iae_state"),
     path("ddets/aci", views.stats_ddets_iae_aci, name="stats_ddets_iae_aci"),
+    path("ddets/orga_etp", views.stats_ddets_iae_orga_etp, name="stats_ddets_iae_orga_etp"),
     # Institution stats - DDETS LOG - department level.
     path("ddets_log/state", views.stats_ddets_log_state, name="stats_ddets_log_state"),
     # Institution stats - DREETS IAE - region level.

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -103,6 +103,7 @@ urlpatterns = [
     path("dreets/iae", views.stats_dreets_iae_iae, name="stats_dreets_iae_iae"),
     path("dreets/hiring", views.stats_dreets_iae_hiring, name="stats_dreets_iae_hiring"),
     path("dreets/state", views.stats_dreets_iae_hiring, name="stats_dreets_iae_state"),
+    path("dreets/orga_etp", views.stats_dreets_iae_orga_etp, name="stats_dreets_iae_orga_etp"),
     # Institution stats - DGEFP - nation level.
     path("dgefp/auto_prescription", views.stats_dgefp_iae_auto_prescription, name="stats_dgefp_iae_auto_prescription"),
     path(

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -131,6 +131,7 @@ urlpatterns = [
     path("dgefp/state", views.stats_dgefp_iae_state, name="stats_dgefp_iae_state"),
     path("dgefp/siae_evaluation", views.stats_dgefp_iae_siae_evaluation, name="stats_dgefp_iae_siae_evaluation"),
     path("dgefp/af", views.stats_dgefp_iae_af, name="stats_dgefp_iae_af"),
+    path("dgefp/orga_etp", views.stats_dgefp_iae_orga_etp, name="stats_dgefp_iae_orga_etp"),
     # Institution stats - DIHAL - nation level.
     path("dihal/state", views.stats_dihal_state, name="stats_dihal_state"),
     # Institution stats - DRIHL - region level - IDF only.

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -167,6 +167,10 @@ def can_view_stats_ddets_iae_aci(request):
     )
 
 
+def can_view_stats_ddets_iae_orga_etp(request):
+    return can_view_stats_ddets_iae(request) and request.current_organization.region in WHITELIST_IAE_ORGA_ETP_REGIONS
+
+
 def can_view_stats_ddets_log(request):
     return (
         request.user.is_labor_inspector

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -14,6 +14,9 @@ from itou.prescribers.enums import (
 from itou.prescribers.models import PrescriberOrganization
 
 
+WHITELIST_IAE_ORGA_ETP_REGIONS = ["Bretagne", "Occitanie"]
+
+
 def can_view_stats_dashboard_widget(request):
     """
     Whether a stats section should be displayed on the user's dashboard.
@@ -65,7 +68,10 @@ def can_view_stats_siae_orga_etp(request):
     """
     Non official stats with very specific access rights.
     """
-    return can_view_stats_siae(request) and request.current_organization.pk in settings.STATS_SIAE_PK_WHITELIST
+    return can_view_stats_siae(request) and (
+        request.current_organization.pk in settings.STATS_SIAE_PK_WHITELIST
+        or request.current_organization.region in WHITELIST_IAE_ORGA_ETP_REGIONS
+    )
 
 
 def can_view_stats_cd(request):

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -105,6 +105,10 @@ def can_view_stats_cd_aci(request):
     )
 
 
+def can_view_stats_cd_orga_etp(request):
+    return can_view_stats_cd(request) and request.current_organization.region in WHITELIST_IAE_ORGA_ETP_REGIONS
+
+
 def can_view_stats_ft(request):
     return (
         request.user.is_prescriber

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -190,6 +190,10 @@ def can_view_stats_dreets_iae(request):
     )
 
 
+def can_view_stats_dreets_iae_orga_etp(request):
+    return can_view_stats_dreets_iae(request) and request.current_organization.region in WHITELIST_IAE_ORGA_ETP_REGIONS
+
+
 def can_view_stats_dgefp_iae(request):
     """
     Users of the DGEFP institution can view the confidential DGEFP stats for all regions and departments.

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -661,6 +661,17 @@ def stats_ddets_iae_aci(request):
     )
 
 
+@login_required
+def stats_ddets_iae_orga_etp(request):
+    if not utils.can_view_stats_ddets_iae_orga_etp(request):
+        raise PermissionDenied
+
+    return render_stats_ddets_iae(
+        request=request,
+        page_title="Suivi des effectifs annuels et mensuels en ETP",
+    )
+
+
 def render_stats_ddets_log(request, page_title, extend_stats_to_whole_region):
     get_current_institution_or_404(request)
     if not utils.can_view_stats_ddets_log(request):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -766,6 +766,17 @@ def stats_dreets_iae_state(request):
     )
 
 
+@login_required
+def stats_dreets_iae_orga_etp(request):
+    if not utils.can_view_stats_dreets_iae_orga_etp(request):
+        raise PermissionDenied
+
+    return render_stats_dreets_iae(
+        request=request,
+        page_title="Suivi des effectifs annuels et mensuels en ETP",
+    )
+
+
 def render_stats_dgefp_iae(request, page_title, extra_params=None, extra_context=None):
     if extra_context is None:
         # Do not use mutable default arguments,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -879,6 +879,15 @@ def stats_dgefp_iae_af(request):
 
 
 @login_required
+def stats_dgefp_iae_orga_etp(request):
+    return render_stats_dgefp_iae(
+        request=request,
+        page_title="Suivi des effectifs annuels et mensuels en ETP",
+        extra_params=get_params_for_whole_country(),
+    )
+
+
+@login_required
 def stats_dihal_state(request):
     get_current_institution_or_404(request)
     if not utils.can_view_stats_dihal(request):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -364,6 +364,18 @@ def stats_cd_aci(request):
     )
 
 
+@login_required()
+def stats_cd_orga_etp(request):
+    get_current_org_or_404(request)
+    if not utils.can_view_stats_cd_orga_etp(request):
+        raise PermissionDenied
+
+    return render_stats_cd(
+        request=request,
+        page_title="Suivi des effectifs annuels et mensuels en ETP",
+    )
+
+
 def render_stats_ft(request, page_title, extra_params=None):
     """
     FT ("France Travail") stats shown to relevant members.

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -232,7 +232,7 @@ def test_stats_ddets_log_log_visit(client, settings, view_name):
     [p.name for p in stats_urls.urlpatterns if p.name.startswith("stats_dreets_iae_")],
 )
 def test_stats_dreets_iae_log_visit(client, settings, view_name):
-    institution = InstitutionWithMembershipFactory(kind="DREETS IAE")
+    institution = InstitutionWithMembershipFactory(kind="DREETS IAE", department="22")
     user = institution.members.get()
 
     client.force_login(user)

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -89,7 +89,7 @@ def test_stats_ft_log_visit(client, view_name):
     [p.name for p in stats_urls.urlpatterns if p.name.startswith("stats_cd_")],
 )
 def test_stats_cd_log_visit(client, settings, view_name):
-    prescriber_org = PrescriberOrganizationWithMembershipFactory(kind="DEPT", authorized=True)
+    prescriber_org = PrescriberOrganizationWithMembershipFactory(kind="DEPT", authorized=True, department="22")
     user = prescriber_org.members.get()
 
     settings.STATS_ACI_DEPARTMENT_WHITELIST = [prescriber_org.department]


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/TB-440-TB-ETP-SIAE-Publier-le-TB-en-Occitanie-et-en-Bretagne-pour-les-SIAE-les-DDETS-les-DREETS-58c28a4ede4645c9ab52970cbf5b52e3

RàF :

- [x] Ouvrir pour les SIAE
- [x] Tester pour les CD/DDETS/DREETS
- [ ] Attendre la confirmation des data et du métier