### PR TITLE
Technique : Simplification de l'accès au serveur de développement local depuis d'autres appareils

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,19 @@ $ make runserver
 
 Vous pouvez y accéder à l'adresse http://localhost:8000/.
 
+### Accéder au serveur de développement depuis un autre appareil (optionnel)
+
+En supposant que votre serveur ait pour IP `100.1.2.3`, ajoutez ces lignes à votre `.envrc` :
+
+```
+export RUNSERVER_DOMAIN=100.1.2.3:8000
+export CUSTOM_ALLOWED_HOST=100.1.2.3
+```
+
+puis `direnv reload` et relancez `make runserver`.
+
+Vous pouvez y accéder à l'adresse http://100.1.2.3:8000/ depuis n'importe quel appareil de votre réseau local.
+
 ## Obtenir une base de données de développement
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ En supposant que votre serveur ait pour IP `100.1.2.3`, ajoutez cette ligne à v
 export RUNSERVER_DOMAIN=100.1.2.3:8000
 ```
 
-puis `direnv reload` et relancez `make runserver`.
+puis `direnv allow`, `direnv reload` et enfin relancez `make runserver`.
 
 Vous pouvez y accéder à l'adresse http://100.1.2.3:8000/ depuis n'importe quel appareil de votre réseau local.
 

--- a/README.md
+++ b/README.md
@@ -119,11 +119,10 @@ Vous pouvez y accéder à l'adresse http://localhost:8000/.
 
 ### Accéder au serveur de développement depuis un autre appareil (optionnel)
 
-En supposant que votre serveur ait pour IP `100.1.2.3`, ajoutez ces lignes à votre `.envrc` :
+En supposant que votre serveur ait pour IP `100.1.2.3`, ajoutez cette ligne à votre `.envrc` :
 
 ```
 export RUNSERVER_DOMAIN=100.1.2.3:8000
-export CUSTOM_ALLOWED_HOST=100.1.2.3
 ```
 
 puis `direnv reload` et relancez `make runserver`.

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -15,8 +15,8 @@ from .test import *  # noqa: E402,F403
 DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "192.168.0.1", "0.0.0.0"]
-if os.getenv("CUSTOM_ALLOWED_HOST"):
-    ALLOWED_HOSTS.append(os.getenv("CUSTOM_ALLOWED_HOST"))
+if os.getenv("RUNSERVER_DOMAIN"):
+    ALLOWED_HOSTS.append(os.getenv("RUNSERVER_DOMAIN").split(":")[0])
 
 ASYNC_EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -15,6 +15,8 @@ from .test import *  # noqa: E402,F403
 DEBUG = True
 
 ALLOWED_HOSTS = ["localhost", "127.0.0.1", "192.168.0.1", "0.0.0.0"]
+if os.getenv("CUSTOM_ALLOWED_HOST"):
+    ALLOWED_HOSTS.append(os.getenv("CUSTOM_ALLOWED_HOST"))
 
 ASYNC_EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si un développeur fait tourner son local dev sur une machine A (ex : un laptop) et veut y accéder depuis une machine B (ex : une tablette), il ne peut jusqu'ici pas le faire proprement (nécessité de modifier `dev.py` qui est versionné) et il manque la documentation de comment y parvenir.

