### PR TITLE
Candidatures : Masquer le bouton « Modifier » des fiches de poste lors du transfert vers un métier de sa structure [GEN-2005]

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -737,6 +737,7 @@ class JobApplicationExternalTransferStep1JobDescriptionCardView(LoginRequiredMix
         return data | {
             "job_app_to_transfer": self.job_application,
             "matomo_custom_title": data["matomo_custom_title"] + " (transfert)",
+            "can_update_job_description": False,
         }
 
 

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -15,6 +15,7 @@ from tests.companies.factories import CompanyFactory, CompanyMembershipFactory, 
 from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.utils.test import parse_response_to_soup
+from tests.www.companies_views.test_job_description_views import POSTULER
 
 
 INTERNAL_TRANSFER_CONFIRM_BUTTON = """
@@ -96,7 +97,7 @@ def test_step_1(client, snapshot):
     )
     assertContains(response, other_company.name.capitalize())
     assertContains(response, job_application.to_company.name.capitalize())
-    assertNotContains(response, "Postuler")
+    assertNotContains(response, POSTULER)
     assertContains(
         response,
         "<span>Transférer la candidature</span>",
@@ -141,7 +142,7 @@ def test_step_1(client, snapshot):
         count=2,
     )
     assertContains(response, job_card_url, count=1)
-    assertNotContains(response, "Postuler")
+    assertNotContains(response, POSTULER)
     assertContains(
         response,
         "<span>Transférer la candidature</span>",
@@ -157,7 +158,7 @@ def test_step_1(client, snapshot):
         count=1,
     )
     assertContains(response, company_card_url, count=1)
-    assertNotContains(response, "Postuler")
+    assertNotContains(response, POSTULER)
     assertContains(
         response,
         "<span>Transférer la candidature</span>",

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -19,6 +19,9 @@ from tests.users.factories import JobSeekerFactory
 from tests.utils.test import assertSnapshotQueries
 
 
+POSTULER = "Postuler"
+
+
 class JobDescriptionAbstract:
     @pytest.fixture(autouse=True)
     def abstract_setup_method(self):
@@ -608,7 +611,7 @@ class TestJobDescriptionCard(JobDescriptionAbstract):
         with assertSnapshotQueries(snapshot):
             response = client.get(self.url)
 
-        assertContains(response, "Postuler auprès de l'employeur inclusif")
+        assertContains(response, f"{POSTULER} auprès de l'employeur inclusif")
         assertContains(response, self.apply_start_url(self.company))
         assertNotContains(
             response,
@@ -621,14 +624,14 @@ class TestJobDescriptionCard(JobDescriptionAbstract):
         with assertSnapshotQueries(snapshot):
             response = client.get(self.url)
 
-        assertContains(response, "Postuler auprès de l'employeur inclusif")
+        assertContains(response, f"{POSTULER} auprès de l'employeur inclusif")
         assertContains(response, self.apply_start_url(self.company))
         assertNotContains(response, self.update_job_description_url(self.job_description))
 
     def test_anonymous_card_actions(self, client):
         response = client.get(self.url)
 
-        assertContains(response, "Postuler auprès de l'employeur inclusif")
+        assertContains(response, f"{POSTULER} auprès de l'employeur inclusif")
         assertContains(response, self.apply_start_url(self.company))
         assertNotContains(response, self.update_job_description_url(self.job_description))
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Demande métier.

https://www.notion.so/plateforme-inclusion/Lorsque-je-transf-re-une-candidature-et-que-je-me-rends-sur-une-fiche-de-poste-mise-par-ma-structur-32bdf1d08cc244f8b9ddedb7aa0acdd9?d=126e8fa5c35b8040a94e001c93e9f791