### PR TITLE
Retirer la classe non utilisée js-period-date-input

### DIFF
--- a/itou/www/employee_record_views/forms.py
+++ b/itou/www/employee_record_views/forms.py
@@ -121,7 +121,6 @@ class NewEmployeeRecordStep1Form(BirthPlaceAndCountryMixin, JobSeekerProfileFiel
             {
                 "min": DuetDatePickerWidget.min_birthdate(),
                 "max": DuetDatePickerWidget.max_birthdate(),
-                "class": "js-period-date-input",
             }
         )
 

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -165,7 +165,6 @@ class CreateOrUpdateJobSeekerStep1Form(
             {
                 "min": DuetDatePickerWidget.min_birthdate(),
                 "max": DuetDatePickerWidget.max_birthdate(),
-                "class": "js-period-date-input",
             }
         )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ratée dans c92937218b13e00946a1dc54fd8ee7f63dc2010d
