### PR TITLE
Versionner les fichiers du stockage S3

### DIFF
--- a/itou/files/management/commands/configure_bucket.py
+++ b/itou/files/management/commands/configure_bucket.py
@@ -42,6 +42,11 @@ class Command(BaseCommand):
             ),
         )
 
+        client.put_bucket_versioning(
+            Bucket=bucket,
+            VersioningConfiguration={"Status": "Enabled"},
+        )
+
         # MinIO does not support setting CORS.
         if not is_minio:
             protocol = "https" if settings.ITOU_ENVIRONMENT != ItouEnvironment.DEV else "http"
@@ -76,7 +81,17 @@ class Command(BaseCommand):
                         "Expiration": {"Days": 7},
                         "Filter": auto_expire_rule_filter,
                         "Status": "Enabled",
-                    }
+                    },
+                    {
+                        "Prefix": "",
+                        "Expiration": {"ExpiredObjectDeleteMarker": True},
+                        "Status": "Enabled",
+                    },
+                    {
+                        "Prefix": "",
+                        "NoncurrentVersionExpiration": {"NoncurrentDays": 365},
+                        "Status": "Enabled",
+                    },
                 ]
             },
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,7 +201,7 @@ def temporary_bucket():
                         Delete={"Objects": [{"Key": obj["Key"]} for obj in page["Contents"]]},
                     )
             client.delete_bucket(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
-        except s3_client.exceptions.NoSuchBucket:
+        except client.exceptions.NoSuchBucket:
             pass
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter une suppression accidentelle d’un fichier sur le stockage.
Les fichiers supprimés par l’application sont inaccessibles, puis réellement supprimés après 90 jours.

## :cake: Comment ? <!-- optionnel -->

En utilisant les _delete markers_ de S3.

- [ ] Notifier `#tech-c1` de lancer un `make buckets`
