### PR TITLE
Candidature : Remplacer le bouton pour passer la recherche de NIR par un <a>

### DIFF
--- a/itou/templates/apply/submit_step_check_job_seeker_nir.html
+++ b/itou/templates/apply/submit_step_check_job_seeker_nir.html
@@ -49,9 +49,9 @@
                         </div>
                         <div class="col">
                             <p class="mb-0">Vous possédez un numéro de sécurité sociale temporaire ?</p>
-                            <button name="skip" value="1" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "candidature" %}>
+                            <a href="{{ temporary_nir_url }}" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "candidature" %}>
                                 Cliquez ici pour accéder à l'étape suivante.
-                            </button>
+                            </a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Corriger un problème empêchant la soumission du NIR et requérant une nouvelle soumission de l’information.

Voir le message de commit pour les détails.

## :desert_island: Comment tester

1. Commencer un parcours de candidature
2. Saisir un NIR invalide
3. Saisir un NIR valide et appuyer sur <kbd>Entrée</kbd> lorsque le champ NIR est focus pour soumettre le formulaire.

Avant : Le NIR n’était pas enregistré
Après : Le NIR est enregistré
