### PR TITLE
PASS IAE: correction de la vue de détail pour d'anciens PASS liés à des candidatures acceptées sans date de début d'embauche

### DIFF
--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -406,6 +406,16 @@ class TestApprovalDetailView:
             # Don't set an ASP_ITOU_PREFIX (see approval.save for details)
             approval__number="XXXXX1234568",
         )
+        # Create another accepted application lacking a proper hiring_start_at (like most old applications):
+        # it should not impact the button display, and it should not crash
+        JobApplicationFactory(
+            hiring_start_at=None,
+            to_company=membership.company,
+            job_seeker=job_application.job_seeker,
+            # Don't set an ASP_ITOU_PREFIX (see approval.save for details)
+            approval=job_application.approval,
+            state=JobApplicationState.ACCEPTED,
+        )
 
         client.force_login(membership.user)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, ça :boom: avec `'>' not supported between instances of 'datetime.date' and 'NoneType'`

Cf https://itou.sentry.io/issues/6011765619/?project=6164438 & https://itou-inclusion.slack.com/archives/C01181Y04LT/p1731954611260899 & 

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
