### PR TITLE
UX/UI: Fix outdated date for the GIP

### DIFF
--- a/itou/templates/includes/gip_address.html
+++ b/itou/templates/includes/gip_address.html
@@ -1,0 +1,5 @@
+Groupement d’intérêt public « Plateforme de l’inclusion »
+<br>
+6 Boulevard Saint-Denis
+<br>
+75010 Paris

--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -109,11 +109,7 @@
                             Adresse :
                             <br>
                             <address>
-                                Groupement d’intérêt public « Plateforme de l’inclusion »
-                                <br>
-                                127 rue de Grenelle
-                                <br>
-                                75007 Paris
+                                {% include "includes/gip_address.html" %}
                             </address>
                         </li>
                     </ul>

--- a/itou/templates/static/legal/notice.html
+++ b/itou/templates/static/legal/notice.html
@@ -12,11 +12,7 @@
                     <h2 id="éditeur">Éditeur</h2>
                     <p>Le site « Les emplois de l’inclusion » est édité par :</p>
                     <address>
-                        Le Groupement d’Intérêt Public « Plateforme de l’inclusion »
-                        <br>
-                        127 Rue de Grenelle
-                        <br>
-                        75007 Paris
+                        {% include "includes/gip_address.html" %}
                     </address>
 
                     <h2 id="directeur-de-la-publication" class="mt-3 mt-lg-5">Directeur de la publication</h2>

--- a/itou/templates/static/legal/privacy.html
+++ b/itou/templates/static/legal/privacy.html
@@ -134,13 +134,9 @@
                         <br>
                         Vous pouvez exercer vos droits également en adressant un courrier à l’attention du Délégué à la Protection des Données du GIP de l’inclusion par courrier :
                     </p>
-                    <adrress class="d-block mb-3">
-                    Groupement de l’inclusion
-                    <br>
-                    127 Rue de Grenelle
-                    <br>
-                    75007 Paris
-                    </adrress>
+                    <address class="d-block mb-3">
+                        {% include "includes/gip_address.html" %}
+                    </address>
                     <p>
                         Puisque ce sont des droits personnels, nous ne traiterons votre demande que si nous sommes en mesure de vous identifier. Dans le cas où nous ne parvenons pas à vous identifier, nous pouvons être amenés à vous demander une preuve de votre identité.
                         <br>


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'ancienne adresse est affichée sur le site sur quelques pages, et il y a besoin de la mettre à jour

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran

<img width="1217" alt="Screenshot 2024-10-24 at 16 45 23" src="https://github.com/user-attachments/assets/f67e1b0e-27f0-45e7-acd5-4bb94290f411">
