### PR TITLE
Candidature: ajout d'un lien vers la fiche structure pour les utilisateurs n'appartenant pas à la structure [GEN-2234]

### DIFF
--- a/itou/templates/apply/includes/job_application_info.html
+++ b/itou/templates/apply/includes/job_application_info.html
@@ -16,7 +16,7 @@
     <ul class="list-data list-data__two-column-md mb-3">
         <li>
             <small>Employeur destinataire</small>
-            <strong>{{ job_application.to_company.display_name }}</strong>
+            <a class="btn btn-link" href="{% url 'companies_views:card' siae_id=job_application.to_company.id %}?back_url={{ request.get_full_path|urlencode }}"><strong>{{ job_application.to_company.display_name }}</strong></a>
         </li>
     </ul>
 {% endif %}

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -431,6 +431,9 @@ class TestProcessViews:
         response = client.get(url)
         assertContains(response, LackOfNIRReason.NIR_ASSOCIATED_TO_OTHER.label, html=True)
 
+        assertContains(response, f"<strong>{job_application.to_company.display_name}</strong>")
+        assertContains(response, reverse("companies_views:card", kwargs={"siae_id": job_application.to_company.pk}))
+
     def test_details_for_prescriber_as_company_when_i_am_not_the_sender(self, client):
         job_application = JobApplicationFactory(sent_by_authorized_prescriber_organisation=True)
         employer = job_application.to_company.members.first()
@@ -508,6 +511,9 @@ class TestProcessViews:
         assertNotContains(response, format_phone(job_application.sender.phone))
 
         assertNotContains(response, PRIOR_ACTION_SECTION_TITLE)
+
+        assertContains(response, f"<strong>{job_application.to_company.display_name}</strong>")
+        assertContains(response, reverse("companies_views:card", kwargs={"siae_id": job_application.to_company.pk}))
 
     def test_details_for_job_seeker_as_other_user(self, client, subtests):
         job_application = JobApplicationFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car ce lien n'existait pas.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
