### PR TITLE
Pilotage: Supprimer l’encart webinaires

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -137,7 +137,7 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
                 "description": "Nous y répondons lors d’un webinaire questions / réponses animé chaque mois.",  # noqa: E501
                 "call_to_action": "Je m’inscris",
                 "url": "https://app.livestorm.co/itou/le-pilotage-de-linclusion-professionnels-de-liae-questions-reponses-sur-les-tableaux-de-bord-1",
-                "is_displayable": lambda: True,
+                "is_displayable": lambda: False,
             }
         ]
     base_context["pilotage_webinar_banners"] = [


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il n'y a plus des webinaires prévues (https://www.notion.so/gip-inclusion/Supprimer-l-encart-webinaires-q-r-1775f321b60480bb906afda8030656ce).

## :cake: Comment ?

Pour l'instant j'ai choisis la solution rapide. À la suite je vais ouvrir un PR qui propose une patterne où on utilise un modèle pour paramétrer l'activation d'encart webinaire.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

Visiter un TdB en local (par example celui pour les administrateurs). Ils sont trouvables par le dashboard.