### PR TITLE
Connexion: AJout de remontée d'erreur en cas de problème de connexion avec ProConnect

### DIFF
--- a/tests/openid_connect/pro_connect/tests.py
+++ b/tests/openid_connect/pro_connect/tests.py
@@ -160,6 +160,22 @@ class TestProConnectModel:
         with pytest.raises(ValidationError):
             pc_user_data.create_or_update_user()
 
+    def test_create_user_from_user_info_with_already_existing_email_but_other_sub(self, caplog):
+        """
+        If there already is an existing user with this emailbut another ProConnect sub,
+        raise an error and log something.
+        """
+        pc_user_data = ProConnectPrescriberData.from_user_info(OIDC_USERINFO)
+        PrescriberFactory(
+            username="another_sub",
+            identity_provider=users_enums.IdentityProvider.PRO_CONNECT,
+            email=pc_user_data.email,
+        )
+        with pytest.raises(EmailInUseException):
+            pc_user_data.create_or_update_user()
+
+        assert caplog.messages == [f"Email {pc_user_data.email} already in used with provider ProConnect"]
+
     def test_join_org(self, caplog):
         # New membership.
         organization = PrescriberPoleEmploiFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

J'ai l'impression qu'un utilisateur n'arrive pas à se connecter alors que son email est déjà lié à un compte ProConnect.
Je voudrais donc pouvoir vérifier si on ne tombe pas dans ce cas de figure là.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
