### PR TITLE
API particulier : Respecter la fréquence d’appels et les workers web

### DIFF
--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -1,0 +1,109 @@
+import logging
+from json import JSONDecodeError
+
+import httpx
+from django.apps import apps
+from django.utils import timezone
+from huey.contrib.djhuey import task
+from huey.exceptions import RetryTask
+
+from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, AdministrativeCriteriaKind
+from itou.utils.apis import api_particulier
+from itou.utils.types import InclusiveDateRange
+
+
+logger = logging.getLogger("APIParticulierClient")
+
+
+def certify_criteria(eligibility_diagnosis):
+    job_seeker = eligibility_diagnosis.job_seeker
+    if not api_particulier.has_required_info(job_seeker):
+        logger.info("Skipping {job_seeker.pk=}, missing required information.")
+        return
+    SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
+    criteria = (
+        SelectedAdministrativeCriteria.objects.filter(
+            administrative_criteria__kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
+            eligibility_diagnosis=eligibility_diagnosis,
+        )
+        .select_for_update(no_key=True)
+        .select_related("administrative_criteria")
+    )
+    with api_particulier.client() as client:
+        for criterion in criteria:
+            # Only the RSA criterion is certifiable at the moment,
+            # but this may change soon with the addition of `parent isolé` and `allocation adulte handicapé`.
+            if criterion.administrative_criteria.kind == AdministrativeCriteriaKind.RSA:
+                try:
+                    data = api_particulier.revenu_solidarite_active(client, job_seeker)
+                except httpx.HTTPStatusError as exc:
+                    criterion.data_returned_by_api = exc.response.json()
+                    logger.error(
+                        "Error certifying criterion %r: code=%d json=%s",
+                        criterion,
+                        exc.response.status_code,
+                        criterion.data_returned_by_api,
+                    )
+                    match exc.response.status_code:
+                        case 400 | 404:
+                            # Job seeker not found or missing profile information.
+                            criterion.certified_at = timezone.now()
+                        case 429:
+                            # https://particulier.api.gouv.fr/developpeurs#respecter-la-volumétrie
+                            raise RetryTask(delay=int(exc.response.headers["Retry-After"])) from exc
+                        case 503:
+                            # TODO: Use the error code instead the message when switching to API v3.
+                            if criterion.data_returned_by_api["message"] == (
+                                "Erreur de fournisseur de donnée : "
+                                "Trop de requêtes effectuées, veuillez réessayer plus tard."
+                            ):
+                                # The data provider for API particulier returned a 429.
+                                # Let’s hope the data provider rate limit has been reset by then.
+                                raise RetryTask(delay=3600) from exc
+                            else:
+                                # The data provider for API particulier likely returned a 500.
+                                # According to the API particulier team, it often means integrity
+                                # errors on the beneficiary case. The data provider itself aggregates data
+                                # from other providers (e.g. regional information systems). When the data
+                                # sources aren’t consistent with each other, the data provider cannot
+                                # answer.
+                                # Retrying won’t fix the issue, and the error has been logged already.
+                                pass
+                        case _:
+                            raise
+                else:
+                    criterion.certified = data["is_certified"]
+                    criterion.certified_at = timezone.now()
+                    criterion.data_returned_by_api = data["raw_response"]
+                    criterion.certification_period = None
+                    start_at, end_at = data["start_at"], data["end_at"]
+                    if start_at and end_at:
+                        criterion.certification_period = InclusiveDateRange(start_at, end_at)
+    SelectedAdministrativeCriteria.objects.bulk_update(
+        criteria,
+        fields=[
+            "certification_period",
+            "certified",
+            "certified_at",
+            "data_returned_by_api",
+        ],
+    )
+
+
+@task(retries=24 * 6, retry_delay=10 * 60)  # Retry every 10 minutes for 24h.
+def async_certify_criteria(model_name, eligibility_diagnosis_pk):
+    model = apps.get_model("eligibility", model_name)
+    eligibility_diagnosis = model.objects.select_related("job_seeker__jobseeker_profile").get(
+        pk=eligibility_diagnosis_pk
+    )
+    try:
+        certify_criteria(eligibility_diagnosis)
+    except (
+        httpx.HTTPError,  # Could not connect, unexpected status code, …
+        JSONDecodeError,  # Response was not JSON (text, HTML, …).
+        RetryTask,  # Rate limiting.
+    ):
+        # Worth retrying.
+        raise
+    except Exception as e:
+        logger.exception(e)

--- a/itou/utils/mocks/api_particulier.py
+++ b/itou/utils/mocks/api_particulier.py
@@ -14,3 +14,15 @@ def rsa_not_found_mocker():
         "reason": "Dossier allocataire inexistant. Le document ne peut être édité.",
         "message": "Dossier allocataire inexistant. Le document ne peut être édité.",
     }
+
+
+def rsa_data_provider_error():
+    reason = (
+        "La réponse retournée par le fournisseur de données est invalide et inconnue de notre service. L'équipe "
+        "technique a été notifiée de cette erreur pour investigation."
+    )
+    return {
+        "error": "provider_unknown_error",
+        "reason": reason,
+        "message": reason,
+    }

--- a/tests/eligibility/test_tasks.py
+++ b/tests/eligibility/test_tasks.py
@@ -1,0 +1,102 @@
+import datetime
+from json import JSONDecodeError
+
+import httpx
+import pytest
+from django.conf import settings
+from freezegun import freeze_time
+from huey.exceptions import RetryTask
+
+from itou.eligibility.enums import AdministrativeCriteriaKind
+from itou.eligibility.tasks import async_certify_criteria
+from itou.utils.mocks.api_particulier import rsa_certified_mocker
+from itou.utils.types import InclusiveDateRange
+from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
+from tests.users.factories import JobSeekerFactory
+
+
+def create(factory, **kwargs):
+    job_seeker = JobSeekerFactory(with_address=True, born_in_france=True)
+    return factory(with_certifiable_criteria=True, job_seeker=job_seeker, **kwargs)
+
+
+def iae_eligibility_factory():
+    return create(IAEEligibilityDiagnosisFactory, from_employer=True)
+
+
+def geiq_eligibility_factory():
+    return create(GEIQEligibilityDiagnosisFactory, from_geiq=True)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(iae_eligibility_factory, id="iae"),
+        pytest.param(geiq_eligibility_factory, id="geiq"),
+    ],
+)
+class TestCertifyCriteria:
+    def test_queue_task(self, factory, respx_mock):
+        eligibility_diagnosis = factory()
+        respx_mock.get(f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active").respond(
+            json=rsa_certified_mocker()
+        )
+
+        async_certify_criteria.call_local(eligibility_diagnosis._meta.model_name, eligibility_diagnosis.pk)
+
+        assert len(respx_mock.calls) == 1
+        SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
+        criterion = SelectedAdministrativeCriteria.objects.filter(
+            administrative_criteria__kind=AdministrativeCriteriaKind.RSA,
+            eligibility_diagnosis=eligibility_diagnosis,
+        ).get()
+        assert criterion.certified is True
+        assert criterion.certified_at is not None
+        assert criterion.data_returned_by_api == rsa_certified_mocker()
+        assert criterion.certification_period == InclusiveDateRange(
+            datetime.date(2024, 8, 1), datetime.date(2024, 10, 31)
+        )
+
+    def test_retry_task_rate_limits(self, factory, respx_mock):
+        with freeze_time("2024-09-12T00:00:00Z"):
+            eligibility_diagnosis = factory()
+            respx_mock.get(f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active").mock(
+                return_value=httpx.Response(429, headers={"Retry-After": "1"}, json={}),
+            )
+
+            with pytest.raises(RetryTask) as exc_info:
+                async_certify_criteria.call_local(eligibility_diagnosis._meta.model_name, eligibility_diagnosis.pk)
+
+            assert exc_info.value.delay == 1
+            assert len(respx_mock.calls) == 1
+            SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
+            criterion = SelectedAdministrativeCriteria.objects.filter(
+                administrative_criteria__kind=AdministrativeCriteriaKind.RSA,
+                eligibility_diagnosis=eligibility_diagnosis,
+            ).get()
+            assert criterion.certified is None
+            assert criterion.certified_at is None
+            assert criterion.data_returned_by_api is None
+            assert criterion.certification_period is None
+
+    @pytest.mark.parametrize(
+        "data,exception",
+        [
+            ({"text": "Internal server error"}, JSONDecodeError),
+            ({"json": {"error": "Internal server error"}}, httpx.HTTPError),
+        ],
+    )
+    def test_retry_task_on_http_error(self, data, exception, factory, respx_mock):
+        eligibility_diagnosis = factory()
+        respx_mock.get(f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active").respond(500, **data)
+        with pytest.raises(exception):
+            async_certify_criteria.call_local(eligibility_diagnosis._meta.model_name, eligibility_diagnosis.pk)
+        # Huey catches the exception and retries the task.
+
+    def test_no_retry_on_exception(self, caplog, factory, respx_mock):
+        eligibility_diagnosis = factory()
+        respx_mock.get(f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active").mock(
+            side_effect=TypeError("Programming error")
+        )
+        async_certify_criteria.call_local(eligibility_diagnosis._meta.model_name, eligibility_diagnosis.pk)
+        assert "TypeError: Programming error" in caplog.text

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -8,9 +8,9 @@ from freezegun import freeze_time
 from pytest_django.asserts import assertInHTML
 
 from itou.eligibility.enums import AdministrativeCriteriaLevel
+from itou.eligibility.tasks import certify_criteria
 from itou.job_applications.enums import Origin
 from itou.jobs.models import Appellation
-from itou.utils.apis import api_particulier
 from itou.utils.context_processors import expose_enums
 from itou.utils.mocks.api_particulier import rsa_certified_mocker
 from itou.www.apply.views.list_views import JobApplicationsListKind
@@ -221,10 +221,7 @@ class TestCertifiedBadgeIae:
             with_certifiable_criteria=True,
             from_employer=True,
         )
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(
             Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": False})
         )
@@ -254,10 +251,7 @@ class TestCertifiedBadgeIae:
             with_certifiable_criteria=True,
             from_prescriber=True,
         )
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(
             Context(self.default_params(diagnosis) | {"is_sent_by_authorized_prescriber": False})
         )
@@ -336,10 +330,7 @@ class TestCertifiedBadgeIae:
             with_certifiable_criteria=True,
             from_employer=True,
         )
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(Context(self.default_params(diagnosis)))
         assert certified_help_text in rendered
 
@@ -389,10 +380,7 @@ class TestCertifiedBadgeGEIQ:
             from_prescriber=True,
         )
         job_application = self.create_job_application(diagnosis)
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -414,10 +402,7 @@ class TestCertifiedBadgeGEIQ:
             from_geiq=True,
         )
         job_application_with_certified_criteria = self.create_job_application(diagnosis)
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(
             Context(self.default_params_geiq(diagnosis, job_application_with_certified_criteria))
         )
@@ -438,10 +423,7 @@ class TestCertifiedBadgeGEIQ:
             from_geiq=True,
         )
         job_application = self.create_job_application(diagnosis, hiring_start_at=datetime.date(2024, 11, 30))
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -459,10 +441,7 @@ class TestCertifiedBadgeGEIQ:
             from_geiq=True,
         )
         job_application = self.create_job_application(diagnosis, hiring_start_at=datetime.date(2025, 2, 28))
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -507,10 +486,7 @@ class TestCertifiedBadgeGEIQ:
             with_certifiable_criteria=True,
             from_geiq=True,
         )
-        criterion = diagnosis.selected_administrative_criteria.first()
-        with api_particulier.client() as client:
-            criterion.certify(client)
-        criterion.save()
+        certify_criteria(diagnosis)
         job_application = self.create_job_application(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis, job_application)))
         assert certified_help_text in rendered


### PR DESCRIPTION
## :thinking: Pourquoi ?

Être un bon citoyen, éviter de tabasser l’API des copains.
Éviter de faire attendre des workers web, car on peut vite saturer notre bande passante (DoS). Par exemple, si l’API se met à répondre avec des 500, chaque worker qui essaye de certifier un critère sera bloqué pour 3 * 2 = 6s, à attendre et réessayer. En augmentant le nombre de critères certifiés, on peut assez vite faire tomber le service, où tous les workers sont en train de `time.sleep(2)` (les fainéants !).

## :cake: Comment ? <!-- optionnel -->

Suivre les [indications de l’API quant à la fréquence des appels](https://particulier.api.gouv.fr/developpeurs/#respecter-la-volum%C3%A9trie).
Ne faire que le premier essai de certification en synchrone. En cas d’échec, démarrer une tâche asynchrone qui effectuera la vérification.
