### PR TITLE
Pilotage : Rajouter l'export de la table marché financier du flux IAE

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_fluxiae.py
+++ b/itou/metabase/management/commands/populate_metabase_fluxiae.py
@@ -101,6 +101,7 @@ class Command(BaseCommand):
         self.populate_fluxiae_view(vue_name="fluxIAE_Financement")
         self.populate_fluxiae_view(vue_name="fluxIAE_Formations")
         self.populate_fluxiae_view(vue_name="fluxIAE_Missions")
+        self.populate_fluxiae_view(vue_name="fluxIAE_MarchesPublics")
         self.populate_fluxiae_view(vue_name="fluxIAE_MissionsEtatMensuelIndiv")
         self.populate_fluxiae_view(vue_name="fluxIAE_PMSMP")
         self.populate_fluxiae_view(vue_name="fluxIAE_Salarie")


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Cr-ation-pour-les-emploi-Rajouter-l-export-de-la-table-march-financier-dans-le-code-populate_flux_-13d5f321b604807caa2ad07bbcabb800?pvs=4