### PR TITLE
Candidature: suppression de liens vers la fiche candidat ou entreprise dans la vue liste des candidatures [GEN-2257]

### DIFF
--- a/itou/templates/apply/includes/list_card_body_company.html
+++ b/itou/templates/apply/includes/list_card_body_company.html
@@ -6,13 +6,7 @@
     <div class="c-box--results__summary">
         <i class="ri-user-line" aria-hidden="true"></i>
         <div>
-            <h3>
-                {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
-                    <a href="{% url "job_seekers_views:details" public_id=job_application.job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}</a>
-                {% else %}
-                    {{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}
-                {% endif %}
-            </h3>
+            <h3>{{ job_application.job_seeker.get_full_name|mask_unless:job_application.user_can_view_personal_information }}</h3>
             <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                 {% if job_application.job_seeker.city %}
                     <span>

--- a/itou/templates/apply/includes/list_card_body_jobseeker.html
+++ b/itou/templates/apply/includes/list_card_body_jobseeker.html
@@ -7,7 +7,7 @@
         <i class="ri-user-line" aria-hidden="true"></i>
         <div>
             <span>{{ job_application.to_company.get_kind_display }}</span>
-            <a href="{% url 'companies_views:card' siae_id=job_application.to_company.id %}" class="h3 d-block text-decoration-none">{{ job_application.to_company.display_name }}</a>
+            <h3>{{ job_application.to_company.display_name }}</h3>
             {% if job_application.next_appointment_start_at %}
                 <span {% if job_application.other_appointments_count %} data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="{% blocktrans count other_appointments_count=job_application.other_appointments_count %}{{ other_appointments_count }} autre rendez-vous prévu, consultez-le dans le détail de candidature"{% plural %}{{ other_appointments_count }} autres rendez-vous prévus, consultez-les dans le détail de candidature{% endblocktrans%}"{% endif %}>
                     <i class="ri-calendar-line font-weight-normal me-1" aria-hidden="true"></i>

--- a/tests/www/apply/__snapshots__/test_list.ambr
+++ b/tests/www/apply/__snapshots__/test_list.ambr
@@ -32,7 +32,7 @@
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
               <span>Entreprise d'insertion</span>
-              <a class="h3 d-block text-decoration-none" href="/company/42/card">Hit pit</a>
+              <h3>Hit pit</h3>
               
           </div>
       </div>
@@ -95,7 +95,7 @@
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
               <span>Entreprise d'insertion</span>
-              <a class="h3 d-block text-decoration-none" href="/company/42/card">Hit pit</a>
+              <h3>Hit pit</h3>
               
           </div>
       </div>
@@ -163,7 +163,7 @@
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
               <span>Entreprise d'insertion</span>
-              <a class="h3 d-block text-decoration-none" href="/company/42/card">Hit pit</a>
+              <h3>Hit pit</h3>
               
           </div>
       </div>
@@ -244,11 +244,7 @@
       <div class="c-box--results__summary">
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
-              <h3>
-                  
-                      <a class="btn-link" href="/job-seekers/details/00000000-1111-2222-3333-444444444444?back_url=/apply/prescriptions/list">J… H…</a>
-                  
-              </h3>
+              <h3>J… H…</h3>
               <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                   
                   
@@ -326,11 +322,7 @@
       <div class="c-box--results__summary">
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
-              <h3>
-                  
-                      <a class="btn-link" href="/job-seekers/details/00000000-1111-2222-3333-444444444444?back_url=/apply/prescriptions/list">J… H…</a>
-                  
-              </h3>
+              <h3>J… H…</h3>
               <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                   
                   
@@ -413,11 +405,7 @@
       <div class="c-box--results__summary">
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
-              <h3>
-                  
-                      <a class="btn-link" href="/job-seekers/details/00000000-1111-2222-3333-444444444444?back_url=/apply/prescriptions/list">J… H…</a>
-                  
-              </h3>
+              <h3>J… H…</h3>
               <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                   
                   
@@ -512,11 +500,7 @@
       <div class="c-box--results__summary">
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
-              <h3>
-                  
-                      Jacques HENRY
-                  
-              </h3>
+              <h3>Jacques HENRY</h3>
               <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                   
                   
@@ -592,11 +576,7 @@
       <div class="c-box--results__summary">
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
-              <h3>
-                  
-                      Jacques HENRY
-                  
-              </h3>
+              <h3>Jacques HENRY</h3>
               <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                   
                   
@@ -677,11 +657,7 @@
       <div class="c-box--results__summary">
           <i aria-hidden="true" class="ri-user-line"></i>
           <div>
-              <h3>
-                  
-                      Jacques HENRY
-                  
-              </h3>
+              <h3>Jacques HENRY</h3>
               <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
                   
                   

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -66,14 +66,11 @@ def test_get(client):
     assert len(response.context["job_applications_page"].object_list) == organization.jobapplication_set.count()
 
     assertContains(response, job_application.job_seeker.get_full_name())
-    assertContains(
-        response, reverse("job_seekers_views:details", kwargs={"public_id": job_application.job_seeker.public_id})
-    )
 
 
 def test_as_unauthorized_prescriber(client, snapshot):
     prescriber = PrescriberFactory()
-    job_application = JobApplicationFactory(
+    JobApplicationFactory(
         job_seeker_with_address=True,
         job_seeker__first_name="Supersecretname",
         job_seeker__last_name="Unknown",
@@ -81,7 +78,7 @@ def test_as_unauthorized_prescriber(client, snapshot):
         sender=prescriber,
         sender_kind=SenderKind.PRESCRIBER,
     )
-    another_job_application = JobApplicationFactory(
+    JobApplicationFactory(
         job_seeker_with_address=True,
         job_seeker__first_name="Liz",
         job_seeker__last_name="Ible",
@@ -95,17 +92,9 @@ def test_as_unauthorized_prescriber(client, snapshot):
     with assertSnapshotQueries(snapshot(name="SQL queries for prescriptions list")):
         response = client.get(list_url)
 
-    job_seeker_detail_url = reverse(
-        "job_seekers_views:details", kwargs={"public_id": job_application.job_seeker.public_id}
-    )
-    assertContains(response, f'<a href="{job_seeker_detail_url}?back_url={list_url}" class="btn-link">S… U…</a>')
+    assertContains(response, "<h3>S… U…</h3>")
     assertNotContains(response, "Supersecretname")
-    another_job_seeker_detail_url = reverse(
-        "job_seekers_views:details", kwargs={"public_id": another_job_application.job_seeker.public_id}
-    )
-    assertContains(
-        response, f'<a href="{another_job_seeker_detail_url}?back_url={list_url}" class="btn-link">Liz IBLE</a>'
-    )
+    assertContains(response, "<h3>Liz IBLE</h3>")
 
 
 def test_filtered_by_state(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car les utilisateurs cliquant sur la carte candidature se retrouvaient par erreur sur la vue Candidat ou la vue Entreprise.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
