### PR TITLE
github: Possiblité de notifier seulement le pilotage

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -9,11 +9,11 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
     if: >
       github.event.pull_request.merged == true
-      && !contains(github.event.pull_request.labels.*.name, 'no-changelog')
       && !contains(github.event.pull_request.labels.*.name, 'dependencies')
     runs-on: ubuntu-latest
     steps:
       - name: "📢 Notify the #mep-c1 channel"
+        if: !contains(github.event.pull_request.labels.*.name, 'no-changelog')
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |


### PR DESCRIPTION
## :thinking: Pourquoi ?

La question c'était posée lors la PR initiale (https://github.com/gip-inclusion/les-emplois/pull/4776), à l'usage cela semble une bonne idée afin de limiter le bruit coté C1.

cc @calummackervoy 