### PR TITLE
[Employeur] Affichage du bouton de blocage des candidature pour les structures sans fiches de poste

### DIFF
--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -42,22 +42,20 @@
                         <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
                             <h2 class="mb-0">Métiers et recrutements</h2>
                             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les candidatures">
-                                {% if job_pager %}
-                                    <form method="post" id="block_job_applications_form" hx-boost="true">
-                                        {% csrf_token %}
-                                        <input type="hidden" name="action" value="block_job_applications" />
-                                        <input type="hidden" name="block_job_applications" value="{% if siae.block_job_applications %}false{% else %}true{% endif %}">
-                                        <button for="block_job_applications" class="d-block w-100 btn btn-secondary btn-ico">
-                                            {% if siae.block_job_applications %}
-                                                <i class="ri-lock-unlock-line ri-lg" aria-hidden="true"></i>
-                                                <span>Débloquer l'envoi de candidatures</span>
-                                            {% else %}
-                                                <i class="ri-lock-line ri-lg" aria-hidden="true"></i>
-                                                <span>Bloquer l'envoi de candidatures</span>
-                                            {% endif %}
-                                        </button>
-                                    </form>
-                                {% endif %}
+                                <form method="post" id="block_job_applications_form" hx-boost="true">
+                                    {% csrf_token %}
+                                    <input type="hidden" name="action" value="block_job_applications" />
+                                    <input type="hidden" name="block_job_applications" value="{% if siae.block_job_applications %}false{% else %}true{% endif %}">
+                                    <button for="block_job_applications" class="d-block w-100 btn btn-secondary btn-ico">
+                                        {% if siae.block_job_applications %}
+                                            <i class="ri-lock-unlock-line ri-lg" aria-hidden="true"></i>
+                                            <span>Débloquer l'envoi de candidatures</span>
+                                        {% else %}
+                                            <i class="ri-lock-line ri-lg" aria-hidden="true"></i>
+                                            <span>Bloquer l'envoi de candidatures</span>
+                                        {% endif %}
+                                    </button>
+                                </form>
                                 <a class="btn btn-primary btn-ico" href="{% url "companies_views:edit_job_description" %}" {% matomo_event "employers" "clic" "creer-fiche-de-poste" %}>
                                     <i class="ri-add-line ri-lg" aria-hidden="true"></i>
                                     <span>Créer une nouvelle fiche de poste</span>


### PR DESCRIPTION
## :thinking: Pourquoi ?

> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._

Le bouton permettant de bloquer ou de débloquer la réception de nouvelles candidatures ne s'affichait que si la structure avait renseigné des fiches de poste. 

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->


## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester
Se connecter en tant qu'employeur, aller dans l'onglet Fiches de poste et activer ou bloquer la réception de nouvelles candidatures.

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/0c688c92-a6ef-4dfa-8197-33ff5fecbbda)

