### PR TITLE
Tableau de bord: correction du message lié au délai de carence pour l'encart PASS IAE du candidat

### DIFF
--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -1075,7 +1075,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
 
         # Approval issuance logic.
         if not self.hiring_without_approval and self.to_company.is_subject_to_eligibility_rules:
-            if self.job_seeker.has_common_approval_in_waiting_period:
+            if self.job_seeker.has_latest_common_approval_in_waiting_period:
                 if self.job_seeker.new_approval_blocked_by_waiting_period(
                     siae=self.to_company, sender_prescriber_organization=self.sender_prescriber_organization
                 ):

--- a/itou/templates/dashboard/includes/job_seeker_approval_card.html
+++ b/itou/templates/dashboard/includes/job_seeker_approval_card.html
@@ -14,7 +14,7 @@
                 <li class="mb-2">
                     {% include "approvals/includes/status.html" with common_approval=user.latest_common_approval hiring_pending=False %}
                 </li>
-                {% if user.has_common_approval_in_waiting_period %}
+                {% if user.has_latest_common_approval_in_waiting_period %}
                     <li class="mb-2">
                         {% if user.has_valid_diagnosis %}
                             <p class="mb-0">

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -516,9 +516,7 @@ class User(AbstractUser, AddressMixin):
 
     @property
     def has_common_approval_in_waiting_period(self):
-        return (self.latest_approval and not self.latest_approval.is_valid()) or (
-            self.latest_pe_approval and not self.latest_pe_approval.is_valid()
-        )
+        return self.latest_common_approval and not self.latest_common_approval.is_valid()
 
     @property
     def has_no_common_approval(self):

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -515,7 +515,7 @@ class User(AbstractUser, AddressMixin):
         return self.latest_approval and self.latest_approval.is_valid()
 
     @property
-    def has_common_approval_in_waiting_period(self):
+    def has_latest_common_approval_in_waiting_period(self):
         return self.latest_common_approval and not self.latest_common_approval.is_valid()
 
     @property
@@ -534,7 +534,7 @@ class User(AbstractUser, AddressMixin):
         # Only diagnoses made by authorized prescribers are taken into account.
         has_valid_diagnosis = self.has_valid_diagnosis()
         return (
-            self.has_common_approval_in_waiting_period
+            self.has_latest_common_approval_in_waiting_period
             and siae.is_subject_to_eligibility_rules
             and not (is_sent_by_authorized_prescriber or has_valid_diagnosis)
         )

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1077,6 +1077,23 @@ class TestLatestApproval:
         assert user.latest_approval is None
         assert user.latest_pe_approval == pe_approval
 
+    def test_status_with_expired_pole_emploi_approval_and_valid_approval(self):
+        user = JobSeekerFactory(with_pole_emploi_id=True)
+        pe_approval = PoleEmploiApprovalFactory(
+            pole_emploi_id=user.jobseeker_profile.pole_emploi_id,
+            birthdate=user.jobseeker_profile.birthdate,
+            start_at=timezone.localdate() - datetime.timedelta(3 * 365),
+        )
+        assert not pe_approval.is_valid()
+        approval = ApprovalFactory(user=user)
+        assert approval.is_valid()
+
+        assert not user.has_no_common_approval
+        assert user.has_valid_approval  # PoleEmploiFactory aren't checked anymore
+        assert not user.has_common_approval_in_waiting_period
+        assert user.latest_approval == approval
+        assert user.latest_pe_approval == pe_approval
+
     def test_new_approval_blocked_by_waiting_period(self):
         user = user_with_approval_in_waiting_period()
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1038,7 +1038,7 @@ class TestLatestApproval:
         user = JobSeekerFactory()
         assert user.has_no_common_approval
         assert not user.has_valid_approval
-        assert not user.has_common_approval_in_waiting_period
+        assert not user.has_latest_common_approval_in_waiting_period
         assert user.latest_approval is None
 
     def test_status_with_valid_approval(self):
@@ -1046,14 +1046,14 @@ class TestLatestApproval:
         approval = ApprovalFactory(user=user, start_at=timezone.localdate() - relativedelta(days=1))
         assert not user.has_no_common_approval
         assert user.has_valid_approval
-        assert not user.has_common_approval_in_waiting_period
+        assert not user.has_latest_common_approval_in_waiting_period
         assert user.latest_approval == approval
 
     def test_status_approval_in_waiting_period(self):
         user = user_with_approval_in_waiting_period()
         assert not user.has_no_common_approval
         assert not user.has_valid_approval
-        assert user.has_common_approval_in_waiting_period
+        assert user.has_latest_common_approval_in_waiting_period
         assert user.latest_approval == user.latest_approval
 
     def test_status_approval_with_elapsed_waiting_period(self):
@@ -1063,7 +1063,7 @@ class TestLatestApproval:
         ApprovalFactory(user=user, start_at=start_at, end_at=end_at)
         assert user.has_no_common_approval
         assert not user.has_valid_approval
-        assert not user.has_common_approval_in_waiting_period
+        assert not user.has_latest_common_approval_in_waiting_period
         assert user.latest_approval is None
 
     def test_status_with_valid_pole_emploi_approval(self):
@@ -1073,7 +1073,7 @@ class TestLatestApproval:
         )
         assert not user.has_no_common_approval
         assert not user.has_valid_approval  # PoleEmploiFactory aren't checked anymore
-        assert not user.has_common_approval_in_waiting_period
+        assert not user.has_latest_common_approval_in_waiting_period
         assert user.latest_approval is None
         assert user.latest_pe_approval == pe_approval
 
@@ -1090,7 +1090,7 @@ class TestLatestApproval:
 
         assert not user.has_no_common_approval
         assert user.has_valid_approval  # PoleEmploiFactory aren't checked anymore
-        assert not user.has_common_approval_in_waiting_period
+        assert not user.has_latest_common_approval_in_waiting_period
         assert user.latest_approval == approval
         assert user.latest_pe_approval == pe_approval
 

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -506,6 +506,7 @@
         'origin': list([
           'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
           'User.latest_pe_approval[users/models.py]',
+          'User.latest_common_approval[users/models.py]',
           'User.has_common_approval_in_waiting_period[users/models.py]',
           'User.new_approval_blocked_by_waiting_period[users/models.py]',
           'check_waiting_period[www/apply/views/process_views.py]',

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -507,7 +507,7 @@
           'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
           'User.latest_pe_approval[users/models.py]',
           'User.latest_common_approval[users/models.py]',
-          'User.has_common_approval_in_waiting_period[users/models.py]',
+          'User.has_latest_common_approval_in_waiting_period[users/models.py]',
           'User.new_approval_blocked_by_waiting_period[users/models.py]',
           'check_waiting_period[www/apply/views/process_views.py]',
           'accept[www/apply/views/process_views.py]',

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -459,6 +459,7 @@
         'origin': list([
           'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
           'User.latest_pe_approval[users/models.py]',
+          'User.latest_common_approval[users/models.py]',
           'User.has_common_approval_in_waiting_period[users/models.py]',
           'User.new_approval_blocked_by_waiting_period[users/models.py]',
           '_check_job_seeker_approval[www/apply/views/submit_views.py]',

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -460,7 +460,7 @@
           'CommonApprovalQuerySet.first[<site-packages>/django/db/models/query.py]',
           'User.latest_pe_approval[users/models.py]',
           'User.latest_common_approval[users/models.py]',
-          'User.has_common_approval_in_waiting_period[users/models.py]',
+          'User.has_latest_common_approval_in_waiting_period[users/models.py]',
           'User.new_approval_blocked_by_waiting_period[users/models.py]',
           '_check_job_seeker_approval[www/apply/views/submit_views.py]',
           'hire_confirmation[www/apply/views/submit_views.py]',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, même avec un PASS IAE valide, un candidat voyait le message ["Un prescripteur habilité a réalisé un diagnostic d'éligibilité. **Vous pouvez commencer un nouveau parcours.**"](https://github.com/gip-inclusion/les-emplois/blob/61131e5e907aab7632effc294ff2e89fcf85a139/itou/templates/dashboard/includes/job_seeker_approval_card.html#L21) s'il avait un précédent agrément PE dans le délai de carence.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
