### PR TITLE
GPS: Mise en page de la liste des bénéficiaires

### DIFF
--- a/itou/templates/gps/includes/memberships_results.html
+++ b/itou/templates/gps/includes/memberships_results.html
@@ -3,10 +3,10 @@
 
 <section aria-labelledby="results" id="follow-up-groups-section">
     {% if not memberships_page %}
-        <div class="my-3 my-md-4 s-box__row row membership-card">Aucun résultat.</div>
+        <div class="my-3 my-md-4 px-3 s-box__row row membership-card">Aucun résultat.</div>
     {% else %}
         {% for membership in memberships_page %}
-            <div class="my-3 my-md-4 s-box__row row membership-card">
+            <div class="my-3 my-md-4 pt-0 s-box__row row membership-card">
                 <div class="c-box--results__header">
 
                     <div class="c-box--results__summary">
@@ -20,7 +20,7 @@
 
                 <hr class="m-0 pb-4" />
 
-                <div class="d-flex justify-content-between mb-4">
+                <div class="d-flex justify-content-between mb-4 ps-4">
                     <div>
                         {% with membership.nb_members|add:"-1" as counter %}
                             <div>
@@ -40,82 +40,75 @@
                         {% endwith %}
                     </div>
 
-
                 </div>
-                <div class="d-flex justify-content-between">
+                <div class="d-flex flex-column flex-md-row gap-3 ps-4 justify-content-between">
 
                     {% with membership.follow_up_group.beneficiary.public_id as public_id %}
-                        <div>
+                        {% url 'gps:leave_group' group_id=membership.follow_up_group.id as leave_group_url %}
+                        <a href="{% url 'users:details' public_id=public_id %}"
+                           class="btn btn-warning btn-block w-100 w-md-auto btn-ico me-auto"
+                           aria-label="Ne plus suivre {{ membership.follow_up_group.beneficiary.get_full_name }}"
+                           data-bs-toggle="modal"
+                           data-bs-target="#confirm_modal"
+                           data-bs-title="Êtes-vous sûr de ne plus vouloir suivre {{ membership.follow_up_group.beneficiary.get_full_name }} ?"
+                           data-bs-body="Vous pourrez toujours suivre ce bénéficiaire de nouveau plus tard."
+                           data-bs-confirm-text="Ne plus suivre"
+                           data-bs-confirm-url="{{ leave_group_url }}"
+                           data-bs-confirm-class="btn-danger">
+                            <i class="ri-user-unfollow-line" aria-hidden="true"></i>
+                            <span>Ne plus suivre</span>
 
-                            {% url 'gps:leave_group' group_id=membership.follow_up_group.id as leave_group_url %}
-                            <a href="{% url 'users:details' public_id=public_id %}"
+                        </a>
+
+
+                        {% if membership.is_referent %}
+
+                            {% url 'gps:toggle_referent' group_id=membership.follow_up_group.id as remove_referent_url %}
+                            <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}"
                                class="btn btn-warning btn-block w-100 w-md-auto btn-ico"
-                               aria-label="Ne plus suivre {{ membership.follow_up_group.beneficiary.get_full_name }}"
+                               aria-label="Ne plus être référent de {{ membership.follow_up_group.beneficiary.get_full_name }}"
                                data-bs-toggle="modal"
                                data-bs-target="#confirm_modal"
-                               data-bs-title="Êtes-vous sûr de ne plus vouloir suivre {{ membership.follow_up_group.beneficiary.get_full_name }} ?"
-                               data-bs-body="Vous pourrez toujours suivre ce bénéficiaire de nouveau plus tard."
-                               data-bs-confirm-text="Ne plus suivre"
-                               data-bs-confirm-url="{{ leave_group_url }}"
+                               data-bs-title="Êtes-vous sûr de ne plus vouloir être référent de {{ membership.follow_up_group.beneficiary.get_full_name }} ?"
+                               data-bs-body="Vous pourrez toujours devenir référent de ce bénéficiaire plus tard."
+                               data-bs-confirm-text="Ne plus être référent"
+                               data-bs-confirm-url="{{ remove_referent_url }}"
                                data-bs-confirm-class="btn-danger">
-                                <i class="ri-user-unfollow-line" aria-hidden="true"></i>
-                                <span>Ne plus suivre</span>
+
+                                <i class="ri-map-pin-user-line fw-normal me-1" aria-hidden="true"></i>
+                                <span>Ne plus être référent</span>
 
                             </a>
 
+                        {% endif %}
 
-                            {% if membership.is_referent %}
+                        {% if not membership.is_referent %}
+                            {% url 'gps:toggle_referent' group_id=membership.follow_up_group.id as add_referent_url %}
 
-                                {% url 'gps:toggle_referent' group_id=membership.follow_up_group.id as remove_referent_url %}
-                                <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}"
-                                   class="btn btn-warning btn-block w-100 w-md-auto btn-ico"
-                                   aria-label="Ne plus être référent de {{ membership.follow_up_group.beneficiary.get_full_name }}"
-                                   data-bs-toggle="modal"
-                                   data-bs-target="#confirm_modal"
-                                   data-bs-title="Êtes-vous sûr de ne plus vouloir être référent de {{ membership.follow_up_group.beneficiary.get_full_name }} ?"
-                                   data-bs-body="Vous pourrez toujours devenir référent de ce bénéficiaire plus tard."
-                                   data-bs-confirm-text="Ne plus être référent"
-                                   data-bs-confirm-url="{{ remove_referent_url }}"
-                                   data-bs-confirm-class="btn-danger">
+                            <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}"
+                               class="btn btn-outline-success btn-block w-100 w-md-auto btn-ico"
+                               aria-label="Devenir référent de {{ membership.follow_up_group.beneficiary.get_full_name }}"
+                               data-bs-toggle="modal"
+                               data-bs-target="#confirm_modal"
+                               data-bs-title="Êtes-vous sûr de vouloir devenir référent de {{ membership.follow_up_group.beneficiary.get_full_name }} ?"
+                               data-bs-body="Vous pourrez toujours ne plus être référent de ce bénéficiaire plus tard."
+                               data-bs-confirm-text="Devenir référent"
+                               data-bs-confirm-url="{{ add_referent_url }}"
+                               data-bs-confirm-class="btn-success">
 
-                                    <i class="ri-map-pin-user-line fw-normal me-1" aria-hidden="true"></i>
-                                    <span>Ne plus être référent</span>
+                                <i class="ri-map-pin-user-line fw-normal me-1" aria-hidden="true"></i>
+                                <span>Devenir référent</span>
 
-                                </a>
-
-                            {% endif %}
-                        </div>
-
-
-                        <div>
-                            {% if not membership.is_referent %}
-                                {% url 'gps:toggle_referent' group_id=membership.follow_up_group.id as add_referent_url %}
-
-                                <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}"
-                                   class="btn btn-outline-success btn-block w-100 w-md-auto btn-ico"
-                                   aria-label="Devenir référent de {{ membership.follow_up_group.beneficiary.get_full_name }}"
-                                   data-bs-toggle="modal"
-                                   data-bs-target="#confirm_modal"
-                                   data-bs-title="Êtes-vous sûr de vouloir devenir référent de {{ membership.follow_up_group.beneficiary.get_full_name }} ?"
-                                   data-bs-body="Vous pourrez toujours ne plus être référent de ce bénéficiaire plus tard."
-                                   data-bs-confirm-text="Devenir référent"
-                                   data-bs-confirm-url="{{ add_referent_url }}"
-                                   data-bs-confirm-class="btn-success">
-
-                                    <i class="ri-map-pin-user-line fw-normal me-1" aria-hidden="true"></i>
-                                    <span>Devenir référent</span>
-
-                                </a>
-
-                            {% endif %}
-                            <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}?back_url={{ request.get_full_path|urlencode }}"
-                               class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto"
-                               aria-label="Consulter la fiche de {{ membership.follow_up_group.beneficiary.get_full_name }}"
-                               {% matomo_event "GPS_liste_groupes" "clic" "consulter_fiche_candidat" %}>
-                                <i class="ri-eye-line ri-xl fw-medium" aria-hidden="true"></i>
-                                <span>Consulter la fiche</span>
                             </a>
-                        </div>
+
+                        {% endif %}
+                        <a href="{% url 'users:details' public_id=membership.follow_up_group.beneficiary.public_id %}?back_url={{ request.get_full_path|urlencode }}"
+                           class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto"
+                           aria-label="Consulter la fiche de {{ membership.follow_up_group.beneficiary.get_full_name }}"
+                           {% matomo_event "GPS_liste_groupes" "clic" "consulter_fiche_candidat" %}>
+                            <i class="ri-eye-line ri-xl fw-medium" aria-hidden="true"></i>
+                            <span>Consulter la fiche</span>
+                        </a>
                     {% endwith %}
 
                 </div>

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -5,55 +5,46 @@
 {% load str_filters %}
 {% load tally %}
 
-{% block title %}Mes bénéficiaires {{ block.super }}{% endblock %}
-
-{% block title_content %}<h1>Mes bénéficiaires</h1>{% endblock %}
+{% block title %}GPS - Mes bénéficiaires {{ block.super }}{% endblock %}
 
 {% block title_prevstep %}
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
+{% block title_content %}
+    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between align-items-md-center">
+        <h1 class="m-0">Mes bénéficiaires</h1>
+        <div class="d-flex flex-column flex-md-row gap-md-3" role="group" aria-label="Actions sur les groupes de suivi">
+            <a href='{% tally_form_url form_id="w5kLqM" user_public_id=user.public_id user_first_name=user.first_name user_last_name=user.last_name %}&{% if request.current_organization %}&user_organization_uid={{ request.current_organization.uid }}&user_organization_name={{ request.current_organization.display_name }}{% endif %}'
+               rel="noopener"
+               target="_blank"
+               class="btn btn-lg btn-ico btn-secondary mt-3 mt-md-0"
+               aria-label="Inviter un partenaire"
+               {% matomo_event "gps" "clic" "liste_benef_inviter_partenaire" %}>
+                <i class="ri-mail-send-line" aria-hidden="true"></i>
+                <span>Inviter un partenaire</span>
+            </a>
+            <a href="{% url 'gps:join_group' %}" class="btn btn-lg btn-ico btn-primary mt-3 mt-md-0" aria-label="Suivre un nouveau bénéficiaire" {% matomo_event "GPS_liste_groupes" "clic" "ajout_groupe" %}>
+                <i class="ri-user-add-line" aria-hidden="true"></i>
+                <span>Ajouter un bénéficiaire</span>
+            </a>
+        </div>
+    </div>
+{% endblock %}
+
+
 {% block content %}
-    <section class="s-box" id="gps-my-groups">
-        <div class="s-box__container container">
-            <div class="s-box__row row">
+    <section class="s-secion" id="gps-my-groups">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
                 <div class="col-12">
-                    <div class="alert alert-info alert-dismissible fade show" role="status">
-                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-                        <div class="row">
-                            <div class="col-auto pe-0">
-                                <i class="ri-mail-send-line ri-xl text-info" aria-hidden="true"></i>
-                            </div>
-                            <div class="col">
-                                <p class="mb-2">
-                                    <strong>Inviter un partenaire</strong>
-                                </p>
-                                <p class="mb-0">
-                                    Invitez un partenaire à rejoindre l’expérimentation GPS pour suivre ses propres bénéficiaires. Votre partenaire recevra un email de votre part afin de créer son compte.
-                                </p>
-                            </div>
-                            <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                                <a href='{% tally_form_url form_id="w5kLqM" user_public_id=user.public_id user_first_name=user.first_name user_last_name=user.last_name %}&{% if request.current_organization %}&user_organization_uid={{ request.current_organization.uid }}&user_organization_name={{ request.current_organization.display_name }}{% endif %}'
-                                   rel="noopener"
-                                   target="_blank"
-                                   aria-label="Inviter un partenaire."
-                                   class="btn btn-sm btn-primary"
-                                   {% matomo_event "gps" "clic" "liste_benef_inviter_partenaire" %}>
-                                    <span>Inviter un partenaire</span>
-                                    <i class="ri-external-link-line fw-normal ms-2"></i>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-12">
-                    <div class="d-flex flex-column flex-md-row my-3 my-md-4">
+                    <div class="d-flex flex-column flex-md-row my-3 my-md-4 gap-3 align-items-md-center">
                         <h3 class="h4 mb-0 flex-grow-1" id="results">
                             {% with memberships_page.paginator.count as counter %}
                                 {{ counter }} bénéficiaire{{ counter|pluralizefr }} suivi{{ counter|pluralizefr }}
                             {% endwith %}
                         </h3>
-                        <form class="px-3"
+                        <form class="px-md-3"
                               hx-get="{{ request.path }}"
                               hx-trigger="change delay:.5s, duetChange delay:.5s, change from:#id_beneficiary"
                               hx-indicator="#follow-up-groups-section"
@@ -63,12 +54,6 @@
                               hx-push-url="true">
                             {% bootstrap_field filters_form.beneficiary wrapper_class="w-lg-400px" show_label=False %}
                         </form>
-                        <div class="btn-group btn-group-sm btn-group-action" role="group" aria-label="Actions sur les groupes de suivi">
-                            <a href="{% url 'gps:join_group' %}" class="btn btn-ico btn-primary mt-3 mt-md-0" aria-label="Rejoindre un group de suivi" {% matomo_event "GPS_liste_groupes" "clic" "ajout_groupe" %}>
-                                <i class="ri-user-add-line" aria-hidden="true"></i>
-                                <span>Ajouter un bénéficiaire</span>
-                            </a>
-                        </div>
                     </div>
                 </div>
                 <div class="col-12">{% include "gps/includes/memberships_results.html" with memberships_page=memberships_page %}</div>

--- a/itou/templates/users/details.html
+++ b/itou/templates/users/details.html
@@ -3,7 +3,7 @@
 {% load str_filters %}
 {% load format_filters %}
 
-{% block title %}Profil de {{ beneficiary.get_full_name }} {{ block.super }}{% endblock %}
+{% block title %}GPS - Profil de {{ beneficiary.get_full_name }} {{ block.super }}{% endblock %}
 
 {% block title_content %}<h1>{{ beneficiary.get_full_name }}</h1>{% endblock %}
 

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -265,7 +265,7 @@
 # ---
 # name: test_my_groups[test_my_groups__group_card]
   '''
-  <div class="my-3 my-md-4 s-box__row row membership-card">
+  <div class="my-3 my-md-4 pt-0 s-box__row row membership-card">
                   <div class="c-box--results__header">
   
                       <div class="c-box--results__summary">
@@ -279,7 +279,7 @@
   
                   <hr class="m-0 pb-4"/>
   
-                  <div class="d-flex justify-content-between mb-4">
+                  <div class="d-flex justify-content-between mb-4 ps-4">
                       <div>
                           
                               <div>
@@ -297,42 +297,35 @@
                           
                       </div>
   
-  
                   </div>
-                  <div class="d-flex justify-content-between">
+                  <div class="d-flex flex-column flex-md-row gap-3 ps-4 justify-content-between">
   
                       
-                          <div>
+                          
+                          <a aria-label="Ne plus suivre Jane DOE" class="btn btn-warning btn-block w-100 w-md-auto btn-ico me-auto" data-bs-body="Vous pourrez toujours suivre ce bénéficiaire de nouveau plus tard." data-bs-confirm-class="btn-danger" data-bs-confirm-text="Ne plus suivre" data-bs-confirm-url="/gps/groups/[PK of Group]/leave" data-bs-target="#confirm_modal" data-bs-title="Êtes-vous sûr de ne plus vouloir suivre Jane DOE ?" data-bs-toggle="modal" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a">
+                              <i aria-hidden="true" class="ri-user-unfollow-line"></i>
+                              <span>Ne plus suivre</span>
   
+                          </a>
+  
+  
+                          
+  
+                          
                               
-                              <a aria-label="Ne plus suivre Jane DOE" class="btn btn-warning btn-block w-100 w-md-auto btn-ico" data-bs-body="Vous pourrez toujours suivre ce bénéficiaire de nouveau plus tard." data-bs-confirm-class="btn-danger" data-bs-confirm-text="Ne plus suivre" data-bs-confirm-url="/gps/groups/[PK of Group]/leave" data-bs-target="#confirm_modal" data-bs-title="Êtes-vous sûr de ne plus vouloir suivre Jane DOE ?" data-bs-toggle="modal" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a">
-                                  <i aria-hidden="true" class="ri-user-unfollow-line"></i>
-                                  <span>Ne plus suivre</span>
+  
+                              <a aria-label="Devenir référent de Jane DOE" class="btn btn-outline-success btn-block w-100 w-md-auto btn-ico" data-bs-body="Vous pourrez toujours ne plus être référent de ce bénéficiaire plus tard." data-bs-confirm-class="btn-success" data-bs-confirm-text="Devenir référent" data-bs-confirm-url="/gps/groups/[PK of Group]/toggle_referent" data-bs-target="#confirm_modal" data-bs-title="Êtes-vous sûr de vouloir devenir référent de Jane DOE ?" data-bs-toggle="modal" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a">
+  
+                                  <i aria-hidden="true" class="ri-map-pin-user-line fw-normal me-1"></i>
+                                  <span>Devenir référent</span>
   
                               </a>
   
-  
-                              
-                          </div>
-  
-  
-                          <div>
-                              
-                                  
-  
-                                  <a aria-label="Devenir référent de Jane DOE" class="btn btn-outline-success btn-block w-100 w-md-auto btn-ico" data-bs-body="Vous pourrez toujours ne plus être référent de ce bénéficiaire plus tard." data-bs-confirm-class="btn-success" data-bs-confirm-text="Devenir référent" data-bs-confirm-url="/gps/groups/[PK of Group]/toggle_referent" data-bs-target="#confirm_modal" data-bs-title="Êtes-vous sûr de vouloir devenir référent de Jane DOE ?" data-bs-toggle="modal" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a">
-  
-                                      <i aria-hidden="true" class="ri-map-pin-user-line fw-normal me-1"></i>
-                                      <span>Devenir référent</span>
-  
-                                  </a>
-  
-                              
-                              <a aria-label="Consulter la fiche de Jane DOE" class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="GPS_liste_groupes" data-matomo-event="true" data-matomo-option="consulter_fiche_candidat" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/gps/groups">
-                                  <i aria-hidden="true" class="ri-eye-line ri-xl fw-medium"></i>
-                                  <span>Consulter la fiche</span>
-                              </a>
-                          </div>
+                          
+                          <a aria-label="Consulter la fiche de Jane DOE" class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="GPS_liste_groupes" data-matomo-event="true" data-matomo-option="consulter_fiche_candidat" href="/users/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/gps/groups">
+                              <i aria-hidden="true" class="ri-eye-line ri-xl fw-medium"></i>
+                              <span>Consulter la fiche</span>
+                          </a>
                       
   
                   </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La proximité du bouton "Ajouter un bénéficiaire" avec le filtre de la liste créait de la confusion pour les utilisateurs (cf. [retours au support](https://plateforme-inclusion.zendesk.com/agent/tickets/21700)).

## :cake: Comment ?

Passer les principaux boutons d'action dans le header (sur le modèle, par exemple, de [la liste des candidatures reçues](https://github.com/gip-inclusion/les-emplois/blob/18a7a0f9e600fa1c8b2bb7656b4b030ce7bf1e2f/itou/templates/apply/list_for_siae.html#L4)).

On en profite pour résoudre des bugs visuels sur les petites tailles d'écran.

## :computer: Captures d'écran

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/b3d8a0a5-ebfd-4328-92d8-89d43aa04412">
