### PR TITLE
Fiches salarié : Utilisation de XWorkflows pour gérer les états et leurs transitions

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -8,7 +8,6 @@ from django.utils.html import format_html
 
 import itou.employee_record.models as models
 from itou.companies import models as companies_models
-from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecordUpdateNotification
 from itou.utils.admin import ItouModelAdmin, ItouTabularInline, ReadonlyMixin, get_admin_view_link
 from itou.utils.templatetags.str_filters import pluralizefr
@@ -101,7 +100,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
         for employee_record in queryset:
             _, created = models.EmployeeRecordUpdateNotification.objects.update_or_create(
                 employee_record=employee_record,
-                status=Status.NEW,
+                status=models.NotificationStatus.NEW,
                 defaults={"updated_at": timezone.now},
             )
             total_created += int(created)

--- a/itou/employee_record/exceptions.py
+++ b/itou/employee_record/exceptions.py
@@ -1,6 +1,2 @@
 class SerializationError(Exception):
     """Mainly raised during serialization phases in employee record management commands."""
-
-
-class InvalidStatusError(Exception):
-    """Raised when changing status from an invalid previous status value."""

--- a/itou/employee_record/management/commands/archive_employee_records.py
+++ b/itou/employee_record/management/commands/archive_employee_records.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
             self.logger.info(f"Archiving {employee_record.pk=}")
             if wet_run:
                 try:
-                    employee_record.update_as_archived()
+                    employee_record.archive()
                 except Exception as ex:
                     self.logger.warning("Can't archive employee_record=%d ex=%s", employee_record.pk, ex)
                 else:

--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -3,7 +3,7 @@ from django.db.models import F, Max
 from django.db.models.functions import Greatest
 from django.utils import timezone
 
-from itou.employee_record.enums import Status
+from itou.employee_record.enums import NotificationStatus, Status
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
 from itou.utils.command import BaseCommand
 
@@ -81,7 +81,7 @@ class Command(BaseCommand):
             for employee_record in employee_record_with_missing_notification[: self.MAX_MISSED_NOTIFICATIONS_CREATED]:
                 _, created = EmployeeRecordUpdateNotification.objects.update_or_create(
                     employee_record=employee_record,
-                    status=Status.NEW,
+                    status=NotificationStatus.NEW,
                     defaults={"updated_at": timezone.now},
                 )
                 total_created += int(created)

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -8,7 +8,7 @@ from sentry_sdk.crons import monitor
 
 from itou.approvals.models import Approval
 from itou.employee_record.common_management import EmployeeRecordTransferCommand, IgnoreFile
-from itou.employee_record.enums import MovementType, Status
+from itou.employee_record.enums import MovementType, NotificationStatus, Status
 from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordBatchSerializer
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, EmployeeRecordUpdateNotification
@@ -120,7 +120,7 @@ class Command(EmployeeRecordTransferCommand):
                             if approval.suspension_set.exists() or approval.prolongation_set.exists():
                                 # Mimic the SQL trigger function "create_employee_record_notification()"
                                 EmployeeRecordUpdateNotification.objects.update_or_create(
-                                    status=Status.NEW,
+                                    status=NotificationStatus.NEW,
                                     employee_record=employee_record,
                                     defaults={"updated_at": timezone.now},
                                 )

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -56,9 +56,7 @@ class Command(EmployeeRecordTransferCommand):
             # and store in which file they have been sent
             renderer = JSONRenderer()
             for idx, employee_record in enumerate(employee_records, 1):
-                employee_record.update_as_sent(
-                    remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1])
-                )
+                employee_record.sent(remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1]))
 
     def _parse_feedback_file(self, feedback_file: str, batch: dict, dry_run: bool) -> None:
         """
@@ -97,7 +95,7 @@ class Command(EmployeeRecordTransferCommand):
             archived_json = JSONRenderer().render(raw_employee_record)
             if processing_code == EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE:  # Processed by ASP
                 if not dry_run:
-                    employee_record.update_as_processed(processing_code, processing_label, archived_json)
+                    employee_record.process(processing_code, processing_label, archived_json)
                 else:
                     self.stdout.write(f"DRY-RUN: Accepted {employee_record=}, {processing_code=}, {processing_label=}")
             else:  # Rejected by ASP
@@ -105,9 +103,7 @@ class Command(EmployeeRecordTransferCommand):
                     # One special case added for support concerns:
                     # 3436 processing code are automatically converted as PROCESSED
                     if processing_code == EmployeeRecord.ASP_DUPLICATE_ERROR_CODE:
-                        employee_record.update_as_processed(
-                            processing_code, processing_label, archived_json, as_duplicate=True
-                        )
+                        employee_record.process(processing_code, processing_label, archived_json, as_duplicate=True)
 
                         # If the ASP mark the employee record as duplicate,
                         # and there is a suspension or a prolongation for the associated approval,
@@ -127,7 +123,7 @@ class Command(EmployeeRecordTransferCommand):
 
                         continue
 
-                    employee_record.update_as_rejected(processing_code, processing_label, archived_json)
+                    employee_record.reject(processing_code, processing_label, archived_json)
                 else:
                     self.stdout.write(f"DRY-RUN: Rejected {employee_record=}, {processing_code=}, {processing_label=}")
 

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -56,7 +56,9 @@ class Command(EmployeeRecordTransferCommand):
             # and store in which file they have been sent
             renderer = JSONRenderer()
             for idx, employee_record in enumerate(employee_records, 1):
-                employee_record.sent(remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1]))
+                employee_record.wait_for_asp_response(
+                    remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1])
+                )
 
     def _parse_feedback_file(self, feedback_file: str, batch: dict, dry_run: bool) -> None:
         """

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -62,7 +62,9 @@ class Command(EmployeeRecordTransferCommand):
 
             renderer = JSONRenderer()
             for idx, notification in enumerate(notifications, 1):
-                notification.sent(remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1]))
+                notification.wait_for_asp_response(
+                    remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1])
+                )
 
     def _parse_feedback_file(self, feedback_file: str, batch: dict, dry_run: bool) -> None:
         """

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -62,9 +62,7 @@ class Command(EmployeeRecordTransferCommand):
 
             renderer = JSONRenderer()
             for idx, notification in enumerate(notifications, 1):
-                notification.update_as_sent(
-                    remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1])
-                )
+                notification.sent(remote_path, idx, renderer.render(batch_data["lignesTelechargement"][idx - 1]))
 
     def _parse_feedback_file(self, feedback_file: str, batch: dict, dry_run: bool) -> None:
         """
@@ -102,12 +100,12 @@ class Command(EmployeeRecordTransferCommand):
             archived_json = JSONRenderer().render(employee_record)
             if processing_code == EmployeeRecordUpdateNotification.ASP_PROCESSING_SUCCESS_CODE:  # Processed by ASP
                 if not dry_run:
-                    notification.update_as_processed(processing_code, processing_label, archived_json)
+                    notification.process(processing_code, processing_label, archived_json)
                 else:
                     self.stdout.write(f"DRY-RUN: Processed {notification}, {processing_code=}, {processing_label=}")
             else:  # Rejected by ASP
                 if not dry_run:
-                    notification.update_as_rejected(processing_code, processing_label, archived_json)
+                    notification.reject(processing_code, processing_label, archived_json)
                 else:
                     self.stdout.write(f"DRY-RUN: Rejected {notification}: {processing_code=}, {processing_label=}")
 

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -6,7 +6,7 @@ from rest_framework.renderers import JSONRenderer
 from sentry_sdk.crons import monitor
 
 from itou.employee_record.common_management import EmployeeRecordTransferCommand, IgnoreFile
-from itou.employee_record.enums import MovementType, NotificationStatus, Status
+from itou.employee_record.enums import MovementType, NotificationStatus
 from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordUpdateNotificationBatchSerializer
 from itou.employee_record.models import EmployeeRecordBatch, EmployeeRecordUpdateNotification
@@ -92,10 +92,10 @@ class Command(EmployeeRecordTransferCommand):
                 )
                 # Do not count as an error
                 continue
-            if notification.status in [Status.PROCESSED, Status.REJECTED]:
+            if notification.status in [NotificationStatus.PROCESSED, NotificationStatus.REJECTED]:
                 self.stdout.write(f"Skipping, employee record notification is already {notification.status}")
                 continue
-            if notification.status != Status.SENT:
+            if notification.status != NotificationStatus.SENT:
                 self.stdout.write(f"Skipping, incoherent status for {notification=}")
                 continue
 

--- a/itou/employee_record/migrations/0003_alter_employeerecord_status_and_more.py
+++ b/itou/employee_record/migrations/0003_alter_employeerecord_status_and_more.py
@@ -1,0 +1,37 @@
+import django_xworkflows.models
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("employee_record", "0002_fix_archived_json_as_string"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="employeerecord",
+            name="status",
+            field=django_xworkflows.models.StateField(
+                max_length=10,
+                verbose_name="statut",
+                workflow=django_xworkflows.models._SerializedWorkflow(
+                    initial_state="NEW",
+                    name="EmployeeRecordWorkflow",
+                    states=["NEW", "READY", "SENT", "REJECTED", "PROCESSED", "DISABLED", "ARCHIVED"],
+                ),
+            ),
+        ),
+        migrations.AlterField(
+            model_name="employeerecordupdatenotification",
+            name="status",
+            field=django_xworkflows.models.StateField(
+                max_length=10,
+                verbose_name="statut",
+                workflow=django_xworkflows.models._SerializedWorkflow(
+                    initial_state="NEW",
+                    name="EmployeeRecordUpdateNotificationWorkflow",
+                    states=["NEW", "SENT", "PROCESSED", "REJECTED"],
+                ),
+            ),
+        ),
+    ]

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -607,19 +607,19 @@ class EmployeeRecordUpdateNotification(ASPExchangeInformation):
         self.save()
 
     def update_as_rejected(self, code, label, archive):
-        if not self.status == Status.SENT:
+        if not self.status == NotificationStatus.SENT:
             raise ValidationError(f"Invalid status to update as REJECTED (currently: {self.status})")
 
-        self.status = Status.REJECTED
+        self.status = NotificationStatus.REJECTED
         self.set_asp_processing_information(code, label, archive)
 
         self.save()
 
     def update_as_processed(self, code, label, archive):
-        if not self.status == Status.SENT:
+        if not self.status == NotificationStatus.SENT:
             raise ValidationError(f"Invalid status to update as PROCESSED (currently: {self.status})")
 
-        self.status = Status.PROCESSED
+        self.status = NotificationStatus.PROCESSED
         self.set_asp_processing_information(code, label, archive)
 
         self.save()

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -122,7 +122,7 @@
             </div>
         {% else %}
             <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-                {% if employee_record.update_as_disabled.is_available %}
+                {% if employee_record.disable.is_available %}
                     <a href="{% url "employee_record_views:disable" employee_record.id %}"
                        class="btn btn-outline-primary btn-block w-100 w-md-auto"
                        aria-label="Désactiver la fiche salarié de {{ employee_record.job_application.job_seeker.get_full_name }}">Désactiver</a>

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -122,7 +122,7 @@
             </div>
         {% else %}
             <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-                {% if employee_record.can_be_disabled %}
+                {% if employee_record.update_as_disabled.is_available %}
                     <a href="{% url "employee_record_views:disable" employee_record.id %}"
                        class="btn btn-outline-primary btn-block w-100 w-md-auto"
                        aria-label="Désactiver la fiche salarié de {{ employee_record.job_application.job_seeker.get_full_name }}">Désactiver</a>

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -409,7 +409,7 @@ def create_step_5(request, job_application_id, template_name="employee_record/cr
 
     if request.method == "POST":
         back_url = f"{reverse('employee_record_views:list')}?status={employee_record.status}"
-        employee_record.update_as_ready()
+        employee_record.ready()
         toast_title, toast_message = (
             "La création de cette fiche salarié est terminée",
             "Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts.",
@@ -467,12 +467,12 @@ def disable(request, employee_record_id, template_name="employee_record/disable.
 
     back_url = f"{reverse('employee_record_views:list')}?status={employee_record.status}"
 
-    if not employee_record.update_as_disabled.is_available():
+    if not employee_record.disable.is_available():
         messages.error(request, EmployeeRecord.ERROR_EMPLOYEE_RECORD_INVALID_STATE)
         return HttpResponseRedirect(back_url)
 
     if request.method == "POST" and request.POST.get("confirm") == "true":
-        employee_record.update_as_disabled()
+        employee_record.disable()
         messages.success(request, "La fiche salarié a bien été désactivée.", extra_tags="toast")
         return HttpResponseRedirect(back_url)
 
@@ -504,7 +504,7 @@ def reactivate(request, employee_record_id, template_name="employee_record/react
 
     if request.method == "POST" and request.POST.get("confirm") == "true":
         try:
-            employee_record.update_as_new()
+            employee_record.enable()
             messages.success(request, "La fiche salarié a bien été réactivée.")
             return HttpResponseRedirect(back_url)
         except ValidationError as ex:

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -467,7 +467,7 @@ def disable(request, employee_record_id, template_name="employee_record/disable.
 
     back_url = f"{reverse('employee_record_views:list')}?status={employee_record.status}"
 
-    if not employee_record.can_be_disabled:
+    if not employee_record.update_as_disabled.is_available():
         messages.error(request, EmployeeRecord.ERROR_EMPLOYEE_RECORD_INVALID_STATE)
         return HttpResponseRedirect(back_url)
 

--- a/tests/api/employee_record_api/tests.py
+++ b/tests/api/employee_record_api/tests.py
@@ -101,7 +101,7 @@ class TestEmployeeRecordAPIFetchList:
         # Get list without filtering by status (PROCESSED)
         # note: there is no way to create a processed employee record
         # (and this is perfectly normal)
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
 
         # There should be no result at this point
@@ -131,7 +131,7 @@ class TestEmployeeRecordAPIFetchList:
         result = response.json()
         assert len(result.get("results")) == 0
 
-        employee_record_sent.sent(faker.asp_batch_filename(), 1, None)
+        employee_record_sent.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         response = api_client.get(ENDPOINT_URL + "?status=SENT", format="json")
         assert response.status_code == 200
 
@@ -143,7 +143,7 @@ class TestEmployeeRecordAPIFetchList:
         job_application = JobApplicationWithCompleteJobSeekerProfileFactory(to_company=self.siae)
         employee_record_rejected = EmployeeRecord.from_job_application(job_application=job_application)
         employee_record_rejected.ready()
-        employee_record_rejected.sent(faker.asp_batch_filename(), 1, None)
+        employee_record_rejected.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         # There should be no result at this point
         response = api_client.get(ENDPOINT_URL + "?status=REJECTED", format="json")
@@ -230,7 +230,7 @@ class TestEmployeeRecordAPIParameters:
         )
         employee_record = EmployeeRecord.from_job_application(job_application_2)
         employee_record.ready()
-        employee_record.sent(faker.asp_batch_filename(), 1, None)
+        employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         member = employee_record.job_application.to_company.members.first()
         api_client.force_login(member)

--- a/tests/employee_record/__snapshots__/test_archive_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_archive_employee_records.ambr
@@ -12,6 +12,7 @@
     'Start archiving employee records',
     'Found 1 archivable employee record(s)',
     'Archiving employee_record.pk=42',
+    '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.archive (NEW -> ARCHIVED)',
     '1/1 employee record(s) were archived',
   ])
 # ---

--- a/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
@@ -1,7 +1,16 @@
 # serializer version: 1
+# name: test_missed_notifications
+  list([
+    'found 1 missed employee records notifications',
+    '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
+    '1/1 notifications created',
+  ])
+# ---
 # name: test_missed_notifications_limit
   list([
     'found 3 missed employee records notifications',
+    '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
+    '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
     '2/3 notifications created',
   ])
 # ---

--- a/tests/employee_record/factories.py
+++ b/tests/employee_record/factories.py
@@ -83,4 +83,4 @@ class EmployeeRecordUpdateNotificationFactory(BareEmployeeRecordUpdateNotificati
     employee_record = factory.SubFactory(EmployeeRecordWithProfileFactory)
 
     class Params:
-        ready_for_transfer = factory.Trait(status=Status.NEW)
+        ready_for_transfer = factory.Trait(status=NotificationStatus.NEW)

--- a/tests/employee_record/test_admin.py
+++ b/tests/employee_record/test_admin.py
@@ -22,12 +22,12 @@ def test_schedule_approval_update_notification_when_notification_do_not_exists(a
     )
     notification = models.EmployeeRecordUpdateNotification.objects.latest("created_at")
     assert notification.employee_record == employee_record
-    assert notification.status == models.Status.NEW
+    assert notification.status == models.NotificationStatus.NEW
     assertMessages(response, [messages.Message(messages.SUCCESS, "1 notification planifiée")])
 
 
 def test_schedule_approval_update_notification_when_new_notification_already_exists(admin_client):
-    notification = factories.BareEmployeeRecordUpdateNotificationFactory(status=models.Status.NEW)
+    notification = factories.BareEmployeeRecordUpdateNotificationFactory(status=models.NotificationStatus.NEW)
     save_updated_at = notification.updated_at
 
     response = admin_client.post(
@@ -42,7 +42,7 @@ def test_schedule_approval_update_notification_when_new_notification_already_exi
     assertMessages(response, [messages.Message(messages.SUCCESS, "1 notification mise à jour")])
 
 
-@pytest.mark.parametrize("status", [status for status in models.Status if status != models.Status.NEW])
+@pytest.mark.parametrize("status", set(models.NotificationStatus) - {models.NotificationStatus.NEW})
 def test_schedule_approval_update_notification_when_other_than_new_notification_already_exists(admin_client, status):
     notification = factories.BareEmployeeRecordUpdateNotificationFactory(status=status)
     save_updated_at = notification.updated_at
@@ -59,7 +59,7 @@ def test_schedule_approval_update_notification_when_other_than_new_notification_
     created_notification = models.EmployeeRecordUpdateNotification.objects.latest("created_at")
     assert created_notification != notification
     assert created_notification.employee_record == notification.employee_record
-    assert created_notification.status == models.Status.NEW
+    assert created_notification.status == models.NotificationStatus.NEW
     assertMessages(response, [messages.Message(messages.SUCCESS, "1 notification planifiée")])
 
 

--- a/tests/employee_record/test_archive_employee_records.py
+++ b/tests/employee_record/test_archive_employee_records.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from django.core.management import call_command
 
@@ -31,7 +33,7 @@ def test_management_command_wet_run(command, snapshot, caplog):
 
     assert employee_record.status == Status.ARCHIVED
     assert employee_record.archived_json is None
-    assert caplog.messages == snapshot
+    assert [re.sub(r"<EmployeeRecord: .+?>", "[EMPLOYEE RECORD]", msg) for msg in caplog.messages] == snapshot()
 
 
 def test_management_command_name():

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -348,14 +348,14 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.status == Status.READY
 
     def test_state_sent(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 42, "{}")
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 42, "{}")
 
         assert self.employee_record.status == Status.SENT
         assert self.employee_record.asp_batch_line_number == 42
         assert self.employee_record.archived_json == {}
 
     def test_state_rejected(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         self.employee_record.reject("12", "JSON Invalide", "{}")
         assert self.employee_record.status == Status.REJECTED
@@ -364,7 +364,7 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.archived_json == {}
 
     def test_state_processed(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         process_code, process_message = (
             EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE,
@@ -378,7 +378,7 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.archived_json == {}
 
     def test_state_processed_when_archive_is_none(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         process_code, process_message = (
             EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE,
@@ -392,7 +392,7 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.archived_json is None
 
     def test_state_processed_when_archive_is_empty(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         process_code, process_message = (
             EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE,
@@ -406,7 +406,7 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.archived_json == ""
 
     def test_state_processed_when_archive_is_not_json(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         process_code, process_message = (
             EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE,
@@ -426,7 +426,7 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.status == Status.READY
 
         # Employee record in SENT state can't be disabled
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         with pytest.raises(xworkflows.InvalidTransitionError):
             self.employee_record.disable()
         assert self.employee_record.status == Status.SENT
@@ -451,14 +451,14 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.status == Status.DISABLED
 
     def test_state_disabled_with_reject(self, faker):
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         self.employee_record.reject("12", "JSON Invalide", None)
         self.employee_record.disable()
         assert self.employee_record.status == Status.DISABLED
 
     def test_reactivate(self, faker):
-        self.employee_record.sent(faker.unique.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.unique.asp_batch_filename(), 1, None)
         process_code = EmployeeRecord.ASP_PROCESSING_SUCCESS_CODE
         process_message = "La ligne de la fiche salarié a été enregistrée avec succès."
         archive_first = '{"libelleTraitement":"La ligne de la fiche salarié a été enregistrée avec succès [1]."}'
@@ -476,7 +476,7 @@ class TestEmployeeRecordLifeCycle:
 
         filename_second = faker.unique.asp_batch_filename()
         archive_second = '{"libelleTraitement":"La ligne de la fiche salarié a été enregistrée avec succès [2]."}'
-        self.employee_record.sent(filename_second, 1, archive_second)
+        self.employee_record.wait_for_asp_response(filename_second, 1, archive_second)
         assert self.employee_record.asp_batch_file == filename_second
         assert self.employee_record.archived_json == json.loads(archive_second)
 
@@ -496,7 +496,7 @@ class TestEmployeeRecordLifeCycle:
         assert self.employee_record.siret == old_company.siret
         assert self.employee_record.asp_id == old_company.convention.asp_id
 
-        self.employee_record.sent(faker.unique.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.unique.asp_batch_filename(), 1, None)
         self.employee_record.process("", "", None)
         self.employee_record.disable()
 

--- a/tests/employee_record/test_transfer_employee_records.py
+++ b/tests/employee_record/test_transfer_employee_records.py
@@ -191,7 +191,7 @@ def test_duplicates_with_an_extension_generate_an_update_notification(sftp_direc
 
     command.handle(upload=False, download=True, preflight=False, wet_run=True)
     assert employee_record.update_notifications.count() == 1
-    assert employee_record.update_notifications.get().status == Status.NEW
+    assert employee_record.update_notifications.get().status == NotificationStatus.NEW
 
 
 @pytest.mark.parametrize("status", set(NotificationStatus) - {NotificationStatus.NEW})
@@ -208,7 +208,7 @@ def test_duplicates_with_an_extension_generate_a_pristine_update_notification(
 
     command.handle(upload=False, download=True, preflight=False, wet_run=True)
     assert employee_record.update_notifications.count() == 2
-    assert employee_record.update_notifications.latest("created_at").status == Status.NEW
+    assert employee_record.update_notifications.latest("created_at").status == NotificationStatus.NEW
 
 
 @pytest.mark.parametrize("extension_class", [ProlongationFactory, SuspensionFactory])
@@ -225,5 +225,5 @@ def test_duplicates_with_an_extension_update_the_existing_new_notification(sftp_
         command.handle(upload=False, download=True, preflight=False, wet_run=True)
     assert employee_record.update_notifications.count() == 1
     notification = employee_record.update_notifications.get()
-    assert notification.status == Status.NEW
+    assert notification.status == NotificationStatus.NEW
     assert notification.updated_at == expected_updated_at

--- a/tests/employee_record/test_transfer_employee_records_updates.py
+++ b/tests/employee_record/test_transfer_employee_records_updates.py
@@ -5,7 +5,7 @@ import freezegun
 import pytest
 from django.test.utils import override_settings
 
-from itou.employee_record.enums import Status
+from itou.employee_record.enums import NotificationStatus
 from itou.employee_record.management.commands import transfer_employee_records_updates
 from itou.employee_record.models import EmployeeRecordBatch
 from itou.utils.asp import REMOTE_DOWNLOAD_DIR, REMOTE_UPLOAD_DIR
@@ -60,7 +60,7 @@ def test_connection_error(mocker, command):
         command.handle(upload=True, download=False, preflight=False, wet_run=True)
 
     notification.refresh_from_db()
-    assert notification.status == Status.NEW
+    assert notification.status == NotificationStatus.NEW
     assert command.stdout.getvalue() == ""
 
 
@@ -97,7 +97,7 @@ def test_upload_file_error(faker, snapshot, sftp_directory, command):
     command.handle(upload=True, download=False, preflight=False, wet_run=True)
 
     notification.refresh_from_db()
-    assert notification.status == Status.NEW
+    assert notification.status == NotificationStatus.NEW
     assert command.stdout.getvalue() == snapshot
 
 
@@ -135,7 +135,7 @@ def test_dry_run_upload_and_download(command):
 
     command.handle(upload=True, download=True, preflight=False, wet_run=False)
     notification.refresh_from_db()
-    assert notification.status == Status.NEW
+    assert notification.status == NotificationStatus.NEW
 
 
 @freezegun.freeze_time("2021-09-27")
@@ -144,7 +144,7 @@ def test_upload_and_download(snapshot, sftp_directory, command):
 
     command.handle(upload=True, download=False, preflight=False, wet_run=True)
     notification.refresh_from_db()
-    assert notification.status == Status.SENT
+    assert notification.status == NotificationStatus.SENT
     assert notification.asp_batch_line_number == 1
     assert notification.asp_batch_file is not None
 
@@ -152,7 +152,7 @@ def test_upload_and_download(snapshot, sftp_directory, command):
 
     command.handle(upload=False, download=True, preflight=False, wet_run=True)
     notification.refresh_from_db()
-    assert notification.status == Status.PROCESSED
+    assert notification.status == NotificationStatus.PROCESSED
     assert notification.asp_processing_code == "0000"
     assert notification.archived_json.get("libelleTraitement") == "OK"
 

--- a/tests/www/employee_record_views/test_disable.py
+++ b/tests/www/employee_record_views/test_disable.py
@@ -40,7 +40,7 @@ class TestDisableEmployeeRecords:
         assert self.employee_record.status == Status.DISABLED
 
     def test_disable_employee_record_ready(self, client):
-        self.employee_record.update_as_ready()
+        self.employee_record.ready()
 
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.READY
@@ -54,8 +54,8 @@ class TestDisableEmployeeRecords:
         assert self.employee_record.status == Status.READY
 
     def test_disable_employee_record_sent(self, client, faker):
-        self.employee_record.update_as_ready()
-        self.employee_record.update_as_sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.ready()
+        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
 
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.SENT
@@ -69,10 +69,10 @@ class TestDisableEmployeeRecords:
         assert self.employee_record.status == Status.SENT
 
     def test_disable_employee_record_rejected(self, client, faker):
-        self.employee_record.update_as_ready()
-        self.employee_record.update_as_sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.ready()
+        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
         err_code, err_message = "12", "JSON Invalide"
-        self.employee_record.update_as_rejected(err_code, err_message, None)
+        self.employee_record.reject(err_code, err_message, None)
 
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.REJECTED
@@ -88,10 +88,10 @@ class TestDisableEmployeeRecords:
         assert self.employee_record.status == Status.DISABLED
 
     def test_disable_employee_record_completed(self, client, faker):
-        self.employee_record.update_as_ready()
-        self.employee_record.update_as_sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.ready()
+        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
-        self.employee_record.update_as_processed(process_code, process_message, "{}")
+        self.employee_record.process(process_code, process_message, "{}")
 
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.PROCESSED

--- a/tests/www/employee_record_views/test_disable.py
+++ b/tests/www/employee_record_views/test_disable.py
@@ -55,7 +55,7 @@ class TestDisableEmployeeRecords:
 
     def test_disable_employee_record_sent(self, client, faker):
         self.employee_record.ready()
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
 
         self.employee_record.refresh_from_db()
         assert self.employee_record.status == Status.SENT
@@ -70,7 +70,7 @@ class TestDisableEmployeeRecords:
 
     def test_disable_employee_record_rejected(self, client, faker):
         self.employee_record.ready()
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         err_code, err_message = "12", "JSON Invalide"
         self.employee_record.reject(err_code, err_message, None)
 
@@ -89,7 +89,7 @@ class TestDisableEmployeeRecords:
 
     def test_disable_employee_record_completed(self, client, faker):
         self.employee_record.ready()
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
         self.employee_record.process(process_code, process_message, "{}")
 

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -252,7 +252,7 @@ class TestListEmployeeRecords:
 
         record = employee_record_factories.EmployeeRecordWithProfileFactory(job_application__to_company=self.company)
         record.ready()
-        record.sent(faker.asp_batch_filename(), 1, None)
+        record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         record.reject("0012", "JSON Invalide", None)
 
         response = client.get(self.URL, data={"status": Status.REJECTED})
@@ -367,7 +367,7 @@ class TestListEmployeeRecords:
         )
         for i, record in enumerate((recordA, recordZ)):
             record.ready()
-            record.sent(f"RIAE_FS_2021041013000{i}.json", 1, None)
+            record.wait_for_asp_response(f"RIAE_FS_2021041013000{i}.json", 1, None)
             record.reject("0012", "JSON Invalide", None)
 
         # Zzzzz's hiring start is more recent

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -66,7 +66,7 @@ class TestListEmployeeRecords:
             job_application__job_seeker__last_name="Aaaaa",
             job_application__hiring_start_at=timezone.localdate() - relativedelta(days=15),
         )
-        record.update_as_ready()
+        record.ready()
         client.force_login(self.user)
         url = f"{self.URL}?status=READY"
         response = client.get(url)
@@ -251,9 +251,9 @@ class TestListEmployeeRecords:
         client.force_login(self.user)
 
         record = employee_record_factories.EmployeeRecordWithProfileFactory(job_application__to_company=self.company)
-        record.update_as_ready()
-        record.update_as_sent(faker.asp_batch_filename(), 1, None)
-        record.update_as_rejected("0012", "JSON Invalide", None)
+        record.ready()
+        record.sent(faker.asp_batch_filename(), 1, None)
+        record.reject("0012", "JSON Invalide", None)
 
         response = client.get(self.URL, data={"status": Status.REJECTED})
         assertContains(response, "Erreur 0012")
@@ -292,7 +292,7 @@ class TestListEmployeeRecords:
         for err_code, err_message, custom_err_message in tests_specs:
             with subtests.test(err_code):
                 record.status = Status.SENT
-                record.update_as_rejected(err_code, err_message, "{}")
+                record.reject(err_code, err_message, "{}")
 
                 response = client.get(self.URL, data={"status": Status.REJECTED})
                 assertContains(response, f"Erreur {err_code}")
@@ -366,9 +366,9 @@ class TestListEmployeeRecords:
             job_application__hiring_start_at=timezone.localdate() - relativedelta(days=10),
         )
         for i, record in enumerate((recordA, recordZ)):
-            record.update_as_ready()
-            record.update_as_sent(f"RIAE_FS_2021041013000{i}.json", 1, None)
-            record.update_as_rejected("0012", "JSON Invalide", None)
+            record.ready()
+            record.sent(f"RIAE_FS_2021041013000{i}.json", 1, None)
+            record.reject("0012", "JSON Invalide", None)
 
         # Zzzzz's hiring start is more recent
         self._check_employee_record_order(
@@ -417,7 +417,7 @@ class TestListEmployeeRecords:
             job_application__hiring_start_at=timezone.localdate() - relativedelta(days=10),
         )
         for record in (recordA, recordZ):
-            record.update_as_ready()
+            record.ready()
 
         # Zzzzz's hiring start is more recent
         self._check_employee_record_order(

--- a/tests/www/employee_record_views/test_reactivate.py
+++ b/tests/www/employee_record_views/test_reactivate.py
@@ -22,11 +22,11 @@ class TestReactivateEmployeeRecords:
         self.url = reverse("employee_record_views:reactivate", args=(self.employee_record.id,))
 
     def test_reactivate_employee_record(self, client, faker):
-        self.employee_record.update_as_ready()
-        self.employee_record.update_as_sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.ready()
+        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
-        self.employee_record.update_as_processed(process_code, process_message, "{}")
-        self.employee_record.update_as_disabled()
+        self.employee_record.process(process_code, process_message, "{}")
+        self.employee_record.disable()
 
         client.force_login(self.user)
         response = client.get(f"{self.url}?status=DISABLED")

--- a/tests/www/employee_record_views/test_reactivate.py
+++ b/tests/www/employee_record_views/test_reactivate.py
@@ -23,7 +23,7 @@ class TestReactivateEmployeeRecords:
 
     def test_reactivate_employee_record(self, client, faker):
         self.employee_record.ready()
-        self.employee_record.sent(faker.asp_batch_filename(), 1, None)
+        self.employee_record.wait_for_asp_response(faker.asp_batch_filename(), 1, None)
         process_code, process_message = "0000", "La ligne de la fiche salarié a été enregistrée avec succès."
         self.employee_record.process(process_code, process_message, "{}")
         self.employee_record.disable()

--- a/tests/www/employee_record_views/test_summary.py
+++ b/tests/www/employee_record_views/test_summary.py
@@ -40,7 +40,7 @@ class TestSummaryEmployeeRecords:
         assertNotContains(response, HORODATAGE)
 
         self.employee_record.ready()
-        self.employee_record.sent("RIAE_FS_20210410130000.json", 1, None)
+        self.employee_record.wait_for_asp_response("RIAE_FS_20210410130000.json", 1, None)
 
         response = client.get(self.url)
         assertContains(response, HORODATAGE)

--- a/tests/www/employee_record_views/test_summary.py
+++ b/tests/www/employee_record_views/test_summary.py
@@ -39,8 +39,8 @@ class TestSummaryEmployeeRecords:
         response = client.get(self.url)
         assertNotContains(response, HORODATAGE)
 
-        self.employee_record.update_as_ready()
-        self.employee_record.update_as_sent("RIAE_FS_20210410130000.json", 1, None)
+        self.employee_record.ready()
+        self.employee_record.sent("RIAE_FS_20210410130000.json", 1, None)
 
         response = client.get(self.url)
         assertContains(response, HORODATAGE)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Étape 1 de [Historique d’une fiche salarié](https://www.notion.so/plateforme-inclusion/Historique-d-une-fiche-salari-FS-99398b749d304d62925241f8a32259ff?pvs=4)

## :cake: Comment ? <!-- optionnel -->

![](https://i.giphy.com/bnDYyn2HMzqpDEUecP.gif)

Je ne me suis pas trop attardé sur l'histoire des `Status` _vs._ `NotificationStatus` vu qu'à la fin il n'en restera plus qu'un, mais c'est le passage à XWorkflows qui a fait apparaître le problème dans un des tests :see_no_evil:.

## :desert_island: Comment tester

La suite de tests est normalement suffisante :crossed_fingers:.