### PR TITLE
Inscription : Remplacer le bouton pour passer la recherche de NIR par un <a>

### DIFF
--- a/itou/templates/signup/job_seeker_nir.html
+++ b/itou/templates/signup/job_seeker_nir.html
@@ -37,9 +37,9 @@
                                         </div>
                                         <div class="col">
                                             <p class="mb-0">Vous possédez un numéro de sécurité sociale temporaire ?</p>
-                                            <button name="skip" value="1" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "inscription" %}>
+                                            <a href="{% url "signup:job_seeker" %}" class="btn btn-link p-0" {% matomo_event "nir-temporaire" "etape-suivante" "inscription" %}>
                                                 Cliquez ici pour accéder à l'étape suivante.
-                                            </button>
+                                            </a>
                                         </div>
                                     </div>
                                 </div>

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -154,19 +154,15 @@ def job_seeker_situation(request, template_name="signup/job_seeker_situation.htm
 def job_seeker_nir(request, template_name="signup/job_seeker_nir.html"):
     form = forms.JobSeekerNirForm(data=request.POST or None)
 
-    if request.method == "POST":
+    if request.method == "POST" and form.is_valid():
         next_url = reverse("signup:job_seeker")
-        if form.is_valid():
-            request.session[global_constants.ITOU_SESSION_NIR_KEY] = form.cleaned_data["nir"]
+        request.session[global_constants.ITOU_SESSION_NIR_KEY] = form.cleaned_data["nir"]
 
-            # forward next page
-            if REDIRECT_FIELD_NAME in form.data:
-                next_url = f"{next_url}?{REDIRECT_FIELD_NAME}={form.data[REDIRECT_FIELD_NAME]}"
+        # forward next page
+        if REDIRECT_FIELD_NAME in form.data:
+            next_url = f"{next_url}?{REDIRECT_FIELD_NAME}={form.data[REDIRECT_FIELD_NAME]}"
 
-            return HttpResponseRedirect(next_url)
-
-        if form.data.get("skip"):
-            return HttpResponseRedirect(next_url)
+        return HttpResponseRedirect(next_url)
 
     context = {
         "form": form,

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -139,12 +139,20 @@ class TestJobSeekerSignup:
         url = reverse("signup:job_seeker_nir")
         post_data = {"nir": nir}
         response = client.post(url, post_data)
-        assert response.status_code == 200
+        assertContains(
+            response,
+            f"""
+            <a href="{reverse('signup:job_seeker')}"
+                class="btn btn-link p-0"
+                data-matomo-event="true"
+                data-matomo-category="nir-temporaire"
+                data-matomo-action="etape-suivante"
+                data-matomo-option="inscription">
+               Cliquez ici pour accéder à l'étape suivante.
+            </a>""",
+            html=True,
+        )
         assert not response.context.get("form").is_valid()
-
-        post_data = {"nir": nir, "skip": 1}
-        response = client.post(url, post_data)
-        assertRedirects(response, reverse("signup:job_seeker"))
         assert global_constants.ITOU_SESSION_NIR_KEY not in list(client.session.keys())
         assert not client.session.get(global_constants.ITOU_SESSION_NIR_KEY)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Corriger un problème empêchant la soumission du NIR et requérant une nouvelle soumission de l’information.

Voir le message de commit pour les détails.

## :desert_island: Comment tester

1. Commencer un parcours d’inscription candidat
2. Choisir un critère
2. Saisir un NIR invalide
3. Saisir un NIR valide et appuyer sur <kbd>Entrée</kbd> lorsque le champ NIR est focus pour soumettre le formulaire.

Avant : Le NIR n’était pas enregistré
Après : Le NIR est enregistré
