### PR TITLE
tests: détection d'erreur de rendu dans les templates Django

### DIFF
--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -123,6 +123,9 @@ class ItouClient(Client):
             assert " ondrop=" not in content
             assert " oninput=" not in content
             assert "<script>" not in content
+            # Detect rendering issues in templates
+            assert "{{" not in content
+            assert "{%" not in content
         return response
 
 

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -100,12 +100,14 @@ def parse_response_to_soup(response, selector=None, no_html_body=False, replace_
     return soup
 
 
-class NoInlineClient(Client):
+class ItouClient(Client):
     def request(self, **request):
-        response = super().request(**request)
+        with TestCase.captureOnCommitCallbacks(execute=True):
+            response = super().request(**request)
         content_type = response["Content-Type"].split(";")[0]
         if content_type == "text/html" and response.content:
             content = response.content.decode(response.charset)
+            # Detect unwanted inline JS
             assert " onclick=" not in content
             assert " onbeforeinput=" not in content
             assert " onbeforeinput=" not in content
@@ -122,12 +124,6 @@ class NoInlineClient(Client):
             assert " oninput=" not in content
             assert "<script>" not in content
         return response
-
-
-class ItouClient(NoInlineClient):
-    def request(self, *args, **kwargs):
-        with TestCase.captureOnCommitCallbacks(execute=True):
-            return super().request(*args, **kwargs)
 
 
 class reload_module(TestContextDecorator):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela aurait attrapé: https://github.com/gip-inclusion/les-emplois/pull/4953/files et ça ne coûte pas bien cher.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
