### PR TITLE
Éligibilité : Rattrapage de dates de fin incorrectes de l’API Particulier

### DIFF
--- a/itou/eligibility/migrations/0009_fix_selectedadministrativecriteria_certification_period.py
+++ b/itou/eligibility/migrations/0009_fix_selectedadministrativecriteria_certification_period.py
@@ -1,0 +1,32 @@
+import datetime
+
+from django.db import migrations
+from django.utils import timezone
+
+from itou.utils.types import InclusiveDateRange
+
+
+def set_certification_period_end_date(apps, editor):
+    SelectedAdministrativeCriteria = apps.get_model("eligibility", "SelectedAdministrativeCriteria")
+    crits = []
+    changed = 0
+    for crit in SelectedAdministrativeCriteria.objects.exclude(certification_period=None):
+        new_end = timezone.localdate(crit.certified_at) + datetime.timedelta(days=92)
+        if crit.certification_period.upper is None or abs((new_end - crit.certification_period.upper).days) >= 7:
+            changed += 1
+        crit.certification_period = InclusiveDateRange(crit.certification_period.lower, new_end)
+        crits.append(crit)
+    updated_objs = SelectedAdministrativeCriteria.objects.bulk_update(crits, fields=["certification_period"])
+    print("\nChanged selected administrative criteria:")
+    print(f"- {changed} end dates moved more than a week")
+    print(f"- {updated_objs - changed} end dates moved <= week")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("eligibility", "0008_alter_eligibilitydiagnosis_expires_at_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_certification_period_end_date, elidable=True),
+    ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

L’API particulier calculait le champ `dateFin` avec la formule : `dateDebut + 3 mois`. Cette information est très déroutante, car une personne bénéficiaire depuis 2009-06-01 aurait comme réponse:
```json
{
    "statut": "beneficiaire",
    "dateDebut": "2009-06-01",
    "dateFin": "2009-09-01",
}
```

Cependant, le `statut` indique que cette personne est bénéficiaire **aujourd’hui**, malgré la `dateFin` (qui est erronée).

L’API vient d’évoluer pour toujours définir `dateFin=null` afin de limiter les mauvaises interprétations. https://github.com/gip-inclusion/les-emplois/pull/5337

Correction d’environ 11 000 diagnostics, en utilisant la date d’appel à l’API pour le calcul de la date de fin de certification.

L’exemple ci-dessus provient de données actuellement en production.

:warning: **Ne relire que le second commit**