### PR TITLE
Déplacer les vues, formulaires et URLs de vérification des infos à `job_seekers_views`

### DIFF
--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -20,43 +20,12 @@ from itou.eligibility.models import AdministrativeCriteria
 from itou.files.forms import ItouFileField
 from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, PriorAction
-from itou.users.forms import JobSeekerProfileFieldsMixin
-from itou.users.models import JobSeekerProfile, User
+from itou.users.models import JobSeekerProfile
 from itou.utils import constants as global_constants
 from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.types import InclusiveDateRange
 from itou.utils.widgets import DuetDatePickerWidget
 from itou.www.companies_views.forms import JobAppellationAndLocationMixin
-
-
-class CheckJobSeekerInfoForm(JobSeekerProfileFieldsMixin, forms.ModelForm):
-    PROFILE_FIELDS = ["birthdate", "pole_emploi_id", "lack_of_pole_emploi_id_reason"]
-
-    class Meta:
-        model = User
-        fields = [
-            "phone",
-        ]
-        help_texts = {
-            "birthdate": "Au format JJ/MM/AAAA, par exemple 20/12/1978.",
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["birthdate"].required = True
-        self.fields["birthdate"].widget = DuetDatePickerWidget(
-            {
-                "min": DuetDatePickerWidget.min_birthdate(),
-                "max": DuetDatePickerWidget.max_birthdate(),
-            }
-        )
-
-    def clean(self):
-        super().clean()
-        JobSeekerProfile.clean_pole_emploi_fields(self.cleaned_data)
-        JobSeekerProfile.clean_nir_title_birthdate_fields(
-            self.cleaned_data | {"nir": self.instance.jobseeker_profile.nir}, remind_nir_in_error=True
-        )
 
 
 class ApplicationJobsForm(forms.ModelForm):

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from itou.www.apply.views import edit_views, list_views, process_views, submit_views
 from itou.www.job_seekers_views.views import (
+    CheckJobSeekerInformations,
+    CheckJobSeekerInformationsForHire,
     CheckNIRForJobSeekerView,
     CheckNIRForSenderView,
     CreateJobSeekerStep1ForSenderView,
@@ -65,9 +67,10 @@ urlpatterns = [
         name="check_nir_for_job_seeker",
     ),
     # Submit - common.
+    # Ewen: deprecated url. These urls are going to job_seekers_views
     path(
         "<int:company_pk>/create/<uuid:job_seeker_public_id>/check_job_seeker_info",
-        submit_views.CheckJobSeekerInformations.as_view(),
+        CheckJobSeekerInformations.as_view(),
         name="step_check_job_seeker_info",
     ),
     path(
@@ -186,9 +189,10 @@ urlpatterns = [
         name="update_job_seeker_step_end_for_hire",
         kwargs={"hire_process": True},
     ),
+    # Ewen: deprecated url. These urls are going to job_seekers_views
     path(
         "<int:company_pk>/hire/<uuid:job_seeker_public_id>/check-infos",
-        submit_views.CheckJobSeekerInformationsForHire.as_view(),
+        CheckJobSeekerInformationsForHire.as_view(),
         name="check_job_seeker_info_for_hire",
         kwargs={"hire_process": True},
     ),

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -280,7 +280,7 @@ def _geiq_eligibility_criteria(
         "allowance_amount": allowance_amount,
         "progress": 66,
         "back_url": reverse(
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             kwargs={"job_seeker_public_id": job_seeker.public_id, "company_pk": company.pk},
         ),
     }

--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -97,6 +97,12 @@ urlpatterns = [
         name="update_job_seeker_step_end_for_hire",
         kwargs={"hire_process": True},
     ),
+    path(
+        "<int:company_pk>/hire/<uuid:job_seeker_public_id>/check-infos",
+        views.CheckJobSeekerInformationsForHire.as_view(),
+        name="check_job_seeker_info_for_hire",
+        kwargs={"hire_process": True},
+    ),
     # For job seeker
     path(
         "<int:company_pk>/job-seeker/check-nir",
@@ -123,5 +129,11 @@ urlpatterns = [
         "<int:company_pk>/update/<uuid:job_seeker_public_id>/end",
         views.UpdateJobSeekerStepEndView.as_view(),
         name="update_job_seeker_step_end",
+    ),
+    # Common
+    path(
+        "<int:company_pk>/create/<uuid:job_seeker_public_id>/check-infos",
+        views.CheckJobSeekerInformations.as_view(),
+        name="check_job_seeker_info",
     ),
 ]

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -102,7 +102,7 @@ class TestApply:
 
         job_seeker = JobSeekerFactory()
         for viewname in (
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             "apply:step_check_prev_applications",
             "apply:application_jobs",
             "apply:application_eligibility",
@@ -149,7 +149,7 @@ class TestApply:
         prescriber = PrescriberFactory()
         client.force_login(prescriber)
         for viewname in (
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             "apply:step_check_prev_applications",
             "apply:application_jobs",
             "apply:application_eligibility",
@@ -210,7 +210,7 @@ class TestHire:
 
         job_seeker = JobSeekerFactory()
         for viewname in (
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             "apply:check_prev_applications_for_hire",
             "apply:eligibility_for_hire",
             "apply:geiq_eligibility_for_hire",
@@ -271,7 +271,7 @@ class TestHire:
         prescriber = PrescriberFactory()
         client.force_login(company.members.first())
         for viewname in (
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             "apply:check_prev_applications_for_hire",
             "apply:eligibility_for_hire",
             "apply:geiq_eligibility_for_hire",
@@ -287,7 +287,7 @@ class TestHire:
         job_seeker = user_with_approval_in_waiting_period()
         client.force_login(company.members.first())
         for viewname in (
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             "apply:check_prev_applications_for_hire",
             "apply:eligibility_for_hire",
             "apply:hire_confirmation",
@@ -388,7 +388,7 @@ class TestApplyAsJobSeeker:
         assert user.jobseeker_profile.nir == nir
 
         next_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": user.public_id},
         )
         assert response.url == next_url
@@ -530,7 +530,7 @@ class TestApplyAsJobSeeker:
         user.jobseeker_profile.refresh_from_db()
         assert not user.jobseeker_profile.nir
         check_job_seeker_info_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": user.public_id},
         )
         assertContains(
@@ -584,7 +584,7 @@ class TestApplyAsJobSeeker:
         response = client.get(next_url)
 
         next_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         assert response.url == next_url
@@ -1810,7 +1810,7 @@ class TestApplyAsPrescriber:
         )
 
         next_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": dummy_job_seeker.public_id},
         )
 
@@ -1912,7 +1912,7 @@ class TestApplyAsPrescriberNirExceptions:
         assertRedirects(
             response,
             reverse(
-                "apply:step_check_job_seeker_info",
+                "job_seekers_views:check_job_seeker_info",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
             ),
             target_status_code=302,
@@ -1970,7 +1970,7 @@ class TestApplyAsPrescriberNirExceptions:
         assertRedirects(
             response,
             reverse(
-                "apply:step_check_job_seeker_info",
+                "job_seekers_views:check_job_seeker_info",
                 kwargs={"company_pk": siae.pk, "job_seeker_public_id": job_seeker.public_id},
             ),
             target_status_code=302,
@@ -2372,7 +2372,7 @@ class TestApplyAsCompany:
         )
 
         next_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": dummy_job_seeker.public_id},
         )
 
@@ -2730,7 +2730,7 @@ class TestDirectHireFullProcess:
         assertTemplateNotUsed(response, "approvals/includes/status.html")
         assertContains(response, "Valider l’embauche")
         check_infos_url = reverse(
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": new_job_seeker.public_id},
         )
         assertContains(response, LINK_RESET_MARKUP % check_infos_url)
@@ -2805,7 +2805,7 @@ class TestDirectHireFullProcess:
 
         response = client.post(check_nir_url, data={"nir": job_seeker.jobseeker_profile.nir, "confirm": 1})
         check_infos_url = reverse(
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         assertRedirects(response, check_infos_url, fetch_redirect_response=False)
@@ -2876,7 +2876,7 @@ class TestDirectHireFullProcess:
         assertTemplateNotUsed(response, "approvals/includes/status.html")
         assertContains(response, "Valider l’embauche")
         check_infos_url = reverse(
-            "apply:check_job_seeker_info_for_hire",
+            "job_seekers_views:check_job_seeker_info_for_hire",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         assertContains(response, LINK_RESET_MARKUP % check_infos_url)
@@ -3805,7 +3805,7 @@ class TestUpdateJobSeekerForHire(UpdateJobSeekerTestMixin):
     STEP_2_VIEW_NAME = "job_seekers_views:update_job_seeker_step_2_for_hire"
     STEP_3_VIEW_NAME = "job_seekers_views:update_job_seeker_step_3_for_hire"
     STEP_END_VIEW_NAME = "job_seekers_views:update_job_seeker_step_end_for_hire"
-    FINAL_REDIRECT_VIEW_NAME = "apply:check_job_seeker_info_for_hire"
+    FINAL_REDIRECT_VIEW_NAME = "job_seekers_views:check_job_seeker_info_for_hire"
 
     def test_anonymous_step_1(self, client):
         response = client.get(self.step_1_url)
@@ -4415,7 +4415,7 @@ class TestCheckPreviousApplicationsView:
         self.company = CompanyFactory(subject_to_eligibility=True, with_membership=True)
         self.job_seeker = JobSeekerFactory()
         self.check_infos_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
         self.check_prev_applications_url = reverse(
@@ -4594,7 +4594,7 @@ class TestFindJobSeekerForHireView:
         assertRedirects(
             response,
             reverse(
-                "apply:check_job_seeker_info_for_hire",
+                "job_seekers_views:check_job_seeker_info_for_hire",
                 kwargs={"company_pk": self.company.pk, "job_seeker_public_id": job_seeker.public_id},
             ),
         )
@@ -4652,7 +4652,7 @@ class TestFindJobSeekerForHireView:
         assertRedirects(
             response,
             reverse(
-                "apply:check_job_seeker_info_for_hire",
+                "job_seekers_views:check_job_seeker_info_for_hire",
                 kwargs={"company_pk": self.company.pk, "job_seeker_public_id": job_seeker.public_id},
             ),
         )
@@ -4716,7 +4716,7 @@ class TestCheckJobSeekerInformationsForHire:
         client.force_login(company.members.first())
         response = client.get(
             reverse(
-                "apply:check_job_seeker_info_for_hire",
+                "job_seekers_views:check_job_seeker_info_for_hire",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
             )
         )
@@ -4759,7 +4759,7 @@ class TestCheckJobSeekerInformationsForHire:
         client.force_login(company.members.first())
         response = client.get(
             reverse(
-                "apply:check_job_seeker_info_for_hire",
+                "job_seekers_views:check_job_seeker_info_for_hire",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
             )
         )
@@ -4869,7 +4869,7 @@ class TestEligibilityForHire:
         response = client.get(self._reverse("apply:eligibility_for_hire"))
         assertContains(response, "Déclarer l’embauche de Ellie GIBILITAY")
         assertContains(response, "Valider l'éligibilité IAE")
-        assertContains(response, self._reverse("apply:check_job_seeker_info_for_hire"))  # cancel button
+        assertContains(response, self._reverse("job_seekers_views:check_job_seeker_info_for_hire"))  # cancel button
 
         criterion1 = AdministrativeCriteria.objects.level1().get(pk=1)
         criterion2 = AdministrativeCriteria.objects.level2().get(pk=5)
@@ -4919,7 +4919,7 @@ class TestGEIQEligibilityForHire:
         response = client.get(self._reverse("apply:geiq_eligibility_for_hire"))
         assertContains(response, "Déclarer l’embauche de Ellie GIBILITAY")
         assertContains(response, "Eligibilité GEIQ")
-        assertContains(response, self._reverse("apply:check_job_seeker_info_for_hire"))  # cancel button
+        assertContains(response, self._reverse("job_seekers_views:check_job_seeker_info_for_hire"))  # cancel button
 
         response = client.post(
             self._reverse("apply:geiq_eligibility_for_hire"),
@@ -4929,7 +4929,7 @@ class TestGEIQEligibilityForHire:
         criteria_url = add_url_params(
             self._reverse("apply:geiq_eligibility_criteria_for_hire"),
             {
-                "back_url": self._reverse("apply:check_job_seeker_info_for_hire"),
+                "back_url": self._reverse("job_seekers_views:check_job_seeker_info_for_hire"),
                 "next_url": self._reverse("apply:hire_confirmation"),
             },
         )

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -555,7 +555,7 @@ class TestApplyAsJobSeeker:
         client.force_login(job_seeker)
 
         check_info_url = reverse(
-            "apply:step_check_job_seeker_info",
+            "job_seekers_views:check_job_seeker_info",
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         # Step apply to company

--- a/tests/www/welcoming_tour/tests.py
+++ b/tests/www/welcoming_tour/tests.py
@@ -113,11 +113,11 @@ class TestWelcomingTourExceptions:
         # another action before signing up.
         assert response.wsgi_request.path not in reverse("welcoming_tour:index")
 
-        # The user is redirected to "apply:step_check_job_seeker_info"
+        # The user is redirected to "job_seekers_views:check_job_seeker_info"
         # as birthdate and pole_emploi_id are missing from the signup form.
         # This is a valid behavior that may change in the future so
         # let's avoid too specific tests.
-        assert response.wsgi_request.path.startswith("/apply")
+        assert response.wsgi_request.path.startswith("/job-seekers")
 
         content = mailoutbox[0].body
         assert next_to in content


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR, on déplace les vues, formulaires et URLs relatives à la vérification des informations (en fin de formulaire) :
- vues, formulaires : déplacés
- URLs : copiés, pour ne pas casser les parcours en cours en production. Les anciennes seront supprimées dans un second temps.

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :desert_island: Comment tester

Seul changement perceptible : les URLs de vérification des infos commencent par `job-seekers` et non plus `apply`.

