### PR TITLE
Correctif du script de génération du journal des changements.

### DIFF
--- a/scripts/mkchangelog
+++ b/scripts/mkchangelog
@@ -135,16 +135,18 @@ def main(publish):
                     )
                 log_entries[pr_changelog_labels.pop()].append(title)
 
-            if any(log_entries.values()):
-                # Changelog entries are up to the next Monday (excluded).
-                new_changelog.write(f"## {sprint_end + datetime.timedelta(days=1)}\n\n")
+            # Changelog entries are up to the next Monday (excluded).
+            new_changelog.write(f"## {sprint_end + datetime.timedelta(days=1)}\n\n")
 
-            for label, label_title in LABEL_TITLES.items():
-                if log_entries[label]:
-                    new_changelog.write(f"### {label_title}\n\n")
-                    for title in ci_sort(log_entries[label]):
-                        new_changelog.write(f"- {title}\n")
-                    new_changelog.write("\n")
+            if any(log_entries.values()):
+                for label, label_title in LABEL_TITLES.items():
+                    if log_entries[label]:
+                        new_changelog.write(f"### {label_title}\n\n")
+                        for title in ci_sort(log_entries[label]):
+                            new_changelog.write(f"- {title}\n")
+                        new_changelog.write("\n")
+            else:
+                new_changelog.write("Rien à signaler cette semaine\n\n")
 
             # Don’t forget the previous header.
             new_changelog.write(last_entry_header)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour le corriger :)

Avec cette PR la prochaine entrée du changelog sera 
```
# Journal des modifications
 
## 2024-12-30

Rien à signaler cette semaine

## 2024-12-23
...
```

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
