### PR TITLE
Admin : Renseigner le champ `User.created_by` lors de la création

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -14,6 +14,7 @@ from itou.employee_record.constants import get_availability_date_for_kind
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
 from itou.utils.admin import (
+    CreatedOrUpdatedByMixin,
     InconsistencyCheckMixin,
     ItouModelAdmin,
     ItouStackedInline,
@@ -184,7 +185,7 @@ class StartDateFilter(admin.SimpleListFilter):
 
 
 @admin.register(models.Approval)
-class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
+class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelAdmin):
     form = ApprovalAdminForm
     list_display = (
         "pk",
@@ -325,7 +326,6 @@ class ApprovalAdmin(InconsistencyCheckMixin, ItouModelAdmin):
 
     def save_model(self, request, obj, form, change):
         if not change:
-            obj.created_by = request.user
             obj.origin = Origin.ADMIN
 
         # Prevent the approval modification when an employee record exists and is READY, SENT, or PROCESSED
@@ -455,7 +455,7 @@ class FromProlongationRequest(admin.SimpleListFilter):
 
 
 @admin.register(models.Suspension)
-class SuspensionAdmin(ItouModelAdmin):
+class SuspensionAdmin(CreatedOrUpdatedByMixin, ItouModelAdmin):
     list_display = (
         "pk",
         "approval",
@@ -483,13 +483,8 @@ class SuspensionAdmin(ItouModelAdmin):
     def is_in_progress(self, obj):
         return obj.is_in_progress
 
-    def save_model(self, request, obj, form, change):
-        if not change:
-            obj.created_by = request.user
-        super().save_model(request, obj, form, change)
 
-
-class ProlongationCommonAdmin(ItouModelAdmin):
+class ProlongationCommonAdmin(CreatedOrUpdatedByMixin, ItouModelAdmin):
     list_display = (
         "pk",
         "approval",
@@ -537,13 +532,6 @@ class ProlongationCommonAdmin(ItouModelAdmin):
             default_storage.url(obj.report_file.key),
             obj.report_file.key,
         )
-
-    def save_model(self, request, obj, form, change):
-        if change:
-            obj.updated_by = request.user
-        else:
-            obj.created_by = request.user
-        super().save_model(request, obj, form, change)
 
 
 @admin.register(models.ProlongationRequest)

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -15,6 +15,7 @@ from itou.companies import enums, models, transfer
 from itou.companies.admin_forms import CompanyChooseFieldsToTransfer, SelectTargetCompanyForm
 from itou.siae_evaluations.models import EvaluatedSiae
 from itou.utils.admin import (
+    CreatedOrUpdatedByMixin,
     ItouGISMixin,
     ItouModelAdmin,
     ItouTabularInline,
@@ -115,7 +116,7 @@ def _companies_serializer(queryset):
 
 
 @admin.register(models.Company)
-class CompanyAdmin(ItouGISMixin, OrganizationAdmin):
+class CompanyAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, OrganizationAdmin):
     @admin.action(description="Exporter les entreprises selectionnées")
     def export(self, request, queryset):
         export_qs = queryset.select_related("created_by")
@@ -223,7 +224,6 @@ class CompanyAdmin(ItouGISMixin, OrganizationAdmin):
 
     def save_model(self, request, obj, form, change):
         if not change:
-            obj.created_by = request.user
             obj.source = models.Company.SOURCE_STAFF_CREATED
             if not obj.geocoding_score and obj.geocoding_address:
                 try:

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -7,7 +7,7 @@ from itou.common_apps.organizations.admin import HasMembersFilter, MembersInline
 from itou.prescribers.admin_forms import PrescriberOrganizationAdminForm
 from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
-from itou.utils.admin import ItouGISMixin, PkSupportRemarkInline
+from itou.utils.admin import CreatedOrUpdatedByMixin, ItouGISMixin, PkSupportRemarkInline
 from itou.utils.apis.exceptions import GeocodingDataError
 
 
@@ -74,7 +74,7 @@ class PrescriberOrganizationMembersInline(MembersInline):
 
 
 @admin.register(PrescriberOrganization)
-class PrescriberOrganizationAdmin(ItouGISMixin, OrganizationAdmin):
+class PrescriberOrganizationAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, OrganizationAdmin):
     class Media:
         css = {"all": ("css/itou-admin.css",)}
 
@@ -171,7 +171,6 @@ class PrescriberOrganizationAdmin(ItouGISMixin, OrganizationAdmin):
 
     def save_model(self, request, obj, form, change):
         if not change:
-            obj.created_by = request.user
             if not obj.geocoding_score and obj.geocoding_address:
                 try:
                     # Set geocoding.

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -31,6 +31,7 @@ from itou.users.admin_forms import (
 from itou.users.enums import IdentityProvider, UserKind
 from itou.utils.admin import (
     ChooseFieldsToTransfer,
+    CreatedOrUpdatedByMixin,
     InconsistencyCheckMixin,
     ItouModelAdmin,
     ItouTabularInline,
@@ -298,7 +299,7 @@ def get_fields_to_transfer_for_job_seekers():
 
 
 @admin.register(models.User)
-class ItouUserAdmin(InconsistencyCheckMixin, UserAdmin):
+class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, UserAdmin):
     class Media:
         css = {"all": ("css/itou-admin.css",)}
 

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -181,6 +181,14 @@ class ReadonlyMixin:
         return False
 
 
+class CreatedOrUpdatedByMixin:
+    def save_model(self, request, obj, form, change):
+        attr = "updated_by" if change else "created_by"
+        if hasattr(obj, attr):
+            setattr(obj, attr, request.user)
+        super().save_model(request, obj, form, change)
+
+
 class ChooseFieldsToTransfer(forms.Form):
     fields_to_transfer = forms.MultipleChoiceField(
         choices=[],


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car ce n'était pas le cas jusqu'à présent, que [ça été demandé](https://github.com/gip-inclusion/les-emplois/pull/5309/files#r1899721912), que ça semble une bonne chose, et que ça évite de devoir aller trifouiller dans les `admin.LogEntry`.
La seule interaction à laquelle j'ai pensée est la logique de _proxy_ mais ça ne devrais pas poser problème dans le futur, on pourrais même dire qu'un utilisateur créé depuis l'admin est bien géré par un proxy :).

## :desert_island: Comment tester

Créer un utilisateur depuis l'admin
