### PR TITLE
Limitation du prénom à 30 caractères dans le sérialiseur à destination de l'ASP

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -49,7 +49,11 @@ class _PersonSerializer(serializers.Serializer):
         return unidecode(obj.job_application.job_seeker.last_name).upper()
 
     def get_prenom(self, obj: EmployeeRecord) -> str:
-        return unidecode(obj.job_application.job_seeker.first_name).upper()
+        # ASP limits first names to 30 chars
+        first_names = unidecode(obj.job_application.job_seeker.first_name).upper()
+        if len(first_names) > 30:
+            return first_names[:30].rsplit(" ", 1)[0]
+        return first_names
 
     def get_codeComInsee(self, obj: EmployeeRecord) -> CodeComInsee:
         # Another ASP subtlety, making top-level and children with the same name

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -13,10 +13,32 @@ from itou.employee_record.serializers import (
     EmployeeRecordUpdateNotificationBatchSerializer,
     EmployeeRecordUpdateNotificationSerializer,
     _AddressSerializer,
+    _PersonSerializer,
 )
 from tests.asp.factories import CommuneFactory
 from tests.employee_record.factories import EmployeeRecordUpdateNotificationFactory, EmployeeRecordWithProfileFactory
 from tests.users.factories import JobSeekerFactory
+
+
+class TestEmployeeRecordPersonSerializer:
+    def test_get_prenom(self):
+        employee_record = EmployeeRecordWithProfileFactory(job_application__job_seeker__first_name="")
+        job_seeker = employee_record.job_application.job_seeker
+        serializer = _PersonSerializer(employee_record)
+
+        assert serializer.get_prenom(employee_record) == ""
+
+        job_seeker.first_name = "Jean"
+        assert serializer.get_prenom(employee_record) == "JEAN"
+
+        job_seeker.first_name = "Jean-Philippe"
+        assert serializer.get_prenom(employee_record) == "JEAN-PHILIPPE"
+
+        job_seeker.first_name = "Jean-Philippe René"
+        assert serializer.get_prenom(employee_record) == "JEAN-PHILIPPE RENE"
+
+        job_seeker.first_name = "Jean-Philippe René Hippolyte Gilbert Dufaël"
+        assert serializer.get_prenom(employee_record) == "JEAN-PHILIPPE RENE HIPPOLYTE"
 
 
 class TestEmployeeRecordAddressSerializer:


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'ASP n'accepte que 30 caractères au maximum.

Cf. https://itou-inclusion.slack.com/archives/C01181Y04LT/p1729762979362779

## :rotating_light: Notes

- Pas touché au sérialiseur de l'API, uniquement celui destiné au fichier déposé en sftp