### PR TITLE
Contrôle a posteriori : Garder actives les campagnes en attente de sanctions [GEN-2209]

### DIFF
--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -139,8 +139,9 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
                 ).count()
     elif request.user.is_labor_inspector:
         current_org = get_current_institution_or_404(request)
+        six_months_ago = timezone.now() - timezone.timedelta(days=182)
         for campaign in EvaluationCampaign.objects.for_institution(current_org).viewable():
-            if campaign.ended_at is None:
+            if campaign.ended_at is None or campaign.ended_at >= six_months_ago:
                 context["active_campaigns"].append(campaign)
             else:
                 context["closed_campaigns"].append(campaign)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Communiquer que des actions sont en attente côté les DDETS.

Le calcul de l’état de la campagne devient coûteux, peut-être ne devrait-on le faire que pour les campagnes portant l’année précédente ?
cf https://www.notion.so/IMPORTANT-Maintenir-le-lien-d-acc-s-la-campagne-de-contr-le-visible-tant-que-les-notifications-n-130e8fa5c35b80f59d95ccf3539d7788?d=134e8fa5c35b805491a1001c82c36584&pvs=4
