### PR TITLE
Pilotage: Utiliser une date qui prend en compte la timezone pour EligibilityDiagnosis.created_at

### DIFF
--- a/itou/metabase/utils.py
+++ b/itou/metabase/utils.py
@@ -1,6 +1,18 @@
+import datetime
+
+from django.utils import timezone
+
+
 def convert_boolean_to_int(b):
     # True => 1, False => 0, None => None.
     return None if b is None else int(b)
+
+
+def convert_datetime_to_local_date(dt):
+    if isinstance(dt, datetime.datetime):
+        # Datetimes are stored in UTC.
+        return timezone.localdate(dt)
+    return dt
 
 
 def compose(f, g):

--- a/tests/eligibility/factories.py
+++ b/tests/eligibility/factories.py
@@ -39,7 +39,7 @@ class AbstractEligibilityDiagnosisModelFactory(factory.django.DjangoModelFactory
         expired = factory.Trait(
             expires_at=factory.LazyFunction(lambda: timezone.localdate() - datetime.timedelta(days=1)),
             created_at=factory.LazyAttribute(
-                lambda obj: timezone.make_aware(faker.date_time(end_datetime=obj.expires_at))
+                lambda obj: faker.date_time(tzinfo=timezone.get_current_timezone(), end_datetime=obj.expires_at)
             ),
         )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Problème d’interprétation de date (naïve), révélé par `pytest --randomly-seed=3296184821 tests/metabase/management/test_populate_metabase_emplois.py::test_populate_job_seekers -vv`.
