### PR TITLE
UX/UI: Passer le bouton “Modifier” de la fiche de poste à droite

### DIFF
--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -25,28 +25,35 @@
     {% if job_app_to_transfer %}
         {% include "apply/includes/job_application_external_transfer_progress.html" with job_app_to_transfer=job_app_to_transfer step=1 only %}
     {% endif %}
-    <h1>{{ job.display_name }}</h1>
-    {% if job.is_active %}
-        <p>
-            <span class="badge rounded-pill bg-success">
-                {{ job.open_positions }} poste{{ job.open_positions|pluralizefr }} ouvert{{ job.open_positions|pluralizefr }} au recrutement
-            </span>
-        </p>
-    {% endif %}
-    <div class="c-box c-box--action">
-        <h2 class="visually-hidden">Actions rapides</h2>
-        <div class="form-row align-items-center gx-3">
-            {% if can_update_job_description %}
-                <div class="form-group col-12 col-lg-auto">
-                    <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}"
-                       class="btn btn-lg btn-white btn-block btn-ico"
-                       aria-label="Modifier la fiche de poste"
-                       {% matomo_event "employeurs" "clic" "edit-fiche-de-poste" %}>
-                        <i class="ri-pencil-line fw-medium" aria-hidden="true"></i>
-                        <span>Modifier</span>
-                    </a>
-                </div>
-            {% else %}
+
+    <div class="d-flex flex-column flex-md-row gap-3 mb-3 mb-md-4 justify-content-md-between">
+        <div>
+            <h1 class="mb-0">{{ job.display_name }}</h1>
+            {% if job.is_active %}
+                <p class="mt-1 mb-0">
+                    <span class="badge rounded-pill bg-success">
+                        {{ job.open_positions }} poste{{ job.open_positions|pluralizefr }} ouvert{{ job.open_positions|pluralizefr }} au recrutement
+                    </span>
+                </p>
+            {% endif %}
+        </div>
+        {% if can_update_job_description %}
+            <div>
+                <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}"
+                   class="btn btn-lg btn-block btn-primary btn-ico"
+                   aria-label="Modifier la fiche de poste"
+                   {% matomo_event "employeurs" "clic" "edit-fiche-de-poste" %}>
+                    <i class="ri-pencil-line fw-medium" aria-hidden="true"></i>
+                    <span>Modifier</span>
+                </a>
+            </div>
+        {% endif %}
+    </div>
+
+    {% if not can_update_job_description %}
+        <div class="c-box c-box--action">
+            <h2 class="visually-hidden">Actions rapides</h2>
+            <div class="form-row align-items-center gx-3">
                 {% if job.is_active and not siae.block_job_applications %}
                     {% if job_app_to_transfer %}
                         <div class="form-group col-12 col-lg-auto">
@@ -96,9 +103,9 @@
                         </li>
                     </ul>
                 </div>
-            {% endif %}
+            </div>
         </div>
-    </div>
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -554,9 +554,8 @@
 # name: TestJobDescriptionCardView.test_card_tally_url_no_user
   '''
   <div class="c-box c-box--action">
-          <h2 class="visually-hidden">Actions rapides</h2>
-          <div class="form-row align-items-center gx-3">
-              
+              <h2 class="visually-hidden">Actions rapides</h2>
+              <div class="form-row align-items-center gx-3">
                   
                       
                           <div class="form-group col-12 col-lg-auto">
@@ -590,17 +589,15 @@
                           </li>
                       </ul>
                   </div>
-              
+              </div>
           </div>
-      </div>
   '''
 # ---
 # name: TestJobDescriptionCardView.test_card_tally_url_with_user[with_other_jobs]
   '''
   <div class="c-box c-box--action">
-          <h2 class="visually-hidden">Actions rapides</h2>
-          <div class="form-row align-items-center gx-3">
-              
+              <h2 class="visually-hidden">Actions rapides</h2>
+              <div class="form-row align-items-center gx-3">
                   
                       
                           <div class="form-group col-12 col-lg-auto">
@@ -641,17 +638,15 @@
                           </li>
                       </ul>
                   </div>
-              
+              </div>
           </div>
-      </div>
   '''
 # ---
 # name: TestJobDescriptionCardView.test_card_tally_url_with_user[without_other_jobs]
   '''
   <div class="c-box c-box--action">
-          <h2 class="visually-hidden">Actions rapides</h2>
-          <div class="form-row align-items-center gx-3">
-              
+              <h2 class="visually-hidden">Actions rapides</h2>
+              <div class="form-row align-items-center gx-3">
                   
                       
                           <div class="form-group col-12 col-lg-auto">
@@ -685,9 +680,8 @@
                           </li>
                       </ul>
                   </div>
-              
+              </div>
           </div>
-      </div>
   '''
 # ---
 # name: TestJobDescriptionCardView.test_job_description_card


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcqu'il était tout seul dans une barre d'action prévue pour plusieurs boutons et que nous avons une mise en page prévue pour un seul bouton d'action

## :computer: Captures d'écran <!-- optionnel -->
**Avant**
![capture 2024-10-31 à 15 41 38](https://github.com/user-attachments/assets/eb80ba98-37d3-4476-8451-52b0035cb03d)

**Apres**
![capture 2024-10-31 à 15 42 14](https://github.com/user-attachments/assets/5debbb2f-b904-4057-9917-3bf3e6dacd26)
