### PR TITLE
Tests: suppression du trait `job_seeker_with_address`

### DIFF
--- a/tests/job_applications/factories.py
+++ b/tests/job_applications/factories.py
@@ -40,9 +40,6 @@ class JobApplicationFactory(AutoNowOverrideMixin, factory.django.DjangoModelFact
         skip_postgeneration_save = True
 
     class Params:
-        job_seeker_with_address = factory.Trait(
-            job_seeker=factory.SubFactory(JobSeekerFactory, with_mocked_address=True)
-        )
         with_approval = factory.Trait(
             state=JobApplicationState.ACCEPTED,
             approval=factory.SubFactory(

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -76,18 +76,18 @@ def test_get(client):
 def test_as_unauthorized_prescriber(client, snapshot):
     prescriber = PrescriberFactory()
     JobApplicationFactory(
-        job_seeker_with_address=True,
         job_seeker__first_name="Supersecretname",
         job_seeker__last_name="Unknown",
         job_seeker__created_by=PrescriberFactory(),  # to check for useless queries
+        job_seeker__with_mocked_address=True,
         sender=prescriber,
         sender_kind=SenderKind.PRESCRIBER,
     )
     JobApplicationFactory(
-        job_seeker_with_address=True,
         job_seeker__first_name="Liz",
         job_seeker__last_name="Ible",
         job_seeker__created_by=prescriber,  # to check for useless queries
+        job_seeker__with_mocked_address=True,
         sender=prescriber,
         sender_kind=SenderKind.PRESCRIBER,
     )

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -462,11 +462,11 @@ class TestProcessViews:
         """As an unauthorized prescriber I cannot access personnal information of arbitrary job seekers"""
         prescriber = PrescriberFactory()
         job_application = JobApplicationFactory(
-            job_seeker_with_address=True,
             job_seeker__first_name="Supersecretname",
             job_seeker__last_name="Unknown",
             job_seeker__jobseeker_profile__nir="11111111111111",
             job_seeker__post_code="59140",
+            job_seeker__with_mocked_address=True,
             sender=prescriber,
             sender_kind=job_applications_enums.SenderKind.PRESCRIBER,
         )
@@ -487,7 +487,7 @@ class TestProcessViews:
         """As a job seeker, I can access the job_applications details for job seekers."""
         job_seeker = JobSeekerFactory()
 
-        job_application = JobApplicationFactory(job_seeker=job_seeker, job_seeker_with_address=True)
+        job_application = JobApplicationFactory(job_seeker=job_seeker)
         job_application.process()
 
         client.force_login(job_seeker)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3357,7 +3357,7 @@ class TestApplicationView:
 
 
 def test_application_end_update_job_seeker(client):
-    job_application = JobApplicationFactory(job_seeker_with_address=True)
+    job_application = JobApplicationFactory(job_seeker__with_mocked_address=True)
     job_seeker = job_application.job_seeker
     # Ensure sender cannot update job seeker infos
     assert not job_seeker.can_edit_personal_information(job_application.sender)

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -239,8 +239,8 @@ def test_apply_for_button_as_authorized_prescriber(client):
 
     job_application = JobApplicationFactory(
         sender=authorized_prescriber,
-        job_seeker_with_address=True,
         created_at=timezone.now() + datetime.timedelta(seconds=10),  # Most recent, stabilize ordering.
+        job_seeker__with_mocked_address=True,
     )
     job_application_without_address = JobApplicationFactory(
         sender=authorized_prescriber,
@@ -290,8 +290,8 @@ def test_apply_for_button_as_unauthorized_prescriber(client):
 
     job_application = JobApplicationFactory(
         sender=unauthorized_prescriber,
-        job_seeker_with_address=True,
         created_at=timezone.now() + datetime.timedelta(seconds=10),  # Most recent, stabilize ordering.
+        job_seeker__with_mocked_address=True,
     )
     client.force_login(unauthorized_prescriber)
     url = reverse("job_seekers_views:details", kwargs={"public_id": job_application.job_seeker.public_id})

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -82,7 +82,6 @@ def test_multiple(client, snapshot):
         job_seeker__first_name="David",
         job_seeker__last_name="Waterford",
         job_seeker__public_id="44444444-4444-4444-4444-444444444444",
-        job_seeker_with_address=False,
     )
     # Other app for which the current user cannot see the personal information
     unauthorized_prescriber = PrescriberFactory(membership=False)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car l'utilisation directe du trait `with_mocked_address` du `JobSeekerFactory` est plus simple/clair (et évite de faire croire que `JobApplicationFactory(job_seeker=job_seeker, job_seeker_with_address=True)` va fournir un candidat avec adresse :see_no_evil: )

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
