### PR TITLE
github: Possiblité de notifier seulement le pilotage (pour de vrai cette fois)

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📢 Notify the #mep-c1 channel"
-        if: !contains(github.event.pull_request.labels.*.name, 'no-changelog')
+        # Can't use `!contains(...)` because it give us a "tag suffix cannot contain flow indicator characters" error.
+        # Oddly enough, using `if: > !contains(...)` works...
+        if: contains(github.event.pull_request.labels.*.name, 'no-changelog') == false
         uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |


### PR DESCRIPTION
## :thinking: Pourquoi ?

Erreur passée inaperçue : https://github.com/gip-inclusion/les-emplois/actions/runs/11435968045/workflow