### PR TITLE
Connexion: Bloquer l'accès à la connexion Inclusion Connect quand ProConnect est activé

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -115,6 +115,10 @@ def _add_user_kind_error_message(request, existing_user, new_user_kind):
 
 
 def inclusion_connect_authorize(request):
+    # Block access if ProConnect is enabled
+    if settings.PRO_CONNECT_BASE_URL:
+        return HttpResponseRedirect(reverse("search:employers_home"))
+
     # Start a new session.
     user_kind = request.GET.get("user_kind")
     previous_url = request.GET.get("previous_url", reverse("search:employers_home"))
@@ -219,6 +223,10 @@ def _get_user_info(request, access_token):
 
 
 def inclusion_connect_callback(request):
+    # Block access if ProConnect is enabled
+    if settings.PRO_CONNECT_BASE_URL:
+        return HttpResponseRedirect(reverse("search:employers_home"))
+
     code = request.GET.get("code")
     state = request.GET.get("state")
     if code is None or state is None:

--- a/tests/openid_connect/inclusion_connect/tests.py
+++ b/tests/openid_connect/inclusion_connect/tests.py
@@ -44,6 +44,7 @@ from tests.openid_connect.inclusion_connect.test import (
     inclusion_connect_setup,
     mock_oauth_dance,
 )
+from tests.openid_connect.pro_connect.test import pro_connect_setup
 from tests.prescribers.factories import PrescriberPoleEmploiFactory
 from tests.users.factories import (
     DEFAULT_PASSWORD,
@@ -981,3 +982,16 @@ class TestInclusionConnectmapChannel:
                 ),
             ],
         )
+
+
+def test_inclusion_connect_is_forbidden_when_pro_connect_is_enabled(client):
+    with pro_connect_setup():
+        url = f"{reverse('inclusion_connect:authorize')}?user_kind={UserKind.PRESCRIBER}"
+        response = client.get(url)
+        assertRedirects(response, reverse("search:employers_home"))
+        assert constants.INCLUSION_CONNECT_SESSION_KEY not in client.session
+
+        url = f"{reverse('inclusion_connect:callback')}"
+        response = client.get(url)
+        assertRedirects(response, reverse("search:employers_home"))
+        assert constants.INCLUSION_CONNECT_SESSION_KEY not in client.session


### PR DESCRIPTION
## :thinking: Pourquoi ?

Même si les liens ne sont pas accessible, il ne faut pas qu'un marque page enregistré par un utilisateur fonctionne
-> https://itou.sentry.io/issues/5647707850/?project=6164438&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=8

Il y a encore des utilisateurs qui finissent dessus

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
