### PR TITLE
candidature: correction de l'affichage d'une candidature geiq acceptée sans diagnostic

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -72,8 +72,9 @@ def check_waiting_period(job_application):
 def _get_geiq_eligibility_diagnosis(job_application, only_prescriber):
     # Return the job_application diagnosis if it's accepted
     if job_application.state.is_accepted:
-        # but not if the viewer is a prescriber and the diangosis was made by the company
-        if only_prescriber and job_application.geiq_eligibility_diagnosis.author_geiq:
+        # or None if the viewer is a prescriber and the diangosis was made by the company
+        # NB. the job application may not have a geiq diagnosis
+        if only_prescriber and getattr(job_application.geiq_eligibility_diagnosis, "author_geiq", None):
             return None
         return job_application.geiq_eligibility_diagnosis
     return GEIQEligibilityDiagnosis.objects.diagnoses_for(

--- a/tests/www/apply/test_geiq.py
+++ b/tests/www/apply/test_geiq.py
@@ -229,6 +229,16 @@ class TestJobApplicationGEIQEligibilityDetails:
         assertNotContains(response, self.EXPIRED_DIAGNOSIS_EXPLANATION)
         assertNotContains(response, self.CONFIRMATION_MODAL)
 
+    def test_accepted_without_diagnosis(self, client):
+        job_application = JobApplicationFactory(
+            state=JobApplicationState.ACCEPTED,
+            to_company__kind=CompanyKind.GEIQ,
+            eligibility_diagnosis=None,
+        )
+
+        response = self.get_response(client, job_application, job_application.sender)
+        assert response.status_code == 200
+
 
 def test_get_geiq_eligibility_diagnosis(subtests):
     expired_prescriber_diagnosis = GEIQEligibilityDiagnosisFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Je ne savais pas que c'était possible ça :/
mais c'est plus d'un quart des candidature geiq acceptées, donc mieux vaut le corriger

https://inclusion.sentry.io/issues/15627811/?project=4508410589020240&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=16

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
