### PR TITLE
UX/UI: Suppression du bouton retour sur la page présentation des structures

### DIFF
--- a/itou/templates/companies/overview.html
+++ b/itou/templates/companies/overview.html
@@ -6,10 +6,6 @@
 
 {% block title %}Présentation {{ block.super }}{% endblock %}
 
-{% block title_prevstep %}
-    {% include "layout/previous_step.html" with back_url=back_url only %}
-{% endblock %}
-
 {% block title_content %}<h1>Structure</h1>{% endblock %}
 
 {% block title_extra %}

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -116,7 +116,6 @@ def overview(request, template_name="companies/overview.html"):
     context = {
         "company": company,
         "can_show_financial_annexes": company.convention_can_be_accessed_by(request.user),
-        "back_url": reverse("dashboard:index"),
     }
     return render(request, template_name, context)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?
Bouton "retour" plus utile sur les pages de premier niveau
> https://www.notion.so/plateforme-inclusion/Pr-sentation-de-ma-structure-Supprimer-bouton-retour-151e8fa5c35b80d6b772fdd0d8985737?pvs=4
