### PR TITLE
UX/UI: Suppression de la redirection de repli sur page nouveautés

### DIFF
--- a/itou/templates/announcements/news.html
+++ b/itou/templates/announcements/news.html
@@ -65,6 +65,7 @@
                         </article>
                     </li>
                 {% endfor %}
+                {% if not news_page %}<p>Aucune nouveauté pour le moment.</p>{% endif %}
             </ul>
         </div>
         {% include "includes/pagination.html" with page=news_page %}

--- a/itou/www/announcements/views.py
+++ b/itou/www/announcements/views.py
@@ -1,12 +1,10 @@
 from django.db.models import Count, Prefetch, Q
-from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
 from django.views.generic import TemplateView
 
 from itou.communications.models import AnnouncementCampaign, AnnouncementItem
 from itou.users.enums import UserKind
-from itou.utils.constants import ITOU_HELP_CENTER_URL
 from itou.utils.pagination import pager
 from itou.utils.urls import get_safe_url
 
@@ -27,16 +25,5 @@ class NewsView(TemplateView):
             .order_by("-start_date")
         )
 
-        if not campaigns.count():
-            raise AnnouncementCampaign.DoesNotExist()
-
         news_page = pager(campaigns, self.request.GET.get("page"), items_per_page=12)
         return {"back_url": get_safe_url(self.request, "back_url", reverse("home:hp")), "news_page": news_page}
-
-    def get(self, request, *args, **kwargs):
-        try:
-            return super().get(request, *args, **kwargs)
-        except AnnouncementCampaign.DoesNotExist:
-            # TODO: this redirect can be removed once there is guaranteed news for all users
-            # the purpose is to avoid serving a blank page, on production
-            return redirect(f"{ ITOU_HELP_CENTER_URL }/categories/25225629682321--Nouveaut%C3%A9s")

--- a/tests/www/announcements/__snapshots__/test_views.ambr
+++ b/tests/www/announcements/__snapshots__/test_views.ambr
@@ -156,6 +156,17 @@
                           </article>
                       </li>
                   
+                  
+              </ul>
+          </div>
+  '''
+# ---
+# name: TestNewsRender.test_none_exists[none_exists]
+  '''
+  <div class="s-section__container container">
+              <ul class="list-group list-group-collapse list-group-flush">
+                  
+                  <p>Aucune nouveauté pour le moment.</p>
               </ul>
           </div>
   '''


### PR DESCRIPTION
## :thinking: Pourquoi ?

Maintenant que sur production il y a des nouveautés pour tout type d'utilisateur, on va supprimer la page ancienne des nouveautés du site.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Supprimer toute campagne en local par le site admin ou avec le shell :

```
python manage.py shell_plus
>>> AnnouncementCampaign.objects.all().delete()
```

Visitez la page nouveautés (http://localhost:8000/announcements/news/)

Pour tester la pagination, on peut créer des campagnes d'annonce rapidement avec:

```python
AnnouncementCampaignFactory.create_batch(26, with_items_for_every_user_kind=True)
```

## :computer: Captures d'écran

<img width="397" alt="Screenshot 2024-11-07 at 09 50 57" src="https://github.com/user-attachments/assets/02e6a312-bef1-4f89-bfdf-417ad5074d99">
