### PR TITLE
Correction de la gestion des tokens lors de la fusion d'utilisateurs

### DIFF
--- a/itou/www/itou_staff_views/views.py
+++ b/itou/www/itou_staff_views/views.py
@@ -278,7 +278,7 @@ def merge_users_confirm(request, user_1_pk, user_2_pk, template_name="itou_staff
                 return HttpResponseRedirect(
                     reverse(
                         "itou_staff_views:merge_users_confirm",
-                        kwargs={"user_1_pk": to_user.pk, "user_2_pk": from_user.pk},
+                        kwargs={"user_1_pk": to_user_pk, "user_2_pk": from_user_pk},
                     )
                 )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

On ne peut pas avoir 2 tokens pour un même utilisateur

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
