### PR TITLE
Suppression d'une mixin inutilisée 

### DIFF
--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -385,8 +385,7 @@ class CheckNIRForSenderView(JobSeekerForSenderBaseView):
         }
 
 
-class SearchByEmailForSenderView(SessionNamespaceRequiredMixin, JobSeekerForSenderBaseView):
-    required_session_namespaces = ["job_seeker_session"]
+class SearchByEmailForSenderView(JobSeekerForSenderBaseView):
     template_name = "job_seekers_views/step_search_job_seeker_by_email.html"
 
     def __init__(self):


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans notre grand nettoyage (#5180) on a oublié d'enlever `SessionNamespaceRequiredMixin` inutile dans `SearchByEmailForSenderView`.

La classe `JobSeekerForSenderBaseView` s'assure déjà qu'on a bien une session.
