### PR TITLE
Fiches salarié : Corriger définitivement la sérialisation des vieilles archives JSON

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -67,10 +67,6 @@ class ASPExchangeInformationAdminMixin:
         if not obj.archived_json:
             return self.get_empty_value_display()
 
-        # Handle older data serialized from the JSON as string
-        if not isinstance(obj.archived_json, dict):
-            obj._set_archived_json(obj.archived_json)
-
         siret = obj.archived_json["siret"]
         measure = obj.archived_json["mesure"]
         return f"{siret} ({measure})"
@@ -79,10 +75,6 @@ class ASPExchangeInformationAdminMixin:
     def user_data_sent(self, obj):
         if not obj.archived_json:
             return self.get_empty_value_display()
-
-        # Handle older data serialized from the JSON as string
-        if not isinstance(obj.archived_json, dict):
-            obj._set_archived_json(obj.archived_json)
 
         firstname = obj.archived_json["personnePhysique"]["prenom"]
         lastname = obj.archived_json["personnePhysique"]["nomUsage"]
@@ -93,10 +85,6 @@ class ASPExchangeInformationAdminMixin:
     def approval_data_sent(self, obj):
         if not obj.archived_json:
             return self.get_empty_value_display()
-
-        # Handle older data serialized from the JSON as string
-        if not isinstance(obj.archived_json, dict):
-            obj._set_archived_json(obj.archived_json)
 
         number = obj.archived_json["personnePhysique"]["passIae"]
         start = obj.archived_json["personnePhysique"]["passDateDeb"]

--- a/itou/employee_record/migrations/0002_fix_archived_json_as_string.py
+++ b/itou/employee_record/migrations/0002_fix_archived_json_as_string.py
@@ -1,0 +1,36 @@
+import json
+import time
+
+from django.db import migrations
+
+
+def forward(apps, schema_editor):
+    print()
+    EmployeeRecord = apps.get_model("employee_record", "EmployeeRecord")
+    total_updated = 0
+    to_update = []
+    for obj in EmployeeRecord.objects.filter(archived_json__isnull=False, archived_json__startswith='"{').only(
+        "pk", "archived_json"
+    ):
+        obj.archived_json = json.loads(obj.archived_json)
+        to_update.append(obj)
+        if len(to_update) % 1000 == 0:
+            total_updated += EmployeeRecord.objects.bulk_update(to_update, {"archived_json"})
+            print(f"{total_updated} objects updated")
+            to_update = []
+            time.sleep(0.5)
+    if to_update:
+        total_updated += EmployeeRecord.objects.bulk_update(to_update, {"archived_json"})
+        print(f"{total_updated} objects updated")
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("employee_record", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(code=forward, reverse_code=migrations.RunPython.noop, elidable=True),
+    ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car pendant un certain temps c'était la sérialisation JSON de la sérialisation JSON de l'archive qui était stockée : `"{\"numLigne\":124,\"typeMouvement\":\"C\",...}"`
Alors que l'on veux juste la sérialisation JSON : `{"numLigne":124,"typeMouvement":"C",...}`

Commits associés :
- https://github.com/gip-inclusion/les-emplois/pull/1659/commits/37c890ffd42c98dad5ffbfb25f1e810cb25d6e4a
- https://github.com/gip-inclusion/les-emplois/pull/3761/commits/adccc5ff1ce313cff28dbae80d85c4fa24ec7644#r1522958833