### PR TITLE
Admin: Permettre de libérer des comptes ProConnect pour bascule Employer <-> Prescripteur

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -426,20 +426,20 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
             )
         return "Aucune"
 
-    @admin.action(description="Désactiver le compte IC pour changement prescripteur <-> employeur")
-    def free_ic_email(self, request, queryset):
+    @admin.action(description="Désactiver le compte IC / PC pour changement prescripteur <-> employeur")
+    def free_sso_email(self, request, queryset):
         try:
             [user] = queryset
         except ValueError:
             messages.error(request, "Vous ne pouvez selectionner qu'un seul utilisateur à la fois")
             return
 
-        if user.identity_provider != IdentityProvider.INCLUSION_CONNECT:
-            messages.error(request, "Vous devez sélectionner un compte Inclusion Connect")
+        if user.identity_provider not in [IdentityProvider.INCLUSION_CONNECT, IdentityProvider.PRO_CONNECT]:
+            messages.error(request, "Vous devez sélectionner un compte Inclusion Connect ou ProConnect")
             return
 
         if user.username.startswith("old"):
-            messages.error(request, "Ce compte a déjà été libré de l'emprise d'Inclusion Connect")
+            messages.error(request, "Ce compte a déjà été libéré")
             return
 
         user.email = f"{user.email}_old"
@@ -451,7 +451,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
 
         messages.success(request, "L'utilisateur peut à présent se créer un nouveau compte")
 
-    actions = [free_ic_email]
+    actions = [free_sso_email]
 
     def get_queryset(self, request):
         """


### PR DESCRIPTION
## :thinking: Pourquoi ?

Découvert grâce au mood support

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
