### PR TITLE
Tech: restriction des URLs exposés par anymail

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,3 +1,4 @@
+from anymail.webhooks.mailjet import MailjetTrackingWebhookView
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path, register_converter
@@ -86,9 +87,9 @@ urlpatterns = [
     path("users/", include("itou.www.users_views.urls")),
     path("announcements/", include("itou.www.announcements.urls")),
     path("versions/", include("itou.www.releases.urls")),
-    # Enable Anymail’s status tracking
+    # Enable Mailjet status tracking
     # https://anymail.readthedocs.io/en/stable/esps/mailjet/#status-tracking-webhooks
-    re_path(r"^webhooks/anymail/", include("anymail.urls")),
+    path("webhooks/anymail/mailjet/tracking/", MailjetTrackingWebhookView.as_view()),
     path("welcoming_tour/", include("itou.www.welcoming_tour.urls")),
     # Static pages.
     path("accessibility/", TemplateView.as_view(template_name="static/accessibility.html"), name="accessibility"),

--- a/tests/www/test_anymail.py
+++ b/tests/www/test_anymail.py
@@ -1,0 +1,19 @@
+import base64
+
+
+def test_access(client, settings):
+    # Setup access
+    settings.ANYMAIL = dict(settings.ANYMAIL) | {"WEBHOOK_SECRET": "S3cr3t"}
+
+    # Try without credentials
+    response = client.post("/webhooks/anymail/mailjet/tracking/", content_type="application/json", data=[])
+    assert response.status_code == 400
+
+    # and with
+    response = client.post(
+        "/webhooks/anymail/mailjet/tracking/",
+        content_type="application/json",
+        data=[],
+        headers={"Authorization": "Basic " + base64.b64encode(b"S3cr3t").decode()},
+    )
+    assert response.status_code == 200


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour limiter le nombre d'URLs exposés au minimum.
Ajouts de tests basiques pour vérifier le fonctionnement, notamment en vu du passage à `LoginRequiredMiddleware`.
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
