### PR TITLE
Création de compte candidat : déconnecter la création du parcours `apply` 

### DIFF
--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -28,6 +28,27 @@ urlpatterns = [
         name="search_by_email_for_sender",
     ),
     path(
+        "<uuid:session_uuid>/sender/create/1",
+        views.CreateJobSeekerStep1ForSenderView.as_view(),
+        name="create_job_seeker_step_1_for_sender",
+    ),
+    path(
+        "<uuid:session_uuid>/sender/create/2",
+        views.CreateJobSeekerStep2ForSenderView.as_view(),
+        name="create_job_seeker_step_2_for_sender",
+    ),
+    path(
+        "<uuid:session_uuid>/sender/create/3",
+        views.CreateJobSeekerStep3ForSenderView.as_view(),
+        name="create_job_seeker_step_3_for_sender",
+    ),
+    path(
+        "<uuid:session_uuid>/sender/create/end",
+        views.CreateJobSeekerStepEndForSenderView.as_view(),
+        name="create_job_seeker_step_end_for_sender",
+    ),
+    # TODO(ewen): deprecated URLs
+    path(
         "<int:company_pk>/sender/create/<uuid:session_uuid>/1",
         views.CreateJobSeekerStep1ForSenderView.as_view(),
         name="create_job_seeker_step_1_for_sender",
@@ -73,6 +94,31 @@ urlpatterns = [
         name="search_by_email_for_hire",
         kwargs={"hire_process": True},
     ),
+    path(
+        "<uuid:session_uuid>/hire/create/1",
+        views.CreateJobSeekerStep1ForSenderView.as_view(),
+        name="create_job_seeker_step_1_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<uuid:session_uuid>/hire/create/2",
+        views.CreateJobSeekerStep2ForSenderView.as_view(),
+        name="create_job_seeker_step_2_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<uuid:session_uuid>/hire/create/3",
+        views.CreateJobSeekerStep3ForSenderView.as_view(),
+        name="create_job_seeker_step_3_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    path(
+        "<uuid:session_uuid>/hire/create/end",
+        views.CreateJobSeekerStepEndForSenderView.as_view(),
+        name="create_job_seeker_step_end_for_hire",
+        kwargs={"hire_process": True},
+    ),
+    # TODO(ewen): deprecated URLs
     path(
         "<int:company_pk>/hire/create/<uuid:session_uuid>/1",
         views.CreateJobSeekerStep1ForSenderView.as_view(),

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -544,9 +544,7 @@ class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, JobSeekerForSend
                 )
 
                 return HttpResponseRedirect(
-                    reverse(
-                        view_name, kwargs={"company_pk": self.company.pk, "session_uuid": self.job_seeker_session.name}
-                    )
+                    reverse(view_name, kwargs={"session_uuid": self.job_seeker_session.name})
                     + ("?gps=true" if self.is_gps else "")
                 )
 
@@ -607,29 +605,25 @@ class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, JobSeekerForSend
         }
 
 
-class CreateJobSeekerForSenderBaseView(SessionNamespaceRequiredMixin, ApplyStepForSenderBaseView):
+class CreateJobSeekerForSenderBaseView(JobSeekerForSenderBaseView):
     required_session_namespaces = ["job_seeker_session"]
 
     def __init__(self):
         super().__init__()
         self.job_seeker_session = None
 
-    def setup(self, request, *args, **kwargs):
-        self.job_seeker_session = SessionNamespace(request.session, kwargs["session_uuid"])
-        super().setup(request, *args, **kwargs)
-
     def get_back_url(self):
         view_name = self.previous_hire_url if self.hire_process else self.previous_apply_url
         return reverse(
             view_name,
-            kwargs={"company_pk": self.company.pk, "session_uuid": self.job_seeker_session.name},
+            kwargs={"session_uuid": self.job_seeker_session.name},
         ) + ("?gps=true" if self.is_gps else "")
 
     def get_next_url(self):
         view_name = self.next_hire_url if self.hire_process else self.next_apply_url
         return reverse(
             view_name,
-            kwargs={"company_pk": self.company.pk, "session_uuid": self.job_seeker_session.name},
+            kwargs={"session_uuid": self.job_seeker_session.name},
         ) + ("?gps=true" if self.is_gps else "")
 
 

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -106,7 +106,7 @@ def test_create_job_seeker(_mock, client):
     next_url = (
         reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
     )
@@ -153,7 +153,7 @@ def test_create_job_seeker(_mock, client):
     next_url = (
         reverse(
             "job_seekers_views:create_job_seeker_step_2_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
     )
@@ -177,7 +177,7 @@ def test_create_job_seeker(_mock, client):
     next_url = (
         reverse(
             "job_seekers_views:create_job_seeker_step_3_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
     )
@@ -211,7 +211,7 @@ def test_create_job_seeker(_mock, client):
     next_url = (
         reverse(
             "job_seekers_views:create_job_seeker_step_end_for_sender",
-            kwargs={"company_pk": singleton.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         + "?gps=true"
     )

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -148,7 +148,7 @@ class TestApply:
         )
         assert response.status_code == 404
 
-    def test_we_raise_a_permission_denied_on_missing_temporary_session_for_create_job_seeker(self, client, subtests):
+    def test_we_raise_a_404_on_missing_temporary_session_for_create_job_seeker(self, client, subtests):
         routes = {
             "job_seekers_views:create_job_seeker_step_1_for_sender",
             "job_seekers_views:create_job_seeker_step_2_for_sender",
@@ -156,14 +156,11 @@ class TestApply:
             "job_seekers_views:create_job_seeker_step_end_for_sender",
         }
         user = JobSeekerFactory()
-        company = CompanyFactory(with_jobs=True)
-
         client.force_login(user)
         for route in routes:
             with subtests.test(route=route):
-                response = client.get(reverse(route, kwargs={"company_pk": company.pk, "session_uuid": uuid.uuid4()}))
-                assert response.status_code == 403
-                assert response.context["exception"] == "A session namespace doesn't exist."
+                response = client.get(reverse(route, kwargs={"session_uuid": uuid.uuid4()}))
+                assert response.status_code == 404
 
     def test_404_when_trying_to_apply_for_a_prescriber(self, client):
         company = CompanyFactory(with_jobs=True)
@@ -266,7 +263,7 @@ class TestHire:
         )
         assert response.status_code == 404
 
-    def test_we_raise_a_permission_denied_on_missing_temporary_session_for_create_job_seeker(self, client, subtests):
+    def test_we_raise_a_404_on_missing_temporary_session_for_create_job_seeker(self, client, subtests):
         routes = {
             "job_seekers_views:create_job_seeker_step_1_for_hire",
             "job_seekers_views:create_job_seeker_step_2_for_hire",
@@ -274,14 +271,12 @@ class TestHire:
             "job_seekers_views:create_job_seeker_step_end_for_hire",
         }
         user = JobSeekerFactory()
-        company = CompanyFactory(with_jobs=True)
 
         client.force_login(user)
         for route in routes:
             with subtests.test(route=route):
-                response = client.get(reverse(route, kwargs={"company_pk": company.pk, "session_uuid": uuid.uuid4()}))
-                assert response.status_code == 403
-                assert response.context["exception"] == "A session namespace doesn't exist."
+                response = client.get(reverse(route, kwargs={"session_uuid": uuid.uuid4()}))
+                assert response.status_code == 404
 
     def test_404_when_trying_to_update_a_prescriber(self, client):
         company = CompanyFactory(with_jobs=True, with_membership=True)
@@ -924,7 +919,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -950,7 +945,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -993,7 +988,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_2_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1018,7 +1013,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_3_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1053,7 +1048,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_end_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1218,7 +1213,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1252,7 +1247,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1296,7 +1291,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_2_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1321,7 +1316,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_3_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1357,7 +1352,7 @@ class TestApplyAsAuthorizedPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_end_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1688,7 +1683,7 @@ class TestApplyAsPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1762,7 +1757,7 @@ class TestApplyAsPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_2_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1786,7 +1781,7 @@ class TestApplyAsPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_3_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -1822,7 +1817,7 @@ class TestApplyAsPrescriber:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_end_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2304,7 +2299,7 @@ class TestApplyAsCompany:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2331,7 +2326,7 @@ class TestApplyAsCompany:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2405,7 +2400,7 @@ class TestApplyAsCompany:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_2_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2430,7 +2425,7 @@ class TestApplyAsCompany:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_3_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2466,7 +2461,7 @@ class TestApplyAsCompany:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_end_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2807,7 +2802,7 @@ class TestDirectHireFullProcess:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_hire",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2839,7 +2834,7 @@ class TestDirectHireFullProcess:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_hire",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2912,7 +2907,7 @@ class TestDirectHireFullProcess:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_2_for_hire",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2938,7 +2933,7 @@ class TestDirectHireFullProcess:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_3_for_hire",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -2974,7 +2969,7 @@ class TestDirectHireFullProcess:
 
         next_url = reverse(
             "job_seekers_views:create_job_seeker_step_end_for_hire",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         assert response.url == next_url
 
@@ -4376,7 +4371,7 @@ def test_detect_existing_job_seeker(client):
 
     next_url = reverse(
         "job_seekers_views:create_job_seeker_step_1_for_sender",
-        kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     assert response.url == next_url
 
@@ -4402,7 +4397,7 @@ def test_detect_existing_job_seeker(client):
 
     next_url = reverse(
         "job_seekers_views:create_job_seeker_step_1_for_sender",
-        kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     assert response.url == next_url
 
@@ -4465,7 +4460,7 @@ def test_detect_existing_job_seeker(client):
 
     next_url = reverse(
         "job_seekers_views:create_job_seeker_step_2_for_sender",
-        kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     assert response.url == next_url
 
@@ -5060,7 +5055,7 @@ class TestFindJobSeekerForHireView:
             response,
             reverse(
                 "job_seekers_views:create_job_seeker_step_1_for_hire",
-                kwargs={"company_pk": self.company.pk, "session_uuid": job_seeker_session_name},
+                kwargs={"session_uuid": job_seeker_session_name},
             ),
         )
 

--- a/tests/www/job_seekers_views/test_create.py
+++ b/tests/www/job_seekers_views/test_create.py
@@ -133,19 +133,19 @@ class TestCreateForSender:
         email = "jean_dujardain@email.com"
         post_data = {"email": email, "confirm": 1}
         response = client.post(deprecated_email_url, data=post_data)
-        deprecated_create_url = reverse(
+        create_url = reverse(
             "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+            kwargs={"session_uuid": job_seeker_session_name},
         )
         expected_job_seeker_session |= {"user": {"email": email}}
 
-        assert response.url == deprecated_create_url
+        assert response.url == create_url
         assert client.session[job_seeker_session_name] == expected_job_seeker_session
-        assertRedirects(response, deprecated_create_url)
+        assertRedirects(response, create_url)
 
         # Create job seeker step 1.
         # ----------------------------------------------------------------------
-        response = client.get(deprecated_create_url)
+        response = client.get(create_url)
         new_email_url = reverse(
             "job_seekers_views:search_by_email_for_sender", kwargs={"session_uuid": job_seeker_session_name}
         )
@@ -159,3 +159,55 @@ class TestCreateForSender:
                 </a>""",
             html=True,
         )
+
+        # Create job seeker step 1, without company_pk in session (if user arrived at this step before migration)
+        # ----------------------------------------------------------------------
+        del expected_job_seeker_session["apply"]
+        client.session[job_seeker_session_name] = expected_job_seeker_session
+        deprecated_create_url = reverse(
+            "job_seekers_views:create_job_seeker_step_1_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        )
+
+        response = client.get(deprecated_create_url)
+        expected_job_seeker_session |= {"apply": {"company_pk": company.pk}}
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session
+
+        # Create job seeker step 2, without company_pk in session (if user arrived at this step before migration)
+        # ----------------------------------------------------------------------
+        del expected_job_seeker_session["apply"]
+        client.session[job_seeker_session_name] = expected_job_seeker_session
+        deprecated_create2_url = reverse(
+            "job_seekers_views:create_job_seeker_step_2_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        )
+
+        response = client.get(deprecated_create2_url)
+        expected_job_seeker_session |= {"apply": {"company_pk": company.pk}}
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session
+
+        # Create job seeker step 3, without company_pk in session (if user arrived at this step before migration)
+        # ----------------------------------------------------------------------
+        del expected_job_seeker_session["apply"]
+        client.session[job_seeker_session_name] = expected_job_seeker_session
+        deprecated_create3_url = reverse(
+            "job_seekers_views:create_job_seeker_step_3_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        )
+
+        response = client.get(deprecated_create3_url)
+        expected_job_seeker_session |= {"apply": {"company_pk": company.pk}}
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session
+
+        # Create job seeker step end, without company_pk in session (if user arrived at this step before migration)
+        # ----------------------------------------------------------------------
+        del expected_job_seeker_session["apply"]
+        client.session[job_seeker_session_name] = expected_job_seeker_session
+        deprecated_createend_url = reverse(
+            "job_seekers_views:create_job_seeker_step_3_for_sender",
+            kwargs={"company_pk": company.pk, "session_uuid": job_seeker_session_name},
+        )
+
+        response = client.get(deprecated_createend_url)
+        expected_job_seeker_session |= {"apply": {"company_pk": company.pk}}
+        assert client.session[job_seeker_session_name] == expected_job_seeker_session


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR, on déconnecte les étapes de création/modification de candidat, pour que ces vues ne dépendent plus de classes dans `apply`.

La suite, c'est les vues `Update*` !

**À noter :** 
Pour ne pas casser les parcours de candidature en cours en production, nous devons temporairement avoir 2 jeux d'URLs fonctionnels, avec et sans le paramètre `company_pk`. Cette fois-ci, pas besoin de vue dépréciée par contre ! :-)

--- 

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657






