### PR TITLE
Invitations: utiliser automatiquement toutes les invitations valides disponibles à la connexion [GEN-2221]

### DIFF
--- a/itou/openid_connect/inclusion_connect/views.py
+++ b/itou/openid_connect/inclusion_connect/views.py
@@ -18,6 +18,7 @@ from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.constants import ITOU_HELP_CENTER_URL
 from itou.utils.urls import add_url_params, get_absolute_url
+from itou.www.invitations_views.helpers import accept_all_pending_invitations
 
 from ..errors import redirect_with_error_sso_email_conflict_on_registration
 from ..models import (
@@ -348,6 +349,8 @@ def inclusion_connect_callback(request):
     # reattach prescriber session
     if prescriber_session_data := ic_state.data.get("prescriber_session_data"):
         request.session.update(prescriber_session_data)
+
+    accept_all_pending_invitations(request)
 
     next_url = ic_state.data["next_url"] or get_adapter(request).get_login_redirect_url(request)
     return HttpResponseRedirect(next_url)

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -19,6 +19,7 @@ from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.constants import ITOU_HELP_CENTER_URL
 from itou.utils.urls import add_url_params, get_absolute_url
+from itou.www.invitations_views.helpers import accept_all_pending_invitations
 
 from ..errors import redirect_with_error_sso_email_conflict_on_registration
 from ..models import (
@@ -297,6 +298,8 @@ def pro_connect_callback(request):
     # reattach prescriber session
     if prescriber_session_data := pro_connect_state.data.get("prescriber_session_data"):
         request.session.update(prescriber_session_data)
+
+    accept_all_pending_invitations(request)
 
     next_url = pro_connect_state.data["next_url"] or get_adapter(request).get_login_redirect_url(request)
     return HttpResponseRedirect(next_url)

--- a/itou/www/invitations_views/helpers.py
+++ b/itou/www/invitations_views/helpers.py
@@ -1,0 +1,66 @@
+from django.contrib import messages
+from django.core.exceptions import PermissionDenied
+
+from itou.invitations.models import EmployerInvitation, LaborInspectorInvitation, PrescriberWithOrgInvitation
+from itou.users.enums import UserKind
+
+
+def handle_prescriber_intivation(invitation, request):
+    if not invitation.guest_can_join_organization(request):
+        raise PermissionDenied()
+
+    if invitation.can_be_accepted:
+        invitation.add_invited_user_to_organization()
+        # Send an email after the model changes
+        invitation.accept()
+        messages.success(
+            request, f"Vous êtes désormais membre de l'organisation {invitation.organization.display_name}."
+        )
+    elif not invitation.accepted_at:
+        messages.error(request, "Cette invitation n'est plus valide.")
+
+
+def handle_employer_invitation(invitation, request):
+    if not invitation.guest_can_join_company(request):
+        raise PermissionDenied()
+
+    if not invitation.company.is_active:
+        messages.error(request, "Cette structure n'est plus active.")
+    elif invitation.can_be_accepted:
+        invitation.add_invited_user_to_company()
+        invitation.accept()
+        messages.success(request, f"Vous êtes désormais membre de la structure {invitation.company.display_name}.")
+    elif not invitation.accepted_at:
+        messages.error(request, "Cette invitation n'est plus valide.")
+
+
+def handle_labor_inspector_invitation(invitation, request):
+    if not invitation.guest_can_join_institution(request):
+        raise PermissionDenied()
+
+    if invitation.can_be_accepted:
+        invitation.add_invited_user_to_institution()
+        invitation.accept()
+        messages.success(
+            request, f"Vous êtes désormais membre de l'organisation {invitation.institution.display_name}."
+        )
+    elif not invitation.accepted_at:
+        messages.error(request, "Cette invitation n'est plus valide.")
+
+
+def accept_all_pending_invitations(request):
+    if not request.user.is_authenticated:
+        return False
+
+    MAPPING = {
+        UserKind.PRESCRIBER: (PrescriberWithOrgInvitation, handle_prescriber_intivation),
+        UserKind.EMPLOYER: (EmployerInvitation, handle_employer_invitation),
+        UserKind.LABOR_INSPECTOR: (LaborInspectorInvitation, handle_labor_inspector_invitation),
+    }
+
+    InvitationModel, handle_invitation = MAPPING[request.user.kind]
+
+    invitations = list(InvitationModel.objects.pending().filter(email=request.user.email))
+    for invitation in invitations:
+        handle_invitation(invitation, request)
+    return invitations

--- a/tests/invitations/factories.py
+++ b/tests/invitations/factories.py
@@ -5,41 +5,65 @@ from django.utils import timezone
 
 from itou.invitations import models
 from tests.companies.factories import CompanyFactory
+from tests.institutions.factories import InstitutionWithMembershipFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
-from tests.users.factories import EmployerFactory, PrescriberFactory
 
 
 class EmployerInvitationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.EmployerInvitation
 
+    class Params:
+        expired = factory.Trait(
+            sent_at=factory.LazyFunction(
+                lambda: timezone.now() - timedelta(days=models.InvitationAbstract.DEFAULT_VALIDITY_DAYS)
+            )
+        )
+
     email = factory.Sequence("email{}@employer.com".format)
     first_name = factory.Sequence("first_name{}".format)
     last_name = factory.Sequence("last_name{}".format)
-    sender = factory.SubFactory(EmployerFactory)
-    company = factory.SubFactory(CompanyFactory, with_membership=True)
-
-
-class SentEmployerInvitationFactory(EmployerInvitationFactory):
     sent = True
     sent_at = factory.LazyFunction(timezone.now)
-
-
-class ExpiredEmployerInvitationFactory(EmployerInvitationFactory):
-    sent = True
-    sent_at = factory.LazyFunction(
-        lambda: timezone.now() - timedelta(days=models.InvitationAbstract.DEFAULT_VALIDITY_DAYS)
-    )
+    company = factory.SubFactory(CompanyFactory, with_membership=True)
+    sender = factory.LazyAttribute(lambda o: o.company.members.first())
 
 
 class PrescriberWithOrgSentInvitationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.PrescriberWithOrgInvitation
 
+    class Params:
+        expired = factory.Trait(
+            sent_at=factory.LazyFunction(
+                lambda: timezone.now() - timedelta(days=models.InvitationAbstract.DEFAULT_VALIDITY_DAYS)
+            )
+        )
+
     email = factory.Faker("email", locale="fr_FR")
     first_name = factory.Faker("first_name", locale="fr_FR")
     last_name = factory.Faker("last_name", locale="fr_FR")
-    sender = factory.SubFactory(PrescriberFactory)
     sent = True
     sent_at = factory.LazyFunction(timezone.now)
     organization = factory.SubFactory(PrescriberOrganizationWithMembershipFactory)
+    sender = factory.LazyAttribute(lambda o: o.organization.members.first())
+
+
+class LaborInspectorInvitationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.LaborInspectorInvitation
+
+    class Params:
+        expired = factory.Trait(
+            sent_at=factory.LazyFunction(
+                lambda: timezone.now() - timedelta(days=models.InvitationAbstract.DEFAULT_VALIDITY_DAYS)
+            )
+        )
+
+    email = factory.Sequence("email{}@employer.com".format)
+    first_name = factory.Sequence("first_name{}".format)
+    last_name = factory.Sequence("last_name{}".format)
+    sent = True
+    sent_at = factory.LazyFunction(timezone.now)
+    institution = factory.SubFactory(InstitutionWithMembershipFactory)
+    sender = factory.LazyAttribute(lambda o: o.institution.members.first())

--- a/tests/www/invitations_views/test_helpers.py
+++ b/tests/www/invitations_views/test_helpers.py
@@ -1,0 +1,78 @@
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from django.utils import timezone
+
+from itou.www.invitations_views.helpers import accept_all_pending_invitations
+from tests.invitations.factories import (
+    EmployerInvitationFactory,
+    LaborInspectorInvitationFactory,
+    PrescriberWithOrgSentInvitationFactory,
+)
+from tests.users.factories import EmployerFactory, LaborInspectorFactory, PrescriberFactory
+from tests.utils.tests import get_response_for_middlewaremixin
+
+
+def test_anonymous_user():
+    request = RequestFactory()
+    request.user = AnonymousUser()
+    assert accept_all_pending_invitations(request) == 0
+
+
+def fake_request():
+    request = RequestFactory().get("/")
+    SessionMiddleware(get_response_for_middlewaremixin).process_request(request)
+    MessageMiddleware(get_response_for_middlewaremixin).process_request(request)
+    return request
+
+
+def test_accept_prescriber_invitations():
+    request = fake_request()
+    prescriber = PrescriberFactory()
+    request.user = prescriber
+
+    valid_invitation_1 = PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+    valid_invitation_2 = PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+    # non pending invitations
+    PrescriberWithOrgSentInvitationFactory(email=prescriber.email, expired=True)
+    PrescriberWithOrgSentInvitationFactory(email=prescriber.email, accepted=True, accepted_at=timezone.now())
+    # other user kind invitations
+    EmployerInvitationFactory(email=prescriber.email)
+    LaborInspectorInvitationFactory(email=prescriber.email)
+
+    assert accept_all_pending_invitations(request) == [valid_invitation_1, valid_invitation_2]
+
+
+def test_accept_employer_invitations():
+    request = fake_request()
+    prescriber = EmployerFactory()
+    request.user = prescriber
+
+    valid_invitation_1 = EmployerInvitationFactory(email=prescriber.email)
+    valid_invitation_2 = EmployerInvitationFactory(email=prescriber.email)
+    # non pending invitations
+    EmployerInvitationFactory(email=prescriber.email, expired=True)
+    EmployerInvitationFactory(email=prescriber.email, accepted=True, accepted_at=timezone.now())
+    # other user kind invitations
+    PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+    LaborInspectorInvitationFactory(email=prescriber.email)
+
+    assert accept_all_pending_invitations(request) == [valid_invitation_1, valid_invitation_2]
+
+
+def test_accept_labor_inspector_invitations():
+    request = fake_request()
+    prescriber = LaborInspectorFactory()
+    request.user = prescriber
+
+    valid_invitation_1 = LaborInspectorInvitationFactory(email=prescriber.email)
+    valid_invitation_2 = LaborInspectorInvitationFactory(email=prescriber.email)
+    # non pending invitations
+    LaborInspectorInvitationFactory(email=prescriber.email, expired=True)
+    LaborInspectorInvitationFactory(email=prescriber.email, accepted=True, accepted_at=timezone.now())
+    # other user kind invitations
+    EmployerInvitationFactory(email=prescriber.email)
+    PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+
+    assert accept_all_pending_invitations(request) == [valid_invitation_1, valid_invitation_2]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela permet d'être sur que les prescripteurs et employeurs utilisant ProConnect et Inclusion Connect soient correctement associés à leur structures.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
