### PR TITLE
Création de compte candidat : déconnecter la recherche par email du parcours `apply` 

### DIFF
--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -17,6 +17,12 @@ urlpatterns = [
         name="check_nir_for_sender",
     ),
     path(
+        "<uuid:session_uuid>/sender/search-by-email",
+        views.SearchByEmailForSenderView.as_view(),
+        name="search_by_email_for_sender",
+    ),
+    # TODO(ewen): deprecated URL
+    path(
         "<int:company_pk>/sender/search-by-email/<uuid:session_uuid>",
         views.SearchByEmailForSenderView.as_view(),
         name="search_by_email_for_sender",
@@ -54,6 +60,13 @@ urlpatterns = [
         name="check_nir_for_hire",
         kwargs={"hire_process": True},
     ),
+    path(
+        "<uuid:session_uuid>/hire/search-by-email",
+        views.SearchByEmailForSenderView.as_view(),
+        name="search_by_email_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    # TODO(ewen): deprecated URL
     path(
         "<int:company_pk>/hire/search-by-email/<uuid:session_uuid>",
         views.SearchByEmailForSenderView.as_view(),

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -74,7 +74,7 @@ def test_create_job_seeker(_mock, client):
     next_url = (
         reverse(
             "job_seekers_views:search_by_email_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
     )
@@ -125,7 +125,7 @@ def test_create_job_seeker(_mock, client):
         response,
         reverse(
             "job_seekers_views:search_by_email_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         ),
     )
 
@@ -304,7 +304,7 @@ def test_existing_user_with_email(client):
     next_url = (
         reverse(
             "job_seekers_views:search_by_email_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
     )

--- a/tests/www/job_seekers_views/test_create.py
+++ b/tests/www/job_seekers_views/test_create.py
@@ -1,11 +1,13 @@
 import datetime
 
+import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertRedirects
 
 from tests.companies.factories import CompanyFactory
 from tests.users.factories import (
     JobSeekerFactory,
+    PrescriberFactory,
 )
 from tests.utils.test import KNOWN_SESSION_KEYS
 
@@ -78,3 +80,82 @@ class TestCreateForSender:
         )
 
         assertContains(response, company.display_name)
+
+    # TODO(ewen): to be removed after migration is complete
+    @pytest.mark.ignore_unknown_variable_template_error(
+        "job_seeker", "update_job_seeker", "readonly_form", "confirmation_needed"
+    )
+    def test_company_in_searchbyemail_after_deprecated_checknir(self, client):
+        company = CompanyFactory(with_membership=True)
+        user = PrescriberFactory(membership=True)
+        client.force_login(user)
+
+        # Check NIR.
+        # ----------------------------------------------------------------------
+        deprecated_checknir_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"company_pk": company.pk})
+        nir = "141068078200557"
+        post_data = {"nir": nir, "confirm": 1}
+        response = client.post(deprecated_checknir_url, data=post_data)
+        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        deprecated_email_url = reverse(
+            "job_seekers_views:search_by_email_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        )
+        expected_job_seeker_session = {
+            "profile": {
+                "nir": nir,
+            },
+        }
+
+        assert response.url == deprecated_email_url
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session
+        assertRedirects(response, deprecated_email_url)
+
+        # Search by email
+        # ----------------------------------------------------------------------
+        response = client.get(deprecated_email_url)
+        new_checknir_url = reverse(
+            "job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name}
+        )
+        expected_job_seeker_session |= {"profile": {"nir": nir}, "apply": {"company_pk": company.pk}}
+        assertContains(response, f"<h3>{company.display_name}</h3>", html=True)
+        assertContains(
+            response,
+            f"""<a href="{new_checknir_url}"
+                class="btn btn-block btn-outline-primary"
+                aria-label="Retourner à l’étape précédente">
+                    <span>Retour</span>
+                </a>""",
+            html=True,
+        )
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session
+
+        email = "jean_dujardain@email.com"
+        post_data = {"email": email, "confirm": 1}
+        response = client.post(deprecated_email_url, data=post_data)
+        deprecated_create_url = reverse(
+            "job_seekers_views:create_job_seeker_step_1_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        )
+        expected_job_seeker_session |= {"user": {"email": email}}
+
+        assert response.url == deprecated_create_url
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session
+        assertRedirects(response, deprecated_create_url)
+
+        # Create job seeker step 1.
+        # ----------------------------------------------------------------------
+        response = client.get(deprecated_create_url)
+        new_email_url = reverse(
+            "job_seekers_views:search_by_email_for_sender", kwargs={"session_uuid": job_seeker_session_name}
+        )
+        assert response.status_code == 200
+        assertContains(
+            response,
+            f"""<a href="{new_email_url}"
+                class="btn btn-block btn-outline-primary"
+                aria-label="Retourner à l’étape précédente">
+                    <span>Retour</span>
+                </a>""",
+            html=True,
+        )


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR, on déconnecte l'étape de recherche de candidat par email pour que la vue `SearchByEmailForSenderView` ne dépende plus de classes dans `apply`.

**À noter :** 
Pour ne pas casser les parcours de candidature en cours en production, nous devons temporairement avoir 2 jeux d'URLs fonctionnels, avec et sans le paramètre `company_pk`. Cette fois-ci, pas besoin de vue dépréciée par contre ! :-)

--- 

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657





