### PR TITLE
Pilotage : Récupérer la validité des diagnostic directement dans les emplois

### DIFF
--- a/itou/metabase/tables/job_seekers.py
+++ b/itou/metabase/tables/job_seekers.py
@@ -297,6 +297,18 @@ def get_table():
                 "fn": lambda o: getattr(get_latest_diagnosis(o), "created_at", None),
             },
             {
+                "name": "date_expiration_diagnostic",
+                "type": "date",
+                "comment": "Date d'expiration du dernier diagnostic",
+                "fn": lambda o: getattr(get_latest_diagnosis(o), "expires_at", None),
+            },
+            {
+                "name": "diagnostic_valide",
+                "type": "boolean",
+                "comment": "Validité du dernier diagnostic au moment de l'import",
+                "fn": lambda o: getattr(get_latest_diagnosis(o), "is_valid", None),
+            },
+            {
                 "name": "id_auteur_diagnostic_prescripteur",
                 "type": "integer",
                 "comment": "ID auteur diagnostic si prescripteur",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -156,6 +156,7 @@ def test_populate_job_seekers():
     #  - job_application / approval from ai stock
     #  - created by an employer
     #  - outside QPV
+    #  - expired eligibility diagnosis
     user_2 = JobSeekerFactory(
         created_by=EmployerFactory(),
         jobseeker_profile__nir="271049232724647",
@@ -165,6 +166,7 @@ def test_populate_job_seekers():
     )
     job_application_2 = JobApplicationFactory(
         with_approval=True,
+        eligibility_diagnosis__expired=True,
         approval__eligibility_diagnosis=None,
         job_seeker=user_2,
         approval__origin=Origin.AI_STOCK,
@@ -280,6 +282,8 @@ def test_populate_job_seekers():
             None,
             None,
             None,
+            None,
+            None,
             0,
             timezone.localdate() - datetime.timedelta(days=1),
         ),
@@ -306,6 +310,8 @@ def test_populate_job_seekers():
             1,
             1,
             job_application_2.eligibility_diagnosis.created_at.date(),
+            job_application_2.eligibility_diagnosis.expires_at,
+            0,
             job_application_2.eligibility_diagnosis.author_prescriber_organization.id,
             None,
             "Prescripteur",
@@ -358,6 +364,8 @@ def test_populate_job_seekers():
             2,
             2,
             job_application_3.eligibility_diagnosis.created_at.date(),
+            job_application_3.eligibility_diagnosis.expires_at,
+            1,
             None,
             job_application_3.eligibility_diagnosis.author_siae.id,
             "Employeur",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement nous calculons la validité des diag à la main, suite à plusieurs changements métier ce n’est plus vraiment la bonne façon de procéder. 
Cette info est présente sur les emplois donc nous allons la récupérer directement 🙂
