### PR TITLE
Simplification du tri des résultats de la recherche de fiches de poste

### DIFF
--- a/itou/templates/search/includes/siaes_search_top.html
+++ b/itou/templates/search/includes/siaes_search_top.html
@@ -68,8 +68,7 @@
                                 <p class="fw-bold">Pour les résultats des postes ouverts au recrutement, l’ordre de priorité est le suivant&nbsp;:</p>
                                 <ol>
                                     <li>Les postes des emplois de l’inclusion</li>
-                                    <li>Les postes mis à jour récemment</li>
-                                    <li>Les postes créés récemment</li>
+                                    <li>Les postes mis à jour ou créés récemment</li>
                                 </ol>
                             </div>
                             <div class="modal-footer">

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -249,9 +249,7 @@ class JobDescriptionSearchView(EmployerSearchBaseView):
         pass
 
     def get_results_page_and_counts(self, siaes, job_descriptions):
-        job_descriptions = job_descriptions.order_by(
-            F("source_kind").asc(nulls_first=True), "-updated_at", "-created_at"
-        )
+        job_descriptions = job_descriptions.order_by(F("source_kind").asc(nulls_first=True), "-updated_at")
 
         page = pager(job_descriptions, self.request.GET.get("page"), items_per_page=10)
         # Prefer a prefetch_related over annotating the entire queryset with_annotation_is_popular().

--- a/tests/www/search/__snapshots__/tests.ambr
+++ b/tests/www/search/__snapshots__/tests.ambr
@@ -187,8 +187,7 @@
                  AND "companies_company"."is_searchable"
                  AND NOT ("companies_company"."block_job_applications"))
           ORDER BY "companies_jobdescription"."source_kind" ASC NULLS FIRST,
-                   "companies_jobdescription"."updated_at" DESC,
-                   "companies_jobdescription"."created_at" DESC
+                   "companies_jobdescription"."updated_at" DESC
           LIMIT 1
         ''',
       }),
@@ -502,8 +501,7 @@
                  AND "companies_company"."is_searchable"
                  AND NOT ("companies_company"."block_job_applications"))
           ORDER BY "companies_jobdescription"."source_kind" ASC NULLS FIRST,
-                   "companies_jobdescription"."updated_at" DESC,
-                   "companies_jobdescription"."created_at" DESC
+                   "companies_jobdescription"."updated_at" DESC
           LIMIT 1
         ''',
       }),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ces résultats sont jusqu'ici triés par catégorie puis par date de modification puis par date de création.

Or la date de modification `updated_at` étant un `datetime`, il n'arrive jamais en pratique que deux valeurs soient identiques.

On peut s'en convaincre avec un simple `select count(*), count(DISTINCT(created_at)), count(DISTINCT(updated_at)) from companies_jobdescription;` sur le jeu de données de prod.

Conclusion : le troisième tri (date de création) n'est jamais utilisé en pratique. C'est un écran de fumée qui induit en erreur le developpeur sur la nature du tri.

Noter que pour un object créé puis jamais modifié, son `updated_at` est égal à sa date de création.

## :cake: Comment ?

En virant le tri superflu, et en mettant à jour la description du tri sur le frontend.

## :desert_island: Qui fait la revue ?

C'est pour Xavier.

Léo mon binôme sur la recherche est off deux semaines, je l'ajoute seulemnent pour son info à son retour. On en avait deja discuté en réunion.
