### PR TITLE
admin: Utiliser le SIRET et le nom de l’entreprise pour identifier l’appartenance d’un employeur

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -58,7 +58,7 @@ class JobApplicationInline(ItouStackedInline):
     def has_add_permission(self, request, obj=None):
         return False
 
-    @admin.display(description="Entreprises destinataire")
+    @admin.display(description="Entreprise destinataire")
     def to_company_link(self, obj):
         return get_company_view_link(obj.to_company)
 

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -20,6 +20,7 @@ from itou.utils.admin import (
     ItouTabularInline,
     PkSupportRemarkInline,
     get_admin_view_link,
+    get_company_view_link,
 )
 from itou.utils.templatetags.str_filters import pluralizefr
 
@@ -59,12 +60,7 @@ class JobApplicationInline(ItouStackedInline):
 
     @admin.display(description="Entreprises destinataire")
     def to_company_link(self, obj):
-        return format_html(
-            "{} — SIRET : {} ({})",
-            get_admin_view_link(obj.to_company, content=obj.to_company.display_name),
-            obj.to_company.siret,
-            obj.to_company.kind,
-        )
+        return get_company_view_link(obj.to_company)
 
     # Custom read-only fields as workaround :
     # there is no direct relation between approvals and employee records

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -37,6 +37,7 @@ from itou.utils.admin import (
     PkSupportRemarkInline,
     add_support_remark_to_obj,
     get_admin_view_link,
+    get_company_view_link,
 )
 
 
@@ -83,7 +84,7 @@ class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
     extra = 0
     raw_id_fields = ("company",)
     readonly_fields = (
-        "company_id_link",
+        "company_siret_link",
         "joined_at",
         "is_admin",
         "is_active",
@@ -103,8 +104,9 @@ class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
     def has_add_permission(self, request, obj=None):
         return True
 
-    def company_id_link(self, obj):
-        return get_admin_view_link(obj.company)
+    @admin.display(description="Entreprise")
+    def company_siret_link(self, obj):
+        return get_company_view_link(obj.company)
 
 
 class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline):

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -20,6 +20,15 @@ def get_admin_view_link(obj, *, content=None, view="change"):
     return format_html('<a href="{}">{}</a>', url, content or obj.pk)
 
 
+def get_company_view_link(company):
+    return format_html(
+        "{} — SIRET : {} ({})",
+        get_admin_view_link(company, content=company.display_name),
+        company.siret,
+        company.kind,
+    )
+
+
 class AbstractSupportRemarkInline(GenericStackedInline):
     min_num = 0
     max_num = 1


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://itou-inclusion.slack.com/archives/C02J7LWNT6Z/p1733493909992649

## :computer: Captures d'écran <!-- optionnel -->
![2024-12-09_16-08](https://github.com/user-attachments/assets/8aee6a73-80e3-4c70-ab15-e7db9f9a6bae)
