### PR TITLE
Création de compte candidat : remise à plat des query params pour les vues Update

### DIFF
--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -37,7 +37,7 @@
         <p>
             Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}
             {% if can_view_personal_information and not request.user.is_job_seeker %}
-                <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id company=siae.pk from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
+                <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
             {% endif %}
             {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning"></i>{% endif %}
         </p>

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -14,8 +14,7 @@
     <div class="c-box my-4">
         <h2>
             Informations personnelles
-            <a class="btn btn-outline-primary float-end"
-               href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id company=siae.pk from_url=request.get_full_path|urlencode %}">Mettre à jour</a>
+            <a class="btn btn-outline-primary float-end" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Mettre à jour</a>
         </h2>
 
         {% include "apply/includes/profile_infos.html" %}

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -23,16 +23,11 @@ from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.session import SessionNamespace
 from itou.utils.urls import add_url_params
-from itou.www.apply.forms import (
-    ApplicationJobsForm,
-    SubmitJobApplicationForm,
-)
+from itou.www.apply.forms import ApplicationJobsForm, SubmitJobApplicationForm
 from itou.www.apply.views import common as common_views, constants as apply_view_constants
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
 from itou.www.geiq_eligibility_views.forms import GEIQAdministrativeCriteriaForm
-from itou.www.job_seekers_views.forms import (
-    CreateOrUpdateJobSeekerStep2Form,
-)
+from itou.www.job_seekers_views.forms import CreateOrUpdateJobSeekerStep2Form
 
 
 logger = logging.getLogger(__name__)

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -775,12 +775,9 @@ class UpdateJobSeekerStartView(View):
         except ValidationError:
             raise Http404("Aucun candidat n'a été trouvé")
 
-        try:
-            company = get_object_or_404(Company.objects.with_has_active_members(), pk=request.GET.get("company"))
-        except ValueError:
-            raise Http404("Aucune entreprise n'a été trouvée")
-
-        from_url = get_safe_url(request, "from_url", fallback_url=reverse("dashboard:index"))
+        from_url = get_safe_url(request, "from_url")
+        if not from_url:
+            raise Http404
 
         if request.user.is_job_seeker or not request.user.can_view_personal_information(job_seeker):
             raise PermissionDenied("Votre utilisateur n'est pas autorisé à vérifier les informations de ce candidat")
@@ -790,7 +787,6 @@ class UpdateJobSeekerStartView(View):
             data={
                 "config": {"from_url": from_url, "session_kind": "job-seeker-update"},
                 "job_seeker_pk": job_seeker.pk,
-                "apply": {"company_pk": company.pk},
             },
         )
 

--- a/migrations.md
+++ b/migrations.md
@@ -33,3 +33,8 @@ Cette migration est problématique quand la modale est liée à un `{% include %
 car on ne peut pas avoir des `{% include %}` et des `{% block %}`, mais devrait
 éviter des problèmes de `z-index` lorsque le *markup* de la modale est dans un
 élément avec `z-index` différent.
+
+## Extraction du parcours de recherche/création/modification de compte candidat
+Historiquement, la création de compte candidat par un prescripteur ou un employeur était rattachée au processus de candidature.
+Nous voulons à présent déconnecter les deux processus.
+Trois applications sont impactées : `job_seekers_views`, `apply` et `gps`.

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -941,7 +941,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_authorized_prescriber_with_proxied_job_seeker[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -1102,58 +1102,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'User.is_prescriber_with_authorized_org[users/models.py]',
           'User.can_edit_personal_information[users/models.py]',
           'User.can_view_personal_information[users/models.py]',
@@ -1208,7 +1156,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 13,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -1337,60 +1285,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -1550,7 +1444,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 2]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -1679,60 +1573,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -1809,7 +1649,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 3]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -1938,60 +1778,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -2634,7 +2420,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_proxied_job_seeker[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -2847,58 +2633,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
@@ -2934,7 +2668,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -3115,60 +2849,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -3336,7 +3016,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_proxied_job_seeker[queries - step 2]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -3517,60 +3197,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -3655,7 +3281,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_company_with_proxied_job_seeker[queries - step 3]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -3836,60 +3462,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -4660,7 +4232,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -4821,58 +4393,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'User.is_prescriber_with_authorized_org[users/models.py]',
           'User.can_edit_personal_information[users/models.py]',
           'User.can_view_personal_information[users/models.py]',
@@ -4927,7 +4447,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 13,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -5056,60 +4576,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -5269,7 +4735,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 2]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -5398,60 +4864,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -5528,7 +4940,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 3]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -5657,60 +5069,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -6353,7 +5711,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -6566,58 +5924,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
@@ -6653,7 +5959,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - step 1]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -6834,60 +6140,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -7055,7 +6307,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - step 2]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -7236,60 +6488,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -7374,7 +6572,7 @@
 # ---
 # name: TestUpdateJobSeeker.test_with_job_seeker_without_nir[queries - step 3]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -7555,60 +6753,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -8379,7 +7523,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_authorized_prescriber_with_proxied_job_seeker[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -8540,58 +7684,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'User.is_prescriber_with_authorized_org[users/models.py]',
           'User.can_edit_personal_information[users/models.py]',
           'User.can_view_personal_information[users/models.py]',
@@ -8646,7 +7738,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 13,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -8775,60 +7867,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -8988,7 +8026,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 2]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -9117,60 +8155,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -9247,7 +8231,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_authorized_prescriber_with_proxied_job_seeker[queries - step 3]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -9376,60 +8360,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -9543,7 +8473,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_proxied_job_seeker[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -9756,58 +8686,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
@@ -9843,7 +8721,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -10024,60 +8902,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -10245,7 +9069,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_proxied_job_seeker[queries - step 2]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -10426,60 +9250,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -10564,7 +9334,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_company_with_proxied_job_seeker[queries - step 3]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -10745,60 +9515,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -11609,7 +10325,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -11770,58 +10486,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'User.is_prescriber_with_authorized_org[users/models.py]',
           'User.can_edit_personal_information[users/models.py]',
           'User.can_view_personal_information[users/models.py]',
@@ -11876,7 +10540,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 1]
   dict({
-    'num_queries': 13,
+    'num_queries': 12,
     'queries': list([
       dict({
         'origin': list([
@@ -12005,60 +10669,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -12218,7 +10828,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 2]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -12347,60 +10957,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -12477,7 +11033,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_as_unauthorized_prescriber_that_created_proxied_job_seeker[queries - step 3]
   dict({
-    'num_queries': 9,
+    'num_queries': 8,
     'queries': list([
       dict({
         'origin': list([
@@ -12606,60 +11162,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -12773,7 +11275,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - start]
   dict({
-    'num_queries': 11,
+    'num_queries': 10,
     'queries': list([
       dict({
         'origin': list([
@@ -12986,58 +11488,6 @@
       }),
       dict({
         'origin': list([
-          'UpdateJobSeekerStartView.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
@@ -13073,7 +11523,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - step 1]
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -13254,60 +11704,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep1View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -13475,7 +11871,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - step 2]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -13656,60 +12052,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep2View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([
@@ -13794,7 +12136,7 @@
 # ---
 # name: TestUpdateJobSeekerForHire.test_with_job_seeker_without_nir[queries - step 3]
   dict({
-    'num_queries': 10,
+    'num_queries': 9,
     'queries': list([
       dict({
         'origin': list([
@@ -13975,60 +12317,6 @@
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-          'UpdateJobSeekerStep3View.setup[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 EXISTS
-            (SELECT %s AS "a"
-             FROM "companies_companymembership" U0
-             WHERE (U0."company_id" = ("companies_company"."id")
-                    AND U0."is_active")
-             LIMIT 1) AS "has_active_members"
-          FROM "companies_company"
-          WHERE (NOT ("companies_company"."siret" = %s)
-                 AND "companies_company"."id" = %s)
-          LIMIT 21
-        ''',
       }),
       dict({
         'origin': list([

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -263,7 +263,7 @@ class TestHire:
         client.force_login(company.members.first())
         params = {
             "job_seeker": prescriber.public_id,
-            "company": company.pk,
+            "from_url": reverse("dashboard:index"),
         }
         url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
         response = client.get(url)
@@ -3415,7 +3415,6 @@ class TestLastCheckedAtView:
 
         params = {
             "job_seeker": self.job_seeker.public_id,
-            "company": self.company.pk,
             "from_url": url,
         }
         update_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -3468,7 +3467,6 @@ class UpdateJobSeekerTestMixin:
             kwargs={"company_pk": self.company.pk, "job_seeker_public_id": self.job_seeker.public_id},
         )
         self.config = {
-            "apply": {"company_pk": self.company.pk},
             "config": {"from_url": from_url, "session_kind": "job-seeker-update"},
             "job_seeker_pk": self.job_seeker.pk,
         }
@@ -3486,7 +3484,6 @@ class UpdateJobSeekerTestMixin:
 
         params = {
             "job_seeker": self.job_seeker.public_id,
-            "company": self.company.pk,
             "from_url": from_url,
         }
         self.start_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -4094,7 +4091,10 @@ class TestUpdateJobSeekerStep3View:
         # START to setup jobseeker session
         params = {
             "job_seeker": job_seeker.public_id,
-            "company": company.pk,
+            "from_url": reverse(
+                "apply:application_jobs",
+                kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
+            ),
         }
         url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
         response = client.get(url)
@@ -4885,7 +4885,6 @@ class TestCheckJobSeekerInformationsForHire:
         assertContains(response, "Éligibilité IAE à valider")
         params = {
             "job_seeker": job_seeker.public_id,
-            "company": company.pk,
             "from_url": url_check_infos,
         }
         url_update = f"""
@@ -4929,7 +4928,6 @@ class TestCheckJobSeekerInformationsForHire:
         assertTemplateNotUsed(response, "approvals/includes/box.html")
         params = {
             "job_seeker": job_seeker.public_id,
-            "company": company.pk,
             "from_url": url_check_infos,
         }
         url_update = f"""

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4728,7 +4728,7 @@ class TestFindJobSeekerForHireView:
 
     def get_check_nir_url(self, client):
         # Init session
-        start_url = reverse("apply:start", kwargs={"company_pk": self.company.pk})
+        start_url = reverse("apply:start_hire", kwargs={"company_pk": self.company.pk})
         client.get(start_url)
         [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
         return reverse("job_seekers_views:check_nir_for_hire", kwargs={"session_uuid": job_seeker_session_name})


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Dans cette PR , on apporte quelques corrections, voir les commits et leur message.

---
**Ancienne description** (car cette PR était plus complexe, le reste sera fait dans une nouvelle PR)

## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Précédemment, dans la série, nous avons introduit une vue `start` (#5177), qui permet d'initialiser la session du bloc et de renvoyer à la vue désirée.
Pour le moment, cette vue `start` n'est branchée qu'à la **mise à jour** de compte candidat.
Cette PR est dédiée à la généralisation de la vue `start` au bloc entier, c'est-à-dire que l'on branche à `start` les vues `CheckNIRFor*`, qui permettent de rechercher ou de créer un nouveau compte candidat.

--- 

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657

