### PR TITLE
github: Pouvoir lancer `ci.yml` sur les PR ouvertes depuis un fork publique

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: 🔮 CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Notre configuration sur le dépôt fait que Github bloque le lancement des workflows pour les nouveaux contributeurs, dans le bloc de fusion [1] il y a alors un bouton _"Approve and run"_ qui permet de lancer le workflow si on fait confiance aux modifications apportées par la PR, mais notre action de CI n'est pas relancée lorsqu'on clique sur ce bouton, ce qui bloque la fusion de la PR.

Je me souviens de discussion à ce propos mais pas retrouver de _commit_ donc j'imagine qu'on repart pour un tour :sweat_smile:.

### 1. `push` + `pull_request`
Inconvénient : Ouvrir la PR relance le workflow en entier, même si pas de changement depuis.

### 2. `push: master` + `pull_request`

Inconvénient : Oblige d'ouvrir une PR (au moins en _draft_) pour avoir la CI de lancée.

### Cas pratique

https://github.com/gip-inclusion/les-emplois/pull/5323



[1]
![image](https://github.com/user-attachments/assets/b051dc49-2c1f-4ea0-bd6f-f474a5b177b8)
