### PR TITLE
Déplacer les vues, formulaires et URLs de vérification du NIR à `job_seekers_views`

### DIFF
--- a/itou/templates/apply/submit_step_pending_authorization.html
+++ b/itou/templates/apply/submit_step_pending_authorization.html
@@ -29,7 +29,7 @@
                             <strong>Êtes-vous certain de vouloir continuer ?</strong>
                         </div>
                         {% url 'search:employers_home' as reset_url %}
-                        {% url 'apply:check_nir_for_sender' company_pk=siae.pk as primary_url %}
+                        {% url 'job_seekers_views:check_nir_for_sender' company_pk=siae.pk as primary_url %}
                         {% itou_buttons_form primary_label="Suivant" primary_url=primary_url reset_url=reset_url %}
                     </div>
                 </div>

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -49,7 +49,7 @@
                         <span>Déclarer une embauche</span>
                     </span>
                 {% else %}
-                    <a href="{% url 'apply:check_nir_for_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
+                    <a href="{% url 'job_seekers_views:check_nir_for_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
                         <i class="ri-user-follow-line fw-medium"></i>
                         <span>Déclarer une embauche</span>
                     </a>

--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -25,7 +25,7 @@
                     {% else %}
                         Cet espace vous permet d’enregistrer une nouvelle candidature.
                     {% endif %}
-                    Si vous souhaitez déclarer directement une embauche, veuillez vous rendre sur <a href="{% url 'apply:check_nir_for_hire' company_pk=siae.pk %}">Déclarer une embauche</a> depuis le tableau de bord.
+                    Si vous souhaitez déclarer directement une embauche, veuillez vous rendre sur <a href="{% url 'job_seekers_views:check_nir_for_hire' company_pk=siae.pk %}">Déclarer une embauche</a> depuis le tableau de bord.
                 {% endif %}
             </p>
         {% endif %}

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from itou.www.apply.views import edit_views, list_views, process_views, submit_views
+from itou.www.job_seekers_views.views import CheckNIRForJobSeekerView, CheckNIRForSenderView
 
 
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
@@ -15,9 +16,8 @@ urlpatterns = [
         submit_views.PendingAuthorizationForSender.as_view(),
         name="pending_authorization_for_sender",
     ),
-    path(
-        "<int:company_pk>/sender/check_nir", submit_views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"
-    ),
+    # Ewen: deprecated url. These urls are going to job_seekers_views.views
+    path("<int:company_pk>/sender/check_nir", CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
     path(
         "<int:company_pk>/sender/search-by-email/<uuid:session_uuid>",
         submit_views.SearchByEmailForSenderView.as_view(),
@@ -44,9 +44,10 @@ urlpatterns = [
         name="create_job_seeker_step_end_for_sender",
     ),
     # Submit - job seeker.
+    # Ewen: deprecated url. These urls are going to job_seekers_views.views
     path(
         "<int:company_pk>/job_seeker/check_nir",
-        submit_views.CheckNIRForJobSeekerView.as_view(),
+        CheckNIRForJobSeekerView.as_view(),
         name="check_nir_for_job_seeker",
     ),
     # Submit - common.
@@ -107,9 +108,10 @@ urlpatterns = [
         name="update_job_seeker_step_end",
     ),
     # Direct hire process
+    # Ewen: deprecated url. These urls are going to job_seekers_views.views
     path(
         "<int:company_pk>/hire/check-nir",
-        submit_views.CheckNIRForSenderView.as_view(),
+        CheckNIRForSenderView.as_view(),
         name="check_nir_for_hire",
         kwargs={"hire_process": True},
     ),

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -34,7 +34,6 @@ from itou.utils.urls import add_url_params
 from itou.www.apply.forms import (
     ApplicationJobsForm,
     CheckJobSeekerInfoForm,
-    CheckJobSeekerNirForm,
     CreateOrUpdateJobSeekerStep1Form,
     CreateOrUpdateJobSeekerStep2Form,
     CreateOrUpdateJobSeekerStep3Form,
@@ -302,126 +301,13 @@ class StartView(ApplyStepBaseView):
             )
 
         return HttpResponseRedirect(
-            reverse(f"apply:check_nir_for_{tunnel}", kwargs={"company_pk": self.company.pk})
+            reverse(f"job_seekers_views:check_nir_for_{tunnel}", kwargs={"company_pk": self.company.pk})
             + ("?gps=true" if self.is_gps else "")
         )
 
 
 class PendingAuthorizationForSender(ApplyStepForSenderBaseView):
     template_name = "apply/submit_step_pending_authorization.html"
-
-
-class CheckNIRForJobSeekerView(ApplyStepBaseView):
-    template_name = "job_seekers_views/step_check_job_seeker_nir.html"
-
-    def __init__(self):
-        super().__init__()
-        self.job_seeker = None
-        self.form = None
-
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        self.job_seeker = request.user
-        self.form = CheckJobSeekerNirForm(job_seeker=self.job_seeker, data=request.POST or None)
-
-    def dispatch(self, request, *args, **kwargs):
-        if request.user.is_authenticated and not self.job_seeker.is_job_seeker:
-            return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
-        return super().dispatch(request, *args, **kwargs)
-
-    def get(self, request, *args, **kwargs):
-        # The NIR already exists, go to next step
-        if self.job_seeker.jobseeker_profile.nir:
-            return HttpResponseRedirect(
-                reverse(
-                    "apply:step_check_job_seeker_info",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
-                )
-            )
-
-        return super().get(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        next_url = reverse(
-            "apply:step_check_job_seeker_info",
-            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
-        )
-        if self.form.is_valid():
-            self.job_seeker.jobseeker_profile.nir = self.form.cleaned_data["nir"]
-            self.job_seeker.jobseeker_profile.lack_of_nir_reason = ""
-            self.job_seeker.jobseeker_profile.save()
-            return HttpResponseRedirect(next_url)
-        else:
-            kwargs["temporary_nir_url"] = next_url
-
-        return self.render_to_response(self.get_context_data(**kwargs))
-
-    def get_context_data(self, **kwargs):
-        return super().get_context_data(**kwargs) | {
-            "form": self.form,
-            "preview_mode": False,
-        }
-
-
-class CheckNIRForSenderView(ApplyStepForSenderBaseView):
-    template_name = "job_seekers_views/step_check_job_seeker_nir.html"
-
-    def __init__(self):
-        super().__init__()
-        self.form = None
-
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        self.form = CheckJobSeekerNirForm(job_seeker=None, data=request.POST or None, is_gps=self.is_gps)
-
-    def search_by_email_url(self, session_uuid):
-        view_name = "apply:search_by_email_for_hire" if self.hire_process else "apply:search_by_email_for_sender"
-        return reverse(view_name, kwargs={"company_pk": self.company.pk, "session_uuid": session_uuid}) + (
-            "?gps=true" if self.is_gps else ""
-        )
-
-    def post(self, request, *args, **kwargs):
-        context = {}
-        if self.form.is_valid():
-            job_seeker = self.form.get_job_seeker()
-
-            # No user found with that NIR, save the NIR in the session and redirect to search by e-mail address.
-            if not job_seeker:
-                job_seeker_session = SessionNamespace.create_temporary(request.session)
-                job_seeker_session.init({"profile": {"nir": self.form.cleaned_data["nir"]}})
-                return HttpResponseRedirect(self.search_by_email_url(job_seeker_session.name))
-
-            # The NIR we found is correct
-            if self.form.data.get("confirm"):
-                if self.is_gps:
-                    FollowUpGroup.objects.follow_beneficiary(
-                        beneficiary=job_seeker, user=request.user, is_referent=True
-                    )
-                    return HttpResponseRedirect(reverse("gps:my_groups"))
-                else:
-                    return self.redirect_to_check_infos(job_seeker.public_id)
-
-            context = {
-                # Ask the sender to confirm the NIR we found is associated to the correct user
-                "preview_mode": bool(self.form.data.get("preview")),
-                "job_seeker": job_seeker,
-                "can_view_personal_information": self.sender.can_view_personal_information(job_seeker),
-            }
-        else:
-            # Require at least one attempt with an invalid NIR to access the search by email feature.
-            # The goal is to prevent users from skipping the search by NIR and creating duplicates.
-            job_seeker_session = SessionNamespace.create_temporary(request.session)
-            job_seeker_session.init({})
-            context["temporary_nir_url"] = self.search_by_email_url(job_seeker_session.name)
-
-        return self.render_to_response(self.get_context_data(**kwargs) | context)
-
-    def get_context_data(self, **kwargs):
-        return super().get_context_data(**kwargs) | {
-            "form": self.form,
-            "job_seeker": None,
-            "preview_mode": False,
-        }
 
 
 class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, ApplyStepForSenderBaseView):
@@ -512,7 +398,9 @@ class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, ApplyStepForSend
         )
 
     def get_back_url(self):
-        view_name = "apply:check_nir_for_hire" if self.hire_process else "apply:check_nir_for_sender"
+        view_name = (
+            "job_seekers_views:check_nir_for_hire" if self.hire_process else "job_seekers_views:check_nir_for_sender"
+        )
         return reverse(view_name, kwargs={"company_pk": self.company.pk})
 
     def get_context_data(self, **kwargs):
@@ -869,7 +757,7 @@ class CheckJobSeekerInformationsForHire(ApplicationBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "profile": self.job_seeker.jobseeker_profile,
-            "back_url": reverse("apply:check_nir_for_hire", kwargs={"company_pk": self.company.pk}),
+            "back_url": reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": self.company.pk}),
         }
 
 

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -1,5 +1,12 @@
 from django import forms
+from django.utils.html import format_html
 from django_select2.forms import Select2Widget
+
+from itou.users.enums import UserKind
+from itou.users.models import User
+from itou.utils import constants as global_constants
+from itou.utils.emails import redact_email_address
+from itou.utils.validators import validate_nir
 
 
 class FilterForm(forms.Form):
@@ -20,3 +27,66 @@ class FilterForm(forms.Form):
             for job_seeker in job_seeker_qs.order_by("first_name", "last_name")
             if job_seeker.get_full_name()
         ]
+
+
+class CheckJobSeekerNirForm(forms.Form):
+    nir = forms.CharField(
+        label="Numéro de sécurité sociale",
+        max_length=21,  # 15 + 6 white spaces
+        required=True,
+        strip=True,
+        validators=[validate_nir],
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "2 69 05 49 588 157 80",
+            }
+        ),
+    )
+
+    def __init__(self, *args, job_seeker=None, is_gps=False, **kwargs):
+        self.job_seeker = job_seeker
+        super().__init__(*args, **kwargs)
+        if self.job_seeker:
+            self.fields["nir"].label = "Votre numéro de sécurité sociale"
+        else:
+            self.fields["nir"].label = "Numéro de sécurité sociale du " + ("bénéficiaire" if is_gps else "candidat")
+
+    def clean_nir(self):
+        nir = self.cleaned_data["nir"].upper()
+        nir = nir.replace(" ", "")
+        existing_account = User.objects.filter(jobseeker_profile__nir=nir).first()
+
+        # Job application sent by autonomous job seeker.
+        if self.job_seeker:
+            if existing_account:
+                error_message = (
+                    "Ce numéro de sécurité sociale est déjà utilisé par un autre compte. Merci de vous "
+                    "reconnecter avec l'adresse e-mail <b>{}</b>. "
+                    "Si vous ne vous souvenez plus de votre mot de passe, vous pourrez "
+                    "cliquer sur « mot de passe oublié ». "
+                    'En cas de souci, vous pouvez <a href="{}" rel="noopener" '
+                    'target="_blank" aria-label="Ouverture dans un nouvel onglet">nous contacter</a>.'
+                )
+                raise forms.ValidationError(
+                    format_html(
+                        error_message,
+                        redact_email_address(existing_account.email),
+                        global_constants.ITOU_HELP_CENTER_URL,
+                    )
+                )
+        else:
+            # For the moment, consider NIR to be unique among users.
+            self.job_seeker = existing_account
+        return nir
+
+    def clean(self):
+        super().clean()
+        if self.job_seeker and self.job_seeker.kind != UserKind.JOB_SEEKER:
+            error_message = (
+                "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
+                "n'est pas associé à un compte candidat."
+            )
+            raise forms.ValidationError(error_message)
+
+    def get_job_seeker(self):
+        return self.job_seeker

--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -8,4 +8,22 @@ app_name = "job_seekers_views"
 urlpatterns = [
     path("details/<uuid:public_id>", views.JobSeekerDetailView.as_view(), name="details"),
     path("list", views.JobSeekerListView.as_view(), name="list"),
+    # For sender
+    # TODO(ewen): this URL will change to a new one with a session_uuid instead of a company_pk
+    path("<int:company_pk>/sender/check-nir", views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
+    # Direct hire process
+    # TODO(ewen): this URL will change to a new one with a session_uuid instead of a company_pk
+    path(
+        "<int:company_pk>/hire/check-nir",
+        views.CheckNIRForSenderView.as_view(),
+        name="check_nir_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    # For job seeker
+    # TODO(ewen): this URL will change to a new one with a session_uuid instead of a company_pk
+    path(
+        "<int:company_pk>/job-seeker/check-nir",
+        views.CheckNIRForJobSeekerView.as_view(),
+        name="check_nir_for_job_seeker",
+    ),
 ]

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -1,18 +1,23 @@
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.db.models import Count, DateTimeField, Exists, IntegerField, Max, OuterRef, Subquery
 from django.db.models.functions import Coalesce
+from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.views.generic import DetailView, ListView
 
 from itou.companies.enums import CompanyKind
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
 from itou.eligibility.models.iae import EligibilityDiagnosis
+from itou.gps.models import FollowUpGroup
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.pagination import ItouPaginator
+from itou.utils.session import SessionNamespace
 from itou.utils.urls import get_safe_url
+from itou.www.apply.views.submit_views import ApplyStepBaseView, ApplyStepForSenderBaseView
 
-from .forms import FilterForm
+from .forms import CheckJobSeekerNirForm, FilterForm
 
 
 class JobSeekerDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
@@ -155,3 +160,116 @@ class JobSeekerListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             query = query.filter(pk=job_seeker_pk)
 
         return query
+
+
+class CheckNIRForJobSeekerView(ApplyStepBaseView):
+    template_name = "job_seekers_views/step_check_job_seeker_nir.html"
+
+    def __init__(self):
+        super().__init__()
+        self.job_seeker = None
+        self.form = None
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.job_seeker = request.user
+        self.form = CheckJobSeekerNirForm(job_seeker=self.job_seeker, data=request.POST or None)
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated and not self.job_seeker.is_job_seeker:
+            return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        # The NIR already exists, go to next step
+        if self.job_seeker.jobseeker_profile.nir:
+            return HttpResponseRedirect(
+                reverse(
+                    "apply:step_check_job_seeker_info",
+                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
+                )
+            )
+
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        next_url = reverse(
+            "apply:step_check_job_seeker_info",
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
+        )
+        if self.form.is_valid():
+            self.job_seeker.jobseeker_profile.nir = self.form.cleaned_data["nir"]
+            self.job_seeker.jobseeker_profile.lack_of_nir_reason = ""
+            self.job_seeker.jobseeker_profile.save()
+            return HttpResponseRedirect(next_url)
+        else:
+            kwargs["temporary_nir_url"] = next_url
+
+        return self.render_to_response(self.get_context_data(**kwargs))
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "form": self.form,
+            "preview_mode": False,
+        }
+
+
+class CheckNIRForSenderView(ApplyStepForSenderBaseView):
+    template_name = "job_seekers_views/step_check_job_seeker_nir.html"
+
+    def __init__(self):
+        super().__init__()
+        self.form = None
+
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.form = CheckJobSeekerNirForm(job_seeker=None, data=request.POST or None, is_gps=self.is_gps)
+
+    def search_by_email_url(self, session_uuid):
+        view_name = "apply:search_by_email_for_hire" if self.hire_process else "apply:search_by_email_for_sender"
+        return reverse(view_name, kwargs={"company_pk": self.company.pk, "session_uuid": session_uuid}) + (
+            "?gps=true" if self.is_gps else ""
+        )
+
+    def post(self, request, *args, **kwargs):
+        context = {}
+        if self.form.is_valid():
+            job_seeker = self.form.get_job_seeker()
+
+            # No user found with that NIR, save the NIR in the session and redirect to search by e-mail address.
+            if not job_seeker:
+                job_seeker_session = SessionNamespace.create_temporary(request.session)
+                job_seeker_session.init({"profile": {"nir": self.form.cleaned_data["nir"]}})
+                return HttpResponseRedirect(self.search_by_email_url(job_seeker_session.name))
+
+            # The NIR we found is correct
+            if self.form.data.get("confirm"):
+                if self.is_gps:
+                    FollowUpGroup.objects.follow_beneficiary(
+                        beneficiary=job_seeker, user=request.user, is_referent=True
+                    )
+                    return HttpResponseRedirect(reverse("gps:my_groups"))
+                else:
+                    return self.redirect_to_check_infos(job_seeker.public_id)
+
+            context = {
+                # Ask the sender to confirm the NIR we found is associated to the correct user
+                "preview_mode": bool(self.form.data.get("preview")),
+                "job_seeker": job_seeker,
+                "can_view_personal_information": self.sender.can_view_personal_information(job_seeker),
+            }
+        else:
+            # Require at least one attempt with an invalid NIR to access the search by email feature.
+            # The goal is to prevent users from skipping the search by NIR and creating duplicates.
+            job_seeker_session = SessionNamespace.create_temporary(request.session)
+            job_seeker_session.init({})
+            context["temporary_nir_url"] = self.search_by_email_url(job_seeker_session.name)
+
+        return self.render_to_response(self.get_context_data(**kwargs) | context)
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "form": self.form,
+            "job_seeker": None,
+            "preview_mode": False,
+        }

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -54,7 +54,7 @@ def test_create_job_seeker(_mock, client):
     apply_start_url = reverse("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
 
     response = client.get(apply_start_url)
-    next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     assertRedirects(response, next_url)
     response = client.get(next_url)
     france_travail = Company.unfiltered_objects.get(siret=POLE_EMPLOI_SIRET)
@@ -227,7 +227,7 @@ def test_gps_bypass(client):
     apply_start_url = reverse("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     response = client.get(apply_start_url)
 
-    next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     assertRedirects(response, next_url)
 
     # SIAE has an active suspension, but we should be able to create the job_seeker for GPS
@@ -243,7 +243,7 @@ def test_gps_bypass(client):
     apply_start_url = reverse("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     response = client.get(apply_start_url)
 
-    next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     assertRedirects(response, next_url)
 
 
@@ -267,7 +267,10 @@ def test_existing_user_with_email(client):
     # …until a job seeker has to be determined.
     assert response.status_code == 200
     last_url = response.redirect_chain[-1][0]
-    assert last_url == reverse("apply:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    assert (
+        last_url
+        == reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    )
 
     # Enter a non-existing NIR.
     # ----------------------------------------------------------------------
@@ -328,7 +331,10 @@ def test_existing_user_with_nir(client):
     # …until a job seeker has to be determined.
     assert response.status_code == 200
     last_url = response.redirect_chain[-1][0]
-    assert last_url == reverse("apply:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    assert (
+        last_url
+        == reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+    )
 
     # Enter an existing NIR.
     # ----------------------------------------------------------------------
@@ -375,5 +381,5 @@ def test_creation_by_user_kind(client, UserFactory, factory_args, expected_acces
     assert response.status_code == 302
     assert (
         response["Location"]
-        == reverse("apply:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
+        == reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     )

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -13,58 +13,7 @@ from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import (
     JobSeekerFactory,
-    JobSeekerProfileFactory,
-    PrescriberFactory,
 )
-
-
-class TestCheckJobSeekerNirForm:
-    def test_form_job_seeker_not_found(self):
-        # This NIR is unique.
-        nir = JobSeekerProfileFactory.build().nir
-        form_data = {"nir": nir}
-        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
-        assert form.is_valid()
-        assert form.job_seeker is None
-
-    def test_form_job_seeker_found(self):
-        # A job seeker with this NIR already exists.
-        nir = "141062A78200555"
-        job_seeker = JobSeekerFactory(jobseeker_profile__nir=nir)
-        form_data = {"nir": job_seeker.jobseeker_profile.nir}
-        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
-        # A job seeker has been found.
-        assert form.is_valid()
-        assert form.job_seeker == job_seeker
-
-        # NIR should be case insensitive.
-        form_data = {"nir": job_seeker.jobseeker_profile.nir.lower()}
-        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
-        # A job seeker has been found.
-        assert form.is_valid()
-        assert form.job_seeker == job_seeker
-
-    def test_form_not_valid(self):
-        # Application sent by a job seeker whose NIR is already used by another account.
-        existing_account = JobSeekerFactory(email="unlikely@random.tld")
-        user = JobSeekerFactory()
-        form_data = {"nir": existing_account.jobseeker_profile.nir}
-        form = apply_forms.CheckJobSeekerNirForm(job_seeker=user, data=form_data)
-        assert not form.is_valid()
-        error_msg = form.errors["nir"][0]
-        assert "Ce numéro de sécurité sociale est déjà utilisé par un autre compte." in error_msg
-        assert existing_account.email not in error_msg
-        assert "u*******@r*****.t**" in error_msg
-
-        existing_account = PrescriberFactory()
-        profile = JobSeekerProfileFactory(user=existing_account)  # This should not be possible
-        form_data = {"nir": profile.nir}
-        form = apply_forms.CheckJobSeekerNirForm(data=form_data)
-        assert not form.is_valid()
-        assert (
-            "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
-            "n'est pas associé à un compte candidat."
-        ) == form.errors["__all__"][0]
 
 
 class TestAcceptForm:

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -93,8 +93,8 @@ class TestApply:
         for viewname in (
             "apply:start",
             "apply:pending_authorization_for_sender",
-            "apply:check_nir_for_sender",
-            "apply:check_nir_for_job_seeker",
+            "job_seekers_views:check_nir_for_sender",
+            "job_seekers_views:check_nir_for_job_seeker",
         ):
             url = reverse(viewname, kwargs={"company_pk": company.pk})
             response = client.get(url)
@@ -204,7 +204,7 @@ class TestApply:
 class TestHire:
     def test_anonymous_access(self, client):
         company = CompanyFactory(with_jobs=True, with_membership=True)
-        url = reverse("apply:check_nir_for_hire", kwargs={"company_pk": company.pk})
+        url = reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk})
         response = client.get(url)
         assertRedirects(response, reverse("account_login") + f"?next={url}")
 
@@ -314,7 +314,7 @@ def test_check_nir_job_seeker_with_lack_of_nir_reason(client):
     response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
     assert response.status_code == 302
 
-    next_url = reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
+    next_url = reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
     assert response.url == next_url
 
     # Step check job seeker NIR.
@@ -348,7 +348,8 @@ class TestApplyAsJobSeeker:
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         # The suspension does not prevent access to the process
         assertRedirects(
-            response, expected_url=reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
+            response,
+            expected_url=reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": company.pk}),
         )
 
     def test_apply_as_jobseeker(self, client, pdf_file):
@@ -366,7 +367,7 @@ class TestApplyAsJobSeeker:
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         assert response.status_code == 302
 
-        next_url = reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
         assert response.url == next_url
 
         # Step check job seeker NIR.
@@ -520,7 +521,7 @@ class TestApplyAsJobSeeker:
 
         # Follow all redirections until NIR.
         # ----------------------------------------------------------------------
-        next_url = reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
 
         response = client.post(next_url, data={"nir": "123456789KLOIU"})
         assert response.status_code == 200
@@ -552,7 +553,7 @@ class TestApplyAsJobSeeker:
         client.force_login(user)
 
         client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))  # Init the session
-        response = client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk}))
         assertRedirects(
             response, reverse("apply:start", kwargs={"company_pk": company.pk}), fetch_redirect_response=False
         )
@@ -577,7 +578,7 @@ class TestApplyAsJobSeeker:
             {"job_description_id": job_description.pk},
         )
 
-        next_url = reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": company.pk})
         assert response.url == next_url
         response = client.get(next_url)
 
@@ -817,7 +818,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         response = client.get(next_url)
 
-        next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         assertContains(response, "Statut de prescripteur habilité non vérifié")
         assertContains(response, next_url)
 
@@ -1082,7 +1083,7 @@ class TestApplyAsAuthorizedPrescriber:
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         assert response.status_code == 302
 
-        next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         assert response.url == next_url
 
         # Step determine the job seeker with a NIR.
@@ -1345,7 +1346,7 @@ class TestApplyAsAuthorizedPrescriber:
         user = prescriber_organization.members.first()
         client.force_login(user)
 
-        nir_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        nir_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         response = client.get(nir_url)
         assert response.status_code == 200
 
@@ -1402,7 +1403,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         assert response.status_code == 302
-        assertRedirects(response, reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk}))
+        assertRedirects(response, reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk}))
 
         response = client.post(response.url, {"nir": "invalid"})
         known_session_keys = {
@@ -1458,7 +1459,7 @@ class TestApplyAsPrescriber:
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         # The suspension does not prevent the access to the process
         assertRedirects(
-            response, expected_url=reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+            response, expected_url=reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         )
 
     @pytest.mark.ignore_unknown_variable_template_error(
@@ -1486,7 +1487,7 @@ class TestApplyAsPrescriber:
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         assert response.status_code == 302
 
-        next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         assert response.url == next_url
 
         # Step determine the job seeker with a NIR.
@@ -1786,7 +1787,7 @@ class TestApplyAsPrescriber:
         client.force_login(user)
 
         client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))  # Use that view to init the session
-        response = client.get(reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": company.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": company.pk}))
         assertRedirects(
             response, reverse("apply:start", kwargs={"company_pk": company.pk}), fetch_redirect_response=False
         )
@@ -1870,7 +1871,7 @@ class TestApplyAsPrescriberNirExceptions:
         # …until a job seeker has to be determined.
         assert response.status_code == 200
         last_url = response.redirect_chain[-1][0]
-        assert last_url == reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        assert last_url == reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
 
         # Enter a non-existing NIR.
         # ----------------------------------------------------------------------
@@ -1943,7 +1944,7 @@ class TestApplyAsPrescriberNirExceptions:
         # …until a job seeker has to be determined.
         assert response.status_code == 200
         last_url = response.redirect_chain[-1][0]
-        assert last_url == reverse("apply:check_nir_for_sender", kwargs={"company_pk": siae.pk})
+        assert last_url == reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": siae.pk})
 
         # Enter a non-existing NIR.
         # ----------------------------------------------------------------------
@@ -2002,7 +2003,8 @@ class TestApplyAsCompany:
 
         response = client.get(reverse("apply:start", kwargs={"company_pk": company_2.pk}))
         assertRedirects(
-            response, expected_url=reverse("apply:check_nir_for_sender", kwargs={"company_pk": company_2.pk})
+            response,
+            expected_url=reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company_2.pk}),
         )
 
     def test_apply_as_siae_with_suspension_sanction(self, client):
@@ -2036,7 +2038,7 @@ class TestApplyAsCompany:
         response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
         assert response.status_code == 302
 
-        next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         assert response.url == next_url
 
         # Step determine the job seeker with a NIR.
@@ -2394,7 +2396,7 @@ class TestApplyAsCompany:
         user = membership.user
         client.force_login(user)
 
-        nir_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        nir_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
         response = client.get(nir_url)
         assert response.status_code == 200
 
@@ -2439,7 +2441,7 @@ class TestDirectHireFullProcess:
         user = company_1.members.first()
         client.force_login(user)
 
-        response = client.get(reverse("apply:check_nir_for_hire", kwargs={"company_pk": company_2.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company_2.pk}))
         assert response.status_code == 403
 
     def test_hire_as_siae_with_suspension_sanction(self, client):
@@ -2490,7 +2492,7 @@ class TestDirectHireFullProcess:
         # Step determine the job seeker with a NIR.
         # ----------------------------------------------------------------------
 
-        check_nir_url = reverse("apply:check_nir_for_hire", kwargs={"company_pk": company.pk})
+        check_nir_url = reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk})
         response = client.get(check_nir_url)
         assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url_dashboard)
@@ -2791,7 +2793,7 @@ class TestDirectHireFullProcess:
         # Step determine the job seeker with a NIR.
         # ----------------------------------------------------------------------
 
-        check_nir_url = reverse("apply:check_nir_for_hire", kwargs={"company_pk": company.pk})
+        check_nir_url = reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk})
         response = client.get(check_nir_url)
         assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url_dashboard)
@@ -2928,8 +2930,8 @@ class TestDirectHireFullProcess:
 class TestApplyAsOther:
     ROUTES = [
         "apply:start",
-        "apply:check_nir_for_job_seeker",
-        "apply:check_nir_for_sender",
+        "job_seekers_views:check_nir_for_job_seeker",
+        "job_seekers_views:check_nir_for_sender",
     ]
 
     def test_labor_inspectors_are_not_allowed_to_submit_application(self, client, subtests):
@@ -2992,7 +2994,7 @@ class TestApplicationView:
         response = client.get(
             reverse("apply:start", kwargs={"company_pk": company.pk}), {"job_description_id": "invalid"}
         )
-        assertRedirects(response, reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk}))
+        assertRedirects(response, reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk}))
         assert self.apply_session_key(company) not in client.session
 
     def test_access_without_session(self, client):
@@ -3985,7 +3987,7 @@ def test_detect_existing_job_seeker(client):
     response = client.get(reverse("apply:start", kwargs={"company_pk": company.pk}))
     assert response.status_code == 302
 
-    next_url = reverse("apply:check_nir_for_sender", kwargs={"company_pk": company.pk})
+    next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
     assert response.url == next_url
 
     # Step determine the job seeker with a NIR.
@@ -4565,7 +4567,7 @@ class TestFindJobSeekerForHireView:
     @pytest.fixture(autouse=True)
     def setup_method(self):
         self.company = CompanyFactory(with_membership=True)
-        self.check_nir_url = reverse("apply:check_nir_for_hire", kwargs={"company_pk": self.company.pk})
+        self.check_nir_url = reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": self.company.pk})
 
     def test_job_seeker_found_with_nir(self, client):
         user = self.company.members.first()
@@ -4735,7 +4737,7 @@ class TestCheckJobSeekerInformationsForHire:
 
         assertContains(
             response,
-            reverse("apply:check_nir_for_hire", kwargs={"company_pk": company.pk}),
+            reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk}),
         )
         assertContains(response, reverse("dashboard:index"))
 
@@ -5090,35 +5092,43 @@ class TestNewHireProcessInfo:
 
     def test_as_job_seeker(self, client):
         client.force_login(self.job_seeker)
-        response = client.get(reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": self.company.pk}))
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": self.company.pk})
+        )
         assertNotContains(response, self.OTHER_APPLY_PROCESS_INFO)
         assertNotContains(response, self.OTHER_DIRECT_HIRE_PROCESS_INFO)
-        response = client.get(reverse("apply:check_nir_for_job_seeker", kwargs={"company_pk": self.geiq.pk}))
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"company_pk": self.geiq.pk})
+        )
         assertNotContains(response, self.GEIQ_APPLY_PROCESS_INFO)
         assertNotContains(response, self.GEIQ_DIRECT_HIRE_PROCESS_INFO)
 
     def test_as_prescriber(self, client):
         client.force_login(PrescriberFactory())
-        response = client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": self.company.pk}))
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": self.company.pk})
+        )
         assertNotContains(response, self.OTHER_APPLY_PROCESS_INFO)
         assertNotContains(response, self.OTHER_DIRECT_HIRE_PROCESS_INFO)
-        response = client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": self.geiq.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": self.geiq.pk}))
         assertNotContains(response, self.GEIQ_APPLY_PROCESS_INFO)
         assertNotContains(response, self.GEIQ_DIRECT_HIRE_PROCESS_INFO)
 
     def test_as_employer(self, client):
         client.force_login(self.company.members.first())
-        response = client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": self.company.pk}))
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": self.company.pk})
+        )
         assertContains(response, self.OTHER_APPLY_PROCESS_INFO)
         assertNotContains(response, self.OTHER_DIRECT_HIRE_PROCESS_INFO)
-        response = client.get(reverse("apply:check_nir_for_hire", kwargs={"company_pk": self.company.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": self.company.pk}))
         assertNotContains(response, self.OTHER_APPLY_PROCESS_INFO)
         assertContains(response, self.OTHER_DIRECT_HIRE_PROCESS_INFO)
 
         client.force_login(self.geiq.members.first())
-        response = client.get(reverse("apply:check_nir_for_sender", kwargs={"company_pk": self.geiq.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": self.geiq.pk}))
         assertContains(response, self.GEIQ_APPLY_PROCESS_INFO)
         assertNotContains(response, self.GEIQ_DIRECT_HIRE_PROCESS_INFO)
-        response = client.get(reverse("apply:check_nir_for_hire", kwargs={"company_pk": self.geiq.pk}))
+        response = client.get(reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": self.geiq.pk}))
         assertNotContains(response, self.GEIQ_APPLY_PROCESS_INFO)
         assertContains(response, self.GEIQ_DIRECT_HIRE_PROCESS_INFO)

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -73,7 +73,7 @@ class TestDashboardView:
 
     @staticmethod
     def check_nir_for_hire_url(company):
-        return reverse("apply:check_nir_for_hire", kwargs={"company_pk": company.pk})
+        return reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk})
 
     def test_dashboard(self, client, snapshot):
         company = CompanyFactory(with_membership=True)

--- a/tests/www/job_seekers_views/test_forms.py
+++ b/tests/www/job_seekers_views/test_forms.py
@@ -1,0 +1,55 @@
+from itou.www.job_seekers_views import forms as job_seekers_forms
+from tests.users.factories import (
+    JobSeekerFactory,
+    JobSeekerProfileFactory,
+    PrescriberFactory,
+)
+
+
+class TestCheckJobSeekerNirForm:
+    def test_form_job_seeker_not_found(self):
+        # This NIR is unique.
+        nir = JobSeekerProfileFactory.build().nir
+        form_data = {"nir": nir}
+        form = job_seekers_forms.CheckJobSeekerNirForm(data=form_data)
+        assert form.is_valid()
+        assert form.job_seeker is None
+
+    def test_form_job_seeker_found(self):
+        # A job seeker with this NIR already exists.
+        nir = "141062A78200555"
+        job_seeker = JobSeekerFactory(jobseeker_profile__nir=nir)
+        form_data = {"nir": job_seeker.jobseeker_profile.nir}
+        form = job_seekers_forms.CheckJobSeekerNirForm(data=form_data)
+        # A job seeker has been found.
+        assert form.is_valid()
+        assert form.job_seeker == job_seeker
+
+        # NIR should be case insensitive.
+        form_data = {"nir": job_seeker.jobseeker_profile.nir.lower()}
+        form = job_seekers_forms.CheckJobSeekerNirForm(data=form_data)
+        # A job seeker has been found.
+        assert form.is_valid()
+        assert form.job_seeker == job_seeker
+
+    def test_form_not_valid(self):
+        # Application sent by a job seeker whose NIR is already used by another account.
+        existing_account = JobSeekerFactory(email="unlikely@random.tld")
+        user = JobSeekerFactory()
+        form_data = {"nir": existing_account.jobseeker_profile.nir}
+        form = job_seekers_forms.CheckJobSeekerNirForm(job_seeker=user, data=form_data)
+        assert not form.is_valid()
+        error_msg = form.errors["nir"][0]
+        assert "Ce numéro de sécurité sociale est déjà utilisé par un autre compte." in error_msg
+        assert existing_account.email not in error_msg
+        assert "u*******@r*****.t**" in error_msg
+
+        existing_account = PrescriberFactory()
+        profile = JobSeekerProfileFactory(user=existing_account)  # This should not be possible
+        form_data = {"nir": profile.nir}
+        form = job_seekers_forms.CheckJobSeekerNirForm(data=form_data)
+        assert not form.is_valid()
+        assert (
+            "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
+            "n'est pas associé à un compte candidat."
+        ) == form.errors["__all__"][0]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR, on déplace les vues, formulaires et URLs relatives à la vérification du NIR :
- vues, formulaires : déplacés
- URLs : copiés, pour ne pas casser les parcours en cours en production. Les anciennes seront supprimées dans un second temps.

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :desert_island: Comment tester

Seul changement perceptible : les URLs de vérification du NIR commencent par `job-seekers` et non plus `apply`.
