### PR TITLE
GPS : Cacher les informations de l’entreprise fictive France Travail lors de la création d’un bénéficiaire [GEN-1925]

### DIFF
--- a/itou/templates/apply/submit_base_two_columns.html
+++ b/itou/templates/apply/submit_base_two_columns.html
@@ -10,11 +10,13 @@
 {% block content %}
     <section class="s-section-twocolumns s-section">
         <div class="container">
-            <div class="row">
-                <div class="col-12 col-lg-6 order-md-1 pe-lg-5">
-                    {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" only %}
+            {% if not is_gps %}
+                <div class="row">
+                    <div class="col-12 col-lg-6 order-md-1 pe-lg-5">
+                        {% include "companies/includes/_company_info.html" with company=siae extra_box_class="mb-3 mb-lg-5" only %}
+                    </div>
                 </div>
-            </div>
+            {% endif %}
             <div class="row">
                 <div class="col-12 col-lg-6 order-md-2 ps-lg-5 d-none d-lg-block">
                     <h2 class="h1 ff-extra-01">Où trouver {{ request.user.is_job_seeker|yesno:"mon,le" }} numéro de sécurité sociale ?</h2>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter d’induire les utilisateurs en erreur.

## :cake: Comment ? <!-- optionnel -->

Empiler des hacks 🙈. Cacher l’entreprise destinataire quand `is_gps`, en attendant d’avoir un module de création de compte candidat par un tiers.
