### PR TITLE
Prescripteur : Ignorer les diagnostics d’éligibilité des auto-prescriptions [GEN-1657]

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -165,13 +165,15 @@ class ApplicationBaseView(ApplyStepBaseView):
             User.objects.filter(kind=UserKind.JOB_SEEKER), public_id=kwargs["job_seeker_public_id"]
         )
         _check_job_seeker_approval(request, self.job_seeker, self.company)
+        # Prescribers do not see employer diagnosis.
+        for_company = self.company if self.request.user.is_employer else None
         if self.company.kind == CompanyKind.GEIQ:
             self.geiq_eligibility_diagnosis = GEIQEligibilityDiagnosis.objects.valid_diagnoses_for(
-                self.job_seeker, self.company if self.request.user.is_employer else None
+                self.job_seeker, for_company
             ).first()
         elif self.company.is_subject_to_eligibility_rules:
             self.eligibility_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(
-                self.job_seeker, for_siae=self.company
+                self.job_seeker, for_company
             )
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les prescripteurs voient les diagnostics d’éligibilité établis par les SIAE pour leurs auto-prescriptions. Ceci conduit les prescripteurs à considérer que le candidat bénéficie déjà d’un diagnostic d’éligibilité et à ne pas le refaire. Au final, les candidats sont mis en difficulté, car un diagnostic établi par un prescripteur habilité est valide pour toutes les SIAE, alors que celui établi par une SIAE n’est valide que pour cet employeur.

## :desert_island: Comment tester

1. Se connecter en tant que SIAE (EI)
2. Déclarer une candidature
3. Créer un compte candidat (e.g. NIR 111111111111120)
4. Étudier la candidature
5. Accepter la candidature
6. Établir un diagnostic d’éligibilité
7. Arrêter le parcours à l’étape de détail du contrat
8. Se connecter en tant que prescripteur habilité
9. Faire une candidature pour le candidat (NIR 111111111111120) auprès de l’employeur

Le prescripteur est obligé de remplir le diagnostic d’éligibilité pour le candidat
