### PR TITLE
UX/UI: mise a jour du theme vers v2.5.6

### DIFF
--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -219,11 +219,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.5.5.zip",
-            "sha256": "09a32a1148fd2b8ee77a24d3b3fa1947b824f094746376a907b3ddb0e84d1e31",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.5.7.zip",
+            "sha256": "78930e93a7e8604fbd9236f40f687fd65f4a378c62dba05be9b7120c04c6dc28",
         },
         "extract": {
-            "origin": "itou-theme-2.5.5/dist",
+            "origin": "itou-theme-2.5.7/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour harmoniser les styles des [textarea EasyMDE](https://www.notion.so/plateforme-inclusion/UI-Adapter-le-textarea-de-EasyMDE-au-th-me-161e8fa5c35b80dc8f6cd3c771cdf49a?pvs=4) avec les textarea du thème et ajouter une aide visuelle au focus

## :computer: Captures d'écran 
**Avant**
![capture 2025-01-06 à 15 59 50](https://github.com/user-attachments/assets/99475e78-1e6c-4071-85ff-f3c463ba72c7)

**Apres**
![capture 2025-01-06 à 17 59 30](https://github.com/user-attachments/assets/4a274cb0-466b-4c65-b767-fb02254ea3c8)


