### PR TITLE
[Stats] Convertion des décimaux en entiers pour ne pas enregistrer des zéros

### DIFF
--- a/itou/analytics/admin.py
+++ b/itou/analytics/admin.py
@@ -6,8 +6,9 @@ from .models import Datum, StatsDashboardVisit
 
 @admin.register(Datum)
 class DatumAdmin(ItouModelAdmin):
-    list_display = ["pk", "code", "bucket", "value", "measured_at"]
+    list_display = ["pk", "code", "bucket", "get_value_display", "measured_at"]
     list_filter = ["code"]
+    fields = ["code", "bucket", "get_value_display", "measured_at"]
     ordering = ["-measured_at", "code"]
     date_hierarchy = "measured_at"
 
@@ -19,6 +20,10 @@ class DatumAdmin(ItouModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    @admin.display(description="value")
+    def get_value_display(self, obj):
+        return obj.get_value_display()
 
 
 @admin.register(StatsDashboardVisit)

--- a/itou/analytics/models.py
+++ b/itou/analytics/models.py
@@ -49,6 +49,12 @@ class DatumCode(models.TextChoices):
     TECH_SENTRY_FAILURE_RATE = "SENTRY-002", "Taux de requêtes en échec"
 
 
+PERCENTAGE_DATUM = [
+    DatumCode.TECH_SENTRY_APDEX,
+    DatumCode.TECH_SENTRY_FAILURE_RATE,
+]
+
+
 class Datum(models.Model):
     """Store an aggregated `value` of the `code` data point for the specified `bucket`."""
 
@@ -64,6 +70,15 @@ class Datum(models.Model):
         verbose_name_plural = "data"
         unique_together = ["code", "bucket"]
         indexes = [models.Index(fields=["measured_at", "code"])]
+
+    def get_value_display(self):
+        """
+        `value` column being an integer, it's impossible to store percentage values without lowering its accuracy.
+        So, store the original value multiplied by 10,000 and display it divided by 100.
+        """
+        if self.code in PERCENTAGE_DATUM:
+            return self.value / 100
+        return self.value
 
 
 class StatsDashboardVisit(models.Model):

--- a/itou/analytics/models.py
+++ b/itou/analytics/models.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.db import models
+from django.forms import ValidationError
 from django.utils import timezone
 
 from itou.common_apps.address.departments import DEPARTMENTS
@@ -79,6 +80,14 @@ class Datum(models.Model):
         if self.code in PERCENTAGE_DATUM:
             return self.value / 100
         return self.value
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)
+
+    def clean(self):
+        if not isinstance(self.value, int):
+            raise ValidationError(f"{self.value} is not an integer.")
 
 
 class StatsDashboardVisit(models.Model):

--- a/itou/analytics/tech.py
+++ b/itou/analytics/tech.py
@@ -9,9 +9,9 @@ def collect_analytics_data(before):
     start = (before - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
     end = before.replace(hour=0, minute=0, second=0, microsecond=0)
     sentry_metrics = SentryApiClient().get_metrics(start=start, end=end)
-    # Data is stored as an integer.
 
+    # Data is stored as an integer.
     return {
-        models.DatumCode.TECH_SENTRY_APDEX: round(sentry_metrics["apdex"] * 100),
-        models.DatumCode.TECH_SENTRY_FAILURE_RATE: round(sentry_metrics["failure_rate"] * 100),
+        models.DatumCode.TECH_SENTRY_APDEX: round(sentry_metrics["apdex"] * 10000),
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE: round(sentry_metrics["failure_rate"] * 10000),
     }

--- a/itou/analytics/tech.py
+++ b/itou/analytics/tech.py
@@ -8,9 +8,10 @@ from . import models
 def collect_analytics_data(before):
     start = (before - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
     end = before.replace(hour=0, minute=0, second=0, microsecond=0)
-
     sentry_metrics = SentryApiClient().get_metrics(start=start, end=end)
+    # Data is stored as an integer.
+
     return {
-        models.DatumCode.TECH_SENTRY_APDEX: sentry_metrics["apdex"],
-        models.DatumCode.TECH_SENTRY_FAILURE_RATE: sentry_metrics["failure_rate"],
+        models.DatumCode.TECH_SENTRY_APDEX: round(sentry_metrics["apdex"] * 100),
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE: round(sentry_metrics["failure_rate"] * 100),
     }

--- a/tests/analytics/test_models.py
+++ b/tests/analytics/test_models.py
@@ -1,0 +1,28 @@
+from contextlib import nullcontext
+
+import pytest
+from django.forms import ValidationError
+
+from itou.analytics.models import PERCENTAGE_DATUM, Datum, DatumCode
+
+
+class TestDatumModel:
+    @pytest.mark.parametrize("DatumCodeEnum", set(DatumCode) - set(PERCENTAGE_DATUM))
+    def test_get_value_display__not_percentage(self, DatumCodeEnum):
+        assert Datum(code=DatumCodeEnum, value=13).get_value_display() == 13
+
+    @pytest.mark.parametrize("DatumCodeEnum", PERCENTAGE_DATUM)
+    def test_get_value_display__percentage(self, DatumCodeEnum):
+        assert Datum(code=DatumCodeEnum, value=1111).get_value_display() == 11.11
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (42.5, pytest.raises(ValidationError)),
+            ("You shall not pass.", pytest.raises(ValidationError)),
+            (42, nullcontext()),
+        ],
+    )
+    def test_save_with_exception(self, value, expected):
+        with expected as e:
+            assert Datum(value=value).save() == e

--- a/tests/analytics/test_tech_metrics.py
+++ b/tests/analytics/test_tech_metrics.py
@@ -18,6 +18,6 @@ def test_collect_tech_metrics_return_all_codes(sentry_respx_mock):
 def test_collect_tech_metrics_with_data(sentry_respx_mock):
     now = timezone.now()
     assert tech.collect_analytics_data(before=now) == {
-        models.DatumCode.TECH_SENTRY_APDEX: 0.9556246545071905,
-        models.DatumCode.TECH_SENTRY_FAILURE_RATE: 0.08123341283760084,
+        models.DatumCode.TECH_SENTRY_APDEX: 96,
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE: 8,
     }

--- a/tests/analytics/test_tech_metrics.py
+++ b/tests/analytics/test_tech_metrics.py
@@ -18,6 +18,6 @@ def test_collect_tech_metrics_return_all_codes(sentry_respx_mock):
 def test_collect_tech_metrics_with_data(sentry_respx_mock):
     now = timezone.now()
     assert tech.collect_analytics_data(before=now) == {
-        models.DatumCode.TECH_SENTRY_APDEX: 96,
-        models.DatumCode.TECH_SENTRY_FAILURE_RATE: 8,
+        models.DatumCode.TECH_SENTRY_APDEX: 9556,
+        models.DatumCode.TECH_SENTRY_FAILURE_RATE: 812,
     }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le modèle Datum conserve la valeur en tant qu'entier, or l'apdex et le taux de requête en erreur sont des pourcentages. Ils ont donc une valeur de 0 aujourd'hui. cf #5162 
Les autres mesures étant des valeurs absolues, il me semble inutile de changer le type du champ.
Je ferai une reprise de stock.

```
import datetime
import logging

from dateutil.relativedelta import relativedelta
from itou.utils.apis.sentry import SentryApiClient
from itou.analytics.models import Datum, DatumCode

data = Datum.objects.filter(code__in=[DatumCode.TECH_SENTRY_APDEX, DatumCode.TECH_SENTRY_FAILURE_RATE])

logger = logging.getLogger("itou.analytics")

for datum in data:
    if datum.value > 0:
        continue
    date = datetime.datetime.fromisoformat(datum.bucket)
    start = (date - relativedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
    end = date.replace(hour=0, minute=0, second=0, microsecond=0)
    sentry_metrics = SentryApiClient().get_metrics(start=start, end=end)

    if datum.code == DatumCode.TECH_SENTRY_APDEX:
        datum.value = round(sentry_metrics["apdex"] * 10000)
    elif datum.value == DatumCode.TECH_SENTRY_FAILURE_RATE:
        datum.value = round(sentry_metrics["failure_rate"] * 10000)
    logger.info(f"Updating bucket {datum.bucket} with value {datum.value}.")
    datum.save()

```

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
