### PR TITLE
Amélioration de l'interface de fusion de comptes

### DIFF
--- a/itou/templates/itou_staff_views/merge_users.html
+++ b/itou/templates/itou_staff_views/merge_users.html
@@ -14,16 +14,14 @@
                     <form method="post">
                         {% csrf_token %}
                         {% bootstrap_form_errors form type="non_fields" %}
-                        <div class="form-row">
-                            {% bootstrap_field form.old_email wrapper_class='form-group col-md-5' %}
-                            {% bootstrap_field form.new_email wrapper_class='form-group col-md-5' %}
-                            <div class="form-group col-md-2 mt-5">
-                                <button type="submit" class="btn btn-block btn-primary">
-                                    <span>Chercher</span>
-                                </button>
-                            </div>
-                        </form>
-                    </div>
+                        {% bootstrap_field form.email_1 wrapper_class='form-group col-md-5' %}
+                        {% bootstrap_field form.email_2 wrapper_class='form-group col-md-5' %}
+                        <div class="form-group col-md-2 mt-5">
+                            <button type="submit" class="btn btn-block btn-primary">
+                                <span>Chercher</span>
+                            </button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>

--- a/itou/templates/itou_staff_views/merge_users_confirm.html
+++ b/itou/templates/itou_staff_views/merge_users_confirm.html
@@ -30,7 +30,7 @@
                 </div>
 
                 <h2>Informations personnelles</h2>
-                <div class="row mb-5">
+                <div class="row mb-5" id="users_info">
                     <div class="col">
                         <div class="c-box {% if to_user_error %}bg-danger-lightest border-danger{% endif %}" id="left_user_box">
                             <ul class="list-unstyled">
@@ -60,17 +60,15 @@
                                 <p class="text-danger">{{ to_user_error }}</p>
                             {% else %}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="radio" name="update_personal_data" id="id_update_personal_data_0" value="False">
-                                    <label class="form-check-label" for="id_update_personal_data_0">Conserver ces informations personnelles</label>
+                                    <input class="form-check-input" type="radio" name="user_to_keep" id="id_keep_to_user" value="to_user">
+                                    <label class="form-check-label" for="id_keep_to_user">Utiliser ce compte pour la connexion</label>
+
                                 </div>
                             {% endif %}
                         </div>
                     </div>
-                    <div class="col-1 text-center d-flex justify-content-center align-items-center">
-                        <i class="ri-arrow-left-line ri-3x"></i>
-                    </div>
                     <div class="col">
-                        <div class="c-box {% if from_user_error %}bg-danger-lightest border-danger{% else %}bg-success-lightest border-success{% endif %}" id="right_user_box">
+                        <div class="c-box {% if from_user_error %}bg-danger-lightest border-danger{% endif %}" id="right_user_box">
                             <ul class="list-unstyled">
                                 <li>
                                     <a href="{{ from_user_admin_link }}">Lien vers l'admin</a>
@@ -98,10 +96,8 @@
                                 <p class="text-danger">{{ from_user_error }}</p>
                             {% else %}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="radio" name="update_personal_data" id="id_update_personal_data_1" value="True" checked="checked">
-                                    <label class="form-check-label" for="id_update_personal_data_1">
-                                        Mettre à jour avec ces informations personnelles
-                                    </label>
+                                    <input class="form-check-input" type="radio" name="user_to_keep" id="id_keep_from_user" value="from_user">
+                                    <label class="form-check-label" for="id_keep_from_user">Utiliser ce compte pour la connexion</label>
                                 </div>
                             {% endif %}
                         </div>
@@ -148,10 +144,10 @@
 
     <script nonce="{{ CSP_NONCE }}">
         htmx.onLoad(function() {
-            var left_user_box = $("#left_user_box");
-            var right_user_box = $("#right_user_box");
-            var left_user_choice = $("#id_update_personal_data_0");
-            var right_user_choice = $("#id_update_personal_data_1");
+            const left_user_box = $("#left_user_box");
+            const right_user_box = $("#right_user_box");
+            const left_user_choice = $("#id_keep_to_user");
+            const right_user_choice = $("#id_keep_from_user");
             left_user_choice.change(function() {
                 left_user_box.addClass("bg-success-lightest border-success")
                 right_user_box.removeClass("bg-success-lightest border-success")

--- a/itou/www/itou_staff_views/forms.py
+++ b/itou/www/itou_staff_views/forms.py
@@ -48,14 +48,12 @@ class ItouStaffExportJobApplicationForm(forms.Form):
 
 
 class MergeUserForm(forms.Form):
-    old_email = forms.EmailField(
-        label="Ancien e-mail",
-        help_text="Email du compte à conserver.",
+    email_1 = forms.EmailField(
+        label="E-mail du premier compte",
         widget=forms.TextInput(attrs={"autocomplete": "off"}),
     )
-    new_email = forms.EmailField(
-        label="Nouvel e-mail",
-        help_text="Email du compte dont on va migrer les relations, et les informations personnelles.",
+    email_2 = forms.EmailField(
+        label="E-mail du second compte",
         widget=forms.TextInput(attrs={"autocomplete": "off"}),
     )
 
@@ -65,23 +63,28 @@ class MergeUserForm(forms.Form):
             raise ValidationError("Cet utilisateur n'existe pas.")
         return user
 
-    def clean_old_email(self):
-        self.old_user = self._check_email_exists(self.cleaned_data["old_email"])
+    def clean_email_1(self):
+        self.user_1 = self._check_email_exists(self.cleaned_data["email_1"])
 
-    def clean_new_email(self):
-        self.new_user = self._check_email_exists(self.cleaned_data["new_email"])
+    def clean_email_2(self):
+        self.user_2 = self._check_email_exists(self.cleaned_data["email_2"])
 
     def clean(self):
         cleaned_data = super().clean()
-        new_user = getattr(self, "new_user", None)
-        old_user = getattr(self, "old_user", None)
-        if old_user and new_user and old_user == new_user:
+        user_1 = getattr(self, "user_1", None)
+        user_2 = getattr(self, "user_2", None)
+        if user_2 and user_1 and user_2 == user_1:
             raise ValidationError("Les deux adresses doivent être différentes.")
         return cleaned_data
 
 
 class MergeUserConfirmForm(forms.Form):
-    update_personal_data = forms.TypedChoiceField(
-        coerce=lambda v: v == "True",
-        choices=((False, "False"), (True, "True")),
+    user_to_keep = forms.ChoiceField(
+        choices=(("to_user", "to_user"), ("from_user", "from_user")),
     )
+
+    def clean(self) -> None:
+        cleaned_data = super().clean()
+        if self.errors:
+            self.add_error(None, "Vous devez choisir l'identité à conserver")
+        return cleaned_data

--- a/itou/www/itou_staff_views/merge_utils.py
+++ b/itou/www/itou_staff_views/merge_utils.py
@@ -145,7 +145,7 @@ def migrate_field(model, field_name, from_user, to_user):
 def merge_users(to_user, from_user, update_personal_data):
     assert to_user.kind in [UserKind.EMPLOYER, UserKind.PRESCRIBER]
     assert to_user.kind == from_user.kind
-    support_remark = f"{timezone.localdate()}: Fusion d'utilisateurs {to_user.email} ← {from_user.email}"
+    support_remark = f"{timezone.localdate()}: Fusion des utilisateurs {to_user.email} et {from_user.email}"
     for model, field_name in get_users_relations():
         migrate_field(model, field_name, from_user, to_user)
     if update_personal_data:

--- a/itou/www/itou_staff_views/urls.py
+++ b/itou/www/itou_staff_views/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
     path("export-cta", views.export_cta, name="export_cta"),
     path("merge-users", views.merge_users, name="merge_users"),
     path(
-        "merge-users/<int:to_user_pk>/<int:from_user_pk>",
+        "merge-users/<int:user_1_pk>/<int:user_2_pk>",
         views.merge_users_confirm,
         name="merge_users_confirm",
     ),

--- a/tests/www/itou_staff_views/__snapshots__/tests.ambr
+++ b/tests/www/itou_staff_views/__snapshots__/tests.ambr
@@ -2456,3 +2456,76 @@
     ),
   ])
 # ---
+# name: TestMergeUsers.test_merge_order[same_order]
+  '''
+  <div class="row mb-5" id="users_info">
+                      <div class="col">
+                          <div class="c-box" id="left_user_box">
+                              <ul class="list-unstyled">
+                                  <li>
+                                      <a href="/admin/users/user/[PK of User_1]/change/">Lien vers l'admin</a>
+                                  </li>
+                                  <li>
+                                      Adresse e-mail : <strong>pierre.dupont@test.local</strong>
+                                  </li>
+                                  <li>
+                                      Prénom : <strong>Pierre</strong>
+                                  </li>
+                                  <li>
+                                      Nom : <strong>DUPONT</strong>
+                                  </li>
+                                  <li>
+                                      Type : <strong>prescripteur</strong>
+                                  </li>
+                                  <li>
+                                      Connexion : <strong>Inclusion Connect</strong>
+                                  </li>
+                                  <li>
+                                      Identifiant unique (du SSO) : <strong>8487651a-a6c8-4a57-9663-64fadf1dc764</strong>
+                                  </li>
+                              </ul>
+                              
+                                  <div class="form-check">
+                                      <input class="form-check-input" id="id_keep_to_user" name="user_to_keep" type="radio" value="to_user"/>
+                                      <label class="form-check-label" for="id_keep_to_user">Utiliser ce compte pour la connexion</label>
+  
+                                  </div>
+                              
+                          </div>
+                      </div>
+                      <div class="col">
+                          <div class="c-box" id="right_user_box">
+                              <ul class="list-unstyled">
+                                  <li>
+                                      <a href="/admin/users/user/[PK of User_2]/change/">Lien vers l'admin</a>
+                                  </li>
+                                  <li>
+                                      Adresse e-mail : <strong>jean.laurent@test.local</strong>
+                                  </li>
+                                  <li>
+                                      Prénom : <strong>Jean</strong>
+                                  </li>
+                                  <li>
+                                      Nom : <strong>LAURENT</strong>
+                                  </li>
+                                  <li>
+                                      Type : <strong>prescripteur</strong>
+                                  </li>
+                                  <li>
+                                      Connexion : <strong>Inclusion Connect</strong>
+                                  </li>
+                                  <li>
+                                      Identifiant unique (du SSO) : <strong>471d1de6-e1ff-4cd2-be2e-61f603c04687</strong>
+                                  </li>
+                              </ul>
+                              
+                                  <div class="form-check">
+                                      <input class="form-check-input" id="id_keep_from_user" name="user_to_keep" type="radio" value="from_user"/>
+                                      <label class="form-check-label" for="id_keep_from_user">Utiliser ce compte pour la connexion</label>
+                                  </div>
+                              
+                          </div>
+                      </div>
+                  </div>
+  '''
+# ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter des erreurs de la personne qui fait la fusion :
- on met automatiquement le compte le plus ancien à gauche (celui qui va recevoir les relations)
- -on ne met plus de choix par défaut pour la selection des informations personnelles. 

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
