### PR TITLE
Déplacer CAN_BE_CERTIFIED_KINDS vers AdministrativeCriteriaKind

### DIFF
--- a/itou/eligibility/enums.py
+++ b/itou/eligibility/enums.py
@@ -61,3 +61,6 @@ class AdministrativeCriteriaKind(models.TextChoices):
     AUTRE_MINIMA = "AUTRE_MINIMA", "Autre minima social"
     FT = "FT", "Personne inscrite à France Travail"
     SANS_TRAVAIL_12 = "SANS_TRAVAIL_12", "Personne éloignée du marché du travail (> 1 an)"
+
+
+CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS = frozenset([AdministrativeCriteriaKind.RSA])

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -5,7 +5,12 @@ from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
-from itou.eligibility.enums import AdministrativeCriteriaKind, AdministrativeCriteriaLevel, AuthorKind
+from itou.eligibility.enums import (
+    CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
+    AdministrativeCriteriaKind,
+    AdministrativeCriteriaLevel,
+    AuthorKind,
+)
 from itou.job_applications.enums import SenderKind
 from itou.utils.apis import api_particulier
 from itou.utils.models import InclusiveDateRangeField
@@ -93,7 +98,7 @@ class AbstractEligibilityDiagnosisModel(models.Model):
         SelectedAdministrativeCriteria = self.administrative_criteria.through
         criteria = list(
             SelectedAdministrativeCriteria.objects.filter(
-                administrative_criteria__kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS,
+                administrative_criteria__kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
                 eligibility_diagnosis=self,
             )
         )
@@ -126,7 +131,7 @@ class AdministrativeCriteriaQuerySet(models.QuerySet):
 
     @property
     def certifiable_lookup(self):
-        return models.Q(kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS)
+        return models.Q(kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS)
 
     def certifiable(self):
         return self.filter(self.certifiable_lookup)
@@ -137,10 +142,6 @@ class AdministrativeCriteriaQuerySet(models.QuerySet):
 
 class AbstractAdministrativeCriteria(models.Model):
     MAX_UI_RANK = 32767
-    # RSA only for the moment. AAH and PI to come.
-    CAN_BE_CERTIFIED_KINDS = [
-        AdministrativeCriteriaKind.RSA,
-    ]
 
     level = models.CharField(
         verbose_name="niveau",
@@ -187,7 +188,7 @@ class AbstractAdministrativeCriteria(models.Model):
 
     @property
     def is_certifiable(self):
-        return self.kind in self.CAN_BE_CERTIFIED_KINDS
+        return self.kind in CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS
 
 
 class SelectedAdministrativeCriteriaQuerySet(models.QuerySet):

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -7,10 +7,14 @@ from django.conf import settings
 from django.utils import timezone
 from freezegun import freeze_time
 
-from itou.eligibility.enums import AdministrativeCriteriaKind, AdministrativeCriteriaLevel, AuthorKind
+from itou.eligibility.enums import (
+    CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
+    AdministrativeCriteriaKind,
+    AdministrativeCriteriaLevel,
+    AuthorKind,
+)
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.eligibility.models.common import (
-    AbstractAdministrativeCriteria,
     AbstractSelectedAdministrativeCriteria,
     AdministrativeCriteriaQuerySet,
 )
@@ -524,7 +528,7 @@ def test_eligibility_diagnosis_certify_criteria(mocker, EligibilityDiagnosisFact
 
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
     criterion = SelectedAdministrativeCriteria.objects.get(
-        administrative_criteria__kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS,
+        administrative_criteria__kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
         eligibility_diagnosis=eligibility_diagnosis,
     )
     assert criterion.certified is True

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -27,9 +27,8 @@ from itou.approvals.models import Approval, Suspension
 from itou.asp.models import Commune
 from itou.cities.models import City
 from itou.companies.enums import CompanyKind, ContractType, JobDescriptionSource
-from itou.eligibility.enums import AuthorKind
+from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, AuthorKind
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
-from itou.eligibility.models.common import AbstractAdministrativeCriteria
 from itou.eligibility.models.geiq import GEIQSelectedAdministrativeCriteria
 from itou.eligibility.models.iae import SelectedAdministrativeCriteria
 from itou.employee_record.enums import Status
@@ -2470,7 +2469,7 @@ class TestProcessAcceptViews:
             job_seeker__jobseeker_profile__birthdate=birthdate,
         )
         to_be_certified_criteria = SelectedAdministrativeCriteria.objects.filter(
-            administrative_criteria__kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS,
+            administrative_criteria__kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
             eligibility_diagnosis=job_application.eligibility_diagnosis,
         ).all()
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
@@ -2551,7 +2550,7 @@ class TestProcessAcceptViews:
             job_seeker__jobseeker_profile__birthdate=birthdate,
         )
         to_be_certified_criteria = GEIQSelectedAdministrativeCriteria.objects.filter(
-            administrative_criteria__kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS,
+            administrative_criteria__kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
             eligibility_diagnosis=job_application.geiq_eligibility_diagnosis,
         ).all()
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -21,14 +21,13 @@ from pytest_django.asserts import (
 
 from itou.asp.models import AllocationDuration, Commune, Country, EducationLevel, RSAAllocation
 from itou.companies.enums import CompanyKind, ContractType
-from itou.eligibility.enums import AuthorKind
+from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, AuthorKind
 from itou.eligibility.models import (
     AdministrativeCriteria,
     EligibilityDiagnosis,
     GEIQAdministrativeCriteria,
     GEIQEligibilityDiagnosis,
 )
-from itou.eligibility.models.common import AbstractAdministrativeCriteria
 from itou.job_applications.enums import JobApplicationState, QualificationLevel, QualificationType, SenderKind
 from itou.job_applications.models import JobApplication
 from itou.siae_evaluations.models import Sanctions
@@ -2643,12 +2642,10 @@ class TestDirectHireFullProcess:
         assertTemplateNotUsed(response, "approvals/includes/status.html")
 
         criterion1 = (
-            AdministrativeCriteria.objects.level1()
-            .exclude(kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS)
-            .first()
+            AdministrativeCriteria.objects.level1().exclude(kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS).first()
         )
         [criterion2, criterion3] = AdministrativeCriteria.objects.level2().exclude(
-            kind__in=AbstractAdministrativeCriteria.CAN_BE_CERTIFIED_KINDS
+            kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS
         )[:2]
         response = client.post(
             next_url,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter la gestion des dépendances circulaires.
