### PR TITLE
tests: ignorer les fichier `.DS_Store` dans le test `test_unused_templates`

### DIFF
--- a/tests/test_consistency.py
+++ b/tests/test_consistency.py
@@ -64,6 +64,9 @@ def test_unused_templates():
         for template_dir in template_conf["DIRS"]:
             for dirpath, _dirnames, filenames in os.walk(template_dir):
                 for filename in filenames:
+                    if filename == ".DS_Store":
+                        # Ignore macOS hidden files
+                        continue
                     template_name = os.path.relpath(os.path.join(dirpath, filename), template_dir)
                     if template_name not in APP_TEMPLATES:
                         template_names_to_check.add(template_name)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, le test plante sous macOS, cf https://itou-inclusion.slack.com/archives/C0412CTV63D/p1731663000643109

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
