### PR TITLE
UX/UI: Mise a jour du theme en version 2.5.0

### DIFF
--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -204,11 +204,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.3.3.zip",
-            "sha256": "022177c783181778454027cd07062bde3722209ff131159965f6ff495a9856da",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.5.0.zip",
+            "sha256": "319bba394d290ecd4cc1dd26b01ee9a0f0023ecf7832b5622772d02c814d06f3",
         },
         "extract": {
-            "origin": "itou-theme-2.3.3/dist",
+            "origin": "itou-theme-2.5.0/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mise à jour du thème pour passage de Gulp a Vitejs.
Vitejs compile et minifie les fichiers différemment donc beaucoup de changement dans les fichiers statiques lié au  changement de l'[outil de build](https://github.com/gip-inclusion/itou-theme/commit/3c0de7cbc30e17075b2d905ef587a8779a40f939). 

