### PR TITLE
README : Correction d'un exemple de commande pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ make test
 
 Lancer un test en particulier :
 ```sh
-pytest itou/utils/tests.py::JSONTest::test_encoder
+pytest tests/utils/tests.py::TestJSON::test_encoder
 ```
 
 ## Mettre à jour les dépendances Python


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une commande incorrecte trainait dans le README.