### PR TITLE
Mesurer l’usage de la fonctionnalité RDV-Insertion (Matomo) [GEN-2177]

### DIFF
--- a/itou/templates/apply/includes/appointments.html
+++ b/itou/templates/apply/includes/appointments.html
@@ -1,4 +1,5 @@
 {% load datetime_filters %}
+{% load matomo %}
 
 {% if request.user.is_employer %}
     {% include "apply/includes/invitation_requests.html" with job_application=job_application invitation_requests=invitation_requests %}
@@ -26,7 +27,7 @@
                         <td>{{ participation.appointment.start_at }}</td>
                         <td>{{ participation.appointment.reason }}</td>
                         <td id="participation-{{ participation.pk }}-row" class="text-end w-50px">
-                            <button type="button" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="modal" data-bs-target="#participation-{{ participation.pk }}-modal">
+                            <button type="button" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="modal" data-bs-target="#participation-{{ participation.pk }}-modal" {% matomo_event "candidature" "clic" "visualisation-rdv" %}>
                                 <i class="ri-search-line" data-bs-toggle="tooltip" data-bs-title="Voir"></i>
                             </button>
                             <div class="modal modal--mini fade text-start" id="participation-{{ participation.pk }}-modal" tabindex="-1" aria-labelledby="participation-{{ participation.pk }}-modal-title" aria-hidden="true">

--- a/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
+++ b/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
@@ -20,7 +20,7 @@
                           <td>1 septembre 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -94,7 +94,7 @@
                           <td>1 septembre 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -168,7 +168,7 @@
                           <td>1 septembre 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -224,7 +224,7 @@
                           <td>1 juin 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-22222222-2222-2222-2222-222222222222-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-22222222-2222-2222-2222-222222222222-modal-title" class="modal modal--mini fade text-start" id="participation-22222222-2222-2222-2222-222222222222-modal" tabindex="-1">
@@ -298,7 +298,7 @@
                           <td>1 septembre 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -354,7 +354,7 @@
                           <td>1 juin 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-22222222-2222-2222-2222-222222222222-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-22222222-2222-2222-2222-222222222222-modal-title" class="modal modal--mini fade text-start" id="participation-22222222-2222-2222-2222-222222222222-modal" tabindex="-1">
@@ -428,7 +428,7 @@
                           <td>1 septembre 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -484,7 +484,7 @@
                           <td>4 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-22222222-2222-2222-2222-222222222222-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-22222222-2222-2222-2222-222222222222-modal-title" class="modal modal--mini fade text-start" id="participation-22222222-2222-2222-2222-222222222222-modal" tabindex="-1">
@@ -540,7 +540,7 @@
                           <td>3 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-33333333-3333-3333-3333-333333333333-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-33333333-3333-3333-3333-333333333333-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-33333333-3333-3333-3333-333333333333-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-33333333-3333-3333-3333-333333333333-modal-title" class="modal modal--mini fade text-start" id="participation-33333333-3333-3333-3333-333333333333-modal" tabindex="-1">
@@ -596,7 +596,7 @@
                           <td>2 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-44444444-4444-4444-4444-444444444444-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-44444444-4444-4444-4444-444444444444-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-44444444-4444-4444-4444-444444444444-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-44444444-4444-4444-4444-444444444444-modal-title" class="modal modal--mini fade text-start" id="participation-44444444-4444-4444-4444-444444444444-modal" tabindex="-1">
@@ -652,7 +652,7 @@
                           <td>1 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-55555555-5555-5555-5555-555555555555-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-55555555-5555-5555-5555-555555555555-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-55555555-5555-5555-5555-555555555555-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-55555555-5555-5555-5555-555555555555-modal-title" class="modal modal--mini fade text-start" id="participation-55555555-5555-5555-5555-555555555555-modal" tabindex="-1">
@@ -726,7 +726,7 @@
                           <td>1 septembre 2024 10:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -782,7 +782,7 @@
                           <td>4 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-22222222-2222-2222-2222-222222222222-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-22222222-2222-2222-2222-222222222222-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-22222222-2222-2222-2222-222222222222-modal-title" class="modal modal--mini fade text-start" id="participation-22222222-2222-2222-2222-222222222222-modal" tabindex="-1">
@@ -838,7 +838,7 @@
                           <td>3 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-33333333-3333-3333-3333-333333333333-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-33333333-3333-3333-3333-333333333333-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-33333333-3333-3333-3333-333333333333-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-33333333-3333-3333-3333-333333333333-modal-title" class="modal modal--mini fade text-start" id="participation-33333333-3333-3333-3333-333333333333-modal" tabindex="-1">
@@ -894,7 +894,7 @@
                           <td>2 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-44444444-4444-4444-4444-444444444444-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-44444444-4444-4444-4444-444444444444-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-44444444-4444-4444-4444-444444444444-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-44444444-4444-4444-4444-444444444444-modal-title" class="modal modal--mini fade text-start" id="participation-44444444-4444-4444-4444-444444444444-modal" tabindex="-1">
@@ -950,7 +950,7 @@
                           <td>1 janvier 2024 09:00</td>
                           <td>Entretien d'embauche</td>
                           <td class="text-end w-50px" id="participation-55555555-5555-5555-5555-555555555555-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-55555555-5555-5555-5555-555555555555-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-55555555-5555-5555-5555-555555555555-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-55555555-5555-5555-5555-555555555555-modal-title" class="modal modal--mini fade text-start" id="participation-55555555-5555-5555-5555-555555555555-modal" tabindex="-1">
@@ -1006,7 +1006,7 @@
 # name: TestRdvInsertionAppointmentsList.test_appointments_tooltips[employer-apply:details_for_company]
   '''
   <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">
@@ -1058,7 +1058,7 @@
 # name: TestRdvInsertionAppointmentsList.test_appointments_tooltips[job_seeker-apply:details_for_jobseeker]
   '''
   <td class="text-end w-50px" id="participation-11111111-1111-1111-1111-111111111111-row">
-                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" type="button">
+                              <button class="btn btn-sm btn-link btn-ico-only" data-bs-target="#participation-11111111-1111-1111-1111-111111111111-modal" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="visualisation-rdv" type="button">
                                   <i class="ri-search-line" data-bs-title="Voir" data-bs-toggle="tooltip"></i>
                               </button>
                               <div aria-hidden="true" aria-labelledby="participation-11111111-1111-1111-1111-111111111111-modal-title" class="modal modal--mini fade text-start" id="participation-11111111-1111-1111-1111-111111111111-modal" tabindex="-1">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Tracker l'ensemble des événements prévus :

- Clic bouton proposer un rdv (commun listing/detail de candidature) (déjà en place)
- Clic onglet RDV (déjà en place)
- **Clic sur la modale détails (nouvellement ajouté)**