### PR TITLE
Candidature: Corriger le bouton "Retour" de la modale d'acceptation de candidature [GEN-2376]

### DIFF
--- a/itou/templates/apply/includes/accept_section.html
+++ b/itou/templates/apply/includes/accept_section.html
@@ -14,23 +14,25 @@
                 </p>
                 {% include "companies/includes/_company_info.html" with company=company show_cta=True extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
             </div>
-            <div class="modal-footer has-btn-with-spinner-loading-text"
-                 hx-post="{{ request.path }}"
-                 hx-target="#acceptFormDiv"
-                 hx-swap="outerHTML"
-                 hx-vals='{"confirmed": "True"}'
-                 hx-include="#acceptForm"
-                 {% matomo_event "candidature" "submit" "accept_application_confirmation" %}>
-                <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
-                <button class="btn btn-sm btn-primary">
-                    <div class="stable-text">
-                        <span>Confirmer</span>
-                    </div>
-                    <div class="loading-text">
-                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                        <span>Envoi en cours</span>
-                    </div>
-                </button>
+            <div class="modal-footer">
+                <form class="has-btn-with-spinner-loading-text"
+                      hx-post="{{ request.path }}"
+                      hx-target="#acceptFormDiv"
+                      hx-swap="outerHTML"
+                      hx-vals='{"confirmed": "True"}'
+                      hx-include="#acceptForm"
+                      {% matomo_event "candidature" "submit" "accept_application_confirmation" %}>
+                    <button type="button" class="btn btn-sm btn-outline-primary" data-bs-dismiss="modal">Retour</button>
+                    <button class="btn btn-sm btn-primary">
+                        <div class="stable-text">
+                            <span>Confirmer</span>
+                        </div>
+                        <div class="loading-text">
+                            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                            <span>Envoi en cours</span>
+                        </div>
+                    </button>
+                </form>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Bon, par contre, pour le tester, je me demande si je parse le html pour m'assurer que les éléments parents du bouton n'ont pas d'attribut hx-post, ou si je mets juste une snapshot (qui ne vérifie pas grand chose mais aura au moins le mérite de nous faire remarquer qu'un truc change.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
