### PR TITLE
Ajout d'un middleware pour connecter automatiquement les utilisateurs pro_connect

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -145,6 +145,7 @@ MIDDLEWARE = [
     # Itou specific
     "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
     "itou.www.middleware.never_cache",
+    "itou.openid_connect.pro_connect.middleware.ProConnectLoginMiddleware",
     # Final logger
     "django_datadog_logger.middleware.request_log.RequestLoggingMiddleware",
 ]

--- a/itou/openid_connect/pro_connect/middleware.py
+++ b/itou/openid_connect/pro_connect/middleware.py
@@ -27,7 +27,7 @@ class ProConnectLoginMiddleware(MiddlewareMixin):
         try:
             user = User.objects.get(username=username[0], identity_provider=IdentityProvider.PRO_CONNECT.value)
             return HttpResponseRedirect(
-                reverse("pro_connect:authorize") + f"?user_kind={user.kind}&previous_url={new_url}"
+                reverse("pro_connect:authorize") + f"?user_kind={user.kind}&next_url={new_url}"
             )
         except User.DoesNotExist:
-            return HttpResponseRedirect(reverse("signup:choose_user_kind") + f"?previous_url={new_url}")
+            return HttpResponseRedirect(reverse("signup:choose_user_kind") + f"?next_url={new_url}")

--- a/itou/openid_connect/pro_connect/middleware.py
+++ b/itou/openid_connect/pro_connect/middleware.py
@@ -1,0 +1,33 @@
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.deprecation import MiddlewareMixin
+from django.utils.http import urlencode
+
+from itou.users.enums import IdentityProvider
+from itou.users.models import User
+
+
+class ProConnectLoginMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        if "proconnect_login" not in request.GET:
+            return
+
+        query_params = request.GET.copy()
+        query_params.pop("proconnect_login")
+        username = query_params.pop("username", [None])
+        new_url = (
+            f"{request.path}?{urlencode({k: v for k, v in query_params.items() if v})}"
+            if query_params
+            else request.path
+        )
+
+        if request.user.is_authenticated:
+            return HttpResponseRedirect(new_url)
+
+        try:
+            user = User.objects.get(username=username[0], identity_provider=IdentityProvider.PRO_CONNECT.value)
+            return HttpResponseRedirect(
+                reverse("pro_connect:authorize") + f"?user_kind={user.kind}&previous_url={new_url}"
+            )
+        except User.DoesNotExist:
+            return HttpResponseRedirect(reverse("signup:choose_user_kind") + f"?previous_url={new_url}")

--- a/tests/openid_connect/pro_connect/test_middleware.py
+++ b/tests/openid_connect/pro_connect/test_middleware.py
@@ -1,0 +1,64 @@
+import pytest
+from django.urls import reverse
+from pytest_django.asserts import assertRedirects
+
+from itou.users.enums import IdentityProvider
+from tests.users.factories import EmployerFactory
+
+
+params_tuples = [
+    ("?proconnect_login=true", ""),
+    ("?proconnect_login=true&filter=76", "?filter=76"),
+    ("?proconnect_login=true&filter=76&kind=EI", "?filter=76&kind=EI"),
+]
+
+
+@pytest.mark.parametrize(
+    "params,user,redirection",
+    [
+        ("", lambda: EmployerFactory(with_company=True), "dashboard:index"),
+        ("?param=1", lambda: EmployerFactory(with_company=True), "dashboard:index"),
+        ("?param=1&username=2", lambda: EmployerFactory(with_company=True), "dashboard:index"),
+        ("", None, "search:employers_home"),
+        ("?param=1", None, "search:employers_home"),
+        ("?param=1&username=2", None, "search:employers_home"),
+    ],
+)
+def test_middleware_wo_proconnect_login_param(client, db, params, user, redirection):
+    if user:
+        client.force_login(user())
+    response = client.get(f"{reverse('home:hp')}/{params}")
+    assertRedirects(response, reverse(redirection), fetch_redirect_response=False)
+
+
+@pytest.mark.parametrize("params,expected_params", params_tuples)
+def test_middleware_for_authenticated_user(client, db, params, expected_params):
+    user = EmployerFactory(with_company=True)
+    client.force_login(user)
+
+    for username_param in ["", "&username=123-abc"]:
+        response = client.get(f"/{params}{username_param}")
+        assertRedirects(response, f"/{expected_params}", fetch_redirect_response=False)
+
+
+@pytest.mark.parametrize("params,expected_params", params_tuples)
+def test_middlware_for_non_proconnect_user(client, db, params, expected_params):
+    user = EmployerFactory(with_company=True)
+    for username_param in ["", "&username=123-abc", f"&username={user.username}"]:
+        response = client.get(f"/{params}{username_param}")
+        assertRedirects(
+            response,
+            f"{reverse('signup:choose_user_kind')}?previous_url=/{expected_params}",
+            fetch_redirect_response=False,
+        )
+
+
+@pytest.mark.parametrize("params,expected_params", params_tuples)
+def test_middleware_for_unlogged_proconnect_user(client, db, params, expected_params):
+    user = EmployerFactory(with_company=True, identity_provider=IdentityProvider.PRO_CONNECT)
+    response = client.get(f"/{params}&username={user.username}")
+    assertRedirects(
+        response,
+        f"{reverse("pro_connect:authorize")}?user_kind={user.kind}&previous_url=/{expected_params}",
+        fetch_redirect_response=False,
+    )

--- a/tests/openid_connect/pro_connect/test_middleware.py
+++ b/tests/openid_connect/pro_connect/test_middleware.py
@@ -48,7 +48,7 @@ def test_middlware_for_non_proconnect_user(client, db, params, expected_params):
         response = client.get(f"/{params}{username_param}")
         assertRedirects(
             response,
-            f"{reverse('signup:choose_user_kind')}?previous_url=/{expected_params}",
+            f"{reverse('signup:choose_user_kind')}?next_url=/{expected_params}",
             fetch_redirect_response=False,
         )
 
@@ -59,6 +59,6 @@ def test_middleware_for_unlogged_proconnect_user(client, db, params, expected_pa
     response = client.get(f"/{params}&username={user.username}")
     assertRedirects(
         response,
-        f"{reverse("pro_connect:authorize")}?user_kind={user.kind}&previous_url=/{expected_params}",
+        f"{reverse("pro_connect:authorize")}?user_kind={user.kind}&next_url=/{expected_params}",
         fetch_redirect_response=False,
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Permettre aux utilisateurs ayant une session proconnect active, d'être connectés automatiquement  en provenant des autres sites de la plateforme de l'inclusion

Issue [Commu #846](https://github.com/gip-inclusion/itou-communaute-django/issues/846)

# Catégories changelog

Connexion

## :cake: Comment ? <!-- optionnel -->

* ajout d'un `middleware` activé en présence du paramètre `proconnect_login`
* exploitation du paramètre `username` pour verifier l'existence de l'utilisateur dans les emplois

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md > NON

## :desert_island: Comment tester

> disposer d'une instance Pro Connect accessible

