### PR TITLE
[POC] ajout d'un lien vers la documentation de la communauté

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -730,3 +730,7 @@ API_PARTICULIER_TOKEN = os.getenv("API_PARTICULIER_TOKEN")
 # Brevo
 # ------------------------------------------------------------------------------
 BREVO_API_KEY = os.getenv("BREVO_API_KEY")
+
+# la communaute de l'inclusion
+# ------------------------------------------------------------------------------
+COMMU_BASE_URL = os.getenv("COMMU_BASE_URL", "https://communaute.inclusion.beta.gouv.fr")

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -88,7 +88,7 @@ NAV_ENTRIES = {
     ),
     "documents-search": NavItem(
         label="Une documentation",
-        target="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true",
+        target=f"{settings.COMMU_BASE_URL}/documentation/?proconnect_login=true",
         active_view_names=[],
     ),
     # Job seekers.

--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -86,6 +86,11 @@ NAV_ENTRIES = {
         target=reverse("search:prescribers_results"),
         active_view_names=["search:prescribers_home", "search:prescribers_results"],
     ),
+    "documents-search": NavItem(
+        label="Une documentation",
+        target="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true",
+        active_view_names=[],
+    ),
     # Job seekers.
     "job-seeker-job-apps": NavItem(
         label="Mes candidatures",
@@ -250,6 +255,7 @@ def nav(request):
                 items=[
                     NAV_ENTRIES["employers-search"],
                     NAV_ENTRIES["prescribers-search"],
+                    NAV_ENTRIES["documents-search"],
                 ],
             )
         )

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -93,6 +93,11 @@
                                   Un prescripteur habilité</a>
                               </li>
                           
+                              <li>
+                                  <a href="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true">
+                                  Une documentation</a>
+                              </li>
+                          
                       </ul>
                   </div>
               </li>
@@ -373,6 +378,11 @@
                                   Un prescripteur habilité</a>
                               </li>
                           
+                              <li>
+                                  <a href="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true">
+                                  Une documentation</a>
+                              </li>
+                          
                       </ul>
                   </div>
               </li>
@@ -603,6 +613,11 @@
                               <li>
                                   <a href="/search/prescribers/results">
                                   Un prescripteur habilité</a>
+                              </li>
+                          
+                              <li>
+                                  <a href="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true">
+                                  Une documentation</a>
                               </li>
                           
                       </ul>
@@ -845,6 +860,11 @@
                               <li>
                                   <a href="/search/prescribers/results">
                                   Un prescripteur habilité</a>
+                              </li>
+                          
+                              <li>
+                                  <a href="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true">
+                                  Une documentation</a>
                               </li>
                           
                       </ul>
@@ -1099,6 +1119,11 @@
                                   Un prescripteur habilité</a>
                               </li>
                           
+                              <li>
+                                  <a href="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true">
+                                  Une documentation</a>
+                              </li>
+                          
                       </ul>
                   </div>
               </li>
@@ -1324,6 +1349,11 @@
                               <li>
                                   <a href="/search/prescribers/results">
                                   Un prescripteur habilité</a>
+                              </li>
+                          
+                              <li>
+                                  <a href="https://communaute.inclusion.beta.gouv.fr/documentation/?proconnect_login=true">
+                                  Une documentation</a>
                               </li>
                           
                       </ul>


### PR DESCRIPTION
## :thinking: Pourquoi ?

POC de l'authentification `proconnect` des emplois vers la communauté

## :cake: Comment ?

* Ajout d'un lien dans les `NavItem` vers la communauté avec le paramètre `proconnect_login=true`
* lié à la [PR #117 itou-secrets](https://github.com/gip-inclusion/itou-secrets/pull/117)
* Issue de reference [#846](https://github.com/gip-inclusion/itou-communaute-django/issues/846) : [PR Middleware Emplois #5237](https://github.com/gip-inclusion/les-emplois/pull/5237), [PR Middleware Commu #851](https://github.com/gip-inclusion/les-emplois/pull/5237)

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ? > NON

## :desert_island: Comment tester

1. s'authenfier avec proconnect sur les emplois de prod
2. cliquer sur le lien dans l'instance de test
3. verifier la redirection vers la communauté (prod) avec l'état authentifié

* https://les-emplois-recette-pro-connect.cleverapps.io
* https://staging.communaute.inclusion.beta.gouv.fr

## :computer: Captures d'écran 

![image](https://github.com/user-attachments/assets/f9c6670e-7774-4a6e-a17c-f90fdc077fd2)

