### PR TITLE
Tech: réduction du niveau de log des erreurs `GeocodingDataError`

### DIFF
--- a/itou/common_apps/address/models.py
+++ b/itou/common_apps/address/models.py
@@ -267,7 +267,7 @@ class AddressMixin(models.Model):
         except GeocodingDataError as exc:
             # The coordinates are not erased because they are used in the search engine,
             # even if they no longer correspond to the address.
-            logger.error("No geocoding data could be found for `%s - %s`", self.geocoding_address, self.post_code)
+            logger.info("No geocoding data could be found for the address of <%s - pk=%s>", self.__class__, self.pk)
             raise AddressLookupError(
                 f"L'adresse '{self.geocoding_address}' - {self.post_code}"
                 " n'a pas été trouvée dans la Base Adresse Nationale."

--- a/itou/users/admin_forms.py
+++ b/itou/users/admin_forms.py
@@ -51,10 +51,10 @@ class UserAdminForm(UserChangeForm):
                 try:
                     geocoding_data = api_geocoding.get_geocoding_data(posted_address)
                 except api_geocoding.GeocodingDataError:
-                    logger.error(
-                        "No geocoding data could be found for `%s - %s`",
-                        self.cleaned_data["address_line_1"],
-                        self.cleaned_data["post_code"],
+                    logger.info(
+                        "No geocoding data could be found for the address of <%s - pk=%s>",
+                        self.instance.__class__,
+                        self.instance.pk,
                     )
                 else:
                     self.instance.coords = coords_to_geometry(


### PR DESCRIPTION
## :thinking: Pourquoi ?

On ne fait rien de ces erreurs donc autant les mettre en `info`.
Et plutôt que de logger les adresses postales, on se contente de logger l'objet à l'origine de l'erreur (la plupart du temps).

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
