### PR TITLE
Mise à jour de clever-deploy

### DIFF
--- a/scripts/clever-deploy
+++ b/scripts/clever-deploy
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import argparse
 import json


### PR DESCRIPTION
## :thinking: Pourquoi ?

`/bin/env` n'est pas présent de partout, `/usr/bin/env` est plus courant

