### PR TITLE
Inscription : Ajouter les champs lieu et pays de naissance pour les candidats [GEN-1946]

### DIFF
--- a/itou/templates/signup/job_seeker_signup.html
+++ b/itou/templates/signup/job_seeker_signup.html
@@ -17,6 +17,8 @@
         {% bootstrap_field form.last_name %}
         {% bootstrap_field form.first_name %}
         {% bootstrap_field form.birthdate %}
+        {% bootstrap_field form.birth_place %}
+        {% bootstrap_field form.birth_country %}
 
         <div class="form-group mb-1 form-group-required">
             {% bootstrap_label "Adresse e-mail" label_for="id_email" %}

--- a/itou/templates/signup/job_seeker_signup_credentials.html
+++ b/itou/templates/signup/job_seeker_signup_credentials.html
@@ -40,6 +40,8 @@
         {% bootstrap_field form.last_name %}
         {% bootstrap_field form.first_name %}
         {% bootstrap_field form.birthdate %}
+        {% bootstrap_field form.birth_place %}
+        {% bootstrap_field form.birth_country %}
         {% bootstrap_field form.nir %}
         {% bootstrap_field form.email %}
 

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -227,8 +227,13 @@ class JobSeekerCredentialsSignupForm(SignupForm):
         user.save()
         user.jobseeker_profile.nir = self.prior_cleaned_data["nir"]
         user.jobseeker_profile.birthdate = self.prior_cleaned_data["birthdate"]
-        user.jobseeker_profile.birth_place_id = self.prior_cleaned_data["birth_place"]
-        user.jobseeker_profile.birth_country_id = self.prior_cleaned_data["birth_country"]
+        try:
+            user.jobseeker_profile.birth_place_id = self.prior_cleaned_data["birth_place"]
+            user.jobseeker_profile.birth_country_id = self.prior_cleaned_data["birth_country"]
+        except KeyError:
+            # TODO: Remove try-except next week.
+            # Users signing up during deployment won’t have these in their session.
+            pass
         user.jobseeker_profile.save()
 
         return user

--- a/tests/openid_connect/pe_connect/tests.py
+++ b/tests/openid_connect/pe_connect/tests.py
@@ -250,7 +250,7 @@ class TestPoleEmploiConnect:
     def test_callback_with_nir(self, client):
         # Complete signup with NIR is tested in JobSeekerSignupTest.test_job_seeker_nir
         nir = "141068078200557"
-        job_seeker_data = JobSeekerFactory.build()
+        job_seeker_data = JobSeekerFactory.build(born_in_france=True)
         post_data = {
             "nir": nir,
             "title": job_seeker_data.title,
@@ -258,6 +258,8 @@ class TestPoleEmploiConnect:
             "last_name": job_seeker_data.last_name,
             "email": job_seeker_data.email,
             "birthdate": job_seeker_data.jobseeker_profile.birthdate,
+            "birth_place": job_seeker_data.jobseeker_profile.birth_place_id,
+            "birth_country": job_seeker_data.jobseeker_profile.birth_country_id,
         }
         response = client.post(reverse("signup:job_seeker"), data=post_data)
         assertRedirects(response, reverse("signup:job_seeker_credentials"))

--- a/tests/www/signup/__snapshots__/test_job_seeker.ambr
+++ b/tests/www/signup/__snapshots__/test_job_seeker.ambr
@@ -19,6 +19,35 @@
           <div class="form-group form-group-required"><label class="form-label" for="id_last_name">Nom de famille</label><input class="form-control" id="id_last_name" maxlength="150" name="last_name" placeholder="Durand" required="" type="text"/></div>
           <div class="form-group form-group-required"><label class="form-label" for="id_first_name">Prénom</label><input class="form-control" id="id_first_name" maxlength="150" name="first_name" placeholder="Dominique" required="" type="text"/></div>
           <div class="form-group form-group-required"><label class="form-label" for="id_birthdate">Date de naissance</label><duet-date-picker class="" identifier="id_birthdate" max="2008-10-23" min="1900-01-01" name="birthdate" placeholder="Date de naissance" required=""></duet-date-picker></div>
+          <div class="form-group"><label class="form-label" for="id_birth_place">Commune de naissance</label><select aria-describedby="id_birth_place_helptext" class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes" data-allow-clear="true" data-disable-target="#id_birth_country" data-minimum-input-length="1" data-placeholder="Nom de la commune" data-select2-link-with-birthdate="id_birthdate" data-target-value="91" data-theme="bootstrap-5" id="id_birth_place" lang="fr" name="birth_place">
+    <option value=""></option>
+  
+  </select><div class="form-text">La commune de naissance est obligatoire lorsque vous êtes né en France. Elle ne doit pas être renseignée si vous êtes né à l'étranger.</div>
+  </div>
+          <div class="form-group"><label class="form-label" for="id_birth_country">Pays de naissance</label><select class="form-select" id="id_birth_country" name="birth_country">
+    <option selected="" value="">---------</option>
+  
+    <option value="152">AFGHANISTAN</option>
+  
+    <option value="301">BAHAMAS</option>
+  
+    <option value="12">BORA-BORA</option>
+  
+    <option value="102">BULGARIE</option>
+  
+    <option value="214">CONGO (REPUBLIQUE DEMOCRATIQUE)</option>
+  
+    <option value="92">DANEMARK</option>
+  
+    <option value="91">FRANCE</option>
+  
+    <option value="68">KOUMAC</option>
+  
+    <option value="126">PAYS-BAS</option>
+  
+    <option value="35">PUKAPUKA</option>
+  
+  </select></div>
   
           <div class="form-group mb-1 form-group-required">
               <label class="form-label" for="id_email">Adresse e-mail</label>
@@ -158,6 +187,18 @@
           <div class="form-group"><label class="form-label" for="id_last_name">Nom</label><input class="form-control" disabled="" id="id_last_name" name="last_name" placeholder="Nom" type="text" value="Doe"/></div>
           <div class="form-group"><label class="form-label" for="id_first_name">Prénom</label><input class="form-control" disabled="" id="id_first_name" name="first_name" placeholder="Prénom" type="text" value="Jane"/></div>
           <div class="form-group"><label class="form-label" for="id_birthdate">Date de naissance</label><input class="form-control" disabled="" id="id_birthdate" name="birthdate" placeholder="Date de naissance" type="text" value="01/01/1990"/></div>
+          <div class="form-group"><label class="form-label" for="id_birth_place">Commune de naissance</label><select class="form-select" disabled="" id="id_birth_place" name="birth_place">
+    <option value="">---------</option>
+  
+    <option selected="" value="57089">GEISPOLSHEIM</option>
+  
+  </select></div>
+          <div class="form-group"><label class="form-label" for="id_birth_country">Pays de naissance</label><select class="form-select" disabled="" id="id_birth_country" name="birth_country">
+    <option value="">---------</option>
+  
+    <option selected="" value="91">FRANCE</option>
+  
+  </select></div>
           <div class="form-group"><label class="form-label" for="id_nir">Numéro de sécurité sociale</label><input class="form-control" disabled="" id="id_nir" name="nir" placeholder="Numéro de sécurité sociale" type="text" value="290010101010125"/></div>
           <div class="form-group"><label class="form-label" for="id_email">Adresse e-mail</label><input class="form-control" disabled="" id="id_email" maxlength="320" name="email" placeholder="Adresse e-mail" type="email" value="jane.doe@test.local"/></div>
   

--- a/tests/www/welcoming_tour/tests.py
+++ b/tests/www/welcoming_tour/tests.py
@@ -28,7 +28,7 @@ def verify_email(client, email, request):
 
 class TestWelcomingTour:
     def test_new_job_seeker_sees_welcoming_tour_test(self, client):
-        job_seeker = JobSeekerFactory.build()
+        job_seeker = JobSeekerFactory.build(born_in_france=True)
 
         # First signup step: job seeker personal info.
         url = reverse("signup:job_seeker")
@@ -38,6 +38,8 @@ class TestWelcomingTour:
             "first_name": job_seeker.first_name,
             "last_name": job_seeker.last_name,
             "birthdate": job_seeker.jobseeker_profile.birthdate,
+            "birth_place": job_seeker.jobseeker_profile.birth_place_id,
+            "birth_country": job_seeker.jobseeker_profile.birth_country_id,
             "email": job_seeker.email,
         }
         client.post(url, data=post_data)
@@ -92,7 +94,7 @@ class TestWelcomingTour:
 class TestWelcomingTourExceptions:
     def test_new_job_seeker_is_redirected_after_welcoming_tour_test(self, client, mailoutbox):
         company = CompanyFactory(with_membership=True)
-        job_seeker = JobSeekerFactory.build()
+        job_seeker = JobSeekerFactory.build(born_in_france=True)
 
         # First signup step: job seeker personal info.
         next_to = reverse("apply:start", kwargs={"company_pk": company.pk})
@@ -104,6 +106,8 @@ class TestWelcomingTourExceptions:
             "last_name": job_seeker.last_name,
             "email": job_seeker.email,
             "birthdate": job_seeker.jobseeker_profile.birthdate,
+            "birth_place": job_seeker.jobseeker_profile.birth_place_id,
+            "birth_country": job_seeker.jobseeker_profile.birth_country_id,
         }
         response = client.post(url, data=post_data)
         assert response.status_code == 302  # Destination verified in signup tests


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin de certifier l’éligibilité d’un candidat à certains critères administratifs et lui octroyer automatiquement les droits à un parcours IAE, l’API particulier requiert la commune et le pays de naissance. Ces informations sont maintenant requises pour l’inscription sur les Emplois de l’inclusion.

## :cake: Comment ? <!-- optionnel -->

La classe de base `BirthPlaceAndCountryMixin` hérite désormais de `Form`, non plus de `ModelForm`. Ceci permet au formulaire d’inscription (qui n’est pas un `ModelForm`) de réutiliser le _mixin_. Le point d’extension `_post_clean()` n’est pas disponible sur les `Form`, sa logique a été intégrée dans la méthode `clean()`.

## :desert_island: Comment tester

1. S’inscrire en tant que candidat

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/6e717395-e8a1-47c8-a173-9d295aa31fa4)

![image](https://github.com/user-attachments/assets/b2720266-d0f7-4e6a-8fb5-96b6f3bd149a)
