### PR TITLE
Statistiques: Indicateurs à suivre accessible aux membres de l'équipe des emplois [GEN-2190]

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -160,6 +160,7 @@
                                     {% if user.is_superuser %}
                                         {% include "dashboard/includes/staff_export_card.html" %}
                                     {% endif %}
+                                    {% include "dashboard/includes/staff_stats_card.html" %}
                                 {% endif %}
 
                                 {% if user.is_job_seeker %}

--- a/itou/templates/dashboard/includes/staff_stats_card.html
+++ b/itou/templates/dashboard/includes/staff_stats_card.html
@@ -1,0 +1,15 @@
+<div class="col mb-3 mb-md-5">
+    <div class="c-box p-0 h-100">
+        <div class="p-3 p-lg-4">
+            <span class="h4 m-0">Statistiques</span>
+        </div>
+        <div class="px-3 px-lg-4 pt-3 pt-lg-4">
+            <p class="mb-3 mb-lg-5">
+                <a href="{% url 'stats:stats_staff_service_indicators' %}" class="btn-link btn-ico">
+                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                    <span>Indicateurs à suivre</span>
+                </a>
+            </p>
+        </div>
+    </div>
+</div>

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -298,6 +298,9 @@ METABASE_DASHBOARDS = {
     "stats_convergence_job_application": {
         "dashboard_id": 469,
     },
+    "stats_staff_service_indicators": {
+        "dashboard_id": 438,
+    },
 }
 
 

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -145,4 +145,6 @@ urlpatterns = [
         views.stats_convergence_job_application,
         name="stats_convergence_job_application",
     ),
+    # Staff stats - Les Emplois
+    path("staff/service_indicators", views.stats_staff_service_indicators, name="stats_staff_service_indicators"),
 ]

--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -12,6 +12,7 @@ from itou.prescribers.enums import (
     PrescriberOrganizationKind,
 )
 from itou.prescribers.models import PrescriberOrganization
+from itou.users.enums import UserKind
 
 
 WHITELIST_IAE_ORGA_ETP_REGIONS = ["Bretagne", "Occitanie"]
@@ -235,6 +236,10 @@ def can_view_stats_convergence(request):
         and isinstance(request.current_organization, Institution)
         and request.current_organization.kind == InstitutionKind.CONVERGENCE
     )
+
+
+def can_view_stats_staff(request):
+    return request.user.is_authenticated and (request.user.kind == UserKind.ITOU_STAFF or request.user.is_staff)
 
 
 def get_stats_ft_departments(request):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -920,3 +920,11 @@ def stats_convergence_job_application(request):
             "page_title": "Traitement et résultats des candidatures",
         },
     )
+
+
+@login_required
+def stats_staff_service_indicators(request):
+    """Indicator statistics for Les Emplois staff"""
+    if not utils.can_view_stats_staff(request):
+        raise PermissionDenied
+    return render_stats(request=request, context={"page_title": "Indicateurs à suivre"})

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -16,6 +16,10 @@ from tests.prescribers.factories import (
     PrescriberOrganizationWithMembershipFactory,
 )
 from tests.users.factories import (
+    EmployerFactory,
+    ItouStaffFactory,
+    JobSeekerFactory,
+    LaborInspectorFactory,
     PrescriberFactory,
 )
 from tests.utils.tests import get_response_for_middlewaremixin
@@ -322,3 +326,17 @@ def test_can_view_stats_dgefp_iae():
     request = get_request(institution.members.get())
     assert not utils.can_view_stats_dgefp_iae(request)
     assert utils.can_view_stats_dashboard_widget(request)
+
+
+def test_can_view_stats_staff():
+    for user in [
+        EmployerFactory(with_company=True),
+        PrescriberFactory(),
+        LaborInspectorFactory(membership=True),
+        JobSeekerFactory(),
+    ]:
+        request = get_request(user)
+        assert request.user.is_authenticated
+        assert not utils.can_view_stats_staff(request)
+
+    assert utils.can_view_stats_staff(get_request(ItouStaffFactory()))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce fonctionnalité permet les membres de l'équipe des emplois d'accéder aux stats indicateurs clés de la service

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran

<img width="1311" alt="Screenshot 2024-10-28 at 15 56 38" src="https://github.com/user-attachments/assets/c1f69b05-aae3-407e-b450-699041446bc2">
