### PR TITLE
[Analytics] Récupération du taux de disponibilité de notre applicatif et de l'apdex (Updown)

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -712,6 +712,11 @@ API_SENTRY_STATS_TOKEN = os.getenv("API_SENTRY_STATS_TOKEN")
 API_SENTRY_ORG_NAME = os.getenv("API_SENTRY_ORG_NAME")
 API_SENTRY_PROJECT_ID = os.getenv("API_SENTRY_PROJECT_ID")
 
+# Updown
+API_UPDOWN_TOKEN = os.getenv("API_UPDOWN_TOKEN")
+API_UPDOWN_BASE_URL = "https://updown.io/api"
+API_UPDOWN_CHECK_ID = os.getenv("API_UPDOWN_CHECK_ID")
+
 # RDV-I/S
 # ------------------------------------------------------------------------------
 RDV_SOLIDARITES_API_BASE_URL = os.getenv("RDV_SOLIDARITES_API_BASE_URL")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -49,6 +49,8 @@ API_SENTRY_BASE_URL = "https://www.sinatra.com"
 API_SENTRY_STATS_TOKEN = "stry_xxx"
 API_SENTRY_ORG_ID = "gip"
 
+API_UPDOWN_TOKEN = "ro-XXXXXXXX"
+API_UPDOWN_CHECK_ID = "blabla"
 
 if os.getenv("DEBUG_SQL_SNAPSHOT"):
     # Mandatory to have detailed stacktrace inside templates

--- a/itou/analytics/migrations/0001_initial.py
+++ b/itou/analytics/migrations/0001_initial.py
@@ -52,6 +52,8 @@ class Migration(migrations.Migration):
                             ("API-012", "API structures : total d'appels reçus"),
                             ("SENTRY-001", "Apdex"),
                             ("SENTRY-002", "Taux de requêtes en échec"),
+                            ("UPDOWN-001", "Taux de disponibilité"),
+                            ("UPDOWN-002", "Apdex"),
                         ]
                     ),
                 ),

--- a/itou/analytics/models.py
+++ b/itou/analytics/models.py
@@ -48,11 +48,15 @@ class DatumCode(models.TextChoices):
     # Tech metrics
     TECH_SENTRY_APDEX = "SENTRY-001", "Apdex"
     TECH_SENTRY_FAILURE_RATE = "SENTRY-002", "Taux de requêtes en échec"
+    TECH_UPDOWN_UPTIME = "UPDOWN-001", "Taux de disponibilité"
+    TECH_UPDOWN_APDEX = "UPDOWN-002", "Apdex"
 
 
 PERCENTAGE_DATUM = [
     DatumCode.TECH_SENTRY_APDEX,
     DatumCode.TECH_SENTRY_FAILURE_RATE,
+    DatumCode.TECH_UPDOWN_UPTIME,
+    DatumCode.TECH_UPDOWN_APDEX,
 ]
 
 

--- a/itou/analytics/tech.py
+++ b/itou/analytics/tech.py
@@ -1,6 +1,7 @@
 from dateutil.relativedelta import relativedelta
 
 from itou.utils.apis.sentry import SentryApiClient
+from itou.utils.apis.updown import UpdownApiClient
 
 from . import models
 
@@ -9,9 +10,14 @@ def collect_analytics_data(before):
     start = (before - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
     end = before.replace(hour=0, minute=0, second=0, microsecond=0)
     sentry_metrics = SentryApiClient().get_metrics(start=start, end=end)
-
-    # Data is stored as an integer.
-    return {
+    # uptime is already multiplied by 100 by Updown.
+    updown_metrics = UpdownApiClient().get_metrics(start=start, end=end)
+    data = {
         models.DatumCode.TECH_SENTRY_APDEX: round(sentry_metrics["apdex"] * 10000),
         models.DatumCode.TECH_SENTRY_FAILURE_RATE: round(sentry_metrics["failure_rate"] * 10000),
+        models.DatumCode.TECH_UPDOWN_UPTIME: round(updown_metrics["uptime"]),
     }
+    if updown_metrics.get("apdex"):
+        data[models.DatumCode.TECH_UPDOWN_APDEX] = round(updown_metrics["apdex"] * 10000)
+
+    return data

--- a/itou/utils/apis/updown.py
+++ b/itou/utils/apis/updown.py
@@ -1,0 +1,39 @@
+import logging
+
+import httpx
+import tenacity
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class UpdownApiClient:
+    def __init__(self):
+        self.client = httpx.Client(
+            base_url=f"{settings.API_UPDOWN_BASE_URL}",
+            params={"api-key": settings.API_UPDOWN_TOKEN},
+            headers={
+                "Content-Type": "application/json",
+            },
+        )
+
+    @tenacity.retry(wait=tenacity.wait_fixed(2), stop=tenacity.stop_after_attempt(8))
+    def _request(self, endpoint, start, end):
+        params = {
+            "from": start.isoformat(),
+            "to": end.isoformat(),
+        }
+        response = self.client.get(endpoint, params=params)
+        response.raise_for_status()
+        return response
+
+    def get_metrics(self, start, end):
+        endpoint = f"/checks/{settings.API_UPDOWN_CHECK_ID}/metrics/"
+        response = self._request(endpoint=endpoint, start=start, end=end)
+        data = response.json()
+        # Apdex is optional because it's unavailable for data before November 1st, 2024.
+        return {
+            "uptime": data["uptime"],
+            "apdex": data.get("apdex"),
+        }

--- a/tests/analytics/test_collect_analytics_data_management_command.py
+++ b/tests/analytics/test_collect_analytics_data_management_command.py
@@ -132,7 +132,7 @@ def test_save_data_with_a_float(command):
 
 
 @freeze_time("2024-12-03")
-def test_management_command_name_and_that_all_codes_are_saved(datadog_client, sentry_respx_mock):
+def test_management_command_name_and_that_all_codes_are_saved(datadog_client, sentry_respx_mock, updown_respx_mock):
     call_command("collect_analytics_data", save=True)
 
     assert Datum.objects.all().count() == len(DatumCode)

--- a/tests/analytics/test_tech_metrics.py
+++ b/tests/analytics/test_tech_metrics.py
@@ -5,19 +5,22 @@ from itou.analytics import models, tech
 
 
 @freeze_time("2024-12-03")
-def test_collect_tech_metrics_return_all_codes(sentry_respx_mock):
+def test_collect_tech_metrics_return_all_codes(sentry_respx_mock, updown_respx_mock):
     now = timezone.now()
     assert tech.collect_analytics_data(before=now).keys() == {
         models.DatumCode.TECH_SENTRY_APDEX,
         models.DatumCode.TECH_SENTRY_FAILURE_RATE,
-        # next: uptime rate. https://docs.sentry.io/product/alerts/uptime-monitoring/
+        models.DatumCode.TECH_UPDOWN_UPTIME,
+        models.DatumCode.TECH_UPDOWN_APDEX,
     }
 
 
 @freeze_time("2024-12-03")
-def test_collect_tech_metrics_with_data(sentry_respx_mock):
+def test_collect_tech_metrics_with_data(sentry_respx_mock, updown_respx_mock):
     now = timezone.now()
     assert tech.collect_analytics_data(before=now) == {
         models.DatumCode.TECH_SENTRY_APDEX: 9556,
         models.DatumCode.TECH_SENTRY_FAILURE_RATE: 812,
+        models.DatumCode.TECH_UPDOWN_UPTIME: 100,
+        models.DatumCode.TECH_UPDOWN_APDEX: 9860,
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -633,3 +633,42 @@ def detect_silent_date_cast():
         return original_pre_save(self, model_instance, add)
 
     DateField.pre_save = strict_pre_save
+
+
+@pytest.fixture(name="updown_respx_mock")
+def updown_respx_mock_fixture(respx_mock):
+    json = {
+        "uptime": 100.0,
+        "apdex": 0.986,
+        "timings": {"redirect": 148, "namelookup": 1, "connection": 22, "handshake": 25, "response": 99, "total": 295},
+        "requests": {
+            "samples": 44214,
+            "failures": 12,
+            "satisfied": 43256,
+            "tolerated": 664,
+            "by_response_time": {
+                "under125": 42383,
+                "under250": 42874,
+                "under500": 43256,
+                "under1000": 43620,
+                "under2000": 43920,
+                "under4000": 44100,
+                "under8000": 44183,
+                "under16000": 44201,
+                "under32000": 44202,
+            },
+        },
+    }
+    end = datetime.datetime(2024, 12, 3, 0, 0, 0, tzinfo=datetime.UTC)
+    start = end - relativedelta(days=1)
+    params = {
+        "api-key": settings.API_UPDOWN_TOKEN,
+        "from": start.isoformat(),
+        "to": end.isoformat(),
+    }
+    headers = {
+        "Content-Type": "application/json",
+    }
+
+    url = f"{settings.API_UPDOWN_BASE_URL}/checks/{settings.API_UPDOWN_CHECK_ID}/metrics/"
+    return respx_mock.route(headers=headers, method="GET", params=params, url=url).respond(json=json)

--- a/tests/utils/apis/test_updown.py
+++ b/tests/utils/apis/test_updown.py
@@ -1,0 +1,21 @@
+import urllib
+
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.utils import timezone
+from freezegun import freeze_time
+
+from itou.utils.apis.updown import UpdownApiClient
+
+
+@freeze_time("2024-12-03")
+def test_request(updown_respx_mock):
+    end = timezone.now()
+    start = end - relativedelta(days=1)
+
+    response = UpdownApiClient()._request(
+        endpoint=f"/checks/{settings.API_UPDOWN_CHECK_ID}/metrics/", start=start, end=end
+    )
+    assert settings.API_UPDOWN_TOKEN in str(response.url)
+    assert urllib.parse.quote(start.isoformat()) in str(response.url)
+    assert urllib.parse.quote(end.isoformat()) in str(response.url)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suivre l'évolution de notre taux de disponibilité au fil du temps.

cf https://github.com/gip-inclusion/itou-secrets/pull/115

# Reprise de stock

```python

import datetime
import logging

from dateutil.relativedelta import relativedelta
from dateutil.rrule import rrule, DAILY
from django import db
from django.db import transaction
from django.forms import models
from django.utils import timezone

from itou.analytics.models import Datum, DatumCode
from itou.utils.apis.updown import UpdownApiClient


logger = logging.getLogger("itou.analytics")

end = timezone.now()
start = datetime.datetime(2024,10,1, tzinfo=datetime.UTC)
days = (end-start).days
dates = list(rrule(freq=DAILY, dtstart=start, count=days))

def call_and_store(date):
    start = (date - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
    end = date.replace(hour=0, minute=0, second=0, microsecond=0)
    updown_metrics = UpdownApiClient().get_metrics(start=start, end=end)
    data = {
        DatumCode.TECH_UPDOWN_UPTIME: round(updown_metrics["uptime"]),
    }
    # apdex is present from november 1st on.
    if updown_metrics.get("apdex"):
        data[DatumCode.TECH_UPDOWN_APDEX] = round(updown_metrics["apdex"] * 10000)

    bucket = (date.date() - datetime.timedelta(days=1)).isoformat()
    logger.info(f"Saving analytics data in '{bucket=}'.")
    for code, value in data.items():
        datum = Datum(
            code=code.value,
            bucket=bucket,
            value=value,
        )
        try:
            with transaction.atomic():
                datum.save()
        except db.IntegrityError:
            logger.error(f"Failed to save {code.value=} for {bucket=} because it already exists.")
        except models.ValidationError as error:
            message = (
                f"Failed to save {code.value=} for {bucket=} because of a ValidationError: "
                f"{error.message}"
            )
            logger.error(message)
        else:
            logger.info(f"Successfully saved {code.value=} {bucket=} {value=}.")

for date in dates:
    call_and_store(date)

```