### PR TITLE
PASS IAE : Limiter la date de fin prévisionnelle aux dates enregistrées

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -169,13 +169,17 @@ class CommonApprovalMixin(models.Model):
     @property
     def remainder_as_date(self):
         """
-        Return an estimated end date if this approval was "activated" today:
-        prolongations are taken into account but not suspensions as an approval can be unsuspended.
+        Return an estimated end date.
+        Prolongations are taken into account but not suspensions as an approval can be unsuspended.
         """
-        return timezone.localdate() + relativedelta(
-            days=self.remainder.days
-            # end_at is inclusive.
-            - 1,
+        return min(
+            max(self.start_at, timezone.localdate())  # Approval can start in the future
+            + relativedelta(
+                days=self.remainder.days
+                # end_at is inclusive.
+                - 1,
+            ),
+            self.end_at,
         )
 
     @property

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -135,8 +135,8 @@ class CommonApprovalMixin(models.Model):
             datetime.timedelta(0),
         ) - max(obj.start_at - timezone.localdate(), datetime.timedelta(0))
 
-    def _get_human_readable_estimate(self, dt):
-        res = timeuntil(dt)
+    def _get_human_readable_estimate(self, delta: datetime.timedelta) -> str:
+        res = timeuntil(timezone.localdate() + delta)
         res = res.replace("année", "an")
         res = res.split(", ")
         if any(v in res[0] for v in ["an", "mois"]):
@@ -161,7 +161,7 @@ class CommonApprovalMixin(models.Model):
     def get_remainder_display(self):
         remainder_display = f"{self.remainder.days} jour{pluralizefr(self.remainder.days)}"
         if self.remainder.days:
-            remainder_display += f" ({self._get_human_readable_estimate(self.remainder_as_date)})"
+            remainder_display += f" ({self._get_human_readable_estimate(self.remainder)})"
         return remainder_display
 
     get_remainder_display.short_description = "Reliquat"

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -160,7 +160,7 @@ class CommonApprovalMixin(models.Model):
 
     def get_remainder_display(self):
         remainder_display = f"{self.remainder.days} jour{pluralizefr(self.remainder.days)}"
-        if self.remainder.days:
+        if self.remainder.days >= 7:  # Prevent displaying "2 jours (2 jours)"
             remainder_display += f" ({self._get_human_readable_estimate(self.remainder)})"
         return remainder_display
 

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -571,21 +571,21 @@ class TestApprovalModel:
     @freeze_time("2024-07-18")
     def test_human_readable_estimate(self):
         approval = Approval()
-        for date, expected_display in [
-            (datetime.date(2026, 7, 18), "Environ 2 ans"),
-            (datetime.date(2026, 7, 17), "Environ 1 an et 11 mois"),
-            (datetime.date(2025, 7, 28), "Environ 1 an"),
-            (datetime.date(2025, 3, 13), "Environ 7 mois et 3 semaines"),
-            (datetime.date(2024, 12, 26), "Environ 5 mois et 1 semaine"),
-            (datetime.date(2024, 11, 18), "Environ 4 mois"),
-            (datetime.date(2024, 8, 2), "2 semaines et 1 jour"),
-            (datetime.date(2024, 8, 1), "2 semaines"),
-            (datetime.date(2024, 7, 31), "1 semaine et 6 jours"),
-            (datetime.date(2024, 7, 25), "1 semaine"),
-            (datetime.date(2024, 7, 24), "6 jours"),
-            (datetime.date(2024, 7, 19), "1 jour"),
+        for delta, expected_display in [
+            (datetime.timedelta(days=730), "Environ 2 ans"),
+            (datetime.timedelta(days=729), "Environ 1 an et 11 mois"),
+            (datetime.timedelta(days=375), "Environ 1 an"),
+            (datetime.timedelta(days=238), "Environ 7 mois et 3 semaines"),
+            (datetime.timedelta(days=161), "Environ 5 mois et 1 semaine"),
+            (datetime.timedelta(days=123), "Environ 4 mois"),
+            (datetime.timedelta(days=15), "2 semaines et 1 jour"),
+            (datetime.timedelta(days=14), "2 semaines"),
+            (datetime.timedelta(days=13), "1 semaine et 6 jours"),
+            (datetime.timedelta(days=7), "1 semaine"),
+            (datetime.timedelta(days=6), "6 jours"),
+            (datetime.timedelta(days=1), "1 jour"),
         ]:
-            assert approval._get_human_readable_estimate(date) == expected_display
+            assert approval._get_human_readable_estimate(delta) == expected_display
 
     @freeze_time("2023-04-26")
     def test_remainder_as_date(self):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -751,13 +751,22 @@ class TestPoleEmploiApprovalModel:
         approval = PoleEmploiApprovalFactory(start_at=start_at, end_at=end_at)
         assert approval.is_valid()
 
-    @freeze_time("2022-11-22")
-    def test_get_remainder_display(self):
+    @pytest.mark.parametrize(
+        "date,expected",
+        [
+            ("2022-11-22", "123 jours (Environ 4 mois)"),
+            ("2023-03-18", "7 jours (1 semaine)"),
+            ("2023-03-19", "6 jours"),
+            ("2023-03-24", "1 jour"),
+        ],
+    )
+    def test_get_remainder_display(self, date, expected):
         pole_emploi_approval = PoleEmploiApprovalFactory(
             start_at=datetime.date(2021, 3, 25),
             end_at=datetime.date(2023, 3, 24),
         )
-        assert pole_emploi_approval.get_remainder_display() == "123 jours (Environ 4 mois)"
+        with freeze_time(date):
+            assert pole_emploi_approval.get_remainder_display() == expected
 
 
 class TestPoleEmploiApprovalManager:

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -587,8 +587,15 @@ class TestApprovalModel:
         ]:
             assert approval._get_human_readable_estimate(delta) == expected_display
 
-    @freeze_time("2023-04-26")
-    def test_remainder_as_date(self):
+    @pytest.mark.parametrize(
+        "now,expected",
+        [
+            ("2021-07-01", datetime.date(2023, 7, 25)),  # Yet to start
+            ("2022-07-26", datetime.date(2023, 7, 25)),  # In progress
+            ("2023-08-01", datetime.date(2023, 7, 25)),  # Is already ended
+        ],
+    )
+    def test_remainder_as_date(self, now, expected):
         """
         Only test return type and value as the algorithm is already tested in `self.test_remainder`.
         """
@@ -596,7 +603,8 @@ class TestApprovalModel:
             start_at=datetime.date(2021, 7, 26),
             end_at=datetime.date(2023, 7, 25),
         )
-        assert approval.remainder_as_date == datetime.date(2023, 7, 25)
+        with freeze_time(now):
+            assert approval.remainder_as_date == expected
 
     def test_diagnosis_constraint(self):
         ApprovalFactory(origin_ai_stock=True)

--- a/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
@@ -306,7 +306,7 @@
                   <small>Durée de validité <i class="ri-information-line ri-xl text-info"
       data-bs-toggle="tooltip"
       data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
-                  <strong class="text-success">730 jours (Environ 1 an et 11 mois)</strong>
+                  <strong class="text-success">730 jours (Environ 2 ans)</strong>
               </li>
           
       </ul>

--- a/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
@@ -300,7 +300,7 @@
               </li>
               <li class="order-3">
                   <small>Date de fin prévisionnelle <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" data-bs-title="Cette date de fin est susceptible d’évoluer avec les éventuelles suspensions et prolongations du PASS IAE."></i></small>
-                  <strong>05/08/2026</strong>
+                  <strong>31/12/2026</strong>
               </li>
               <li class="order-4">
                   <small>Durée de validité <i class="ri-information-line ri-xl text-info"

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -53,7 +53,7 @@
               </li>
               <li class="order-4 order-lg-3">
                   <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
-                  <strong class="text-success">2 jours (2 jours)</strong>
+                  <strong class="text-success">2 jours</strong>
               </li>
           
       </ul>

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -49,7 +49,7 @@
               </li>
               <li class="order-3 order-lg-4">
                   <small>Date de fin prévisionnelle <i class="ri-information-line ri-xl text-info" data-bs-title="Cette date de fin est susceptible d’évoluer avec les éventuelles suspensions et prolongations du PASS IAE." data-bs-toggle="tooltip"></i></small>
-                  <strong>26/09/2024</strong>
+                  <strong>02/01/2025</strong>
               </li>
               <li class="order-4 order-lg-3">
                   <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -53,7 +53,7 @@
               </li>
               <li class="order-4 order-lg-3">
                   <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
-                  <strong class="text-success">2 jours (1 jour)</strong>
+                  <strong class="text-success">2 jours (2 jours)</strong>
               </li>
           
       </ul>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Nouvelle remontée en mood support ([voir ici pour une précédente](https://itou-inclusion.slack.com/archives/C0412CTV63D/p1729695821094099)).

Le cas d'école est l'affichage de "Date de fin prévisionnelle" (`approvals/includes/box.html`) pour une première embauche dans le futur, on se retrouve à afficher une date de fin prévisionnelle inférieure à la date de fin enregistrée et qui ne colle donc pas avec la date de début. Cette date de fin prévisionnelle se retrouve à évoluer chaque jour entre maintenant et la date de début, donc quand le support traite le ticket il y a souvent plus rien à voir ou faire.

De mémoire ceci avait été fait historiquement pour afficher à l'utilisateur la date de fin prévisionnelle si il embauchait maintenant, sauf que depuis ce template est utilisé partout et la partie sur le reliquat c'est étoffé donc on va espérer que ça ne posera pas trop problème pour ce cas précis.