### PR TITLE
Amélioration de `pluralizefr` pour correspondre au `pluralize` de Django

### DIFF
--- a/itou/templates/apply/email/cancel_body.txt
+++ b/itou/templates/apply/email/cancel_body.txt
@@ -28,7 +28,7 @@ Nous vous confirmons que l'embauche de {{ job_application.job_seeker.get_full_na
 {% with jobs=job_application.selected_jobs.all %}
 {% if jobs %}
 
-*Métier{{ jobs|pluralizefr }} recherché{{ jobs|pluralizefr }}* :
+*{{ jobs|pluralizefr:"Métier recherché,Métiers recherchés" }}* :
 
 {% for job in jobs %}
 - {{ job.display_name }}{% endfor %}

--- a/itou/templates/apply/email/new_for_employer_body.txt
+++ b/itou/templates/apply/email/new_for_employer_body.txt
@@ -27,7 +27,7 @@ Vous avez reçu une nouvelle candidature !
 {% with jobs=job_application.selected_jobs.all %}
 {% if jobs %}
 
-*Métier{{ jobs|pluralizefr }} recherché{{ jobs|pluralizefr }}* :
+*{{ jobs|pluralizefr:"Métier recherché,Métiers recherchés" }}* :
 
 {% for job in jobs %}
 - {{ job.display_name }}{% endfor %}

--- a/itou/templates/apply/email/new_for_job_seeker_body.txt
+++ b/itou/templates/apply/email/new_for_job_seeker_body.txt
@@ -26,7 +26,7 @@ Candidature chez {{ job_application.to_company.display_name }} envoyée avec suc
 {% with jobs=job_application.selected_jobs.all %}
 {% if jobs %}
 
-*Métier{{ jobs|pluralizefr }} recherché{{ jobs|pluralizefr }}* :
+*{{ jobs|pluralizefr:"Métier recherché,Métiers recherchés" }}* :
 
 {% for job in jobs %}
 - {{ job.display_name }}{% endfor %}

--- a/itou/templates/apply/email/new_for_prescriber_body.txt
+++ b/itou/templates/apply/email/new_for_prescriber_body.txt
@@ -27,7 +27,7 @@ La candidature suivante a été envoyée avec succès à l'entreprise {{ job_app
 {% with jobs=job_application.selected_jobs.all %}
 {% if jobs %}
 
-*Métier{{ jobs|pluralizefr }} recherché{{ jobs|pluralizefr }}* :
+*{{ jobs|pluralizefr:"Métier recherché,Métiers recherchés" }}* :
 
 {% for job in jobs %}
 - {{ job.display_name }}{% endfor %}

--- a/itou/templates/apply/includes/job_application_info.html
+++ b/itou/templates/apply/includes/job_application_info.html
@@ -24,7 +24,7 @@
 {% with jobs=job_application.selected_jobs.all %}
     <span class="d-block fs-sm">
         {% if jobs %}{{ jobs|length }}{% endif %}
-    Poste{{ jobs|pluralizefr }} recherché{{ jobs|pluralizefr }}</span>
+    {{ jobs|pluralizefr:"Poste recherché,Postes recherchés" }}</span>
     <ul class="list-group list-group-flush">
         {% for job in jobs %}
             <li class="list-group-item list-group-item-action py-2">

--- a/itou/templates/apply/includes/list_reset_filters.html
+++ b/itou/templates/apply/includes/list_reset_filters.html
@@ -10,9 +10,7 @@
 {% if btn_dropdown_filter|default:False %}
     <div class="ms-md-auto" id="apply-list-filter-counter"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
         {% if filters_counter > 0 %}
-            <a href="{{ reset_url }}"
-               class="btn btn-ico btn-dropdown-filter"
-               aria-label="Réinitialiser le{{ filters_counter|pluralizefr }} filtre{{ filters_counter|pluralizefr }} actif{{ filters_counter|pluralizefr }}">
+            <a href="{{ reset_url }}" class="btn btn-ico btn-dropdown-filter" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
                 <i class="ri-eraser-line fw-medium" aria-hidden="true"></i>
                 <span>Effacer tout</span>
             </a>
@@ -20,9 +18,7 @@
     </div>
 {% else %}
     {% if filters_counter > 0 %}
-        <a href="{{ reset_url }}"
-           class="btn btn-ico btn-block btn-outline-primary"
-           aria-label="Réinitialiser le{{ filters_counter|pluralizefr }} filtre{{ filters_counter|pluralizefr }} actif{{ filters_counter|pluralizefr }}">
+        <a href="{{ reset_url }}" class="btn btn-ico btn-block btn-outline-primary" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
             <i class="ri-eraser-line fw-medium" aria-hidden="true"></i>
             <span>Effacer tout</span>
         </a>

--- a/itou/templates/apply/includes/selected_jobs_list.html
+++ b/itou/templates/apply/includes/selected_jobs_list.html
@@ -13,7 +13,7 @@
                     aria-expanded="false"
                     type="button"
                     aria-controls="collapse-job-application-{{ job_application.id }}">
-                <span>{{ all_jobs|length }} poste{{ all_jobs|pluralizefr }} recherché{{ all_jobs|pluralizefr }}</span>
+                <span>{{ all_jobs|length }} {{ all_jobs|pluralizefr:"poste recherché,postes recherchés" }}</span>
             </button>
             <div class="c-info__detail collapse" id="collapse-job-application-{{ job_application.id }}">
                 <ul class="list-unstyled">

--- a/itou/templates/approvals/includes/list_reset_filters.html
+++ b/itou/templates/approvals/includes/list_reset_filters.html
@@ -2,9 +2,7 @@
 
 <div class="ms-md-auto" id="approvals-list-filter-counter"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
     {% if filters_counter > 0 %}
-        <a href="{% url 'approvals:list' %}"
-           class="btn btn-ico btn-dropdown-filter"
-           aria-label="Réinitialiser le{{ filters_counter|pluralizefr }} filtre{{ filters_counter|pluralizefr }} actif{{ filters_counter|pluralizefr }}">
+        <a href="{% url 'approvals:list' %}" class="btn btn-ico btn-dropdown-filter" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
             <i class="ri-eraser-line fw-medium" aria-hidden="true"></i>
             <span>Effacer tout</span>
         </a>

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -160,7 +160,7 @@
                         {% if other_jobs_descriptions %}
                             <li class="nav-item" role="presentation">
                                 <a id="autres-metiers-tab" class="nav-link" role="tab" href="#autres-metiers" data-bs-toggle="tab" aria-selected="false" aria-controls="autres-metiers">
-                                    <span>Autre{{ other_jobs_descriptions|pluralizefr }} métier{{ other_jobs_descriptions|pluralizefr }} exercé{{ other_jobs_descriptions|pluralizefr }}</span>
+                                    <span>{{ other_jobs_descriptions|pluralizefr:"Autre métier exercé,Autres métiers exercés" }}</span>
                                     <span class="badge badge-sm rounded-pill ms-2">{{ other_jobs_descriptions|length }}</span>
                                 </a>
                             </li>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -32,7 +32,7 @@
             {% if job.is_active %}
                 <p class="mt-1 mb-0">
                     <span class="badge rounded-pill bg-success">
-                        {{ job.open_positions }} poste{{ job.open_positions|pluralizefr }} ouvert{{ job.open_positions|pluralizefr }} au recrutement
+                        {{ job.open_positions }} {{ job.open_positions|pluralizefr:"poste ouvert,postes ouverts" }} au recrutement
                     </span>
                 </p>
             {% endif %}

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -63,7 +63,7 @@
                             </div>
                         </div>
                         <p class="mb-0">
-                            {{ job_pager.paginator.count }} métier{{ job_pager.paginator.count|pluralizefr }} exercé{{ job_pager.paginator.count|pluralizefr }}
+                            {{ job_pager.paginator.count }} {{ job_pager.paginator.count|pluralizefr:"métier exercé,métiers exercés" }}
                         </p>
                         {% if job_pager %}
                             <div class="table-responsive mt-3 mt-md-4">

--- a/itou/templates/gps/includes/memberships_results.html
+++ b/itou/templates/gps/includes/memberships_results.html
@@ -28,9 +28,7 @@
                             {% if counter < 1 %}
                                 Aucun autre professionnel que vous n'est intervenu auprès de ce bénéficiaire.
                             {% else %}
-                                {{ counter }} autre{{ counter|pluralizefr }} professionnel{{ counter|pluralizefr }}
-                                {{ counter|pluralize:"est,sont" }}
-                                intervenu{{ counter|pluralizefr }} auprès de ce bénéficiaire.
+                                {{ counter }} {{ counter|pluralizefr:"autre professionnel est intervenu,autres professionnels sont intervenus" }} auprès de ce bénéficiaire.
                             {% endif %}
                         </p>
                     {% endwith %}

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -43,7 +43,7 @@
                     <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-between mb-3 mb-md-4">
                         <p class="mb-0 flex-grow-1" id="results">
                             {% with memberships_page.paginator.count as counter %}
-                                {{ counter }} bénéficiaire{{ counter|pluralizefr }} suivi{{ counter|pluralizefr }}
+                                {{ counter }} {{ counter|pluralizefr:"bénéficiaire suivi,bénéficiaires suivis" }}
                             {% endwith %}
                         </p>
                         <form class="flex-column flex-md-row mt-3 mt-md-0"

--- a/itou/templates/search/includes/siaes_search_subtitle.html
+++ b/itou/templates/search/includes/siaes_search_subtitle.html
@@ -4,8 +4,6 @@
     {% if request.resolver_match.view_name == "search:employers_results" or job_app_to_transfer|default:False %}
         <h2 class="mb-3 mb-md-4">Employeur{{ siaes_count|pluralizefr }}</h2>
     {% else %}
-        <h2 class="mb-3 mb-md-4">
-            Poste{{ job_descriptions_count|pluralizefr }} ouvert{{ job_descriptions_count|pluralizefr }} au recrutement
-        </h2>
+        <h2 class="mb-3 mb-md-4">{{ job_descriptions_count|pluralizefr:"Poste ouvert,Postes ouverts" }} au recrutement</h2>
     {% endif %}
 </div>

--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -77,7 +77,7 @@
                     {% if companies_without_members and company_select_form %}
                         <div class="mt-3 mt-md-4">
 
-                            <h3>Entreprise{{ companies_without_members|pluralizefr }} disponible{{ companies_without_members|pluralizefr }}</h3>
+                            <h3>{{ companies_without_members|pluralizefr:"Entreprise disponible,Entreprises disponibles" }}</h3>
 
                             <p class="text-muted">Les données sont fournies par la DGEFP et les extranets IAE 2.0 et EA 2 de l’ASP.</p>
 
@@ -127,16 +127,10 @@
                     {% if companies_with_members %}
                         <div class="mt-3 mt-md-4">
 
-                            <h3>Entreprise{{ companies_with_members|pluralizefr }} déjà inscrite{{ companies_with_members|pluralizefr }}</h3>
+                            <h3>{{ companies_with_members|pluralizefr:"Entreprise déjà inscrite,Entreprises déjà inscrites" }}</h3>
 
                             <p class="text-muted">
-                                Par mesure de sécurité, vous devez obtenir une invitation pour rejoindre
-                                {% if companies_with_members|length == 1 %}
-                                    cette
-                                {% else %}
-                                    ces
-                                {% endif %}
-                                structure{{ companies_with_members|pluralizefr }}.
+                                Par mesure de sécurité, vous devez obtenir une invitation pour rejoindre {{ companies_with_members|pluralizefr:"cette structure,ces structures" }}.
                             </p>
 
                             {% for siae in companies_with_members %}

--- a/itou/utils/templatetags/str_filters.py
+++ b/itou/utils/templatetags/str_filters.py
@@ -15,16 +15,23 @@ register = template.Library()
 @register.filter(is_safe=False)
 def pluralizefr(value, arg="s"):
     """
-    Return a plural suffix if the value is greater than 1
-    NB : the basic django pluralize filter returns the plural suffix for value==0
+    This is the Django's pluralize filter code, adapted to match French rules.
+    (NB : the basic django pluralize filter returns the plural suffix for value==0)
     """
+    if "," not in arg:
+        arg = "," + arg
+    bits = arg.split(",")
+    if len(bits) > 2:
+        return ""
+    singular_suffix, plural_suffix = bits[:2]
+
     try:
-        return arg if float(value) > 1 else ""
+        return singular_suffix if float(value) <= 1 else plural_suffix
     except ValueError:  # Invalid string that's not a number.
         pass
     except TypeError:  # Value isn't a string or a number; maybe it's a list?
         try:
-            return arg if len(value) > 1 else ""
+            return singular_suffix if len(value) <= 1 else plural_suffix
         except TypeError:  # len() of unsized object.
             pass
     return ""

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -249,9 +249,7 @@
                           
                               Vous avez ajouté ce bénéficiaire le <strong>21/06/2024</strong>.
                               
-                                  1 autre professionnel
-                                  est
-                                  intervenu auprès de ce bénéficiaire.
+                                  1 autre professionnel est intervenu auprès de ce bénéficiaire.
                               
                           </p>
                       

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -757,6 +757,22 @@ class TestUtilsTemplateTags:
         out = template.render(Context({"counter": 10}))
         assert out == "résultats"
 
+        template = Template('{% load str_filters %}hibou{{ counter|pluralizefr:"x" }}')
+        out = template.render(Context({"counter": 0}))
+        assert out == "hibou"
+        out = template.render(Context({"counter": 1}))
+        assert out == "hibou"
+        out = template.render(Context({"counter": 10}))
+        assert out == "hiboux"
+
+        template = Template('{% load str_filters %}{{ counter|pluralizefr:"grand hibou,grands hiboux" }}')
+        out = template.render(Context({"counter": 0}))
+        assert out == "grand hibou"
+        out = template.render(Context({"counter": 1}))
+        assert out == "grand hibou"
+        out = template.render(Context({"counter": 10}))
+        assert out == "grands hiboux"
+
     def test_mask_unless(self):
         template = Template("""{% load str_filters %}{{ value|mask_unless:predicate }}""")
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à une discussion avec @rsebille.

Pour éviter les `pluralizefr` / `{% if ... ` en cascade.


## Autres alternatives (ajout d'un nouveau `tag`/`filter` avec un registre de traductions stockées dans un dico) 

Cela nécessitera un test pour vérifier que toutes les entrées du dictionnaire.

Premier commit, utilisation d'un tag `{% plural ...`:

`{% plural "{} bénéficiaire suivi" memberships_page.paginator.count %}`

Version actuelle, utilisation d'un filtre:

`{{ memberships_page.paginator.count|plural:"{} bénéficiaire suivi" }}`

Autre possibilité:

`{{ "{} bénéficiaire suivi"|plural:memberships_page.paginator.count }}`


Cela serait effectivement en alternative/concurrence au natif `{% blocktranslate ... %} ... {% plural %} {% endblocktranslate %}` de Django qui est assez verbeux.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
