### PR TITLE
Définir EligibilityDiagnosis.expires_at pour le CaP

### DIFF
--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -114,6 +114,8 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
     Store the eligibility diagnosis (IAE) of a job seeker.
     """
 
+    EMPLOYER_DIAGNOSIS_VALIDITY_TIMEDELTA = datetime.timedelta(days=92)
+
     # Not in abstract model to avoid 'related_name' clashing (and ugly auto-naming)
     job_seeker = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -171,7 +173,7 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
             # For siae_evaluations, employers must provide a proof for administrative criteria
             # supporting the hire. A proof is valid for 3 months, align employer diagnosis
             # duration with proof validity duration.
-            return now + datetime.timedelta(days=92)
+            return now + cls.EMPLOYER_DIAGNOSIS_VALIDITY_TIMEDELTA
         return now + relativedelta(months=cls.EXPIRATION_DELAY_MONTHS)
 
     @classmethod

--- a/itou/siae_evaluations/fixtures.py
+++ b/itou/siae_evaluations/fixtures.py
@@ -104,6 +104,8 @@ def load_data():
                 author_siae=controlled_siae,
                 job_seeker=job_seeker,
                 created_at=datetime_within_period_range,
+                expires_at=timezone.localdate(datetime_within_period_range)
+                + EligibilityDiagnosis.EMPLOYER_DIAGNOSIS_VALIDITY_TIMEDELTA,
             )
             for criterion_pk in pks_list:
                 eligibility_diagnosis.administrative_criteria.add(criterion_pk)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2818,7 +2818,7 @@ class TestDirectHireFullProcess:
         )
         assert response.url == next_url
         diag = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=new_job_seeker, for_siae=company)
-        assert diag.expires_at == timezone.localdate() + datetime.timedelta(days=92)
+        assert diag.expires_at == timezone.localdate() + EligibilityDiagnosis.EMPLOYER_DIAGNOSIS_VALIDITY_TIMEDELTA
 
         # Hire confirmation
         # ----------------------------------------------------------------------


### PR DESCRIPTION
## :thinking: Pourquoi ?

Réparer `make resetdb`.

```
python manage.py shell -c 'from itou.siae_evaluations import fixtures;fixtures.load_data()'
Traceback (most recent call last):
  File "/home/freitafr/dev/itou3/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/freitafr/dev/itou3/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
psycopg.errors.NotNullViolation: null value in column "expires_at" of relation "eligibility_eligibilitydiagnosis" violates not-null constraint
DETAIL:  Failing row contains (6, employer, 2653, 2024-11-23 15:59:33.079627+00, 2025-01-07 15:59:33.570748+00, 28, null, 48, null).
```
