### PR TITLE
Correctif de la mise à jour des scores de la recherche employeur

### DIFF
--- a/itou/companies/management/commands/update_companies_job_app_score.py
+++ b/itou/companies/management/commands/update_companies_job_app_score.py
@@ -14,10 +14,8 @@ class Command(BaseCommand):
         nb_updated = (
             models.Company.objects.with_computed_job_app_score()
             # Do not update if nothing changes (NULL values have to be handled separately because NULL)
-            .exclude(
-                Q(job_app_score=F("computed_job_app_score"))
-                | Q(job_app_score__isnull=True) & Q(computed_job_app_score__isnull=True)
-            )
+            .exclude(Q(job_app_score=F("computed_job_app_score")) & Q(computed_job_app_score__isnull=False))
+            .exclude(Q(job_app_score__isnull=True) & Q(computed_job_app_score__isnull=True))
             .update(job_app_score=F("computed_job_app_score"))
         )
         self.stdout.write(f"Updated {nb_updated} companies in {time.perf_counter() - start:.3f} seconds")

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -134,6 +134,24 @@ def test_update_companies_job_app_score():
 
     assert company_1.job_app_score is None
     assert company_2.job_app_score is not None
+    assert (
+        company_2.job_app_score
+        == company_2.job_applications_received.count() / company_2.job_description_through.count()
+    )
+
+    # Deleting job descriptions should bring score back to None.
+    for jd in company_2.job_description_through.all():
+        jd.delete()
+    stdout = io.StringIO()
+    management.call_command("update_companies_job_app_score", stdout=stdout)
+    # company_2 changed
+    assert "Updated 1 companies" in stdout.getvalue()
+
+    company_1.refresh_from_db()
+    company_2.refresh_from_db()
+
+    assert company_1.job_app_score is None
+    assert company_2.job_app_score is None
 
 
 @freeze_time("2023-05-01")


### PR DESCRIPTION
## :thinking: Pourquoi ?

En manipulant le script en local pour creuser l'évolution en cours de la recherche employeur, j'ai réalisé qu'on avait un gros souci avec l'algorithme actuel. Des entreprises non pertinentes (grand nombre de candidatures) se retrouvent en toute première page en prod et accumulent des candidatures. Probablement car quand leur nouveau score devient None (si elle n'ont plus aucune fiche de poste après en avoir eu) ce None n'est jamais propagé en db et l'ancien score reste ad vitam eternam.

Voir les exemples d'entreprises non pertinentes dans https://www.notion.so/plateforme-inclusion/Tri-des-employeurs-fiches-de-postes-137e8fa5c35b804b95c7f05f68f69b81

## :cake: Comment ?

J'ai commencé par rajouter du test cassant (TDD). Ca repasse au vert quand j'enlève toute la clause `exclude`. Je propose ici une solution moins radicale pour continuer à ne mettre à jour que ce qui doit l'être, mais j'avoue que je ne comprend pas complètement ni la cause, ni ma solution.
