### PR TITLE
Logger les redirections entre tunnels dans `apply` et `job_seekers_views`

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -230,6 +230,7 @@ class ApplyStepForSenderBaseView(ApplyStepBaseView):
 
     def dispatch(self, request, *args, **kwargs):
         if self.sender.is_authenticated and self.sender.kind not in [UserKind.PRESCRIBER, UserKind.EMPLOYER]:
+            logger.info(f"dispatch ({request.path}) : {self.sender.kind} in sender tunnel")
             return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
         return super().dispatch(request, *args, **kwargs)
 

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -199,6 +199,7 @@ class CheckNIRForJobSeekerView(ApplyStepBaseView):
 
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_authenticated and not self.job_seeker.is_job_seeker:
+            logger.info(f"dispatch ({request.path}) : {request.user.kind} in jobseeker tunnel")
             return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement, dans `apply` et `job_seekers_views`, on vérifie dans un `dispatch()` si on est positionné sur le mauvais tunnel (tunnel `sender` en tant que candidat, ou tunnel `job_seeker` en tant que proxy).

Il est possible que ces redirections ne soient même pas utilisées, il faudrait avoir construit un lien incorrect dans une vue.

Voir https://github.com/gip-inclusion/les-emplois/pull/5066#discussion_r1846962027.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

