### PR TITLE
Création de compte candidat : nettoyage des URLs et vues dépréciées

### DIFF
--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -35,27 +35,6 @@ urlpatterns = [
         views.CreateJobSeekerStepEndForSenderView.as_view(),
         name="create_job_seeker_step_end_for_sender",
     ),
-    # TODO(ewen): deprecated URLs
-    path(
-        "<int:company_pk>/sender/create/<uuid:session_uuid>/1",
-        views.CreateJobSeekerStep1ForSenderView.as_view(),
-        name="create_job_seeker_step_1_for_sender",
-    ),
-    path(
-        "<int:company_pk>/sender/create/<uuid:session_uuid>/2",
-        views.CreateJobSeekerStep2ForSenderView.as_view(),
-        name="create_job_seeker_step_2_for_sender",
-    ),
-    path(
-        "<int:company_pk>/sender/create/<uuid:session_uuid>/3",
-        views.CreateJobSeekerStep3ForSenderView.as_view(),
-        name="create_job_seeker_step_3_for_sender",
-    ),
-    path(
-        "<int:company_pk>/sender/create/<uuid:session_uuid>/end",
-        views.CreateJobSeekerStepEndForSenderView.as_view(),
-        name="create_job_seeker_step_end_for_sender",
-    ),
     # Direct hire process
     path(
         "<uuid:session_uuid>/hire/check-nir",
@@ -89,31 +68,6 @@ urlpatterns = [
     ),
     path(
         "<uuid:session_uuid>/hire/create/end",
-        views.CreateJobSeekerStepEndForSenderView.as_view(),
-        name="create_job_seeker_step_end_for_hire",
-        kwargs={"hire_process": True},
-    ),
-    # TODO(ewen): deprecated URLs
-    path(
-        "<int:company_pk>/hire/create/<uuid:session_uuid>/1",
-        views.CreateJobSeekerStep1ForSenderView.as_view(),
-        name="create_job_seeker_step_1_for_hire",
-        kwargs={"hire_process": True},
-    ),
-    path(
-        "<int:company_pk>/hire/create/<uuid:session_uuid>/2",
-        views.CreateJobSeekerStep2ForSenderView.as_view(),
-        name="create_job_seeker_step_2_for_hire",
-        kwargs={"hire_process": True},
-    ),
-    path(
-        "<int:company_pk>/hire/create/<uuid:session_uuid>/3",
-        views.CreateJobSeekerStep3ForSenderView.as_view(),
-        name="create_job_seeker_step_3_for_hire",
-        kwargs={"hire_process": True},
-    ),
-    path(
-        "<int:company_pk>/hire/create/<uuid:session_uuid>/end",
         views.CreateJobSeekerStepEndForSenderView.as_view(),
         name="create_job_seeker_step_end_for_hire",
         kwargs={"hire_process": True},

--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -8,22 +8,10 @@ app_name = "job_seekers_views"
 urlpatterns = [
     path("details/<uuid:public_id>", views.JobSeekerDetailView.as_view(), name="details"),
     path("list", views.JobSeekerListView.as_view(), name="list"),
-    # TODO(ewen): this URLs will change to new ones without company_pk
     # For sender
     path("<uuid:session_uuid>/sender/check-nir", views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
     path(
-        "<int:company_pk>/sender/check-nir",
-        views.DeprecatedCheckNIRForSenderView.as_view(),
-        name="check_nir_for_sender",
-    ),
-    path(
         "<uuid:session_uuid>/sender/search-by-email",
-        views.SearchByEmailForSenderView.as_view(),
-        name="search_by_email_for_sender",
-    ),
-    # TODO(ewen): deprecated URL
-    path(
-        "<int:company_pk>/sender/search-by-email/<uuid:session_uuid>",
         views.SearchByEmailForSenderView.as_view(),
         name="search_by_email_for_sender",
     ),
@@ -70,12 +58,6 @@ urlpatterns = [
     ),
     # Direct hire process
     path(
-        "<int:company_pk>/hire/check-nir",
-        views.DeprecatedCheckNIRForSenderView.as_view(),
-        name="check_nir_for_hire",
-        kwargs={"hire_process": True},
-    ),
-    path(
         "<uuid:session_uuid>/hire/check-nir",
         views.CheckNIRForSenderView.as_view(),
         name="check_nir_for_hire",
@@ -83,13 +65,6 @@ urlpatterns = [
     ),
     path(
         "<uuid:session_uuid>/hire/search-by-email",
-        views.SearchByEmailForSenderView.as_view(),
-        name="search_by_email_for_hire",
-        kwargs={"hire_process": True},
-    ),
-    # TODO(ewen): deprecated URL
-    path(
-        "<int:company_pk>/hire/search-by-email/<uuid:session_uuid>",
         views.SearchByEmailForSenderView.as_view(),
         name="search_by_email_for_hire",
         kwargs={"hire_process": True},
@@ -174,11 +149,6 @@ urlpatterns = [
         kwargs={"hire_process": True},
     ),
     # For job seeker
-    path(
-        "<int:company_pk>/job-seeker/check-nir",
-        views.DeprecatedCheckNIRForJobSeekerView.as_view(),
-        name="check_nir_for_job_seeker",
-    ),
     path(
         "<uuid:session_uuid>/job-seeker/check-nir",
         views.CheckNIRForJobSeekerView.as_view(),

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -201,9 +201,6 @@ class JobSeekerBaseView(LoginRequiredMixin, TemplateView):
         if not self.job_seeker_session.exists():
             raise Http404
         self.is_gps = "gps" in request.GET and request.GET["gps"] == "true"
-        # TODO(ewen): temporary condition to fill self.company when not using the new session system
-        if company_pk := kwargs.get("company_pk"):
-            self.job_seeker_session.set("apply", {"company_pk": company_pk} | self.job_seeker_session.get("apply", {}))
         if company_pk := self.job_seeker_session.get("apply", {}).get("company_pk"):
             self.company = (
                 get_object_or_404(Company.objects.with_has_active_members(), pk=company_pk)
@@ -577,14 +574,6 @@ class CreateJobSeekerStep1ForSenderView(CreateJobSeekerForSenderBaseView):
                 return HttpResponseRedirect(self.get_next_url())
 
         return self.render_to_response(context)
-
-    # TODO(ewen): remove this method overloading when migration is over
-    def get_back_url(self):
-        view_name = self.previous_hire_url if self.hire_process else self.previous_apply_url
-        kwargs = {"session_uuid": self.job_seeker_session.name}
-        if not self.job_seeker_session.get("apply", {}).get("company_pk"):
-            kwargs["company_pk"] = self.company.pk
-        return reverse(view_name, kwargs=kwargs)
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -28,7 +28,7 @@ from itou.utils.emails import redact_email_address
 from itou.utils.pagination import ItouPaginator
 from itou.utils.session import SessionNamespace, SessionNamespaceRequiredMixin
 from itou.utils.urls import get_safe_url
-from itou.www.apply.views.submit_views import ApplicationBaseView, ApplyStepBaseView, ApplyStepForSenderBaseView
+from itou.www.apply.views.submit_views import ApplicationBaseView, ApplyStepBaseView
 
 from .forms import (
     CheckJobSeekerInfoForm,
@@ -274,59 +274,6 @@ class JobSeekerForSenderBaseView(JobSeekerBaseView):
         return super().dispatch(request, *args, **kwargs)
 
 
-class DeprecatedCheckNIRForJobSeekerView(ApplyStepBaseView):
-    template_name = "job_seekers_views/step_check_job_seeker_nir.html"
-
-    def __init__(self):
-        super().__init__()
-        self.job_seeker = None
-        self.form = None
-
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        self.job_seeker = request.user
-        self.form = CheckJobSeekerNirForm(job_seeker=self.job_seeker, data=request.POST or None)
-
-    def dispatch(self, request, *args, **kwargs):
-        if request.user.is_authenticated and not self.job_seeker.is_job_seeker:
-            logger.info(f"dispatch ({request.path}) : {request.user.kind} in jobseeker tunnel")
-            return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
-        return super().dispatch(request, *args, **kwargs)
-
-    def get(self, request, *args, **kwargs):
-        # The NIR already exists, go to next step
-        if self.job_seeker.jobseeker_profile.nir:
-            return HttpResponseRedirect(
-                reverse(
-                    "job_seekers_views:check_job_seeker_info",
-                    kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
-                )
-            )
-
-        return super().get(request, *args, **kwargs)
-
-    def post(self, request, *args, **kwargs):
-        next_url = reverse(
-            "job_seekers_views:check_job_seeker_info",
-            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
-        )
-        if self.form.is_valid():
-            self.job_seeker.jobseeker_profile.nir = self.form.cleaned_data["nir"]
-            self.job_seeker.jobseeker_profile.lack_of_nir_reason = ""
-            self.job_seeker.jobseeker_profile.save()
-            return HttpResponseRedirect(next_url)
-        else:
-            kwargs["temporary_nir_url"] = next_url
-
-        return self.render_to_response(self.get_context_data(**kwargs))
-
-    def get_context_data(self, **kwargs):
-        return super().get_context_data(**kwargs) | {
-            "form": self.form,
-            "preview_mode": False,
-        }
-
-
 class CheckNIRForJobSeekerView(JobSeekerBaseView):
     template_name = "job_seekers_views/step_check_job_seeker_nir.html"
 
@@ -376,71 +323,6 @@ class CheckNIRForJobSeekerView(JobSeekerBaseView):
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs) | {
             "form": self.form,
-            "preview_mode": False,
-        }
-
-
-class DeprecatedCheckNIRForSenderView(ApplyStepForSenderBaseView):
-    template_name = "job_seekers_views/step_check_job_seeker_nir.html"
-
-    def __init__(self):
-        super().__init__()
-        self.form = None
-
-    def setup(self, request, *args, **kwargs):
-        super().setup(request, *args, **kwargs)
-        self.form = CheckJobSeekerNirForm(job_seeker=None, data=request.POST or None, is_gps=self.is_gps)
-
-    def search_by_email_url(self, session_uuid):
-        view_name = (
-            "job_seekers_views:search_by_email_for_hire"
-            if self.hire_process
-            else "job_seekers_views:search_by_email_for_sender"
-        )
-        return reverse(view_name, kwargs={"company_pk": self.company.pk, "session_uuid": session_uuid}) + (
-            "?gps=true" if self.is_gps else ""
-        )
-
-    def post(self, request, *args, **kwargs):
-        context = {}
-        if self.form.is_valid():
-            job_seeker = self.form.get_job_seeker()
-
-            # No user found with that NIR, save the NIR in the session and redirect to search by e-mail address.
-            if not job_seeker:
-                job_seeker_session = SessionNamespace.create_uuid_namespace(
-                    request.session, data={"profile": {"nir": self.form.cleaned_data["nir"]}}
-                )
-                return HttpResponseRedirect(self.search_by_email_url(job_seeker_session.name))
-
-            # The NIR we found is correct
-            if self.form.data.get("confirm"):
-                if self.is_gps:
-                    FollowUpGroup.objects.follow_beneficiary(
-                        beneficiary=job_seeker, user=request.user, is_referent=True
-                    )
-                    return HttpResponseRedirect(reverse("gps:my_groups"))
-                else:
-                    return self.redirect_to_check_infos(job_seeker.public_id)
-
-            context = {
-                # Ask the sender to confirm the NIR we found is associated to the correct user
-                "preview_mode": bool(self.form.data.get("preview")),
-                "job_seeker": job_seeker,
-                "can_view_personal_information": self.sender.can_view_personal_information(job_seeker),
-            }
-        else:
-            # Require at least one attempt with an invalid NIR to access the search by email feature.
-            # The goal is to prevent users from skipping the search by NIR and creating duplicates.
-            job_seeker_session = SessionNamespace.create_uuid_namespace(request.session, data={})
-            context["temporary_nir_url"] = self.search_by_email_url(job_seeker_session.name)
-
-        return self.render_to_response(self.get_context_data(**kwargs) | context)
-
-    def get_context_data(self, **kwargs):
-        return super().get_context_data(**kwargs) | {
-            "form": self.form,
-            "job_seeker": None,
             "preview_mode": False,
         }
 


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Nous sommes lundi. Dans la nuit, un cron a lancé une commande pour nettoyer les sessions, on peut donc être sûr que les nouvelles sessions ne contiennent plus les URLs dépréciées. Dans cette PR, on supprime le code de :
- CheckNir
- SearchByEmail
- CreateJobSeeker

--- 

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657

