### PR TITLE
Création de compte candidat : une vue `Start` pour la recherche et la création de compte

### DIFF
--- a/itou/www/job_seekers_views/enums.py
+++ b/itou/www/job_seekers_views/enums.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class JobSeekerSessionKinds(StrEnum):
+    CHECK_NIR_JOB_SEEKER = "job-seeker-check-nir-job-seeker"
+    GET_OR_CREATE = "job-seeker-get-or-create"
+    UPDATE = "job-seeker-update"

--- a/itou/www/job_seekers_views/urls.py
+++ b/itou/www/job_seekers_views/urls.py
@@ -8,6 +8,11 @@ app_name = "job_seekers_views"
 urlpatterns = [
     path("details/<uuid:public_id>", views.JobSeekerDetailView.as_view(), name="details"),
     path("list", views.JobSeekerListView.as_view(), name="list"),
+    path(
+        "start",
+        views.GetOrCreateJobSeekerStartView.as_view(),
+        name="get_or_create_start",
+    ),
     # For sender
     path("<uuid:session_uuid>/sender/check-nir", views.CheckNIRForSenderView.as_view(), name="check_nir_for_sender"),
     path(

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -30,6 +30,7 @@ from itou.utils.session import SessionNamespace
 from itou.utils.urls import get_safe_url
 from itou.www.apply.views.submit_views import ApplicationBaseView
 
+from .enums import JobSeekerSessionKinds
 from .forms import (
     CheckJobSeekerInfoForm,
     CheckJobSeekerNirForm,
@@ -276,7 +277,7 @@ class JobSeekerForSenderBaseView(JobSeekerBaseView):
 
 class CheckNIRForJobSeekerView(JobSeekerBaseView):
     template_name = "job_seekers_views/step_check_job_seeker_nir.html"
-    EXPECTED_SESSION_KIND = "job-seeker-get-or-create-job-seeker"
+    EXPECTED_SESSION_KIND = JobSeekerSessionKinds.CHECK_NIR_JOB_SEEKER
 
     def __init__(self):
         super().__init__()
@@ -336,7 +337,7 @@ class CheckNIRForJobSeekerView(JobSeekerBaseView):
 
 class CheckNIRForSenderView(JobSeekerForSenderBaseView):
     template_name = "job_seekers_views/step_check_job_seeker_nir.html"
-    EXPECTED_SESSION_KIND = "job-seeker-get-or-create-sender"
+    EXPECTED_SESSION_KIND = JobSeekerSessionKinds.GET_OR_CREATE
 
     def __init__(self):
         super().__init__()
@@ -398,6 +399,7 @@ class CheckNIRForSenderView(JobSeekerForSenderBaseView):
 
 class SearchByEmailForSenderView(JobSeekerForSenderBaseView):
     template_name = "job_seekers_views/step_search_job_seeker_by_email.html"
+    EXPECTED_SESSION_KIND = JobSeekerSessionKinds.GET_OR_CREATE
 
     def __init__(self):
         super().__init__()
@@ -496,6 +498,7 @@ class SearchByEmailForSenderView(JobSeekerForSenderBaseView):
 
 class CreateJobSeekerForSenderBaseView(JobSeekerForSenderBaseView):
     required_session_namespaces = ["job_seeker_session"]
+    EXPECTED_SESSION_KIND = JobSeekerSessionKinds.GET_OR_CREATE
 
     def __init__(self):
         super().__init__()
@@ -785,7 +788,7 @@ class UpdateJobSeekerStartView(View):
         self.job_seeker_session = SessionNamespace.create_uuid_namespace(
             request.session,
             data={
-                "config": {"from_url": from_url, "session_kind": "job-seeker-update"},
+                "config": {"from_url": from_url, "session_kind": JobSeekerSessionKinds.UPDATE},
                 "job_seeker_pk": job_seeker.pk,
             },
         )
@@ -799,7 +802,7 @@ class UpdateJobSeekerStartView(View):
 
 
 class UpdateJobSeekerBaseView(JobSeekerBaseView):
-    EXPECTED_SESSION_KIND = "job-seeker-update"
+    EXPECTED_SESSION_KIND = JobSeekerSessionKinds.UPDATE
 
     def __init__(self):
         super().__init__()

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -16,6 +16,7 @@ from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.models import User
 from itou.utils.mocks.address_format import mock_get_geocoding_data_by_ban_api_resolved
 from itou.utils.models import InclusiveDateRange
+from itou.www.job_seekers_views.enums import JobSeekerSessionKinds
 from tests.cities.factories import create_city_geispolsheim, create_test_cities
 from tests.companies.factories import CompanyWithMembershipAndJobsFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
@@ -80,6 +81,7 @@ def test_create_job_seeker(_mock, client):
     expected_job_seeker_session = {
         "config": {
             "reset_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+            "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
         "apply": {"company_pk": singleton.pk},
         "profile": {
@@ -309,6 +311,7 @@ def test_existing_user_with_email(client):
     expected_job_seeker_session = {
         "config": {
             "reset_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+            "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
         "apply": {"company_pk": singleton.pk},
         "profile": {

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -16,6 +16,7 @@ from itou.users.enums import LackOfPoleEmploiId, UserKind
 from itou.users.models import User
 from itou.utils.mocks.address_format import mock_get_geocoding_data_by_ban_api_resolved
 from itou.utils.models import InclusiveDateRange
+from itou.utils.urls import add_url_params
 from itou.www.job_seekers_views.enums import JobSeekerSessionKinds
 from tests.cities.factories import create_city_geispolsheim, create_test_cities
 from tests.companies.factories import CompanyWithMembershipAndJobsFactory
@@ -54,6 +55,14 @@ def test_create_job_seeker(_mock, client):
     apply_start_url = reverse("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
 
     response = client.get(apply_start_url)
+    params = {
+        "tunnel": "gps",
+        "from_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+    }
+    next_url = add_url_params(reverse("job_seekers_views:get_or_create_start"), params)
+    assert response.url == next_url
+
+    response = client.get(next_url)
     [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
     next_url = (
         reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
@@ -80,7 +89,8 @@ def test_create_job_seeker(_mock, client):
 
     expected_job_seeker_session = {
         "config": {
-            "reset_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+            "tunnel": "gps",
+            "from_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
             "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
         "apply": {"company_pk": singleton.pk},
@@ -240,6 +250,14 @@ def test_gps_bypass(client):
     apply_start_url = reverse("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     response = client.get(apply_start_url)
 
+    params = {
+        "tunnel": "gps",
+        "from_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+    }
+    next_url = add_url_params(reverse("job_seekers_views:get_or_create_start"), params)
+    assert response.url == next_url
+
+    response = client.get(next_url)
     [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
     next_url = (
         reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
@@ -260,6 +278,14 @@ def test_gps_bypass(client):
     apply_start_url = reverse("apply:start", kwargs={"company_pk": singleton.pk}) + "?gps=true"
     response = client.get(apply_start_url)
 
+    params = {
+        "tunnel": "gps",
+        "from_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+    }
+    next_url = add_url_params(reverse("job_seekers_views:get_or_create_start"), params)
+    assert response.url == next_url
+
+    response = client.get(next_url)
     [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
     next_url = (
         reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
@@ -310,7 +336,8 @@ def test_existing_user_with_email(client):
     )
     expected_job_seeker_session = {
         "config": {
-            "reset_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+            "tunnel": "gps",
+            "from_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
             "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
         "apply": {"company_pk": singleton.pk},
@@ -414,6 +441,14 @@ def test_creation_by_user_kind(client, UserFactory, factory_args, expected_acces
         assert response.status_code == 403
 
     response = client.get(create_beneficiary_url)
+    params = {
+        "tunnel": "gps",
+        "from_url": reverse("companies_views:card", kwargs={"siae_id": singleton.pk}),
+    }
+    next_url = add_url_params(reverse("job_seekers_views:get_or_create_start"), params)
+    assert response.url == next_url
+
+    response = client.get(next_url)
     [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
     assert response.status_code == 302
     assert (

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -39,6 +39,7 @@ from itou.utils.models import InclusiveDateRange
 from itou.utils.session import SessionNamespace
 from itou.utils.urls import add_url_params
 from itou.utils.widgets import DuetDatePickerWidget
+from itou.www.job_seekers_views.enums import JobSeekerSessionKinds
 from tests.approvals.factories import PoleEmploiApprovalFactory
 from tests.asp.factories import CommuneFactory, CountryFranceFactory
 from tests.cities.factories import create_city_geispolsheim, create_city_in_zrr, create_test_cities
@@ -867,6 +868,7 @@ class TestApplyAsAuthorizedPrescriber:
         expected_job_seeker_session = {
             "config": {
                 "reset_url": reverse("companies_views:card", kwargs={"siae_id": company.pk}),
+                "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
             },
             "apply": {"company_pk": company.pk},
             "profile": {
@@ -1148,9 +1150,7 @@ class TestApplyAsAuthorizedPrescriber:
         assert response.status_code == 302
 
         expected_job_seeker_session = {
-            "config": {
-                "reset_url": reset_url_company,
-            },
+            "config": {"reset_url": reset_url_company, "session_kind": JobSeekerSessionKinds.GET_OR_CREATE},
             "apply": {"company_pk": company.pk},
             "user": {
                 "email": dummy_job_seeker.email,
@@ -1553,9 +1553,7 @@ class TestApplyAsPrescriber:
         assert response.url == next_url
 
         expected_job_seeker_session = {
-            "config": {
-                "reset_url": reset_url_company,
-            },
+            "config": {"reset_url": reset_url_company, "session_kind": JobSeekerSessionKinds.GET_OR_CREATE},
             "apply": {"company_pk": company.pk},
             "profile": {"nir": dummy_job_seeker.jobseeker_profile.nir},
         }
@@ -1842,6 +1840,7 @@ class TestApplyAsPrescriber:
         session[session_name] = {
             "config": {
                 "reset_url": reverse("companies_views:card", kwargs={"siae_id": company.pk}),
+                "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
             },
             "apply": {"company_pk": company.pk},
         }
@@ -1850,9 +1849,7 @@ class TestApplyAsPrescriber:
         response = client.get(
             reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"session_uuid": session_name})
         )
-        assertRedirects(
-            response, reverse("apply:start", kwargs={"company_pk": company.pk}), fetch_redirect_response=False
-        )
+        assert response.status_code == 404  # session_kind doesn't match
 
     def test_check_info_as_prescriber_for_job_seeker_with_incomplete_info(self, client):
         company = CompanyFactory(with_membership=True, with_jobs=True, romes=("N1101", "N1105"))
@@ -1950,6 +1947,7 @@ class TestApplyAsPrescriberNirExceptions:
         expected_job_seeker_session = {
             "config": {
                 "reset_url": reverse("companies_views:card", kwargs={"siae_id": company.pk}),
+                "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
             },
             "apply": {"company_pk": company.pk},
             "profile": {
@@ -2035,6 +2033,7 @@ class TestApplyAsPrescriberNirExceptions:
         expected_job_seeker_session = {
             "config": {
                 "reset_url": reverse("companies_views:card", kwargs={"siae_id": siae.pk}),
+                "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
             },
             "apply": {"company_pk": siae.pk},
             "profile": {
@@ -2147,7 +2146,7 @@ class TestApplyAsCompany:
             kwargs={"session_uuid": job_seeker_session_name},
         )
         expected_job_seeker_session = {
-            "config": {"reset_url": reset_url},
+            "config": {"reset_url": reset_url, "session_kind": JobSeekerSessionKinds.GET_OR_CREATE},
             "apply": {"company_pk": company.pk},
             "profile": {
                 "nir": dummy_job_seeker.jobseeker_profile.nir,
@@ -2617,7 +2616,7 @@ class TestDirectHireFullProcess:
         assert response.status_code == 302
 
         expected_job_seeker_session = {
-            "config": {"reset_url": reset_url_dashboard},
+            "config": {"reset_url": reset_url_dashboard, "session_kind": JobSeekerSessionKinds.GET_OR_CREATE},
             "apply": {"company_pk": company.pk},
             "profile": {
                 "nir": dummy_job_seeker.jobseeker_profile.nir,
@@ -4159,6 +4158,7 @@ def test_detect_existing_job_seeker(client):
     expected_job_seeker_session = {
         "config": {
             "reset_url": reverse("companies_views:card", kwargs={"siae_id": company.pk}),
+            "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
         "apply": {"company_pk": company.pk},
         "profile": {
@@ -4849,6 +4849,7 @@ class TestFindJobSeekerForHireView:
         expected_job_seeker_session = {
             "config": {
                 "reset_url": reverse("dashboard:index"),  # Hire: reset_url = dashboard
+                "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
             },
             "apply": {"company_pk": self.company.pk},
             "user": {


### PR DESCRIPTION
## :thinking: Pourquoi ?
Dans l'optique de [Créer un compte candidat depuis l'espace Mes candidats](https://www.notion.so/plateforme-inclusion/5-5-En-tant-qu-utilisateur-je-peux-cr-er-un-compte-candidat-depuis-l-espace-Mes-candidats-3d44374d80444fcb92761d8336752d6a), on [Extrait la création de compte candidat du parcours de candidature](https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7).

Précédemment, dans la série, nous avons introduit une vue `start` pour les vues `Update*` (#5177), qui permet d'initialiser la session du bloc et de renvoyer à la vue désirée.
Cette PR est dédiée à la réalisation du même travail poru les vues relatives à la recherche et la création de compte candidat. On utilise une nouvelle vue `Start` pour initialiser la session avant d'entrer dans le bloc par la vue `CheckNIRForSenderView`, qui est la première étape du processus.

La vue `CheckNIRForJobSeekerView`, qui n'est utilisée par le candidat que pour insérer son NIR, est laissée en l'état.

Concernant GPS, les premières briques sont posées pour déconnecter la création de bénéficiaire de l'application `apply`.

--- 

Les autres étapes : https://www.notion.so/plateforme-inclusion/Extraire-le-parcours-de-cr-ation-de-compte-candidat-130e8fa5c35b80b9947cea2573cf90e7?pvs=4#130e8fa5c35b800b966fdd4722014657


