### PR TITLE
parse_response_to_soup: Amélioration de replace_in_attr

### DIFF
--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1548,6 +1548,15 @@ class TestUtilsParseResponseToSoup:
             "</body></html>"
         )
 
+    def test_replace_in_href_not_hx_get(self):
+        response = HttpResponse(
+            b'<html><head></head><body><div><a href="/path" hx-get="/path">salmon</a></div></body></html>'
+        )
+        soup = parse_response_to_soup(response, replace_in_attr=[("hx-get", "/path", "/new")])
+        assert (
+            str(soup) == '<html><head></head><body><div><a href="/path" hx-get="/new">salmon</a></div></body></html>'
+        )
+
     def test_replace_in_attr_also_replace_on_current_element(self):
         response = HttpResponse('<html><head></head><body><form action="foo">bar</form></body></html>')
         soup = parse_response_to_soup(response, selector="form", replace_in_attr=[("action", "foo", "not foo")])


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter des erreurs de remplacement.
Structure de données plus adaptée.
