### PR TITLE
UX/UI: Passer le "bon à savoir" en composant info

### DIFF
--- a/itou/templates/employee_record/includes/create_step_1.html
+++ b/itou/templates/employee_record/includes/create_step_1.html
@@ -11,17 +11,11 @@
                     <legend>Etat civil du salarié</legend>
                     {% bootstrap_form_errors form type="all" %}
 
-                    <div class="form-row">
-                        <div class="col-12 col-md-6">{% bootstrap_field form.title %}</div>
-                    </div>
-                    <div class="form-row">
-                        <div class="col-12 col-md-6">{% bootstrap_field form.first_name %}</div>
-                        <div class="col-12 col-md-6">{% bootstrap_field form.last_name %}</div>
-                    </div>
-                    <div class="form-row">
-                        <div class="col-12 col-md-6">{% bootstrap_field form.birthdate %}</div>
-                        <div class="col-12 col-md-6">{% bootstrap_field form.birth_country %}</div>
-                    </div>
+                    {% bootstrap_field form.title %}
+                    {% bootstrap_field form.first_name %}
+                    {% bootstrap_field form.last_name %}
+                    {% bootstrap_field form.birthdate %}
+                    {% bootstrap_field form.birth_country %}
                     {% bootstrap_field form.birth_place %}
                 </fieldset>
                 {% url "employee_record_views:list" as secondary_url %}

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -3,108 +3,88 @@
 {% load url_add_query %}
 
 <div class="row">
-    <div class="col-12">
+    <div class="col-12 col-lg-8">
         <div class="c-form">
             <form method="post" action="{% url "employee_record_views:create_step_2" job_application.id %}">
                 {% csrf_token %}
                 <fieldset>
-                    <legend class="h2">Domiciliation du salarié</legend>
-                    <div class="row">
-                        <div class="col-12 col-lg-8">
-                            {% bootstrap_form_errors form type="all" %}
-                            <div class="mb-3 mb-md-5">
-                                <p>
-                                    Merci de bien vouloir vérifier <b>l'adresse qui sera envoyée à l'ASP</b>.
-                                </p>
-                                <ul>
-                                    <li>
-                                        Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Suivant»</b> en bas de page.
-                                    </li>
-                                    <li>
-                                        Si elle ne correspond pas, veuillez la modifier à l'aide du formulaire ci-dessous, puis cliquez
-                                        sur le bouton <b>«Valider cette adresse»</b>.
-                                    </li>
-                                </ul>
-                                {% if profile.hexa_address_filled %}
-                                    <p class="mb-0">
-                                        <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
-                                    </p>
-                                {% else %}
-                                    <div class="alert alert-danger" role="status">
-                                        <p class="mb-2">
-                                            <strong>L'adresse du salarié n'a pu être vérifiée automatiquement.</strong>
-                                        </p>
-                                        <p class="mb-0">Ceci peut être dû à:</p>
-                                        <ul>
-                                            <li>une erreur temporaire de géolocalisation,</li>
-                                            <li>une adresse introuvable (code postal ou voie erronée).</li>
-                                        </ul>
-                                        <p class="m-0">
-                                            <b>Merci de bien vouloir saisir l'adresse du salarié dans le formulaire ci-dessous.</b>
-                                        </p>
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-12 col-lg-8">
-                            <div class="form-row">
-                                <div class="col-12 col-md-3">{% bootstrap_field form.hexa_lane_number %}</div>
-                                <div class="col-12 col-md-3">{% bootstrap_field form.hexa_std_extension %}</div>
-                            </div>
-                            <div class="form-row">
-                                <div class="col-12 col-md-3">{% bootstrap_field form.hexa_lane_type %}</div>
-                                <div class="col-12 col-md-6">{% bootstrap_field form.hexa_lane_name %}</div>
-                            </div>
-                            {% bootstrap_field form.hexa_additional_address %}
-                            <div class="form-row">
-                                <div class="col-12 col-md-3">{% bootstrap_field form.hexa_post_code %}</div>
-                                <div class="col-12 col-md-9">{% bootstrap_field form.hexa_commune %}</div>
-                            </div>
-                        </div>
-                        <div class="col-12 col-lg-4">
-                            <div class="c-form-conseil">
-                                <div>
-                                    <p>
-                                        <i class="ri-lightbulb-line ri-lg me-1"></i><strong>Rappel de l’adresse du salarié renseignée sur Les emplois de l’inclusion</strong>
-                                    </p>
-                                    {% if address_filled %}
-                                        <ul class="list-unstyled mb-0 mt-2">
-                                            <li>{{ job_seeker.address_line_1 }}</li>
-                                            {% if job_seeker.address_line_2 %}<li>{{ job_seeker.address_line_2 }}</li>{% endif %}
-                                            <li>{{ job_seeker.post_code }} {{ job_seeker.city }}</li>
-                                        </ul>
-                                    {% else %}
-                                        <p class="mb-0 mt-2">Aucune adresse n'a été saisie sur les emplois de l'inclusion !</p>
-                                    {% endif %}
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </fieldset>
-                <div class="form-row">
-                    <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                        <button class="btn btn-outline-primary">Valider cette adresse</button>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-12 col-lg-8">
-                        {% url "employee_record_views:create_step_3" job_application.id as primary_url %}
-                        {% url "employee_record_views:create" job_application.id as secondary_url %}
-                        {% url "employee_record_views:list" as reset_url %}
-                        {% if request.GET.status %}
-                            {% url_add_query primary_url status=request.GET.status as primary_url %}
-                            {% url_add_query secondary_url status=request.GET.status as secondary_url %}
-                            {% url_add_query reset_url status=request.GET.status as reset_url %}
-                        {% endif %}
+                    <legend>Domiciliation du salarié</legend>
+                    {% bootstrap_form_errors form type="all" %}
+                    <div class="mb-3">
+                        <p>
+                            Merci de bien vouloir vérifier <b>l'adresse qui sera envoyée à l'ASP</b>.
+                        </p>
+                        <ul>
+                            <li>
+                                Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Suivant»</b> en bas de page.
+                            </li>
+                            <li>
+                                Si elle ne correspond pas, veuillez la modifier à l'aide du formulaire ci-dessous, puis cliquez
+                                sur le bouton <b>«Valider cette adresse»</b>.
+                            </li>
+                        </ul>
                         {% if profile.hexa_address_filled %}
-                            {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url %}
+                            <p class="mb-0">
+                                <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
+                            </p>
                         {% else %}
-                            {% itou_buttons_form primary_label="Suivant" primary_disabled=True secondary_url=secondary_url reset_url=reset_url %}
+                            <div class="alert alert-danger" role="status">
+                                <p class="mb-2">
+                                    <strong>L'adresse du salarié n'a pu être vérifiée automatiquement.</strong>
+                                </p>
+                                <p class="mb-0">Ceci peut être dû à:</p>
+                                <ul>
+                                    <li>une erreur temporaire de géolocalisation,</li>
+                                    <li>une adresse introuvable (code postal ou voie erronée).</li>
+                                </ul>
+                                <p class="m-0">
+                                    <b>Merci de bien vouloir saisir l'adresse du salarié dans le formulaire ci-dessous.</b>
+                                </p>
+                            </div>
                         {% endif %}
                     </div>
-                </div>
+                    <div class="c-info mb-3 mb-md-5">
+                        <button class="c-info__summary">
+                            <span>Rappel de l’adresse du salarié renseignée sur Les emplois de l’inclusion</span>
+                        </button>
+                        <div class="c-info__detail">
+                            {% if address_filled %}
+                                <ul class="list-unstyled mb-0">
+                                    <li>{{ job_seeker.address_line_1 }}</li>
+                                    {% if job_seeker.address_line_2 %}<li>{{ job_seeker.address_line_2 }}</li>{% endif %}
+                                    <li>{{ job_seeker.post_code }} {{ job_seeker.city }}</li>
+                                </ul>
+                            {% else %}
+                                <p class="mb-0">Aucune adresse n'a été saisie sur les emplois de l'inclusion !</p>
+                            {% endif %}
+                        </div>
+                    </div>
+
+                    {% bootstrap_field form.hexa_lane_number %}
+                    {% bootstrap_field form.hexa_std_extension %}
+                    {% bootstrap_field form.hexa_lane_type %}
+                    {% bootstrap_field form.hexa_lane_name %}
+                    {% bootstrap_field form.hexa_additional_address %}
+                    {% bootstrap_field form.hexa_post_code %}
+                    {% bootstrap_field form.hexa_commune %}
+
+                    <button class="btn btn-outline-primary mb-3">Valider cette adresse</button>
+                </fieldset>
+
+                {% url "employee_record_views:create_step_3" job_application.id as primary_url %}
+                {% url "employee_record_views:create" job_application.id as secondary_url %}
+                {% url "employee_record_views:list" as reset_url %}
+                {% if request.GET.status %}
+                    {% url_add_query primary_url status=request.GET.status as primary_url %}
+                    {% url_add_query secondary_url status=request.GET.status as secondary_url %}
+                    {% url_add_query reset_url status=request.GET.status as reset_url %}
+                {% endif %}
+                {% if profile.hexa_address_filled %}
+                    {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url %}
+                {% else %}
+                    {% itou_buttons_form primary_label="Suivant" primary_disabled=True secondary_url=secondary_url reset_url=reset_url %}
+                {% endif %}
+
             </form>
         </div>
     </div>

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -4,36 +4,44 @@
   <form action="/employee_record/create_step_2/[PK of JobApplication]" method="post">
                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                   <fieldset>
-                      <legend class="h2">Domiciliation du salarié</legend>
-                      <div class="row">
-                          <div class="col-12 col-lg-8">
+                      <legend>Domiciliation du salarié</legend>
+                      
+                      <div class="mb-3">
+                          <p>
+                              Merci de bien vouloir vérifier <b>l'adresse qui sera envoyée à l'ASP</b>.
+                          </p>
+                          <ul>
+                              <li>
+                                  Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Suivant»</b> en bas de page.
+                              </li>
+                              <li>
+                                  Si elle ne correspond pas, veuillez la modifier à l'aide du formulaire ci-dessous, puis cliquez
+                                  sur le bouton <b>«Valider cette adresse»</b>.
+                              </li>
+                          </ul>
+                          
+                              <p class="mb-0">
+                                  <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
+                              </p>
+                          
+                      </div>
+                      <div class="c-info mb-3 mb-md-5">
+                          <button class="c-info__summary">
+                              <span>Rappel de l’adresse du salarié renseignée sur Les emplois de l’inclusion</span>
+                          </button>
+                          <div class="c-info__detail">
                               
-                              <div class="mb-3 mb-md-5">
-                                  <p>
-                                      Merci de bien vouloir vérifier <b>l'adresse qui sera envoyée à l'ASP</b>.
-                                  </p>
-                                  <ul>
-                                      <li>
-                                          Si elle est correcte, vous pouvez passer à l'étape suivante en cliquant sur le bouton <b>«Suivant»</b> en bas de page.
-                                      </li>
-                                      <li>
-                                          Si elle ne correspond pas, veuillez la modifier à l'aide du formulaire ci-dessous, puis cliquez
-                                          sur le bouton <b>«Valider cette adresse»</b>.
-                                      </li>
+                                  <ul class="list-unstyled mb-0">
+                                      <li>Rue du Clos de la Grange</li>
+                                      
+                                      <li>58160 Sauvigny-les-Bois</li>
                                   </ul>
-                                  
-                                      <p class="mb-0">
-                                          <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
-                                      </p>
-                                  
-                              </div>
+                              
                           </div>
                       </div>
-                      <div class="row">
-                          <div class="col-12 col-lg-8">
-                              <div class="form-row">
-                                  <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_lane_number">Numéro</label><input class="form-control" id="id_hexa_lane_number" maxlength="10" name="hexa_lane_number" placeholder="Numéro" type="text" value="42"/></div></div>
-                                  <div class="col-12 col-md-3"><div class="form-group"><label class="form-label" for="id_hexa_std_extension">Extension</label><select class="form-select" id="id_hexa_std_extension" name="hexa_std_extension">
+  
+                      <div class="form-group"><label class="form-label" for="id_hexa_lane_number">Numéro</label><input class="form-control" id="id_hexa_lane_number" maxlength="10" name="hexa_lane_number" placeholder="Numéro" type="text" value="42"/></div>
+                      <div class="form-group"><label class="form-label" for="id_hexa_std_extension">Extension</label><select class="form-select" id="id_hexa_std_extension" name="hexa_std_extension">
     <option selected="" value="">---------</option>
   
     <option value="B">Bis</option>
@@ -44,10 +52,8 @@
   
     <option value="C">Quinquies</option>
   
-  </select></div></div>
-                              </div>
-                              <div class="form-row">
-                                  <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_type">Type de voie</label><select class="form-select" id="id_hexa_lane_type" name="hexa_lane_type" required="">
+  </select></div>
+                      <div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_type">Type de voie</label><select class="form-select" id="id_hexa_lane_type" name="hexa_lane_type" required="">
     <option value="">---------</option>
   
     <option value="AER">Aérodrome</option>
@@ -236,49 +242,24 @@
   
     <option value="ZUP">Zone urbanisation prio</option>
   
-  </select></div></div>
-                                  <div class="col-12 col-md-6"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_name">Nom de la voie</label><input class="form-control" id="id_hexa_lane_name" maxlength="120" name="hexa_lane_name" placeholder="Nom de la voie" required="" type="text" value="du Clos de la Grange"/></div></div>
-                              </div>
-                              <div class="form-group"><label class="form-label" for="id_hexa_additional_address">Complément d'adresse</label><input class="form-control" id="id_hexa_additional_address" maxlength="32" name="hexa_additional_address" placeholder="Complément d'adresse" type="text"/></div>
-                              <div class="form-row">
-                                  <div class="col-12 col-md-3"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_post_code">Code postal</label><input class="form-control" id="id_hexa_post_code" maxlength="6" name="hexa_post_code" placeholder="Code postal" required="" type="text" value="58160"/></div></div>
-                                  <div class="col-12 col-md-9"><div class="form-group form-group-required"><label class="form-label" for="id_hexa_commune">Commune</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Nom de la commune" data-theme="bootstrap-5" id="id_hexa_commune" lang="fr" name="hexa_commune" required="">
+  </select></div>
+                      <div class="form-group form-group-required"><label class="form-label" for="id_hexa_lane_name">Nom de la voie</label><input class="form-control" id="id_hexa_lane_name" maxlength="120" name="hexa_lane_name" placeholder="Nom de la voie" required="" type="text" value="du Clos de la Grange"/></div>
+                      <div class="form-group"><label class="form-label" for="id_hexa_additional_address">Complément d'adresse</label><input class="form-control" id="id_hexa_additional_address" maxlength="32" name="hexa_additional_address" placeholder="Complément d'adresse" type="text"/></div>
+                      <div class="form-group form-group-required"><label class="form-label" for="id_hexa_post_code">Code postal</label><input class="form-control" id="id_hexa_post_code" maxlength="6" name="hexa_post_code" placeholder="Code postal" required="" type="text" value="58160"/></div>
+                      <div class="form-group form-group-required"><label class="form-label" for="id_hexa_commune">Commune</label><select class="form-select django-select2" data-ajax--cache="true" data-ajax--type="GET" data-ajax--url="/autocomplete/communes" data-allow-clear="false" data-minimum-input-length="2" data-placeholder="Nom de la commune" data-theme="bootstrap-5" id="id_hexa_commune" lang="fr" name="hexa_commune" required="">
     <option selected="" value="47612">SAUVIGNY-LES-BOIS (058)</option>
   
-  </select></div></div>
-                              </div>
-                          </div>
-                          <div class="col-12 col-lg-4">
-                              <div class="c-form-conseil">
-                                  <div>
-                                      <p>
-                                          <i class="ri-lightbulb-line ri-lg me-1"></i><strong>Rappel de l’adresse du salarié renseignée sur Les emplois de l’inclusion</strong>
-                                      </p>
-                                      
-                                          <ul class="list-unstyled mb-0 mt-2">
-                                              <li>Rue du Clos de la Grange</li>
-                                              
-                                              <li>58160 Sauvigny-les-Bois</li>
-                                          </ul>
-                                      
-                                  </div>
-                              </div>
-                          </div>
-                      </div>
+  </select></div>
+  
+                      <button class="btn btn-outline-primary mb-3">Valider cette adresse</button>
                   </fieldset>
-                  <div class="form-row">
-                      <div class="form-group col-12 col-lg-auto order-1 order-lg-2">
-                          <button class="btn btn-outline-primary">Valider cette adresse</button>
-                      </div>
-                  </div>
-                  <div class="row">
-                      <div class="col-12 col-lg-8">
-                          
-                          
-                          
-                          
-                          
-                              
+  
+                  
+                  
+                  
+                  
+                  
+                      
   
   <div class="row">
       <div class="col-12">
@@ -337,9 +318,8 @@
       </div>
   
   
-                          
-                      </div>
-                  </div>
+                  
+  
               </form>
   '''
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans le formulaire pour "Compléter une fiche salarié" : 
- passer le 'bon à savoir' en composant info
- mettre les label+input l’un en dessous des autres

-> https://www.notion.so/plateforme-inclusion/Compl-ter-une-fiche-salari-Passer-le-bon-savoir-en-composant-info-174e8fa5c35b80f5a483c2f4a9e5f638?pvs=4


## :computer: Captures d'écran <!-- optionnel -->
**Avant**
![image](https://github.com/user-attachments/assets/bc55eb55-4fc2-4de1-a307-8a48ece157b3)


**Apres**
![capture 2025-01-09 à 15 13 58](https://github.com/user-attachments/assets/1ec0c973-ab4a-412d-bd41-fbd433b3f1d3)

