### PR TITLE
UX/UI: Ajouter la date d'émission de la candidature dans l'onglet d'infos générales

### DIFF
--- a/itou/templates/apply/includes/job_application_sender_info.html
+++ b/itou/templates/apply/includes/job_application_sender_info.html
@@ -46,4 +46,9 @@
             {% include 'includes/copy_to_clipboard.html' with content=job_application.sender.phone|cut:" " css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
         </li>
     {% endif %}
+
+    <li>
+        <small>Date</small>
+        <strong>Le {{ job_application.created_at|date:"d/m/Y" }}</strong>
+    </li>
 </ul>


### PR DESCRIPTION
## :thinking: Pourquoi ?

En passant l'historique de la candidature en onglet, les utilisateurs n'ont plus rapidement l'info de la date d'émission de la candidature sur l'onglet d'infos générales

