### PR TITLE
Création de compte candidat : déconnecter la vérification du NIR du parcours `apply`

### DIFF
--- a/itou/templates/apply/submit_step_pending_authorization.html
+++ b/itou/templates/apply/submit_step_pending_authorization.html
@@ -29,8 +29,7 @@
                             <strong>Êtes-vous certain de vouloir continuer ?</strong>
                         </div>
                         {% url 'search:employers_home' as reset_url %}
-                        {% url 'job_seekers_views:check_nir_for_sender' company_pk=siae.pk as primary_url %}
-                        {% itou_buttons_form primary_label="Suivant" primary_url=primary_url reset_url=reset_url %}
+                        {% itou_buttons_form primary_label="Suivant" primary_url=next_url reset_url=reset_url %}
                     </div>
                 </div>
             </div>

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -49,7 +49,7 @@
                         <span>Déclarer une embauche</span>
                     </span>
                 {% else %}
-                    <a href="{% url 'job_seekers_views:check_nir_for_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
+                    <a href="{% url 'apply:start_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
                         <i class="ri-user-follow-line fw-medium"></i>
                         <span>Déclarer une embauche</span>
                     </a>

--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -25,7 +25,7 @@
                     {% else %}
                         Cet espace vous permet d’enregistrer une nouvelle candidature.
                     {% endif %}
-                    Si vous souhaitez déclarer directement une embauche, veuillez vous rendre sur <a href="{% url 'job_seekers_views:check_nir_for_hire' company_pk=siae.pk %}">Déclarer une embauche</a> depuis le tableau de bord.
+                    Si vous souhaitez déclarer directement une embauche, veuillez vous rendre sur <a href="{% url 'apply:start_hire' company_pk=siae.pk %}">Déclarer une embauche</a> depuis le tableau de bord.
                 {% endif %}
             </p>
         {% endif %}

--- a/itou/www/apply/urls.py
+++ b/itou/www/apply/urls.py
@@ -9,6 +9,12 @@ app_name = "apply"
 urlpatterns = [
     # Submit.
     path("<int:company_pk>/start", submit_views.StartView.as_view(), name="start"),
+    path(
+        "<int:company_pk>/hire",
+        submit_views.StartView.as_view(),
+        name="start_hire",
+        kwargs={"hire_process": True},
+    ),
     # Submit - sender.
     path(
         "<int:company_pk>/sender/pending_authorization",

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -306,6 +306,13 @@ class StartView(ApplyStepBaseView):
 class PendingAuthorizationForSender(ApplyStepForSenderBaseView):
     template_name = "apply/submit_step_pending_authorization.html"
 
+    def setup(self, request, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": self.company.pk})
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {"next_url": self.next_url}
+
 
 class CheckPreviousApplications(ApplicationBaseView):
     """

--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -10,7 +10,12 @@ urlpatterns = [
     path("list", views.JobSeekerListView.as_view(), name="list"),
     # TODO(ewen): this URLs will change to new ones without company_pk
     # For sender
-    path("<int:company_pk>/sender/check-nir", views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
+    path("<uuid:session_uuid>/sender/check-nir", views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
+    path(
+        "<int:company_pk>/sender/check-nir",
+        views.DeprecatedCheckNIRForSenderView.as_view(),
+        name="check_nir_for_sender",
+    ),
     path(
         "<int:company_pk>/sender/search-by-email/<uuid:session_uuid>",
         views.SearchByEmailForSenderView.as_view(),
@@ -39,6 +44,12 @@ urlpatterns = [
     # Direct hire process
     path(
         "<int:company_pk>/hire/check-nir",
+        views.DeprecatedCheckNIRForSenderView.as_view(),
+        name="check_nir_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<uuid:session_uuid>/hire/check-nir",
         views.CheckNIRForSenderView.as_view(),
         name="check_nir_for_hire",
         kwargs={"hire_process": True},
@@ -106,6 +117,11 @@ urlpatterns = [
     # For job seeker
     path(
         "<int:company_pk>/job-seeker/check-nir",
+        views.DeprecatedCheckNIRForJobSeekerView.as_view(),
+        name="check_nir_for_job_seeker",
+    ),
+    path(
+        "<uuid:session_uuid>/job-seeker/check-nir",
         views.CheckNIRForJobSeekerView.as_view(),
         name="check_nir_for_job_seeker",
     ),

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -1058,5 +1058,5 @@ class CheckJobSeekerInformationsForHire(ApplicationBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "profile": self.job_seeker.jobseeker_profile,
-            "back_url": reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": self.company.pk}),
+            "back_url": reverse("apply:start_hire", kwargs={"company_pk": self.company.pk}),
         }

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -28,6 +28,16 @@ from itou.common_apps.address.departments import DEPARTMENTS
 BASE_NUM_QUERIES = 2
 
 
+# Used to find the session namespace by elimination
+KNOWN_SESSION_KEYS = {
+    "_auth_user_id",
+    "_auth_user_backend",
+    "_auth_user_hash",
+    "current_organization",
+    "_csrftoken",
+}
+
+
 def pprint_html(response, **selectors):
     """
     Pretty-print HTML responses (or fragment selected with :arg:`selector`)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -92,6 +92,7 @@ class TestApply:
         company = CompanyFactory(with_jobs=True, with_membership=True)
         for viewname in (
             "apply:start",
+            "apply:start_hire",
             "apply:pending_authorization_for_sender",
             "job_seekers_views:check_nir_for_sender",
             "job_seekers_views:check_nir_for_job_seeker",
@@ -204,7 +205,8 @@ class TestApply:
 class TestHire:
     def test_anonymous_access(self, client):
         company = CompanyFactory(with_jobs=True, with_membership=True)
-        url = reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk})
+
+        url = reverse("apply:start_hire", kwargs={"company_pk": company.pk})
         response = client.get(url)
         assertRedirects(response, reverse("account_login") + f"?next={url}")
 
@@ -2446,7 +2448,7 @@ class TestDirectHireFullProcess:
         user = company_1.members.first()
         client.force_login(user)
 
-        response = client.get(reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company_2.pk}))
+        response = client.get(reverse("apply:start_hire", kwargs={"company_pk": company_2.pk}))
         assert response.status_code == 403
 
     def test_hire_as_siae_with_suspension_sanction(self, client):
@@ -2935,6 +2937,7 @@ class TestDirectHireFullProcess:
 class TestApplyAsOther:
     ROUTES = [
         "apply:start",
+        "apply:start_hire",
         "job_seekers_views:check_nir_for_job_seeker",
         "job_seekers_views:check_nir_for_sender",
     ]
@@ -4744,7 +4747,7 @@ class TestCheckJobSeekerInformationsForHire:
 
         assertContains(
             response,
-            reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk}),
+            reverse("apply:start_hire", kwargs={"company_pk": company.pk}),
         )
         assertContains(response, reverse("dashboard:index"))
 

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -65,8 +65,8 @@ class TestDashboardView:
         return reverse("apply:start", kwargs={"company_pk": company.pk})
 
     @staticmethod
-    def check_nir_for_hire_url(company):
-        return reverse("job_seekers_views:check_nir_for_hire", kwargs={"company_pk": company.pk})
+    def apply_start_hire_url(company):
+        return reverse("apply:start_hire", kwargs={"company_pk": company.pk})
 
     def test_dashboard(self, client, snapshot):
         company = CompanyFactory(with_membership=True)
@@ -290,7 +290,7 @@ class TestDashboardView:
                 assertContains(response, APPLICATION_SAVE_LABEL)
                 assertContains(response, self.apply_start_url(company))
                 assertContains(response, self.HIRE_LINK_LABEL)
-                assertContains(response, self.check_nir_for_hire_url(company))
+                assertContains(response, self.apply_start_hire_url(company))
 
         for kind in set(CompanyKind) - set(display_kinds):
             with subtests.test(f"should not display when company_kind={kind}"):
@@ -301,7 +301,7 @@ class TestDashboardView:
                 assertNotContains(response, APPLICATION_SAVE_LABEL)
                 assertNotContains(response, self.apply_start_url(company))
                 assertNotContains(response, self.HIRE_LINK_LABEL)
-                assertNotContains(response, self.check_nir_for_hire_url(company))
+                assertNotContains(response, self.apply_start_hire_url(company))
 
     def test_dashboard_agreements_with_suspension_sanction(self, client):
         company = CompanyFactory(subject_to_eligibility=True, with_membership=True)

--- a/tests/www/job_seekers_views/test_create.py
+++ b/tests/www/job_seekers_views/test_create.py
@@ -1,0 +1,80 @@
+import datetime
+
+from django.urls import reverse
+from pytest_django.asserts import assertContains, assertRedirects
+
+from tests.companies.factories import CompanyFactory
+from tests.users.factories import (
+    JobSeekerFactory,
+)
+from tests.utils.test import KNOWN_SESSION_KEYS
+
+
+class TestCreateForJobSeeker:
+    def test_check_nir_with_session(self, client):
+        company = CompanyFactory(with_membership=True)
+        user = JobSeekerFactory(jobseeker_profile__birthdate=None, jobseeker_profile__nir="")
+        reset_url = reverse("companies_views:card", kwargs={"siae_id": company.pk})
+        client.force_login(user)
+
+        # Init session
+        start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
+        client.get(start_url)
+        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"session_uuid": job_seeker_session_name})
+        )
+
+        assertContains(response, company.display_name)
+        assertContains(
+            response,
+            f"""
+        <a href="{reset_url}" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto"
+           aria-label="Annuler la saisie de ce formulaire">
+            <i class="ri-close-line ri-lg" aria-hidden="true"></i>
+            <span>Annuler</span>
+        </a>""",
+            html=True,
+        )
+
+    def test_cannot_check_nir_if_already_set(self, client):
+        company = CompanyFactory(with_membership=True)
+        user = JobSeekerFactory(
+            jobseeker_profile__birthdate=datetime.date(1994, 2, 22), jobseeker_profile__nir="194022734304328"
+        )
+        client.force_login(user)
+
+        # Init session
+        start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
+        client.get(start_url)
+        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"session_uuid": job_seeker_session_name})
+        )
+        assertRedirects(
+            response,
+            reverse(
+                "job_seekers_views:check_job_seeker_info",
+                kwargs={"company_pk": company.pk, "job_seeker_public_id": user.public_id},
+            ),
+        )
+
+
+class TestCreateForSender:
+    def test_check_nir_with_session(self, client):
+        company = CompanyFactory(with_membership=True)
+        user = JobSeekerFactory(jobseeker_profile__birthdate=None, jobseeker_profile__nir="")
+        client.force_login(user)
+
+        # Init session
+        start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
+        client.get(start_url)
+        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+
+        response = client.get(
+            reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"session_uuid": job_seeker_session_name})
+        )
+
+        assertContains(response, company.display_name)


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR, on déconnecte l'étape de vérification du NIR du parcours de candidature. En effet, les vues `CheckNirForJobSeekerView` et `CheckNirForSenderView` héritaient de classes dans `apply`.

**À noter :** 
Pour ne pas casser les parcours de candidature en cours en production, nous devons temporairement avoir 2 jeux d'URLs fonctionnels :
    - avec une session (eg. `<uuid:session_uuid>/sender/check-nir`) pour les nouvelles vues
    - avec `company_pk` (eg. `<int:company_pk>/sender/check-nir`) (pointant vers les anciennes vues, dépréciées, pour en garder temporairement le mécanisme)

--- 

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657


## :cake: Comment ? <!-- optionnel -->

On utilise une session (`job_seeker_session`) dès le début du parcours de création de compte candidat. Cette session contient les informations du candidat (`job_seeker_session["profile"]`), remplies petit à petit dans les différentes vues. Elle contient aussi les informations permettant de connecter ce bloc à d'autres blocs (`job_seeker_session["_config"]`, contenant `back_url`, `reset_url`, `next_url`).

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?


