### PR TITLE
Fiche entreprise: ne pas afficher le boutons "Voir X autres métiers" quand les métiers ne sont pas visibles

### DIFF
--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -119,23 +119,23 @@
                 </ul>
             {% endif %}
         </div>
+        {% if siae.active_job_descriptions|length > 3 %}
+            <div class="c-box--results__footer">
+                <button class="btn btn-link has-collapse-caret btn-block"
+                        type="button"
+                        data-it-collapse-text-show="Voir"
+                        data-it-collapse-text-hide="Masquer"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#collapseMoreJobs_{{ siae.pk }}"
+                        aria-expanded="false"
+                        aria-controls="collapseMoreJobs_{{ siae.pk }}"
+                        aria-label="Voir ou masquer les autres métiers">
+                    les {{ siae.active_job_descriptions|length|add:"-3" }} autres métiers
+                </button>
+            </div>
+        {% endif %}
     {% endif %}
 
-    {% if siae.active_job_descriptions and siae.active_job_descriptions|length > 3 %}
-        <div class="c-box--results__footer">
-            <button class="btn btn-link has-collapse-caret btn-block"
-                    type="button"
-                    data-it-collapse-text-show="Voir"
-                    data-it-collapse-text-hide="Masquer"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#collapseMoreJobs_{{ siae.pk }}"
-                    aria-expanded="false"
-                    aria-controls="collapseMoreJobs_{{ siae.pk }}"
-                    aria-label="Voir ou masquer les autres métiers">
-                les {{ siae.active_job_descriptions|length|add:"-3" }} autres métiers
-            </button>
-        </div>
-    {% endif %}
 
     {% if siae.has_active_members and not siae.block_job_applications and not siae.active_job_descriptions %}
         {% if job_app_to_transfer|default:False %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les règles d'affichage du bouton avec `data-bs-target="#collapseMoreJobs_{{ siae.pk }}"` ne sont pas les mêmes que celle de `<ul class="list-group list-group-flush list-group-link collapse" id="collapseMoreJobs_{{ siae.pk }}">` amenant à des situation où le bouton est présent mais pas sa cible (typiquement si `siae.has_active_members` vaut `False` ou `siae.block_job_applications` vaut `True`.

Trouvé via #5055.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
