### PR TITLE
Demandeur d’emploi : Correction de la sélection de la commune de naissance pour les personnes nées le dernier jour de validité de la commune

### DIFF
--- a/itou/asp/models.py
+++ b/itou/asp/models.py
@@ -371,7 +371,7 @@ class CommuneQuerySet(PeriodQuerySet):
         "Lookup a Commune object by INSEE code and valid at the given period"
         return (
             self.filter(code=insee_code, start_date__lte=period)
-            .filter(Q(end_date=None) | Q(end_date__gt=period))
+            .filter(Q(end_date=None) | Q(end_date__gte=period))
             .get()
         )
 

--- a/tests/asp/test_communes.py
+++ b/tests/asp/test_communes.py
@@ -1,6 +1,8 @@
 import datetime
 from collections import Counter
 
+from django.utils import timezone
+
 from itou.asp.models import Commune
 
 
@@ -62,14 +64,14 @@ class TestCommuneModel:
         old_commune = Commune(
             code=99999,
             name="ENNUI-SUR-BLASÉ",
-            start_date=datetime.datetime(1940, 1, 1),
-            end_date=datetime.datetime(2021, 12, 31),
+            start_date=datetime.date(1940, 1, 1),
+            end_date=datetime.date(2021, 12, 31),
         )
-        new_commune = Commune(code=99999, name="ENNUI-SUR-BLASÉ", start_date=datetime.datetime(2022, 1, 1))
+        new_commune = Commune(code=99999, name="ENNUI-SUR-BLASÉ", start_date=datetime.date(2022, 1, 1))
         Commune.objects.bulk_create([old_commune, new_commune])
 
-        result = Commune.objects.by_insee_code_and_period(99999, datetime.datetime(1988, 4, 28))
-        assert old_commune == result
+        for period in [old_commune.start_date, datetime.date(1988, 4, 28), old_commune.end_date]:
+            assert Commune.objects.by_insee_code_and_period(99999, period) == old_commune
 
-        result = Commune.objects.by_insee_code_and_period(99999, datetime.datetime(2022, 11, 28))
-        assert new_commune == result
+        for period in [new_commune.start_date, datetime.date(2022, 11, 28), timezone.localdate()]:
+            assert Commune.objects.by_insee_code_and_period(99999, period) == new_commune

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -342,7 +342,8 @@ class JobSeekerProfileFactory(factory.django.DjangoModelFactory):
     advisor_information = factory.Maybe(
         "with_contact", factory.RelatedFactory("tests.gps.factories.FranceTravailContactFactory", "jobseeker_profile")
     )
-    birthdate = factory.fuzzy.FuzzyDate(datetime.date(1968, 1, 1), datetime.date(2000, 1, 1))
+    # Limit the upper value to 1999-12-31 so we don't exclude 36995 (of 76777) `Commune()` with a "1999-12-31" end date
+    birthdate = factory.fuzzy.FuzzyDate(datetime.date(1968, 1, 1), datetime.date(1999, 12, 31))
 
     education_level = factory.fuzzy.FuzzyChoice(EducationLevel.values + [""])
 

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -371,29 +371,3 @@ class TestCertifiedCriteriaInfoRequiredForm:
             data=form_data, birthdate=valid_birthdate, with_birthdate_field=False
         )
         assert form.is_valid()
-
-    def test_submit_commune_invalid_commune_lookup(self):
-        job_seeker = JobSeekerFactory(with_ban_api_mocked_address=True, born_in_france=True)
-
-        birth_place = job_seeker.jobseeker_profile.birth_place
-        early_date = birth_place.start_date - timedelta(days=1)
-
-        form_data = {
-            "address_line_1": job_seeker.address_line_1,
-            "address_line_2": job_seeker.address_line_2,
-            "post_code": job_seeker.post_code,
-            "city": job_seeker.city,
-            "insee_code": job_seeker.insee_code,
-            "ban_api_resolved_address": job_seeker.geocoding_address,
-            "birth_country": job_seeker.jobseeker_profile.birth_country.id,
-            "birth_place": birth_place.id,
-        }
-        form = apply_forms.CertifiedCriteriaInfoRequiredForm(
-            data=form_data, birthdate=early_date, with_birthdate_field=False
-        )
-        assert not form.is_valid()
-
-        expected_msg = (
-            f"Le code INSEE {birth_place.code} n'est pas référencé par l'ASP en date du {early_date:%d/%m/%Y}"
-        )
-        assert form.errors["birth_place"] == [expected_msg]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Test bagottant : https://github.com/gip-inclusion/les-emplois/actions/runs/12235030153/attempts/1
Reproductible avec `pytest --randomly-seed=3864335593 -vv tests/www/employee_record_views/test_create.py::TestCreateEmployeeRecordStep2::test_access_granted`

Les valeurs choisies était "1999-12-31" pour la date de naissance alors que la ville était :
```
  id   | start_date |  end_date  | code  |     name     |          created_at           | city_id 
-------+------------+------------+-------+--------------+-------------------------------+---------
 57089 | 1900-01-01 | 1999-12-31 | 67152 | GEISPOLSHEIM | 2023-10-02 08:19:11.118299+00 |  [NULL]
```