### PR TITLE
[Analytics] Suivi de l'Apdex et des requêtes non abouties (Sentry)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -706,6 +706,12 @@ API_DATADOG_BASE_URL = "https://api.datadoghq.eu/api/v2"
 API_DATADOG_API_KEY = os.getenv("API_DATADOG_API_KEY", None)
 API_DATADOG_APPLICATION_KEY = os.getenv("API_DATADOG_APPLICATION_KEY", None)
 
+# Sentry
+API_SENTRY_BASE_URL = "https://sentry.io/api/0"
+API_SENTRY_STATS_TOKEN = os.getenv("API_SENTRY_STATS_TOKEN")
+API_SENTRY_ORG_NAME = os.getenv("API_SENTRY_ORG_NAME")
+API_SENTRY_PROJECT_ID = os.getenv("API_SENTRY_PROJECT_ID")
+
 # RDV-I/S
 # ------------------------------------------------------------------------------
 RDV_SOLIDARITES_API_BASE_URL = os.getenv("RDV_SOLIDARITES_API_BASE_URL")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -45,6 +45,11 @@ API_DATADOG_APPLICATION_KEY = "fghij"
 API_PARTICULIER_BASE_URL = "https://fake-api-particulier.com/api/"
 API_PARTICULIER_TOKEN = "test"
 
+API_SENTRY_BASE_URL = "https://www.sinatra.com"
+API_SENTRY_STATS_TOKEN = "stry_xxx"
+API_SENTRY_ORG_ID = "gip"
+
+
 if os.getenv("DEBUG_SQL_SNAPSHOT"):
     # Mandatory to have detailed stacktrace inside templates
     TEMPLATES[0]["OPTIONS"]["debug"] = True  # noqa: F405

--- a/itou/analytics/management/commands/collect_analytics_data.py
+++ b/itou/analytics/management/commands/collect_analytics_data.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from itou.utils.command import BaseCommand
 
-from ... import api_usage, approvals, employee_record, users
+from ... import api_usage, approvals, employee_record, tech, users
 from ...models import Datum
 
 
@@ -37,6 +37,7 @@ class Command(BaseCommand):
             **employee_record.collect_analytics_data(before),
             **users.collect_analytics_data(before),
             **api_usage.collect_analytics_data(before),
+            **tech.collect_analytics_data(before),
         }
 
     def show_data(self, data):

--- a/itou/analytics/migrations/0001_initial.py
+++ b/itou/analytics/migrations/0001_initial.py
@@ -50,6 +50,8 @@ class Migration(migrations.Migration):
                             ("API-010", "API siaes : total d'appels reçus"),
                             ("API-011", "API siaes : total de visiteurs uniques (par adresse IP)"),
                             ("API-012", "API structures : total d'appels reçus"),
+                            ("SENTRY-001", "Apdex"),
+                            ("SENTRY-002", "Taux de requêtes en échec"),
                         ]
                     ),
                 ),

--- a/itou/analytics/models.py
+++ b/itou/analytics/models.py
@@ -44,6 +44,9 @@ class DatumCode(models.TextChoices):
     API_TOTAL_CALLS_SIAES = "API-010", "API siaes : total d'appels reçus"
     API_TOTAL_UV_SIAES = "API-011", "API siaes : total de visiteurs uniques (par adresse IP)"
     API_TOTAL_CALLS_STRUCTURES = "API-012", "API structures : total d'appels reçus"
+    # Tech metrics
+    TECH_SENTRY_APDEX = "SENTRY-001", "Apdex"
+    TECH_SENTRY_FAILURE_RATE = "SENTRY-002", "Taux de requêtes en échec"
 
 
 class Datum(models.Model):

--- a/itou/analytics/tech.py
+++ b/itou/analytics/tech.py
@@ -1,0 +1,16 @@
+from dateutil.relativedelta import relativedelta
+
+from itou.utils.apis.sentry import SentryApiClient
+
+from . import models
+
+
+def collect_analytics_data(before):
+    start = (before - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = before.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    sentry_metrics = SentryApiClient().get_metrics(start=start, end=end)
+    return {
+        models.DatumCode.TECH_SENTRY_APDEX: sentry_metrics["apdex"],
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE: sentry_metrics["failure_rate"],
+    }

--- a/itou/utils/apis/sentry.py
+++ b/itou/utils/apis/sentry.py
@@ -1,0 +1,42 @@
+import logging
+
+import httpx
+import tenacity
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class SentryApiClient:
+    def __init__(self):
+        self.client = httpx.Client(
+            base_url=f"{settings.API_SENTRY_BASE_URL}/organizations/{settings.API_SENTRY_ORG_NAME}",
+            headers={
+                "Authorization": f"Bearer {settings.API_SENTRY_STATS_TOKEN}",
+                "Content-Type": "application/json",
+            },
+        )
+
+    @tenacity.retry(wait=tenacity.wait_fixed(2), stop=tenacity.stop_after_attempt(8))
+    def _request(self, start, end):
+        params = {
+            "query": '(event.type:"transaction")',
+            "project": settings.API_SENTRY_PROJECT_ID,
+            "field": ["apdex()", "failure_rate()"],
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+        }
+
+        response = self.client.get("/events/", params=params)
+        response.raise_for_status()
+        return response
+
+    def get_metrics(self, start, end):
+        response = self._request(start=start, end=end)
+
+        data_received = response.json()["data"][0]
+        return {
+            "failure_rate": data_received["failure_rate()"],
+            "apdex": data_received["apdex()"],
+        }

--- a/tests/analytics/test_collect_analytics_data_management_command.py
+++ b/tests/analytics/test_collect_analytics_data_management_command.py
@@ -114,7 +114,8 @@ def test_save_data_with_an_integrity_error(command):
     assert command.stdout.getvalue() == "Successfully saved code=CODE-002 bucket=2021-12-31 value=21.\n"
 
 
-def test_management_command_name_and_that_all_codes_are_saved(datadog_client):
+@freeze_time("2024-12-03")
+def test_management_command_name_and_that_all_codes_are_saved(datadog_client, sentry_respx_mock):
     call_command("collect_analytics_data", save=True)
 
     assert Datum.objects.all().count() == len(DatumCode)

--- a/tests/analytics/test_tech_metrics.py
+++ b/tests/analytics/test_tech_metrics.py
@@ -1,0 +1,23 @@
+from django.utils import timezone
+from freezegun import freeze_time
+
+from itou.analytics import models, tech
+
+
+@freeze_time("2024-12-03")
+def test_collect_tech_metrics_return_all_codes(sentry_respx_mock):
+    now = timezone.now()
+    assert tech.collect_analytics_data(before=now).keys() == {
+        models.DatumCode.TECH_SENTRY_APDEX,
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE,
+        # next: uptime rate. https://docs.sentry.io/product/alerts/uptime-monitoring/
+    }
+
+
+@freeze_time("2024-12-03")
+def test_collect_tech_metrics_with_data(sentry_respx_mock):
+    now = timezone.now()
+    assert tech.collect_analytics_data(before=now) == {
+        models.DatumCode.TECH_SENTRY_APDEX: 0.9556246545071905,
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE: 0.08123341283760084,
+    }

--- a/tests/utils/apis/test_sentry_api.py
+++ b/tests/utils/apis/test_sentry_api.py
@@ -1,0 +1,20 @@
+import urllib
+
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.utils import timezone
+from freezegun import freeze_time
+
+from itou.utils.apis.sentry import SentryApiClient
+
+
+@freeze_time("2024-12-03")
+def test_request(sentry_respx_mock):
+    end = timezone.now()
+    start = end - relativedelta(days=1)
+
+    response = SentryApiClient()._request(start, end)
+    assert response.status_code == 200
+    assert settings.API_SENTRY_STATS_TOKEN in response.request.headers["authorization"]
+    assert urllib.parse.quote(start.isoformat()) in str(response.url)
+    assert urllib.parse.quote(end.isoformat()) in str(response.url)


### PR DESCRIPTION
Afin de suivre l'impact technique de nos actions, nous récoltons l'apdex et le taux de requêtes en échec de Sentry et les conservons dans l'app Analytics.
cf https://github.com/gip-inclusion/les-emplois/pull/5162