### PR TITLE
Robustesse de TestJobDescriptionCardView::test_card_tally_url_with_user

### DIFF
--- a/tests/www/companies_views/test_card_views.py
+++ b/tests/www/companies_views/test_card_views.py
@@ -424,7 +424,7 @@ class TestJobDescriptionCardView:
         soup = parse_response_to_soup(response, selector=".c-box--action")
         assert str(soup) == snapshot(name="without_other_jobs")
         # Create other job_description
-        JobDescriptionFactory(company=job_description.company)
+        JobDescriptionFactory(pk=43, company=job_description.company)
         response = client.get(url)
         soup = parse_response_to_soup(response, selector=".c-box--action")
         assert str(soup) == snapshot(name="with_other_jobs")


### PR DESCRIPTION
The first is set to 42. If the database sequence was at 41, the factory
will use the next available PK (42), which causes:
```
E           django.db.utils.IntegrityError: duplicate key value violates unique constraint "siaes_siaejobdescription_pkey"
E           DETAIL:  Key (id)=(42) already exists.
```
