### PR TITLE
Employeur: Réduction de la durée de validité du diagnostic d’éligibilité à 92 jours [GEN-2276]

### DIFF
--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 
-from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db import models
 from django.utils import timezone
@@ -77,11 +76,6 @@ class AbstractEligibilityDiagnosisModel(models.Model):
 
     def __str__(self):
         return str(self.pk)
-
-    def save(self, *args, **kwargs):
-        if not self.expires_at:
-            self.expires_at = timezone.localdate(self.created_at) + relativedelta(months=self.EXPIRATION_DELAY_MONTHS)
-        return super().save(*args, **kwargs)
 
     @property
     def is_valid(self):

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -198,6 +198,7 @@ class GEIQEligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
             author_kind=author_kind,
             author_prescriber_organization=author_org,
             author_geiq=author_geiq,
+            expires_at=timezone.localdate() + relativedelta(months=cls.EXPIRATION_DELAY_MONTHS),
         )
 
         if administrative_criteria:

--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -180,6 +180,7 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
             author_kind=author.kind,
             author_siae=author_organization if author.is_employer else None,
             author_prescriber_organization=author_organization if author.is_prescriber else None,
+            expires_at=timezone.localdate() + relativedelta(months=cls.EXPIRATION_DELAY_MONTHS),
         )
         if administrative_criteria:
             diagnosis.administrative_criteria.add(*administrative_criteria)

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -535,19 +535,19 @@ class ApplicationEligibilityView(RequireApplySessionMixin, ApplicationBaseView):
         return self.render_to_response(self.get_context_data(**kwargs))
 
     def get_context_data(self, **kwargs):
-        new_expires_at_if_updated = timezone.now() + relativedelta(months=EligibilityDiagnosis.EXPIRATION_DELAY_MONTHS)
-
-        return super().get_context_data(**kwargs) | {
-            "form": self.form,
-            "new_expires_at_if_updated": new_expires_at_if_updated,
-            "progress": 50,
-            "job_seeker": self.job_seeker,
-            "back_url": reverse(
-                "apply:application_jobs",
-                kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
-            ),
-            "full_content_width": True,
-        }
+        context = super().get_context_data(**kwargs)
+        context["form"] = self.form
+        context["progress"] = 50
+        context["job_seeker"] = self.job_seeker
+        context["back_url"] = reverse(
+            "apply:application_jobs",
+            kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
+        )
+        context["full_content_width"] = True
+        context["new_expires_at_if_updated"] = timezone.now() + relativedelta(
+            months=EligibilityDiagnosis.EXPIRATION_DELAY_MONTHS
+        )
+        return context
 
 
 class ApplicationGEIQEligibilityView(RequireApplySessionMixin, ApplicationBaseView):

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -544,9 +544,8 @@ class ApplicationEligibilityView(RequireApplySessionMixin, ApplicationBaseView):
             kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
         context["full_content_width"] = True
-        context["new_expires_at_if_updated"] = timezone.now() + relativedelta(
-            months=EligibilityDiagnosis.EXPIRATION_DELAY_MONTHS
-        )
+        if self.eligibility_diagnosis:
+            context["new_expires_at_if_updated"] = self.eligibility_diagnosis._expiration_date(self.request.user)
         return context
 
 

--- a/tests/eligibility/factories.py
+++ b/tests/eligibility/factories.py
@@ -2,12 +2,14 @@ import datetime
 import random
 
 import factory
+from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 from faker import Faker
 
 from itou.companies.enums import CompanyKind
 from itou.eligibility import models
 from itou.eligibility.enums import AdministrativeCriteriaAnnex, AuthorKind
+from itou.eligibility.models.common import AbstractEligibilityDiagnosisModel
 from tests.companies.factories import CompanyFactory, CompanyWith2MembershipsFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import JobSeekerFactory
@@ -42,6 +44,10 @@ class AbstractEligibilityDiagnosisModelFactory(factory.django.DjangoModelFactory
         )
 
     created_at = factory.LazyFunction(timezone.now)
+    expires_at = factory.LazyAttribute(
+        lambda obj: timezone.localdate(obj.created_at)
+        + relativedelta(months=AbstractEligibilityDiagnosisModel.EXPIRATION_DELAY_MONTHS)
+    )
     job_seeker = factory.SubFactory(JobSeekerFactory)
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Aligner la durée de validité des diagnostics employeur avec la durée de validité des justificatifs (3 mois).

## :desert_island: Comment tester

1. Se connecter en tant qu’employeur
2. Créer une candidature pour un nouveau candidat
3. Dans le parcours d’acceptation de candidature, effectuer un diagnostic d’éligibilité
4. Vérifier dans l’admin que le diagnostic d’éligibilité expire dans 92j.

Vérifier que les diagnostics IAE PH et GEIQ continuent de durer 6 mois.

## :computer: Captures d'écran <!-- optionnel -->
