### PR TITLE
Admin : Donner accès aux candidatures en lecture seule à GPS

### DIFF
--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -80,6 +80,8 @@ def get_permissions_dict():
     group_gps_admin_permissions = {
         gps_models.FollowUpGroup: PERMS_ALL,
         gps_models.FollowUpGroupMembership: PERMS_ALL,
+        job_applications_models.JobApplication: PERMS_READ,
+        job_applications_models.JobApplicationTransitionLog: PERMS_READ,
         users_models.User: PERMS_ADD | PERMS_HIJACK,
         users_models.JobSeekerProfile: PERMS_EDIT,
     }

--- a/tests/users/__snapshots__/test_sync_group_and_perms.ambr
+++ b/tests/users/__snapshots__/test_sync_group_and_perms.ambr
@@ -3,6 +3,8 @@
   list([
     'view_followupgroup',
     'view_followupgroupmembership',
+    'view_jobapplication',
+    'view_jobapplicationtransitionlog',
     'view_jobseekerprofile',
     'view_user',
   ])
@@ -17,6 +19,8 @@
     'change_followupgroupmembership',
     'delete_followupgroupmembership',
     'view_followupgroupmembership',
+    'view_jobapplication',
+    'view_jobapplicationtransitionlog',
     'change_jobseekerprofile',
     'view_jobseekerprofile',
     'add_user',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Demande de LJT :
> Je veux bien que tu nous rajoutes de quoi voir (lecture seule) les prescriptions et candidatures, c’est pratique comme contexte avant de contacter quelqu’un.