### PR TITLE
Candidature: uniformisation de l'affichage des noms de candidat et d'utilisateur dans les filtres de recherche

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -1047,8 +1047,7 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
         self.fields["selected_jobs"].choices = self._get_choices_for_jobs()
 
     def _get_choices_for_sender(self, users):
-        users = [user for user in users if user.get_full_name()]
-        users = [(user.id, user.get_full_name().title()) for user in users]
+        users = [(user.id, user_full_name) for user in users if (user_full_name := user.get_full_name())]
         return sorted(users, key=lambda user: user[1])
 
     def _get_choices_for_administrativecriteria(self):
@@ -1133,8 +1132,7 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
         return queryset
 
     def _get_choices_for_job_seeker(self, users):
-        users = [user for user in users if user.get_full_name()]
-        users = [(user.id, user.get_full_name().title()) for user in users]
+        users = [(user.id, user_full_name) for user in users if (user_full_name := user.get_full_name())]
         return sorted(users, key=lambda user: user[1])
 
     def get_sender_prescriber_organization_choices(self):
@@ -1163,15 +1161,13 @@ class PrescriberFilterJobApplicationsForm(CompanyPrescriberFilterJobApplications
         self.fields["to_companies"].choices += self.get_to_companies_choices()
 
     def _get_choices_for_job_seeker(self, users):
-        users = [user for user in users if user.get_full_name()]
         users = [
             (
                 user.id,
-                mask_unless(
-                    user.get_full_name().title(), predicate=self.request_user.can_view_personal_information(user)
-                ),
+                mask_unless(user_full_name, predicate=self.request_user.can_view_personal_information(user)),
             )
             for user in users
+            if (user_full_name := user.get_full_name())
         ]
         return sorted(users, key=lambda user: user[1])
 

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -194,7 +194,7 @@ def test_filtered_by_job_seeker_for_unauthorized_prescriber(client):
     assert filters_form.fields["job_seeker"].choices == [
         (a_b_job_seeker.pk, "A… B…"),
         (c_d_job_seeker.pk, "C… D…"),
-        (created_job_seeker.pk, "Zorro Martin"),
+        (created_job_seeker.pk, "Zorro MARTIN"),
     ]
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'affichage utilisé partout est `Prénom NOM`.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
