### PR TITLE
Le badge 20+ candidatures sur les résultats de recherche ne doit pas inclure de candidatures archivées

### DIFF
--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -561,7 +561,10 @@ class JobDescriptionQuerySet(models.QuerySet):
         # Avoid a circular import
         from itou.job_applications.models import JobApplicationWorkflow
 
-        job_apps_filters = {"jobapplication__state__in": JobApplicationWorkflow.PENDING_STATES}
+        job_apps_filters = {
+            "jobapplication__state__in": JobApplicationWorkflow.PENDING_STATES,
+            "jobapplication__archived_at": None,
+        }
         annotation = self.with_job_applications_count(filters=job_apps_filters).annotate(
             is_popular=Case(
                 When(job_applications_count__gte=self.model.POPULAR_THRESHOLD, then=True),

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -557,7 +557,7 @@ class JobDescriptionQuerySet(models.QuerySet):
             ),
         )
 
-    def with_annotation_is_popular(self):
+    def with_annotation_is_overwhelmed(self):
         # Avoid a circular import
         from itou.job_applications.models import JobApplicationWorkflow
 
@@ -566,8 +566,8 @@ class JobDescriptionQuerySet(models.QuerySet):
             "jobapplication__archived_at": None,
         }
         annotation = self.with_job_applications_count(filters=job_apps_filters).annotate(
-            is_popular=Case(
-                When(job_applications_count__gte=self.model.POPULAR_THRESHOLD, then=True),
+            is_overwhelmed=Case(
+                When(job_applications_count__gte=self.model.OVERWHELMED_THRESHOLD, then=True),
                 default=False,
                 output_field=BooleanField(),
             )
@@ -604,7 +604,7 @@ class JobDescription(models.Model):
     """
 
     MAX_UI_RANK = 32767
-    POPULAR_THRESHOLD = 20
+    OVERWHELMED_THRESHOLD = 20
     # Max number or workable hours per week in France (Code du Travail)
     MAX_WORKED_HOURS_PER_WEEK = 48
 

--- a/itou/templates/apply/submit/application/jobs.html
+++ b/itou/templates/apply/submit/application/jobs.html
@@ -17,7 +17,7 @@
                                 <label class="fw-bold stretched-link order-2 order-md-1 m-0" for="{{ choice.id_for_label }}">
                                     {{ choice.choice_label }}
                                 </label>
-                                {% if job_description.is_popular %}
+                                {% if job_description.is_overwhelmed %}
                                     <div class="order-1 order-md-2">
                                         <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>20+ candidatures</span>
                                     </div>

--- a/itou/templates/apply/submit/application/jobs.html
+++ b/itou/templates/apply/submit/application/jobs.html
@@ -19,7 +19,7 @@
                                 </label>
                                 {% if job_description.is_overwhelmed %}
                                     <div class="order-1 order-md-2">
-                                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>20+ candidatures</span>
+                                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>{{ job_description.OVERWHELMED_THRESHOLD }}+ candidatures</span>
                                     </div>
                                 {% endif %}
                             </div>

--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -37,10 +37,10 @@
                            {% if job_description.is_external %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte-externe" %} rel="noopener" target="_blank" aria-label="Visiter l'offre sur le site d'origine" {% else %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte" %} aria-label="Aller vers la description de ce poste" {% endif %}>
                             {{ job_description.display_name | capfirst }}
                         </a>
-                        {% if job_description.is_popular %}
+                        {% if job_description.is_overwhelmed %}
                             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
                                 <i class="ri-group-line me-1" aria-hidden="true"></i>
-                                {{ job_description.POPULAR_THRESHOLD }}+<span class="ms-1">candidatures</span>
+                                {{ job_description.OVERWHELMED_THRESHOLD }}+<span class="ms-1">candidatures</span>
                             </span>
                         {% endif %}
                         <ul class="c-box--results__list-contact flex-md-grow-1 mt-1">

--- a/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
@@ -14,10 +14,10 @@
             {% endif %}
             <a href="{{ job_url }}" class="fw-bold text-decoration-none stretched-link" {% matomo_event "candidature" "clic" "clic-metiers" %}>{{ job.display_name }}</a>
         {% endif %}
-        {% if job.is_popular %}
+        {% if job.is_overwhelmed %}
             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
                 <i class="ri-group-line me-1" aria-hidden="true"></i>
-                {{ job.POPULAR_THRESHOLD }}+<span class="ms-1">candidatures</span>
+                {{ job.OVERWHELMED_THRESHOLD }}+<span class="ms-1">candidatures</span>
             </span>
         {% endif %}
         <p class="fs-sm mb-0 mt-1">

--- a/itou/templates/companies/includes/_siae_jobdescription.html
+++ b/itou/templates/companies/includes/_siae_jobdescription.html
@@ -14,9 +14,9 @@
                        class="fw-bold stretched-link order-2 order-md-1"
                        {% matomo_event "candidature" "clic" "clic-metiers" %}>{{ job.display_name }}</a>
                 {% endif %}
-                {% if job.is_popular %}
+                {% if job.is_overwhelmed %}
                     <div class="order-1 order-md-2">
-                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>{{ job.POPULAR_THRESHOLD }}+ candidatures</span>
+                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>{{ job.OVERWHELMED_THRESHOLD }}+ candidatures</span>
                     </div>
                 {% endif %}
             </div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -45,7 +45,7 @@ class ApplicationJobsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["selected_jobs"].queryset = (
-            company.job_description_through.active().with_annotation_is_popular().prefetch_related("appellation")
+            company.job_description_through.active().with_annotation_is_overwhelmed().prefetch_related("appellation")
         )
         if not self.initial.get("selected_jobs"):
             self.initial["spontaneous_application"] = True

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -202,7 +202,7 @@ class EmployerSearchView(EmployerSearchBaseView):
             siaes.prefetch_related(
                 Prefetch(
                     lookup="job_description_through",
-                    queryset=JobDescription.objects.with_annotation_is_popular()
+                    queryset=JobDescription.objects.with_annotation_is_overwhelmed()
                     .filter(company__in=siaes, is_active=True)
                     .select_related("appellation", "location", "company"),
                     to_attr="active_job_descriptions",
@@ -255,7 +255,7 @@ class JobDescriptionSearchView(EmployerSearchBaseView):
         job_descriptions = job_descriptions.order_by(F("source_kind").asc(nulls_first=True), "-updated_at")
 
         page = pager(job_descriptions, self.request.GET.get("page"), items_per_page=10)
-        # Prefer a prefetch_related over annotating the entire queryset with_annotation_is_popular().
+        # Prefer a prefetch_related over annotating the entire queryset with_annotation_is_overwhelmed().
         # That annotation is quite expensive and PostgreSQL runs it on the entire queryset, even
         # though we don’t sort or group by that column. It would be smarter to apply the limit
         # before computing the annotation, but that’s not what PostgreSQL 15 does on 2024-02-21.
@@ -267,8 +267,8 @@ class JobDescriptionSearchView(EmployerSearchBaseView):
             )
         )
         for job_description in page.object_list:
-            job_description.is_popular = (
-                len(job_description.jobapplication_set_pending) >= job_description._meta.model.POPULAR_THRESHOLD
+            job_description.is_overwhelmed = (
+                len(job_description.jobapplication_set_pending) >= job_description._meta.model.OVERWHELMED_THRESHOLD
             )
         return PageAndCounts(
             results_page=page,

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -396,6 +396,18 @@ class TestJobDescriptionQuerySet:
 
         assert not JobDescription.objects.with_annotation_is_overwhelmed().get(pk=job_description.pk).is_overwhelmed
 
+        # Archived job applications should not count towards is_overwhelmed threshold.
+        job_description = siae_job_descriptions[3]
+        JobApplicationFactory.create_batch(
+            threshold_exceeded,
+            to_company=company,
+            job_seeker=job_seeker,
+            selected_jobs=[job_description],
+            archived_at=timezone.now() - timedelta(days=1),
+        )
+
+        assert not JobDescription.objects.with_annotation_is_overwhelmed().get(pk=job_description.pk).is_overwhelmed
+
     def test_with_job_applications_count(self):
         company = CompanyFactory(with_jobs=True)
         job_description = company.job_description_through.first()

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -351,6 +351,7 @@ class TestJobDescriptionQuerySet:
         company = CompanyFactory(with_jobs=True)
         job_seeker = JobSeekerFactory()  # We don't care if it's always the same
         siae_job_descriptions = company.job_description_through.all()
+        threshold_exceeded = JobDescription.OVERWHELMED_THRESHOLD + 1
 
         # Test attribute presence
         siae_job_description = JobDescription.objects.with_annotation_is_overwhelmed().first()
@@ -359,7 +360,7 @@ class TestJobDescriptionQuerySet:
         # Test overwhelmed threshold: overwhelmed job description
         overwhelmed_job_description = siae_job_descriptions[0]
         JobApplicationFactory.create_batch(
-            JobDescription.OVERWHELMED_THRESHOLD + 1,
+            threshold_exceeded,
             to_company=company,
             selected_jobs=[overwhelmed_job_description],
             job_seeker=job_seeker,
@@ -384,7 +385,6 @@ class TestJobDescriptionQuerySet:
         # Overwhelmed job descriptions count related **pending** job applications.
         # They should ignore other states.
         job_description = siae_job_descriptions[2]
-        threshold_exceeded = JobDescription.OVERWHELMED_THRESHOLD + 1
 
         JobApplicationFactory.create_batch(
             threshold_exceeded,

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -358,10 +358,12 @@ class TestJobDescriptionQuerySet:
 
         # Test overwhelmed threshold: overwhelmed job description
         overwhelmed_job_description = siae_job_descriptions[0]
-        for _ in range(JobDescription.OVERWHELMED_THRESHOLD + 1):
-            JobApplicationFactory(
-                to_company=company, selected_jobs=[overwhelmed_job_description], job_seeker=job_seeker
-            )
+        JobApplicationFactory.create_batch(
+            JobDescription.OVERWHELMED_THRESHOLD + 1,
+            to_company=company,
+            selected_jobs=[overwhelmed_job_description],
+            job_seeker=job_seeker,
+        )
 
         assert (
             JobDescription.objects.with_annotation_is_overwhelmed()

--- a/tests/www/search/__snapshots__/tests.ambr
+++ b/tests/www/search/__snapshots__/tests.ambr
@@ -917,10 +917,12 @@
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
                  COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE "job_applications_jobapplication"."state" IN (%s, %s, %s)) AS "job_applications_count",
+                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
                  CASE
                      WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
                  END AS "is_popular",
                  "jobs_appellation"."updated_at",
@@ -1302,10 +1304,12 @@
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
                  COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE "job_applications_jobapplication"."state" IN (%s, %s, %s)) AS "job_applications_count",
+                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
                  CASE
                      WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
                  END AS "is_popular",
                  "jobs_appellation"."updated_at",
@@ -1688,10 +1692,12 @@
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
                  COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE "job_applications_jobapplication"."state" IN (%s, %s, %s)) AS "job_applications_count",
+                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
                  CASE
                      WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
                  END AS "is_popular",
                  "jobs_appellation"."updated_at",
@@ -2073,10 +2079,12 @@
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
                  COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE "job_applications_jobapplication"."state" IN (%s, %s, %s)) AS "job_applications_count",
+                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
                  CASE
                      WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
+                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
                  END AS "is_popular",
                  "jobs_appellation"."updated_at",

--- a/tests/www/search/__snapshots__/tests.ambr
+++ b/tests/www/search/__snapshots__/tests.ambr
@@ -924,7 +924,7 @@
                                                                                                              WHERE ("job_applications_jobapplication"."archived_at" IS NULL
                                                                                                                     AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
-                 END AS "is_popular",
+                 END AS "is_overwhelmed",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -1311,7 +1311,7 @@
                                                                                                              WHERE ("job_applications_jobapplication"."archived_at" IS NULL
                                                                                                                     AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
-                 END AS "is_popular",
+                 END AS "is_overwhelmed",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -1699,7 +1699,7 @@
                                                                                                              WHERE ("job_applications_jobapplication"."archived_at" IS NULL
                                                                                                                     AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
-                 END AS "is_popular",
+                 END AS "is_overwhelmed",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -2086,7 +2086,7 @@
                                                                                                              WHERE ("job_applications_jobapplication"."archived_at" IS NULL
                                                                                                                     AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
                      ELSE %s
-                 END AS "is_popular",
+                 END AS "is_overwhelmed",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -240,24 +240,24 @@ class TestSearchCompany:
         )
         assertContains(response, "Offres clauses sociales")
 
-    def test_is_popular(self, client):
+    def test_is_overwhelmed(self, client):
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         city = create_city_saint_andre()
         company = CompanyFactory(department="44", coords=city.coords, post_code="44117", with_membership=True)
         job = JobDescriptionFactory(company=company)
         JobApplicationFactory.create_batch(19, to_company=company, selected_jobs=[job], state="new")
         response = client.get(self.URL, {"city": city.slug})
-        popular_badge = """
+        overwhelmed_badge = """
             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
                 <i class="ri-group-line me-1" aria-hidden="true"></i>
                 20+<span class="ms-1">candidatures</span>
             </span>
             """
-        assertNotContains(response, popular_badge, html=True)
+        assertNotContains(response, overwhelmed_badge, html=True)
 
         JobApplicationFactory(to_company=company, selected_jobs=[job], state="new")
         response = client.get(self.URL, {"city": city.slug})
-        assertContains(response, popular_badge, html=True)
+        assertContains(response, overwhelmed_badge, html=True)
 
     def test_has_no_active_members(self, client):
         create_test_romes_and_appellations(["N1101"], appellations_per_rome=1)
@@ -798,24 +798,24 @@ class TestJobDescriptionSearchView:
         jobs_results = response.context["results_page"]
         assert list(jobs_results) == [job1, job2, job3]
 
-    def test_is_popular(self, client):
+    def test_is_overwhelmed(self, client):
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         city = create_city_saint_andre()
         company = CompanyFactory(department="44", coords=city.coords, post_code="44117")
         job = JobDescriptionFactory(company=company)
         JobApplicationFactory.create_batch(19, to_company=company, selected_jobs=[job], state="new")
         response = client.get(self.URL, {"city": city.slug})
-        popular_badge = """
+        overwhelmed_badge = """
             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
                 <i class="ri-group-line me-1" aria-hidden="true"></i>
                 20+<span class="ms-1">candidatures</span>
             </span>
             """
-        assertNotContains(response, popular_badge, html=True)
+        assertNotContains(response, overwhelmed_badge, html=True)
 
         JobApplicationFactory(to_company=company, selected_jobs=[job], state="new")
         response = client.get(self.URL, {"city": city.slug})
-        assertContains(response, popular_badge, html=True)
+        assertContains(response, overwhelmed_badge, html=True)
 
     def test_no_department(self, client):
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))


### PR DESCRIPTION
https://www.notion.so/plateforme-inclusion/Le-badge-20-candidature-sur-les-r-sultats-de-recherche-ne-doit-pas-inclure-de-candidatures-archiv-e-177e8fa5c35b80e49344f093e58cf484

## :thinking: Pourquoi ?

Les candidatures archivées (trop anciennes) ne doivent pas être comptées pour l’affichage du badge 20+ candidatures car : 

- il risque de ne jamais disparaître car ces veille candidatures ne seront jamais traitées
- il ne reflète pas l’état actuel du recrutement
- trop nombreux donc perd son impact

## 🌈 Et un petit bonus technique en passant

- Je renomme `popular` en `overwhelmed` qui est plus pertinent car l'état en question est en fait indésirable.
