### PR TITLE
Déplacer les vues, formulaires et URLs de recherche par email à `job_seekers_views`

### DIFF
--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
 
 from itou.www.apply.views import edit_views, list_views, process_views, submit_views
-from itou.www.job_seekers_views.views import CheckNIRForJobSeekerView, CheckNIRForSenderView
+from itou.www.job_seekers_views.views import (
+    CheckNIRForJobSeekerView,
+    CheckNIRForSenderView,
+    SearchByEmailForSenderView,
+)
 
 
 # https://docs.djangoproject.com/en/dev/topics/http/urls/#url-namespaces-and-included-urlconfs
@@ -18,9 +22,10 @@ urlpatterns = [
     ),
     # Ewen: deprecated url. These urls are going to job_seekers_views.views
     path("<int:company_pk>/sender/check_nir", CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
+    # Ewen: deprecated url. These urls are going to job_seekers_views
     path(
         "<int:company_pk>/sender/search-by-email/<uuid:session_uuid>",
-        submit_views.SearchByEmailForSenderView.as_view(),
+        SearchByEmailForSenderView.as_view(),
         name="search_by_email_for_sender",
     ),
     path(
@@ -115,9 +120,10 @@ urlpatterns = [
         name="check_nir_for_hire",
         kwargs={"hire_process": True},
     ),
+    # Ewen: deprecated url. These urls are going to job_seekers_views
     path(
         "<int:company_pk>/hire/search-by-email/<uuid:session_uuid>",
-        submit_views.SearchByEmailForSenderView.as_view(),
+        SearchByEmailForSenderView.as_view(),
         name="search_by_email_for_hire",
         kwargs={"hire_process": True},
     ),

--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -11,12 +11,25 @@ urlpatterns = [
     # For sender
     # TODO(ewen): this URL will change to a new one with a session_uuid instead of a company_pk
     path("<int:company_pk>/sender/check-nir", views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
+    # TODO(ewen): this URL will change to a new one without company_pk
+    path(
+        "<int:company_pk>/sender/search-by-email/<uuid:session_uuid>",
+        views.SearchByEmailForSenderView.as_view(),
+        name="search_by_email_for_sender",
+    ),
     # Direct hire process
     # TODO(ewen): this URL will change to a new one with a session_uuid instead of a company_pk
     path(
         "<int:company_pk>/hire/check-nir",
         views.CheckNIRForSenderView.as_view(),
         name="check_nir_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    # TODO(ewen): this URL will change to a new one without company_pk
+    path(
+        "<int:company_pk>/hire/search-by-email/<uuid:session_uuid>",
+        views.SearchByEmailForSenderView.as_view(),
+        name="search_by_email_for_hire",
         kwargs={"hire_process": True},
     ),
     # For job seeker

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -68,7 +68,7 @@ def test_create_job_seeker(_mock, client):
     job_seeker_session_name = str(resolve(response.url.replace("?gps=true", "")).kwargs["session_uuid"])
     next_url = (
         reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
@@ -111,7 +111,7 @@ def test_create_job_seeker(_mock, client):
     assertContains(
         response,
         reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
         ),
     )
@@ -280,7 +280,7 @@ def test_existing_user_with_email(client):
     job_seeker_session_name = str(resolve(response.url.replace("?gps=true", "")).kwargs["session_uuid"])
     next_url = (
         reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
         )
         + "?gps=true"

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -120,7 +120,7 @@ class TestApply:
         client.force_login(user)
         response = client.get(
             reverse(
-                "apply:search_by_email_for_sender",
+                "job_seekers_views:search_by_email_for_sender",
                 kwargs={"company_pk": company.pk, "session_uuid": str(uuid.uuid4())},
             )
         )
@@ -228,7 +228,8 @@ class TestHire:
         client.force_login(user)
         response = client.get(
             reverse(
-                "apply:search_by_email_for_hire", kwargs={"company_pk": company.pk, "session_uuid": str(uuid.uuid4())}
+                "job_seekers_views:search_by_email_for_hire",
+                kwargs={"company_pk": company.pk, "session_uuid": str(uuid.uuid4())},
             )
         )
         assert response.status_code == 403
@@ -833,7 +834,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
@@ -875,7 +876,7 @@ class TestApplyAsAuthorizedPrescriber:
         assertContains(
             response,
             reverse(
-                "apply:search_by_email_for_sender",
+                "job_seekers_views:search_by_email_for_sender",
                 kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
             ),
         )
@@ -1098,7 +1099,8 @@ class TestApplyAsAuthorizedPrescriber:
 
         session_uuid = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_sender", kwargs={"company_pk": company.pk, "session_uuid": session_uuid}
+            "job_seekers_views:search_by_email_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": session_uuid},
         )
         assert response.url == next_url
 
@@ -1137,7 +1139,7 @@ class TestApplyAsAuthorizedPrescriber:
         assertContains(
             response,
             reverse(
-                "apply:search_by_email_for_sender",
+                "job_seekers_views:search_by_email_for_sender",
                 kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
             ),
         )
@@ -1355,7 +1357,8 @@ class TestApplyAsAuthorizedPrescriber:
 
         session_uuid = str(resolve(response.url).kwargs["session_uuid"])
         email_url = reverse(
-            "apply:search_by_email_for_sender", kwargs={"company_pk": company.pk, "session_uuid": session_uuid}
+            "job_seekers_views:search_by_email_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": session_uuid},
         )
         assert response.url == email_url
 
@@ -1415,7 +1418,7 @@ class TestApplyAsAuthorizedPrescriber:
         }
         [job_seeker_session_name] = [k for k in client.session.keys() if k not in known_session_keys]
         search_by_email_url = reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
         )
         assertContains(
@@ -1502,7 +1505,7 @@ class TestApplyAsPrescriber:
 
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
@@ -1545,7 +1548,7 @@ class TestApplyAsPrescriber:
         assertContains(
             response,
             reverse(
-                "apply:search_by_email_for_sender",
+                "job_seekers_views:search_by_email_for_sender",
                 kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
             ),
         )
@@ -1880,7 +1883,7 @@ class TestApplyAsPrescriberNirExceptions:
         response = client.post(last_url, data=post_data)
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
@@ -1953,7 +1956,8 @@ class TestApplyAsPrescriberNirExceptions:
         response = client.post(last_url, data=post_data)
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_sender", kwargs={"company_pk": siae.pk, "session_uuid": job_seeker_session_name}
+            "job_seekers_views:search_by_email_for_sender",
+            kwargs={"company_pk": siae.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
         assert client.session[job_seeker_session_name] == {"profile": {"nir": nir}}
@@ -2053,7 +2057,7 @@ class TestApplyAsCompany:
 
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_sender",
+            "job_seekers_views:search_by_email_for_sender",
             kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
@@ -2095,7 +2099,7 @@ class TestApplyAsCompany:
         assertContains(
             response,
             reverse(
-                "apply:search_by_email_for_sender",
+                "job_seekers_views:search_by_email_for_sender",
                 kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
             ),
         )
@@ -2405,7 +2409,8 @@ class TestApplyAsCompany:
 
         session_uuid = str(resolve(response.url).kwargs["session_uuid"])
         email_url = reverse(
-            "apply:search_by_email_for_sender", kwargs={"company_pk": company.pk, "session_uuid": session_uuid}
+            "job_seekers_views:search_by_email_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": session_uuid},
         )
         assert response.url == email_url
 
@@ -2502,7 +2507,7 @@ class TestDirectHireFullProcess:
 
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         next_url = reverse(
-            "apply:search_by_email_for_hire",
+            "job_seekers_views:search_by_email_for_hire",
             kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
@@ -2543,7 +2548,7 @@ class TestDirectHireFullProcess:
         assertContains(
             response,
             reverse(
-                "apply:search_by_email_for_hire",
+                "job_seekers_views:search_by_email_for_hire",
                 kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
             ),
         )
@@ -4001,7 +4006,8 @@ def test_detect_existing_job_seeker(client):
     assert response.status_code == 302
     job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
     next_url = reverse(
-        "apply:search_by_email_for_sender", kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name}
+        "job_seekers_views:search_by_email_for_sender",
+        kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
     )
     assert response.url == next_url
     assert client.session[job_seeker_session_name] == {"profile": {"nir": NEW_NIR}}
@@ -4067,7 +4073,8 @@ def test_detect_existing_job_seeker(client):
         html=True,
     )
     check_email_url = reverse(
-        "apply:search_by_email_for_sender", kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name}
+        "job_seekers_views:search_by_email_for_sender",
+        kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
     )
     assertContains(
         response,
@@ -4613,7 +4620,7 @@ class TestFindJobSeekerForHireView:
         }
         [job_seeker_session_name] = [k for k in client.session.keys() if k not in known_session_keys]
         search_by_email_url = reverse(
-            "apply:search_by_email_for_hire",
+            "job_seekers_views:search_by_email_for_hire",
             kwargs={"company_pk": self.company.pk, "session_uuid": job_seeker_session_name},
         )
         assertContains(
@@ -4667,7 +4674,7 @@ class TestFindJobSeekerForHireView:
 
         job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
         search_by_email_url = reverse(
-            "apply:search_by_email_for_hire",
+            "job_seekers_views:search_by_email_for_hire",
             kwargs={"company_pk": self.company.pk, "session_uuid": job_seeker_session_name},
         )
         assert response.url == search_by_email_url


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR, on déplace les vues, formulaires et URLs relatives à la recherche de candidat par adresse email :
- formulaires et vues : déplacés
- URLs : copiés, pour ne pas casser les parcours en cours en production. Les anciennes seront supprimées dans un second temps.

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657


## :desert_island: Comment tester

Seul changement perceptible : les URLs de recherche par email commencent par `job-seekers` et non plus `apply`.

