### PR TITLE
UX/UI: Retirer le bouton “Retour vers la liste des postes”

### DIFF
--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -46,12 +46,6 @@
                         <span>Modifier</span>
                     </a>
                 </div>
-                <div class="form-group col-12 col-lg-auto">
-                    <a href="{% url "companies_views:job_description_list" %}" class="btn btn-lg btn-outline-white btn-block btn-ico">
-                        <i class="ri-arrow-go-back-line fw-medium" aria-hidden="true"></i>
-                        <span>Retour vers la liste des postes</span>
-                    </a>
-                </div>
             {% else %}
                 {% if job.is_active and not siae.block_job_applications %}
                     {% if job_app_to_transfer %}

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -582,7 +582,6 @@ class TestJobDescriptionCard(JobDescriptionAbstract):
 
         assertContains(response, "Modifier la fiche de poste")
         assertContains(response, self.update_job_description_url(self.job_description))
-        assertContains(response, "Retour vers la liste des postes")
         assertContains(response, reverse("companies_views:job_description_list"))
         assertNotContains(response, self.apply_start_url(self.company))
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Bouton redondant avec le bouton "< Retour à la liste" présent dans le .prevstep
