### PR TITLE
Tableau de bord : Utilisation de _snapshots_ pour tester le contenu de l'onglet "Statistiques"

### DIFF
--- a/tests/www/dashboard/__snapshots__/test_dashboard_stats.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard_stats.ambr
@@ -1,0 +1,5310 @@
+# serializer version: 1
+# name: test_index_stats_for_authorized_prescriber[CAP_EMPLOI-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CAP_EMPLOI-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CAP_EMPLOI-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CAP_EMPLOI-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHRS-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHRS-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHRS-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHRS-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHU-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHU-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHU-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[CHU-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[DEPT-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/iae">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/brsa">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
+                              </a>
+                          </li>
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/aci">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du cofinancement des ACI de mon département</span>
+                              </a>
+                          </li>
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[DEPT-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/iae">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/brsa">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[DEPT-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/iae">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/brsa">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
+                              </a>
+                          </li>
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/aci">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du cofinancement des ACI de mon département</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[DEPT-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/iae">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/cd/brsa">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[ML-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[ML-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[ML-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[ML-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[OIL-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[OIL-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[OIL-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[OIL-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[PE-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
+                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir le guide d’analyse France Travail</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultat des candidatures orientées par mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Taux de transformation de mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension de mon territoire</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/delay/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Délai d'entrée en IAE pour mon territoire</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[PE-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
+                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir le guide d’analyse France Travail</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultat des candidatures orientées par mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Taux de transformation de mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension de mon territoire</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/delay/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Délai d'entrée en IAE pour mon territoire</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[PE-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
+                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir le guide d’analyse France Travail</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultat des candidatures orientées par mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Taux de transformation de mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension de mon territoire</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/delay/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Délai d'entrée en IAE pour mon territoire</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[PE-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
+                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir le guide d’analyse France Travail</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultat des candidatures orientées par mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Taux de transformation de mes agences</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension de mon territoire</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/pe/delay/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Délai d'entrée en IAE pour mon territoire</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[RS_FJT-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[RS_FJT-75]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ph/state/main">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mon organisation</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[RS_FJT-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_authorized_prescriber[RS_FJT-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_employer[ACI-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Auto-prescription réalisées par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_employer[ACI-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Auto-prescription réalisées par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_employer[ACI-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Auto-prescription réalisées par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_employer[EI-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Auto-prescription réalisées par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_employer[EI-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Auto-prescription réalisées par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_employer[EI-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Auto-prescription réalisées par ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[Autre-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[Autre-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[Autre-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[CONVERGENCE-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/convergence/prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions et parcours</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/convergence/job_application">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures émises</span>
+                              </a>
+                          </li>
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[CONVERGENCE-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/convergence/prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions et parcours</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/convergence/job_application">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures émises</span>
+                              </a>
+                          </li>
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[CONVERGENCE-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/convergence/prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions et parcours</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/convergence/job_application">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures émises</span>
+                              </a>
+                          </li>
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS GEIQ-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS GEIQ-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS GEIQ-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS IAE-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Focus auto-prescription des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation de mon département</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a href="/stats/ddets/iae" class="btn-link btn-ico">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Données IAE de mon département</span>
+                                  </a>
+                              </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                          
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a class="btn-link btn-ico" href="/stats/ddets/aci">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Suivi du cofinancement des ACI de mon département</span>
+                                  </a>
+                              </li>
+                          
+                          
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a class="btn-link btn-ico" href="/stats/ddets/orga_etp">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
+                                  </a>
+                                  <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                              </li>
+                          
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS IAE-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Focus auto-prescription des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation de mon département</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a href="/stats/ddets/iae" class="btn-link btn-ico">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Données IAE de mon département</span>
+                                  </a>
+                              </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                          
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a class="btn-link btn-ico" href="/stats/ddets/aci">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Suivi du cofinancement des ACI de mon département</span>
+                                  </a>
+                              </li>
+                          
+                          
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS IAE-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Focus auto-prescription des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation de mon département</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a href="/stats/ddets/iae" class="btn-link btn-ico">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Données IAE de mon département</span>
+                                  </a>
+                              </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension des structures de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche de mon département</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                          
+                          
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS LOG-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets_log/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS LOG-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets_log/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DDETS LOG-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/ddets_log/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DGEFP GEIQ-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DGEFP GEIQ-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DGEFP GEIQ-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DGEFP IAE-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Focus auto-prescription</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              Which should happen once the dgefp starts working with us properly
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a href="/stats/dgefp/iae" class="btn-link btn-ico">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE France entière</span>
+                              </a>
+                          </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir les données du contrôle a posteriori (version bêta)</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DGEFP IAE-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Focus auto-prescription</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              Which should happen once the dgefp starts working with us properly
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a href="/stats/dgefp/iae" class="btn-link btn-ico">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE France entière</span>
+                              </a>
+                          </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir les données du contrôle a posteriori (version bêta)</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DGEFP IAE-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Focus auto-prescription</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              Which should happen once the dgefp starts working with us properly
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a href="/stats/dgefp/iae" class="btn-link btn-ico">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données IAE France entière</span>
+                              </a>
+                          </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Voir les données du contrôle a posteriori (version bêta)</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dgefp/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DIHAL-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dihal/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DIHAL-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dihal/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DIHAL-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dihal/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DREETS GEIQ-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DREETS GEIQ-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DREETS GEIQ-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DREETS IAE-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Les auto-prescription des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation de ma région</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a href="/stats/dreets/iae" class="btn-link btn-ico">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Données IAE de ma région</span>
+                                  </a>
+                              </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/orga_etp">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivre les effectifs annuels et mensuels en ETP des structures de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DREETS IAE-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Les auto-prescription des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation de ma région</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a href="/stats/dreets/iae" class="btn-link btn-ico">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Données IAE de ma région</span>
+                                  </a>
+                              </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DREETS IAE-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/auto_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Les auto-prescription des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/ph_prescription">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/follow_siae_evaluation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi du contrôle à posteriori des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/follow_prolongation">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Suivi des demandes de prolongation de ma région</span>
+                              </a>
+                          </li>
+                          <!-- Stats temporarily suspended until we stabilize them
+                              <li class="d-flex justify-content-between align-items-center mb-3">
+                                  <a href="/stats/dreets/iae" class="btn-link btn-ico">
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <span>Données IAE de ma région</span>
+                                  </a>
+                              </li>
+                          -->
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/tension">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Fiches de poste en tension des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Données facilitation à l'embauche des structures de ma région</span>
+                              </a>
+                          </li>
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/dreets/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                          </li>
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DRIHL-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/drihl/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DRIHL-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/drihl/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[DRIHL-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/drihl/state">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Prescriptions des acteurs AHI de ma région</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[R\xe9seau IAE-31]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/iae_network/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[R\xe9seau IAE-84]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/iae_network/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_labor_inspector[R\xe9seau IAE-90]
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <ul class="list-unstyled mb-lg-5">
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                      
+                          <li class="d-flex justify-content-between align-items-center mb-3">
+                              <a class="btn-link btn-ico" href="/stats/iae_network/hiring">
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
+                              </a>
+                              <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
+  
+                          </li>
+                      
+                      
+                  </ul>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---
+# name: test_index_stats_for_non_authorized_prescriber
+  '''
+  <div aria-labelledby="statistiques-tab" class="tab-pane fade show active" id="statistiques" role="tabpanel">
+                              <h2>Statistiques</h2>
+                              <div class="c-banner c-banner--pilotage rounded-3 p-3 py-md-5 mt-3 mt-md-4 mb-3 mb-md-5">
+                                  <img alt="Le pilotage de l'inclusion" height="80" src="/static/vendor/theme-inclusion/images/logo-pilotage-inclusion.svg"/>
+                              </div>
+                              <div class="row row-cols-1 row-cols-md-2 mt-3 mt-md-4"><div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données personnalisées</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              
+                  <p>
+                      Vous ne disposez pas pour le moment de statistiques personnalisées.
+                      Faites-nous part de vos besoins éventuels en nous contactant
+                      <a aria-label="Formulaire de contact (ouverture dans un nouvel onglet)" href="https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr/requests/new" rel="noreferrer noopener" target="_blank" title="Formulaire de contact (ouverture dans un nouvel onglet)">ici</a>.
+                  </p>
+              
+          </div>
+      </div>
+  </div>
+  <div class="col mb-3 mb-md-5">
+      <div class="c-box p-0 h-100">
+          <div class="p-3 p-lg-4">
+              <span class="h4 mb-0">Données publiques</span>
+          </div>
+          <div class="px-3 px-lg-4">
+              <ul class="list-unstyled mb-lg-5">
+                  <li class="d-flex justify-content-between align-items-center mb-3">
+                      <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
+                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <span>Accéder aux tableaux de bord publics</span>
+                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                      </a>
+                  </li>
+              </ul>
+          </div>
+      </div>
+  </div>
+  </div>
+                          </div>
+  '''
+# ---

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -333,50 +333,6 @@ class TestDashboardView:
         assertion = assertContains if user.can_create_siae_antenna(company) else assertNotContains
         assertion(response, "Créer/rejoindre une autre structure")
 
-    def test_dashboard_siae_stats(self, client):
-        membership = CompanyMembershipFactory()
-        client.force_login(membership.user)
-        response = client.get(reverse("dashboard:index_stats"))
-        assertContains(response, "Traitement et résultats des candidatures reçues par ma ou mes structures")
-        assertContains(response, reverse("stats:stats_siae_hiring"))
-        assertContains(response, "Auto-prescription réalisées par ma ou mes structures")
-        assertContains(response, reverse("stats:stats_siae_auto_prescription"))
-        assertContains(response, "Suivi du contrôle a posteriori pour ma ou mes structures")
-        assertContains(response, reverse("stats:stats_siae_follow_siae_evaluation"))
-        # Unofficial stats are only accessible to specific whitelisted siaes.
-        assertNotContains(response, "Suivre les effectifs annuels et mensuels en ETP de ma ou mes structures")
-        assertNotContains(response, reverse("stats:stats_siae_etp"))
-        assertNotContains(response, "Suivi du cofinancement des ACI de mon département")
-        assertNotContains(response, reverse("stats:stats_siae_aci"))
-
-    def test_dashboard_ddets_log_institution_stats(self, client):
-        membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_LOG)
-        client.force_login(membershipfactory.user)
-        response = client.get(reverse("dashboard:index_stats"))
-        assertContains(response, "Prescriptions des acteurs AHI de ma région")
-        assertContains(response, reverse("stats:stats_ddets_log_state"))
-
-    def test_dashboard_dihal_institution_stats(self, client):
-        membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DIHAL)
-        client.force_login(membershipfactory.user)
-        response = client.get(reverse("dashboard:index_stats"))
-        assertContains(response, "Prescriptions des acteurs AHI")
-        assertContains(response, reverse("stats:stats_dihal_state"))
-
-    def test_dashboard_drihl_institution_stats(self, client):
-        membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.DRIHL)
-        client.force_login(membershipfactory.user)
-        response = client.get(reverse("dashboard:index_stats"))
-        assertContains(response, "Prescriptions des acteurs AHI")
-        assertContains(response, reverse("stats:stats_drihl_state"))
-
-    def test_dashboard_iae_network_institution_stats(self, client):
-        membershipfactory = InstitutionMembershipFactory(institution__kind=InstitutionKind.IAE_NETWORK)
-        client.force_login(membershipfactory.user)
-        response = client.get(reverse("dashboard:index_stats"))
-        assertContains(response, "Traitement et résultats des candidatures orientées par mes adhérents")
-        assertContains(response, reverse("stats:stats_iae_network_hiring"))
-
     def test_dashboard_siae_evaluations_institution_access(self, client):
         IN_PROGRESS_LINK = "Campagne en cours"
         membershipfactory = InstitutionMembershipFactory()

--- a/tests/www/dashboard/test_dashboard_stats.py
+++ b/tests/www/dashboard/test_dashboard_stats.py
@@ -1,0 +1,73 @@
+import pytest
+from django.urls import reverse
+
+from itou.companies.enums import CompanyKind
+from itou.institutions.enums import InstitutionKind
+from itou.prescribers.enums import PrescriberOrganizationKind
+from tests.institutions.factories import LaborInspectorFactory
+from tests.users.factories import EmployerFactory, PrescriberFactory
+from tests.utils.test import parse_response_to_soup
+
+
+@pytest.mark.parametrize("department", ["31", "84", "90"])
+@pytest.mark.parametrize("kind", [CompanyKind.EI, CompanyKind.ACI])
+def test_index_stats_for_employer(snapshot, client, kind, department):
+    client.force_login(
+        EmployerFactory(
+            with_company=True,
+            with_company__company__department__kind=kind,
+            with_company__company__department=department,
+        )
+    )
+
+    response = client.get(reverse("dashboard:index_stats"))
+    assert str(parse_response_to_soup(response, selector="#statistiques")) == snapshot()
+
+
+@pytest.mark.parametrize("department", ["31", "75", "84", "90"])
+@pytest.mark.parametrize(
+    "kind",
+    [
+        PrescriberOrganizationKind.DEPT,
+        PrescriberOrganizationKind.PE,
+        PrescriberOrganizationKind.CHRS,
+        PrescriberOrganizationKind.CHU,
+        PrescriberOrganizationKind.OIL,
+        PrescriberOrganizationKind.RS_FJT,
+        PrescriberOrganizationKind.CAP_EMPLOI,
+        PrescriberOrganizationKind.ML,
+    ],
+)
+def test_index_stats_for_authorized_prescriber(snapshot, client, kind, department):
+    client.force_login(
+        PrescriberFactory(
+            membership__organization__authorized=True,
+            membership__organization__kind=kind,
+            membership__organization__department=department,
+        )
+    )
+
+    response = client.get(reverse("dashboard:index_stats"))
+    assert str(parse_response_to_soup(response, selector="#statistiques")) == snapshot()
+
+
+def test_index_stats_for_non_authorized_prescriber(snapshot, client):
+    client.force_login(
+        PrescriberFactory(
+            membership__organization__authorized=False, membership__organization__kind=PrescriberOrganizationKind.OTHER
+        )
+    )
+
+    response = client.get(reverse("dashboard:index_stats"))
+    assert str(parse_response_to_soup(response, selector="#statistiques")) == snapshot()
+
+
+@pytest.mark.parametrize("department", ["31", "84", "90"])
+@pytest.mark.parametrize("kind", InstitutionKind)
+def test_index_stats_for_labor_inspector(snapshot, client, kind, department):
+    client.force_login(
+        LaborInspectorFactory(membership__institution__kind=kind, membership__institution__department=department)
+    )
+
+    response = client.get(reverse("dashboard:index_stats"))
+    assert str(parse_response_to_soup(response, selector="#statistiques")) == snapshot()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Globalement plus simple à maintenir, plus complet également, et ça permet aussi de voir une partie des changements apportés dans #4589.

Pour les `parametrize` j'ai _normalement_ repris toutes les conditions possibles dans les fonctions `can_view_*` afin de tester le plus de cas particuliers sans exploser le nombre de tests générés.