### PR TITLE
parse_response_to_soup: Retirer la forme courte de replace_in_attr

### DIFF
--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -86,26 +86,18 @@ def parse_response_to_soup(response, selector=None, no_html_body=False, replace_
     for img in soup.find_all("source", attrs={"srcset": True}):
         img["srcset"] = remove_static_hash(img["srcset"])
     if replace_in_attr:
-        replacements = [
-            (
-                replacement
-                if isinstance(replacement, tuple)
-                else ("href", str(replacement.pk), f"[PK of {type(replacement).__name__}]")
-            )
-            for replacement in replace_in_attr
-        ]
-
+        replace_in_attr = list(replace_in_attr)
         # Get the list of the attrs (deduplicated) we should search for replacement
-        unique_attrs = set([replace_tuple[0] for replace_tuple in replacements])
+        unique_attrs = set(replace_tuple[0] for replace_tuple in replace_in_attr)
 
         for attr in unique_attrs:
             # Search and replace in descendant nodes
             for links in soup.find_all(attrs={attr: True}):
-                for _, from_str, to_str in replacements:
+                for _, from_str, to_str in replace_in_attr:
                     links.attrs.update({f"{attr}": links.attrs[attr].replace(from_str, to_str)})
             # Also replace attributes in the top node
             if attr in soup.attrs:
-                for _, from_str, to_str in replacements:
+                for _, from_str, to_str in replace_in_attr:
                     soup.attrs.update({f"{attr}": soup.attrs[attr].replace(from_str, to_str)})
     return soup
 

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1525,19 +1525,24 @@ class TestUtilsParseResponseToSoup:
         response = HttpResponse('<html><head></head><body><div id="foo">bar</div></body></html>')
         assert str(parse_response_to_soup(response, selector="#foo")) == '<div id="foo">bar</div>'
 
-    def test_replace_in_href_mixing_tuple_and_object(self):
-        jobseeker = JobSeekerFactory()
+    def test_replace_in_href(self):
         response = HttpResponse(
             "<html><head></head><body>"
-            f'<div><a href="http://server.com/{jobseeker.pk}/">salmon</a></div>'
+            '<div><a href="/path/to/replace">salmon</a></div>'
             '<div><a href="http://server.com/bream/">bream</a></div>'
             '<div><a href="http://server.com/red_mullet/">red mullet</a></div>'
             "</body></html>"
         )
-        soup = parse_response_to_soup(response, replace_in_attr=[jobseeker, ("href", "red_mullet", "slug2")])
+        soup = parse_response_to_soup(
+            response,
+            replace_in_attr=[
+                ("href", "/path/to/replace", "[newpath]"),
+                ("href", "red_mullet", "slug2"),
+            ],
+        )
         assert str(soup) == (
             "<html><head></head><body>"
-            '<div><a href="http://server.com/[PK of User]/">salmon</a></div>'
+            '<div><a href="[newpath]">salmon</a></div>'
             '<div><a href="http://server.com/bream/">bream</a></div>'
             '<div><a href="http://server.com/slug2/">red mullet</a></div>'
             "</body></html>"

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -2972,7 +2972,13 @@ class TestProcessTransferJobApplication:
                 parse_response_to_soup(
                     response,
                     ".c-box--action .dropdown-structure",
-                    replace_in_attr=[job_application],
+                    replace_in_attr=[
+                        (
+                            "href",
+                            f"/apply/{job_application.pk}/siae/external-transfer/1",
+                            "/apply/[PK of JobApplication]/siae/external-transfer/1",
+                        )
+                    ],
                 )
             )
             == snapshot

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -675,7 +675,13 @@ class TestDashboardView:
                 parse_response_to_soup(
                     response,
                     "#gps-card",
-                    replace_in_attr=[("href", str(response.wsgi_request.current_organization.uid), "[UID of org]")],
+                    replace_in_attr=[
+                        (
+                            "href",
+                            f"user_organization_uid={response.wsgi_request.current_organization.uid}",
+                            "user_organization_uid=[UID of org]",
+                        )
+                    ],
                 )
             ) == snapshot(name=snapshot_name)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cette forme encourage le développeur à utiliser un entier (la PK d’un objet) comme cible à remplacer. Les premiers entiers sont souvent présents ailleurs dans la page (compte de résultat,, URL encoded `%3D`, etc), ce qui amène à des remplacements surprenants et des tests instables. Dernier exemple en date : #5119

Encourageons les développeurs à mettre du contexte, pour éviter les remplacements instables.
