### PR TITLE
Pagination : Passer de 50 à 20 résultats par page sur 6 listes dont les listes de candidatures

### DIFF
--- a/itou/www/apply/views/list_views.py
+++ b/itou/www/apply/views/list_views.py
@@ -121,7 +121,7 @@ def list_for_job_seeker(request, template_name="apply/list_for_job_seeker.html")
         job_applications = filters_form.filter(job_applications)
         filters_counter = filters_form.get_qs_filters_counter()
 
-    job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=50)
+    job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=20)
     _add_pending_for_weeks(job_applications_page)
 
     # The candidate has obviously access to its personal info
@@ -178,7 +178,7 @@ def list_prescriptions(request, template_name="apply/list_prescriptions.html"):
         filters_counter = filters_form.get_qs_filters_counter()
         title = annotate_title(title, filters_form.cleaned_data["archived"])
 
-    job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=50)
+    job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=20)
     _add_pending_for_weeks(job_applications_page)
     _add_user_can_view_personal_information(job_applications_page, request.user.can_view_personal_information)
     _add_administrative_criteria(job_applications_page)
@@ -301,7 +301,7 @@ def list_for_siae(request, template_name="apply/list_for_siae.html"):
         - 1,  # Exclude the next appointment
     )
 
-    job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=50)
+    job_applications_page = pager(job_applications, request.GET.get("page"), items_per_page=20)
     _add_pending_for_weeks(job_applications_page)
 
     # SIAE members have access to personal info

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -488,7 +488,7 @@ def prolongation_requests_list(request, template_name="approvals/prolongation_re
 
     context = {
         "form": form,
-        "pager": pager(queryset, request.GET.get("page"), items_per_page=50),
+        "pager": pager(queryset, request.GET.get("page"), items_per_page=20),
         "back_url": reverse("dashboard:index"),
     }
     return render(request, template_name, context)

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -227,7 +227,7 @@ def job_description_list(request, template_name="companies/job_description_list.
 
         return HttpResponseRedirect(f"{reverse('companies_views:job_description_list')}?page={page}")
 
-    job_pager = pager(job_descriptions, page, items_per_page=50)
+    job_pager = pager(job_descriptions, page, items_per_page=20)
 
     context = {
         "siae": company,

--- a/itou/www/geiq_views/views.py
+++ b/itou/www/geiq_views/views.py
@@ -227,7 +227,7 @@ def employee_list(request, assessment_pk, info_type):
 
     context = {
         "active_tab": info_type,
-        "data_page": pager(queryset, request.GET.get("page"), items_per_page=50),
+        "data_page": pager(queryset, request.GET.get("page"), items_per_page=20),
         "InfoType": InfoType,
         "assessment": assessment,
         "back_url": get_safe_url(


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/plateforme-inclusion/Passer-20-r-sultats-en-vue-carte-et-en-vue-tableau-137e8fa5c35b80e7ab9efe482c6fd036

Je cite :

```
On est passés par erreur à 50 résultats en vue carte.
Après discussion on passe tous les résultats à 20 (en vue carte ET en vue tableau)
```