### PR TITLE
Page d’accueil: Éviter le plantage en cas de rupture de la connexion au cache

### DIFF
--- a/itou/utils/cache.py
+++ b/itou/utils/cache.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django_redis.cache import RedisCache
+from django_redis.cache import CONNECTION_INTERRUPTED, RedisCache
 from django_redis.client import DefaultClient
 from django_redis.exceptions import ConnectionInterrupted
 from redis import exceptions as redis_exceptions
@@ -44,8 +44,7 @@ class FailSafeRedisCacheClient(DefaultClient):
                     return attr_or_meth(*args, **kwargs)
                 except IGNORED_EXCEPTIONS as e:
                     capture_exception(e)
-                    # None is the return for a GET where the key does not exist.
-                    return None
+                    return CONNECTION_INTERRUPTED  # return for a GET where the key does not exist.
 
             return report_failure
         return attr_or_meth

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,37 +1,25 @@
 import re
-import socket
 from unittest import mock
 
 from django.core.cache.backends.redis import RedisCacheClient
 
-from itou.utils.cache import FAILSAFE_METHODS, UnclearableCache
+from itou.utils.cache import FAILSAFE_METHODS
 
 
 class TestFailSafeRedisCache:
-    def test_access_with_bad_url(self, settings):
-        with socket.create_server(("localhost", 0)) as s:
-            empty_port = s.getsockname()[1]
-            s.close()
-            cache = UnclearableCache(
-                f"redis://localhost:{empty_port}",
-                {
-                    "OPTIONS": {
-                        "CLIENT_CLASS": "itou.utils.cache.FailSafeRedisCacheClient",
-                    },
-                },
-            )
-            with mock.patch("itou.utils.cache.capture_exception") as sentry_mock:
-                assert cache.get("foo") is None
-            sentry_mock.assert_called_once()
-            [args, kwargs] = sentry_mock.call_args
-            [exception] = args
-            # django-redis chains redis original exceptions through ConnectionInterrupted
-            [exc_msg] = exception.__cause__.args if exception.__cause__ else exception.args
-            # Message error code depends on the platform (Mac or Linux). Should be a variation of the following ones:
-            # Error 99 connecting to localhost:{empty_port}. Cannot assign requested address.
-            # Error 111 connecting to localhost:{empty_port}. Connection refused.
-            assert re.match(r"Error \d+ connecting to localhost", exc_msg)
-            assert kwargs == {}
+    def test_access_with_bad_url(self, settings, failing_cache):
+        with mock.patch("itou.utils.cache.capture_exception") as sentry_mock:
+            assert failing_cache.get("foo") is None
+        sentry_mock.assert_called_once()
+        [args, kwargs] = sentry_mock.call_args
+        [exception] = args
+        # django-redis chains redis original exceptions through ConnectionInterrupted
+        [exc_msg] = exception.__cause__.args if exception.__cause__ else exception.args
+        # Message error code depends on the platform (Mac or Linux). Should be a variation of the following ones:
+        # Error 99 connecting to localhost:{empty_port}. Cannot assign requested address.
+        # Error 111 connecting to localhost:{empty_port}. Connection refused.
+        assert re.match(r"Error \d+ connecting to localhost", exc_msg)
+        assert kwargs == {}
 
     def test_known_public_methods(self):
         actual_keys = {k for k in RedisCacheClient.__dict__ if not k.startswith("_")}


### PR DESCRIPTION
## :thinking: Pourquoi ?

La campagne active est mise en cache pour être utilisée dans une modale qui s'affiche sur le site. Si la connexion au cache est interrompue, une erreur 500 sera générée.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
