### PR TITLE
UX/UI: modification de la couleur du badge "Agrément expiré"

### DIFF
--- a/itou/utils/templatetags/badges.py
+++ b/itou/utils/templatetags/badges.py
@@ -56,7 +56,7 @@ def approval_state_badge(
         }[approval_state]
     else:
         span_class = {
-            ApprovalStatus.EXPIRED: "bg-emploi-light text-primary",
+            ApprovalStatus.EXPIRED: "bg-danger-lighter text-danger",
             ApprovalStatus.FUTURE: "bg-success-lighter text-success",
             ApprovalStatus.SUSPENDED: "bg-success-lighter text-success",
             ApprovalStatus.VALID: "bg-success-lighter text-success",

--- a/tests/utils/__snapshots__/tests.ambr
+++ b/tests/utils/__snapshots__/tests.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: test_approval_state_badge[expired]
   '''
-              <span class="badge badge-sm rounded-pill bg-emploi-light text-primary">
+              <span class="badge badge-sm rounded-pill bg-danger-lighter text-danger">
                   <i class="ri-pass-expired-line" aria-hidden="true"></i>
                   PASS IAE expiré
               </span>

--- a/tests/www/approvals_views/test_list.py
+++ b/tests/www/approvals_views/test_list.py
@@ -227,7 +227,7 @@ class TestApprovalsListView:
         )
         assertContains(
             response,
-            """<span class="badge badge-sm text-wrap rounded-pill bg-emploi-light text-primary">
+            """<span class="badge badge-sm text-wrap rounded-pill bg-danger-lighter text-danger">
                 <i class="ri-pass-expired-line ri-xl" aria-hidden="true"></i>
                 PASS IAE expiré
             </span>""",


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/plateforme-inclusion/Harmoniser-la-couleur-des-badges-PASS-IAE-160e8fa5c35b80599b66d1abfa97d2b5?pvs=4

Acté avec Antoine. Finalement, les couleurs de badges de statues de "Pass IAE" resteront les mêmes dans les cartes de résultats et donc plus clair que ceux dans la box de Pass IAE. Juste une petite correction sur le badge "Agrément expiré"
