### PR TITLE
Inscription: Supprimer code temporaire pour le deploiement de la refonte du parcours d'inscription

### DIFF
--- a/itou/openid_connect/utils.py
+++ b/itou/openid_connect/utils.py
@@ -8,11 +8,3 @@ def init_user_nir_from_session(request, user):
         user.jobseeker_profile.lack_of_nir_reason = ""
         user.jobseeker_profile.save(update_fields=["nir", "lack_of_nir_reason"])
         request.session.pop(global_constants.ITOU_SESSION_JOB_SEEKER_SIGNUP_KEY)
-
-    # TODO(calum): job_seeker_nir is a depreciated cache key, remove the second condition in a few days
-    existing_nir = request.session.get(global_constants.ITOU_SESSION_NIR_KEY)
-    if existing_nir:
-        user.jobseeker_profile.nir = existing_nir
-        user.jobseeker_profile.lack_of_nir_reason = ""
-        user.jobseeker_profile.save(update_fields=["nir", "lack_of_nir_reason"])
-        request.session.pop(global_constants.ITOU_SESSION_NIR_KEY)

--- a/itou/utils/constants.py
+++ b/itou/utils/constants.py
@@ -14,8 +14,6 @@ FRANCE_TRAVAIL_EMAIL_SUFFIX = "@francetravail.fr"
 # when they do span multiple apps.
 ITOU_SESSION_CURRENT_ORGANIZATION_KEY = "current_organization"
 ITOU_SESSION_PRESCRIBER_SIGNUP_KEY = "prescriber_signup"
-# TODO(calum): job_seeker_nir is a depreciated cache key, remove the second condition in a few days
-ITOU_SESSION_NIR_KEY = "job_seeker_nir"
 ITOU_SESSION_JOB_SEEKER_SIGNUP_KEY = "job_seeker_signup"
 
 MATOMO_SITE_PILOTAGE_ID = "146"

--- a/itou/www/signup/urls.py
+++ b/itou/www/signup/urls.py
@@ -1,5 +1,5 @@
-from django.urls import path, re_path, reverse_lazy
-from django.views.generic import RedirectView, TemplateView
+from django.urls import path, re_path
+from django.views.generic import TemplateView
 
 from itou.www.signup import views
 
@@ -10,10 +10,6 @@ app_name = "signup"
 urlpatterns = [
     path("", views.ChooseUserKindSignupView.as_view(), name="choose_user_kind"),
     # Job seeker.
-    # TODO(calum): temporary code for managing deployment, remove me in a few days
-    path(
-        "job_seeker/nir", RedirectView.as_view(url=reverse_lazy("signup:job_seeker_situation")), name="job_seeker_nir"
-    ),
     path(
         "job_seeker/situation",
         views.job_seeker_situation,

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -137,12 +137,6 @@ def job_seeker_situation(request, template_name="signup/job_seeker_situation.htm
 
 
 def job_seeker_signup_info(request, template_name="signup/job_seeker_signup.html"):
-    # TODO(calum): temporary code for aiding the migration, remove in the week following deployment
-    # Restart the signup process if we encounter one ongoing with outdated code
-    if "job_seeker_nir" in request.session:
-        del request.session["job_seeker_nir"]
-        return HttpResponseRedirect(reverse("signup:job_seeker_situation"))
-
     form_class = forms.JobSeekerSignupWithOptionalNirForm if "skip" in request.POST else forms.JobSeekerSignupForm
     form = form_class(data=request.POST or None)
 
@@ -180,12 +174,6 @@ class JobSeekerCredentialsSignupView(SignupView):
     template_name = "signup/job_seeker_signup_credentials.html"
 
     def dispatch(self, request, *args, **kwargs):
-        # TODO(calum): temporary code for aiding the migration, remove in the week following deployment
-        # Restart the signup process if we encounter one ongoing with outdated code
-        if "job_seeker_nir" in request.session:
-            del request.session["job_seeker_nir"]
-            return HttpResponseRedirect(reverse("signup:job_seeker"))
-
         if global_constants.ITOU_SESSION_JOB_SEEKER_SIGNUP_KEY not in request.session:
             return HttpResponseRedirect(reverse("signup:job_seeker"))
         return super().dispatch(request, *args, **kwargs)

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -541,35 +541,3 @@ class TestJobSeekerSignup:
             parse_response_to_soup(response, selector="#message-modal-1-label")
         )
         assertContains(response, reverse("login:existing_user", args=(existing_user.public_id,)))
-
-    # TODO(calum): temporary test relating to code migration, remove in the week following deployment
-    def test_job_seeker_signup_temporary_redirects(self, client):
-        response = client.get(reverse("signup:job_seeker_nir"))
-        assertRedirects(response, reverse("signup:job_seeker_situation"))
-
-        session = client.session
-        session["job_seeker_nir"] = "141068078200557"
-        session.save()
-
-        response = client.get(reverse("signup:job_seeker"))
-        assertRedirects(response, reverse("signup:job_seeker_situation"))
-
-        session["job_seeker_nir"] = "141068078200557"
-        session.save()
-        response = client.get(reverse("signup:job_seeker_credentials"))
-        assertRedirects(response, reverse("signup:job_seeker"))
-
-        # Can continue with the process on the redirected page
-        job_seeker_data = JobSeekerFactory.build()
-        post_data = {
-            "nir": "141068078200557",
-            "title": job_seeker_data.title,
-            "first_name": job_seeker_data.first_name,
-            "last_name": job_seeker_data.last_name,
-            "email": job_seeker_data.email,
-            "birthdate": job_seeker_data.jobseeker_profile.birthdate,
-        }
-
-        response = client.post(response.url, data=post_data)
-        assert client.session.get(global_constants.ITOU_SESSION_JOB_SEEKER_SIGNUP_KEY)
-        assertRedirects(response, reverse("signup:job_seeker_credentials"))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce code a été mis en place pour faciliter la transition pour les utilisateurs en cours d'enregistrement au moment du déploiement, et devait être supprimé peu de temps après.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?