### PR TITLE
Tech: correction du comportement de `member_required`

### DIFF
--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -2,7 +2,7 @@ import uuid
 
 from django.conf import settings
 from django.db import models
-from django.db.models import Prefetch, Q
+from django.db.models import Exists, OuterRef, Prefetch, Q
 from django.forms import ValidationError
 from django.utils import timezone
 
@@ -16,7 +16,16 @@ class OrganizationQuerySet(models.QuerySet):
     """
 
     def member_required(self, user):
-        return self.filter(members=user, members__is_active=True)
+        membership_model = self.model.members.through
+        # through_fields contains a tuple like ("company", "user")
+        structure_field, _user_field = self.model.members.rel.through_fields
+        return self.filter(
+            Exists(
+                membership_model.objects.filter(
+                    user=user, is_active=True, user__is_active=True, **{structure_field: OuterRef("pk")}
+                )
+            )
+        )
 
     def prefetch_active_memberships(self):
         membership_model = self.model.members.through

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -271,6 +271,20 @@ class TestCompanyModel:
 
 
 class TestCompanyQuerySet:
+    def test_member_required(self):
+        company = CompanyFactory()
+        user = EmployerFactory()
+        assert Company.objects.member_required(user).count() == 0
+
+        company.add_or_activate_member(user)
+        assert Company.objects.member_required(user).get() == company
+
+        membership = company.memberships.get()
+        membership.is_active = False
+        membership.save(update_fields=("is_active",))
+
+        assert Company.objects.member_required(user).count() == 0
+
     def test_with_count_recent_received_job_applications(self):
         company = CompanyFactory()
         model = JobApplicationFactory._meta.model

--- a/tests/institutions/tests.py
+++ b/tests/institutions/tests.py
@@ -71,6 +71,22 @@ class TestInstitutionModel:
             institution.add_or_activate_member(wrong_kind_user)
 
 
+class TestInstitutionQuerySet:
+    def test_member_required(self):
+        institution = InstitutionFactory()
+        user = LaborInspectorFactory()
+        assert Institution.objects.member_required(user).count() == 0
+
+        institution.add_or_activate_member(user)
+        assert Institution.objects.member_required(user).get() == institution
+
+        membership = institution.memberships.get()
+        membership.is_active = False
+        membership.save(update_fields=("is_active",))
+
+        assert Institution.objects.member_required(user).count() == 0
+
+
 def test_deactivate_last_admin(admin_client, mailoutbox):
     institution = InstitutionWithMembershipFactory(department="")
     membership = institution.memberships.first()

--- a/tests/prescribers/tests.py
+++ b/tests/prescribers/tests.py
@@ -246,6 +246,22 @@ class TestPrescriberOrganizationModel:
         assert organization.is_head_office is True
 
 
+class TestPrescriberOrganizationQuerySet:
+    def test_member_required(self):
+        organization = PrescriberOrganizationFactory()
+        user = PrescriberFactory()
+        assert PrescriberOrganization.objects.member_required(user).count() == 0
+
+        organization.add_or_activate_member(user)
+        assert PrescriberOrganization.objects.member_required(user).get() == organization
+
+        membership = organization.memberships.get()
+        membership.is_active = False
+        membership.save(update_fields=("is_active",))
+
+        assert PrescriberOrganization.objects.member_required(user).count() == 0
+
+
 class TestPrescriberOrganizationAdmin:
     ACCEPT_BUTTON_LABEL = "Valider l'habilitation"
     REFUSE_BUTTON_LABEL = "Refuser l'habilitation"

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -210,11 +210,16 @@
                  "companies_company"."is_searchable",
                  "companies_company"."rdv_solidarites_id"
           FROM "companies_company"
-          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
-          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
           WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_companymembership"."user_id" = %s
-                 AND "users_user"."is_active"
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
+                    WHERE (U0."company_id" = ("companies_company"."id")
+                           AND U0."is_active"
+                           AND U0."user_id" = %s
+                           AND U2."is_active")
+                    LIMIT 1)
                  AND "companies_company"."id" = %s)
           LIMIT 21
         ''',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les _Memberships_ inactives ne devraient pas être prises en compte.

:warning: Mais je me demande si on ne devrait pas tout simplement se baser sur `request.organizations`, ce qui éviterait des requêtes inutiles et centraliserait la règle métier.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
