### PR TITLE
Retirer l’argument save de SelectedAdministrativeCriteria.certify

### DIFF
--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -221,7 +221,7 @@ class AbstractSelectedAdministrativeCriteria(models.Model):
 
     objects = SelectedAdministrativeCriteriaQuerySet.as_manager()
 
-    def certify(self, client, save=False):
+    def certify(self, client):
         # Call only if self.certified is None?
         if self.administrative_criteria.is_certifiable:
             # Only the RSA criterion is certifiable at the moment,
@@ -236,6 +236,3 @@ class AbstractSelectedAdministrativeCriteria(models.Model):
             start_at, end_at = data["start_at"], data["end_at"]
             if start_at and end_at:
                 self.certification_period = InclusiveDateRange(start_at, end_at)
-
-        if save:
-            self.save()

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -626,8 +626,7 @@ def test_selected_administrative_criteria_certified(
         response_status, json=response
     )
     with api_particulier.client() as client:
-        criterion.certify(client, save=True)
-    criterion.refresh_from_db()
+        criterion.certify(client)
     for attrname, value in expected.items():
         assert getattr(criterion, attrname) == value
     assert len(respx_mock.calls) == 1

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -219,7 +219,8 @@ class TestCertifiedBadgeIae:
         diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_employer=True)
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(
             Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": False})
         )
@@ -247,7 +248,8 @@ class TestCertifiedBadgeIae:
         diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_prescriber=True)
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(
             Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": False})
         )
@@ -312,7 +314,8 @@ class TestCertifiedBadgeIae:
         diagnosis = IAEEligibilityDiagnosisFactory(with_certifiable_criteria=True, from_employer=True)
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(Context(self.default_params(diagnosis)))
         assert certified_help_text in rendered
 
@@ -364,7 +367,8 @@ class TestCertifiedBadgeGEIQ:
         job_application = self.create_job_application(diagnosis)
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -387,7 +391,8 @@ class TestCertifiedBadgeGEIQ:
         job_application_with_certified_criteria = self.create_job_application(diagnosis)
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(
             Context(self.default_params_geiq(diagnosis, job_application_with_certified_criteria))
         )
@@ -409,7 +414,8 @@ class TestCertifiedBadgeGEIQ:
         job_application = self.create_job_application(diagnosis, hiring_start_at=datetime.date(2024, 11, 30))
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -429,7 +435,8 @@ class TestCertifiedBadgeGEIQ:
         job_application = self.create_job_application(diagnosis, hiring_start_at=datetime.date(2025, 2, 28))
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -476,7 +483,8 @@ class TestCertifiedBadgeGEIQ:
         )
         criterion = diagnosis.selected_administrative_criteria.first()
         with api_particulier.client() as client:
-            criterion.certify(client, save=True)
+            criterion.certify(client)
+        criterion.save()
         job_application = self.create_job_application(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert certified_help_text in rendered


### PR DESCRIPTION
## :thinking: Pourquoi ?

Utilisé uniquement dans les tests, pas par du code de production. L’alternative est très simple.
