### PR TITLE
UX/UI: Amélioration du message affiché avant de retirer un collaborateur [GEN-1823]

### DIFF
--- a/itou/templates/includes/deactivate_member.html
+++ b/itou/templates/includes/deactivate_member.html
@@ -1,23 +1,34 @@
 {% load buttons_form %}
 
 <div class="content-small">
-    <h1>Retrait d'un collaborateur</h1>
-    <div class="mt-4 alert alert-warning">
-        Vous allez retirer <b>{{ target_member.get_full_name }}</b>
-        de votre organisation <b>({{ structure.display_name }})</b>.
-    </div>
+    {% with request.user.is_employer|yesno:"structure,organisation" as org_display %}
+        <h1>Retrait d'un collaborateur</h1>
+        <p>
+            Êtes-vous sûr de vouloir retirer <b>{{ target_member.get_full_name }}</b> de votre {{ org_display }} <b>{{ structure.display_name }}</b> ?
+        </p>
 
-    <ul>
-        <li>Le tableau de bord de votre structure ne lui sera plus accessible.</li>
-        <li>Les modifications et ajouts réalisés sont toujours accessibles par les autres membres de votre organisation.</li>
-        <li>Cet utilisateur sera notifié par e-mail de son retrait de votre organisation.</li>
-        <li>En cas d'erreur, vous pourrez toujours lui renvoyer une invitation pour rejoindre votre organisation.</li>
-        {% if current_user.is_employer or current_user.is_prescriber %}
+        <p class="mb-0">Une fois retiré :</p>
+        <ul>
+            <li>Cet utilisateur sera notifié par e-mail de son retrait de votre {{ org_display }}.</li>
+            <li>Le tableau de bord de votre {{ org_display }} ne lui sera plus accessible.</li>
+            {% if request.user.is_prescriber %}
+                <li>Les candidatures effectuées par cet utilisateur resteront dans le tableau de bord de votre {{ org_display }}.</li>
+            {% else %}
+                <li>
+                    Les modifications et ajouts réalisés par cet utilisateur seront toujours accessibles par les autres membres de votre {{ org_display }}.
+                </li>
+            {% endif %}
+            {% if request.user.is_prescriber %}
+                <li>Cet utilisateur sera notifié par mail des éventuelles suites données aux candidatures qu'il a transmises.</li>
+            {% else %}
+                <li>Cet utilisateur continuera de recevoir ses notifications e-mail.</li>
+            {% endif %}
             <li>
-                Toutes les candidatures effectuées par ce collaborateur resteront dans le tableau de bord de l'organisation. Ce collaborateur sera notifié par mail des éventuelles suites données aux candidatures qu'il a transmises.
+                Toutes les notifications emails envoyées à cet utilisateur seront également envoyées aux administrateurs de votre {{ org_display }}.
             </li>
-        {% endif %}
-    </ul>
+        </ul>
+        <p>En cas d'erreur, vous pourrez toujours lui renvoyer une invitation pour rejoindre votre {{ org_display }}.</p>
+    {% endwith %}
 
     <form action="{% url base_url|add:":deactivate_member" target_member.pk %}" method="post">
         {% url base_url|add:":members" as reset_url %}

--- a/itou/templates/includes/update_admin.html
+++ b/itou/templates/includes/update_admin.html
@@ -1,33 +1,35 @@
 {% load buttons_form %}
 
 <div class="content-small">
-    {% if action == "remove" %}
-        <h1>Retrait des droits d'administrateur</h1>
-        <h2 class="text-muted">{{ structure.display_name }}</h2>
-        <div class="mt-4 alert alert-warning">
-            Vous allez retirer les droits d'administrateur de votre structure à <b>{{ target_member.get_full_name }}</b>
-        </div>
-    {% else %}
-        <h1>Ajout des droits d'administrateur</h1>
-        <h2 class="text-muted">{{ structure.display_name }}</h2>
-        <div class="mt-4 alert alert-warning">
-            Vous allez ajouter les droits d'administrateur de votre structure à <b>{{ target_member.get_full_name }}</b>
-        </div>
-    {% endif %}
-
-    <ul>
-        <li>Le role d'administrateur permet d'ajouter ou de retirer des utilisateurs de votre structure.</li>
-        <li>Il permet également d'ajouter ou de retirer de nouveaux administrateurs.</li>
-        <li>Cet utilisateur sera notifié par e-mail de la modification de son rôle.</li>
-    </ul>
-
-    <form action="{% url base_url|add:":update_admin_role" action target_member.pk %}" method="post">
-        {% url base_url|add:":members" as reset_url %}
-        {% csrf_token %}
+    {% with request.user.is_employer|yesno:"structure,organisation" as org_display %}
         {% if action == "remove" %}
-            {% itou_buttons_form primary_label="Retirer les droits administrateur" reset_url=reset_url %}
+            <h1>Retrait des droits d'administrateur</h1>
+            <h2 class="text-muted">{{ structure.display_name }}</h2>
+            <div class="mt-4 alert alert-warning">
+                Vous allez retirer les droits d'administrateur de votre {{ org_display }} à <b>{{ target_member.get_full_name }}</b>
+            </div>
         {% else %}
-            {% itou_buttons_form primary_label="Ajouter les droits administrateur" reset_url=reset_url %}
+            <h1>Ajout des droits d'administrateur</h1>
+            <h2 class="text-muted">{{ structure.display_name }}</h2>
+            <div class="mt-4 alert alert-warning">
+                Vous allez ajouter les droits d'administrateur de votre {{ org_display }} à <b>{{ target_member.get_full_name }}</b>
+            </div>
         {% endif %}
-    </form>
+
+        <ul>
+            <li>Le role d'administrateur permet d'ajouter ou de retirer des utilisateurs de votre {{ org_display }}.</li>
+            <li>Il permet également d'ajouter ou de retirer de nouveaux administrateurs.</li>
+            <li>Cet utilisateur sera notifié par e-mail de la modification de son rôle.</li>
+        </ul>
+
+        <form action="{% url base_url|add:":update_admin_role" action target_member.pk %}" method="post">
+            {% url base_url|add:":members" as reset_url %}
+            {% csrf_token %}
+            {% if action == "remove" %}
+                {% itou_buttons_form primary_label="Retirer les droits administrateur" reset_url=reset_url %}
+            {% else %}
+                {% itou_buttons_form primary_label="Ajouter les droits administrateur" reset_url=reset_url %}
+            {% endif %}
+        </form>
+    {% endwith %}
 </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Je n'ai pas ajouté de test sur le wording pour le moment, je ne sais pas si c'est très utile, à part pour s'assurer que le bon message s'affiche pour les prescripteurs.
Un avis ?

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
