### PR TITLE
Mise à jour du wording "Fiches salarié"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,7 @@
 - [UX/UI : Ajout d'un bouton de retour à la page d'accès aux APIs](https://github.com/gip-inclusion/les-emplois/pull/4678)
 - [UX/UI : Conversion d’une alerte en toast lorsque j’enregistre mes préférences de notifications](https://github.com/gip-inclusion/les-emplois/pull/4670)
 - [UX/UI : Déplacer le texte d’intro dans les 3 onglets “organisation”](https://github.com/gip-inclusion/les-emplois/pull/4683)
-- [UX/UI : Passer « Salariés et PASS IAE » et « Fiches salariés ASP » en onglets](https://github.com/gip-inclusion/les-emplois/pull/4715) 🖼
+- [UX/UI : Passer « Salariés et PASS IAE » et « Fiches salarié ASP » en onglets](https://github.com/gip-inclusion/les-emplois/pull/4715) 🖼
 - [UX/UI : Remplacer les derniers fils d’Ariane par des liens retours](https://github.com/gip-inclusion/les-emplois/pull/4679)
 - [UX/UI : Renommer « organisation » en « structure » pour les employeurs](https://github.com/gip-inclusion/les-emplois/pull/4711)
 - [UX/UI : Retirer l’élément « tableau de bord » du menu « Mon espace »](https://github.com/gip-inclusion/les-emplois/pull/4667)
@@ -149,7 +149,7 @@
 ### Ajouté
 
 - [Candidat: Création d'un espace candidats](https://github.com/gip-inclusion/les-emplois/pull/4535)
-- [Fiches salariés : Préciser comment la liste des salariés est construite à la création](https://github.com/gip-inclusion/les-emplois/pull/4609) 🖼
+- [Fiches salarié : Préciser comment la liste des salariés est construite à la création](https://github.com/gip-inclusion/les-emplois/pull/4609) 🖼
 - [Pilotage : Ajouter des encarts pour les prochains webinaires](https://github.com/gip-inclusion/les-emplois/pull/4592)
 - [Pilotage : Création de l'institution "Convergence France" et ouverture des TB446 et TB469 pour celle-ci](https://github.com/gip-inclusion/les-emplois/pull/4588) 🖼
 - [UX/UI : Refonte des layouts](https://github.com/gip-inclusion/les-emplois/pull/4483)
@@ -523,7 +523,7 @@
 - [Remplacer le fil d'ariane par des boutons retour](https://github.com/gip-inclusion/les-emplois/pull/3884)
 - [UX/UI : Amélioration du dropdown structure](https://github.com/gip-inclusion/les-emplois/pull/3968) 🖼
 - [UX/UI : Filtrer les employeurs et postes de manière plus dynamique](https://github.com/gip-inclusion/les-emplois/pull/3949)
-- [UX/UI : Filtrer les fiches salariés de manière plus dynamique](https://github.com/gip-inclusion/les-emplois/pull/3993)
+- [UX/UI : Filtrer les fiches salarié de manière plus dynamique](https://github.com/gip-inclusion/les-emplois/pull/3993)
 - [UX/UI : Filtrer les salariés et PASS IAE de manière plus dynamique](https://github.com/gip-inclusion/les-emplois/pull/3997)
 - [[DataInclusion] Ne pas appeler l'API quand l'URL n'est pas définie](https://github.com/gip-inclusion/les-emplois/pull/4005)
 
@@ -587,7 +587,7 @@
 
 ### Ajouté
 
-- Fiches Salarié : Ajout d'une commande afin de renvoyer les fiches salariés pour une SIAE
+- Fiches Salarié : Ajout d'une commande afin de renvoyer les fiches salarié pour une SIAE
 - Fiches Salarié : Ouverture du module pour les EITI
 - PASS IAE : Ajout d'un champ "dernière modification"
 - Stats : Publication du TB394 "Déclaration d'embauche" pour les SIAE sur la région Occitanie
@@ -660,7 +660,7 @@
 - PASS IAE : Utiliser une durée fixe (730 jours) lors de sa délivrance
 - Message de promotion temporaire sur le tableau de bord des EITI
 - Refonte UX/UI : Message pour prévenir les utilisateurs des changements d'interface
-- Refonte UX/UI : Cartes fiches salariés
+- Refonte UX/UI : Cartes fiches salarié
 - Refonte UX/UI : Cartes de postes ouverts au recrutement
 - Refonte UX/UI : Cartes salariés et PASS IAE
 - Refonte UX/UI : Cartes prescripteurs

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -69,7 +69,7 @@ class JobApplicationInline(ItouStackedInline):
     # Custom read-only fields as workaround :
     # there is no direct relation between approvals and employee records
     # (YET...)
-    @admin.display(description="situation fiches salariés")
+    @admin.display(description="situation fiches salarié")
     def employee_record_status(self, obj):
         if obj.employee_record.exists():
             return mark_safe(

--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -22,7 +22,7 @@
             </li>
             <li class="nav-item">
                 <a class="nav-link" href="{% url 'employee_record_views:list' %}?status=NEW" {% matomo_event "employeurs" "clic" "onglet-fiches-salaries" %}>
-                    <span>Fiches salariés ASP</span>
+                    <span>Fiches salarié ASP</span>
                     {% if num_rejected_employee_records %}
                         <span class="badge badge-sm rounded-pill bg-warning text-white ms-2">{{ num_rejected_employee_records }}</span>
                     {% endif %}

--- a/itou/templates/dashboard/includes/employer_employees_card.html
+++ b/itou/templates/dashboard/includes/employer_employees_card.html
@@ -15,7 +15,7 @@
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'employee_record_views:list' %}?status=NEW" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-liste-fiches-salaries" %}>
                             <i class="ri-article-line ri-lg fw-normal"></i>
-                            <span>Fiches salariés ASP</span>
+                            <span>Fiches salarié ASP</span>
                         </a>
                         {% if num_rejected_employee_records %}
                             <span class="badge rounded-pill badge-xs bg-warning">{{ num_rejected_employee_records }}</span>

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -21,7 +21,7 @@
             </li>
             <li class="nav-item">
                 <a class="nav-link active" href="{% url 'employee_record_views:list' %}?status=NEW" {% matomo_event "employeurs" "clic" "onglet-fiches-salaries" %}>
-                    <span>Fiches salariés ASP</span>
+                    <span>Fiches salarié ASP</span>
                     {% if num_rejected_employee_records %}
                         <span class="badge badge-sm rounded-pill bg-warning text-white ms-2">{{ num_rejected_employee_records }}</span>
                     {% endif %}

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -142,7 +142,7 @@ NAV_ENTRIES = {
         matomo_event_option="salaries-pass-iae",
     ),
     "employer-employee-records": NavItem(
-        label="Fiches salariés ASP",
+        label="Fiches salarié ASP",
         target=f"{reverse('employee_record_views:list')}?status=NEW",
         active_view_names=["employee_record_views:list"],
         matomo_event_category="offcanvasNav",

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -309,7 +309,7 @@
                           
                               <li>
                                   <a data-matomo-action="clic" data-matomo-category="offcanvasNav" data-matomo-event="true" data-matomo-option="fiches-salaries-asp" href="/employee_record/list?status=NEW">
-                                  Fiches salariés ASP</a>
+                                  Fiches salarié ASP</a>
                               </li>
                           
                       </ul>

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -149,7 +149,7 @@ class TestDashboardView:
 
         url = reverse("dashboard:index")
         response = client.get(url)
-        assertContains(response, "Fiches salariés ASP")
+        assertContains(response, "Fiches salarié ASP")
         assertNotContains(response, WARNING_CLASS)
         assert response.context["num_rejected_employee_records"] == 0
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans "fiches salarié", "salarié" ne s'accorde pas au pluriel.

Souci remonté par Sandrine en direct.

Je n'ai volontairement pas touché aux occurrences dans le changelog.