### PR TITLE
Correction du JS pour désactiver un champ

### DIFF
--- a/itou/static/js/utils.js
+++ b/itou/static/js/utils.js
@@ -56,6 +56,9 @@ htmx.onLoad((target) => {
   * JS to disable/enable and set another select field value.
   **/
   function toggleDisableAndSetValue() {
+    if (this.disabled) {
+      return;
+    }
     const targetId = this.getAttribute("data-disable-target");
     const isSet = $(this).val().length > 0;
     if (isSet) {


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le formulaire de mise à jour de candidat est désactivé si le candidat a pris contrôle de son compte.
Si `birth_place` n'est pas rempli, alors le JS réactive le champ `birth_country`, qui devient alors le seul champ modifiable.
Cette PR propose une correction.


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :desert_island: Comment tester

1. En tant que prescripteur habilité, postuler pour Jacques Henry (test+de@inclusion.beta.gouv.fr)
2. À la page de sélection de poste, cliquer sur *Vérifier le profil* (en haut)
3. Tous les champs devraient être grisés

## :computer: Captures d'écran <!-- optionnel -->
### Avant
![image](https://github.com/user-attachments/assets/f8725ae3-3b4e-4f00-a7be-c724eb126c86)


### Après
![image](https://github.com/user-attachments/assets/b0c237b2-8479-4ba3-9843-6e9121693a04)

