### PR TITLE
Candidats: Ajout des champs commune et pays de naissance dans « Mon profil »

### DIFF
--- a/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
+++ b/itou/templates/dashboard/includes/edit_job_seeker_info_form.html
@@ -22,6 +22,8 @@
     {% bootstrap_field form.lack_of_nir %}
     {% bootstrap_field form.lack_of_nir_reason wrapper_class=form.lack_of_nir_reason.field.form_group_class %}
     {% bootstrap_field form.birthdate %}
+    {% bootstrap_field form.birth_place %}
+    {% bootstrap_field form.birth_country %}
     {% bootstrap_field form.phone %}
     {% bootstrap_field form.address_for_autocomplete %}
     {% bootstrap_field form.address_line_1 %}

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -3,6 +3,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.text import slugify
 
+from itou.asp.forms import BirthPlaceAndCountryMixin
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
 from itou.communications import registry as notification_registry
@@ -30,13 +31,26 @@ class SSOReadonlyMixin:
 # SSOReadonlyMixin needs to be before JobSeekerProfileFieldsMixin here
 # since it disables the birthdate field that is added by JobSeekerProfileFieldsMixin
 class EditJobSeekerInfoForm(
-    JobSeekerNIRUpdateMixin, SSOReadonlyMixin, JobSeekerProfileFieldsMixin, JobSeekerAddressForm, forms.ModelForm
+    BirthPlaceAndCountryMixin,
+    JobSeekerNIRUpdateMixin,
+    SSOReadonlyMixin,
+    JobSeekerProfileFieldsMixin,
+    JobSeekerAddressForm,
+    forms.ModelForm,
 ):
     """
     Edit a job seeker profile.
     """
 
-    PROFILE_FIELDS = ["birthdate", "pole_emploi_id", "lack_of_pole_emploi_id_reason", "nir", "lack_of_nir_reason"]
+    PROFILE_FIELDS = [
+        "birthdate",
+        "birth_place",
+        "birth_country",
+        "pole_emploi_id",
+        "lack_of_pole_emploi_id_reason",
+        "nir",
+        "lack_of_nir_reason",
+    ]
 
     email = forms.EmailField(
         label="Adresse électronique personnelle",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,6 +126,14 @@ def preload_contenttype_cache(django_db_setup, django_db_blocker):
 
 
 @pytest.fixture(autouse=True, scope="session")
+def preload_country_france(django_db_setup, django_db_blocker):
+    from itou.asp.models import Country
+
+    with django_db_blocker.unblock():
+        Country.france_id
+
+
+@pytest.fixture(autouse=True, scope="session")
 def test_bucket():
     # TODO: Remove this code block once we stop using a models.URLField() to store a S3 link (ie. `resume_link`)
     from django.core.validators import URLValidator

--- a/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEditJobSeekerInfo.test_edit_by_company_with_nir[view queries]
   dict({
-    'num_queries': 12,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -289,6 +289,25 @@
       }),
       dict({
         'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[dashboard/includes/edit_job_seeker_info_form.html]',
+          'IncludeNode[dashboard/edit_job_seeker_info.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[dashboard/edit_job_seeker_info.html]',
+          'edit_job_seeker_info[www/dashboard/views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
@@ -324,7 +343,7 @@
 # ---
 # name: TestEditJobSeekerInfo.test_edit_by_prescriber[view queries]
   dict({
-    'num_queries': 11,
+    'num_queries': 14,
     'queries': list([
       dict({
         'origin': list([
@@ -534,6 +553,28 @@
       }),
       dict({
         'origin': list([
+          'EditJobSeekerInfoForm.__init__[users/forms.py]',
+          'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
+          'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',
+          'EditJobSeekerInfoForm.__init__[asp/forms.py]',
+          'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
+          'edit_job_seeker_info[www/dashboard/views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
           'User.has_verified_email[users/models.py]',
           'User.can_edit_email[users/models.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
@@ -546,6 +587,48 @@
                  AND "account_emailaddress"."email" = %s
                  AND "account_emailaddress"."verified")
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'RemoteAutocompleteSelect2Widget.optgroups[utils/widgets.py]',
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[dashboard/includes/edit_job_seeker_info_form.html]',
+          'IncludeNode[dashboard/edit_job_seeker_info.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[dashboard/edit_job_seeker_info.html]',
+          'edit_job_seeker_info[www/dashboard/views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[dashboard/includes/edit_job_seeker_info_form.html]',
+          'IncludeNode[dashboard/edit_job_seeker_info.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[dashboard/edit_job_seeker_info.html]',
+          'edit_job_seeker_info[www/dashboard/views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({

--- a/tests/www/dashboard/__snapshots__/test_edit_user_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_user_info.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEditUserInfoView.test_edit_with_nir
   dict({
-    'num_queries': 9,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -70,6 +70,7 @@
           'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',
+          'EditJobSeekerInfoForm.__init__[asp/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'edit_user_info[www/dashboard/views.py]',
         ]),
@@ -126,6 +127,26 @@
                  AND "external_data_externaldataimport"."source" = %s)
           ORDER BY "external_data_externaldataimport"."id" ASC
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[dashboard/includes/edit_job_seeker_info_form.html]',
+          'IncludeNode[dashboard/edit_user_info.html]',
+          'IfNode[dashboard/edit_user_info.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[dashboard/edit_user_info.html]',
+          'edit_user_info[www/dashboard/views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({
@@ -211,6 +232,10 @@
                                                   
                                               
                                                   
+                                              
+                                                  
+                                              
+                                                  
                                                       <li>
                                                           <strong>Adresse actuelle</strong>
                                                       </li>
@@ -255,6 +280,10 @@
                                                       <li>
                                                           <strong>Civilité</strong>
                                                       </li>
+                                                  
+                                              
+                                                  
+                                              
                                                   
                                               
                                                   

--- a/tests/www/dashboard/test_edit_user_info.py
+++ b/tests/www/dashboard/test_edit_user_info.py
@@ -138,7 +138,7 @@ class TestEditUserInfoView:
         user = JobSeekerFactory(
             jobseeker_profile__nir="178122978200508",
             title="M",
-            jobseeker_profile__birthdate=datetime(1978, 12, 20, tzinfo=UTC),
+            jobseeker_profile__birthdate=date(1978, 12, 20),
         )
         client.force_login(user)
         url = reverse("dashboard:edit_user_info")
@@ -187,7 +187,7 @@ class TestEditUserInfoView:
         user = JobSeekerFactory(
             jobseeker_profile__nir="178332978200553",
             title="M",
-            jobseeker_profile__birthdate=datetime(1978, 12, 20, tzinfo=UTC),
+            jobseeker_profile__birthdate=date(1978, 12, 20),
         )
         client.force_login(user)
         url = reverse("dashboard:edit_user_info")
@@ -213,7 +213,7 @@ class TestEditUserInfoView:
         user = JobSeekerFactory(
             jobseeker_profile__nir="178332978200553",
             title="M",
-            jobseeker_profile__birthdate=datetime(1978, 12, 20, tzinfo=UTC),
+            jobseeker_profile__birthdate=date(1978, 12, 20),
         )
         client.force_login(user)
         url = reverse("dashboard:edit_user_info")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Collecter ces informations pour certifier la situation administrative des candidats (Bénéficiaire RSA, …).

## :desert_island: Comment tester

### En tant que candidat

1. Se connecter en tant que candidat
2. Aller dans « Mon profil » en utilisant le menu déroulant
3. Constater la présence des champs
4. Vérifier la logique de validation

### En tant que prescripteur/orienteur ou employeur

1. Se connecter
2. Dans une candidature ou l’interface mes candidats, cliquer sur « modifier » dans l’encart des informations personnelles d’un candidat
3. Constater la présence des champs
4. Vérifier la logique de validation

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/35756a56-3ec8-4605-b6c5-9718b389f36d)
