### PR TITLE
UX/UI: Mise a jour du theme en version 2.5.3

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -141,17 +141,19 @@
                 "cookieName": "tarteaucitron", /* Cookie name */
                 "orientation": "bottom", /* Banner position (top - bottom) */
                 "groupServices": false, /* Group services by category */
+                "showDetailsOnClick": true, /* Click to expand the description */
                 "serviceDefaultState": "wait", /* Default state (true - wait - false) */
                 "showAlertSmall": false, /* Show the small banner on bottom right */
                 "cookieslist": false, /* Show the cookie list */
                 "closePopup": false, /* Show a close X on the banner */
                 "showIcon": true, /* Show cookie icon to manage cookies */
                 //"iconSrc": "", /* Optionnal: URL or base64 encoded image */
-                "iconPosition": "BottomLeft", /* BottomRight, BottomLeft, TopRight and TopLeft */
+                "iconPosition": "BottomRight", /* BottomRight, BottomLeft, TopRight and TopLeft */
                 "adblocker": false, /* Show a Warning if an adblocker is detected */
                 "DenyAllCta" : true, /* Show the deny all button */
                 "AcceptAllCta" : true, /* Show the accept all button when highPrivacy on */
                 "highPrivacy": true, /* HIGHLY RECOMMANDED Disable auto consent */
+                "alwaysNeedConsent": false, /* Ask the consent for "Privacy by design" services */
                 "handleBrowserDNTRequest": false, /* If Do Not Track == 1, disallow all */
                 "removeCredit": true, /* Remove credit link */
                 "moreInfoLink": true, /* Show more info link */
@@ -160,7 +162,10 @@
                 //"cookieDomain": ".my-multisite-domaine.fr", /* Shared cookie for multisite */
                 "readmoreLink": "{% url 'legal-privacy' %}#cookies", /* Change the default readmore link */
                 "mandatory": true, /* Show a message about mandatory cookies */
-                "mandatoryCta": true /* Show the disabled accept button when mandatory on */
+                "mandatoryCta": true, /* Show the disabled accept button when mandatory on */
+                "customCloserId": "", /* Optional a11y: Custom element ID used to open the panel */
+                "googleConsentMode": true, /* Enable Google Consent Mode v2 for Google ads and GA4 */
+                "partnersList": false /* Show the number of partners on the popup/middle banner */
             });
 
             // Hotjar.

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -64,11 +64,11 @@ ASSET_INFOS = {
     },
     "bootstrap": {
         "download": {
-            "url": "https://github.com/twbs/bootstrap/archive/refs/tags/v5.3.2.zip",
-            "sha256": "5542fdffc10ab7590709c5cbb2a5f8c3e33af534db491bb9aab7e8c46573ce8f",
+            "url": "https://github.com/twbs/bootstrap/archive/refs/tags/v5.3.3.zip",
+            "sha256": "55d7f1ce795040afb8311df09d29d0d34648400c1eaabb2d0a2ed2216b3db05d",
         },
         "extract": {
-            "origin": "bootstrap-5.3.2/dist/js",
+            "origin": "bootstrap-5.3.3/dist/js",
             "destination": "vendor/bootstrap",
             "files": [
                 "bootstrap.min.js",
@@ -202,8 +202,8 @@ ASSET_INFOS = {
     },
     "tarteaucitronjs": {
         "download": {
-            "url": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.14.0.tgz",
-            "sha256": "e7d635b081b165d297809e3e86077c4219b022105e3a0a6a25e3c1f9657a2231",
+            "url": "https://registry.npmjs.org/tarteaucitronjs/-/tarteaucitronjs-1.19.0.tgz",
+            "sha256": "01ecf4f76cc55a358905daa38f2f0bfbec13bc842e53a829800a06ced744abed",
         },
         "extract": {
             "origin": "package",
@@ -219,11 +219,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.5.0.zip",
-            "sha256": "319bba394d290ecd4cc1dd26b01ee9a0f0023ecf7832b5622772d02c814d06f3",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.5.3.zip",
+            "sha256": "ae70bef451073d31f66496aef405942f615469476e978318a2f629661f7dff86",
         },
         "extract": {
-            "origin": "itou-theme-2.5.0/dist",
+            "origin": "itou-theme-2.5.3/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

La mise à jour du thème en v2.5.3 inclus :
- la montée de version de Bootstrap [5.3.2 > 5.3.3](https://github.com/gip-inclusion/itou-theme/commit/2490c151162b4030c93a3bc2e8f1adc18af85287) 
- la montée de version de Tarte au citron [1.14.0 > 1.19.0](https://github.com/gip-inclusion/itou-theme/commit/35e567b77ae3b43decee4c4107351bc42288729e)   
- un fix de z-index pour [tooltip x offcanvas](https://github.com/gip-inclusion/itou-theme/commit/c7dcf8e0ddd730a0453a01f8fb5f8cfb93083fa1)


Changement de côté de l'icône Tarte au citron, car elle chevauchait le footer du menu connecté
![capture 2024-12-12 à 15 57 39](https://github.com/user-attachments/assets/22635026-84fc-4f66-948b-87ffa312c43f)

