### PR TITLE
Pilotage: Ajouter un bandeau sur les tableaux de bord en sursis

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -41,6 +41,24 @@
             </div>
         </div>
     {% endfor %}
+    {% if tally_suspension_form %}
+        <div class="alert alert-info alert-dismissible fade show" role="status">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-2">
+                        <strong>Ce tableau de bord pourrait disparaître : qu’en pensez-vous ?</strong>
+                    </p>
+                    <p class="mb-0">
+                        L’équipe de pilotage de l’inclusion fait le bilan sur l’utilisation des tableaux de bord qui vous sont proposés. Le tableau de bord que vous consultez enregistre peu de connexions de la part nos utilisateurs. En conséquence, nous envisageons de suspendre la mise à disposition de ce tableau de bord à partir d’avril 2025. Si ce tableau de bord vous est utile dans le cadre de vos missions, nous vous invitons à nous le signaler en cliquant <a href="{{ tally_suspension_form }}" target="_blank" rel="noopener">ici</a> !
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -304,6 +304,9 @@ METABASE_DASHBOARDS = {
 }
 
 
+SUSPENDED_DASHBOARD_IDS = [357, 389, 162, 298, 168]
+
+
 # Metabase private / signed URLs
 # See:
 # * https://www.metabase.com/docs/latest/enterprise-guide/full-app-embedding.html

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -111,11 +111,15 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
         params = {}
     view_name = mb.get_view_name(request)
     metabase_dashboard = mb.METABASE_DASHBOARDS.get(view_name)
+    dashboard_id = metabase_dashboard["dashboard_id"]
     tally_popup_form_id = None
     tally_embed_form_id = None
     if settings.TALLY_URL and metabase_dashboard:
         tally_popup_form_id = metabase_dashboard.get("tally_popup_form_id")
         tally_embed_form_id = metabase_dashboard.get("tally_embed_form_id")
+    tally_suspension_form = (
+        f"https://tally.so/r/wkOxRR?URLTB={dashboard_id}" if dashboard_id in mb.SUSPENDED_DASHBOARD_IDS else None
+    )
 
     base_context = {
         "back_url": None,
@@ -126,6 +130,7 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
         "tally_popup_form_id": tally_popup_form_id,
         "tally_embed_form_id": tally_embed_form_id,
         "PILOTAGE_HELP_CENTER_URL": global_constants.PILOTAGE_HELP_CENTER_URL,
+        "tally_suspension_form": tally_suspension_form,
     }
 
     # Key value pairs in context override preexisting pairs in base_context.


### PR DESCRIPTION
## :thinking: Pourquoi ?

Nous souhaitons ajouter un bandeau pour informer nos utilisateurs qu'un tableau de bord est en sursis avec un lien tally pour leur demander leur avis.

https://www.notion.so/gip-inclusion/Ajouter-un-bandeau-sur-les-TB-en-sursis-1765f321b60480919dbece1c355ebf34

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :computer: Captures d'écran

<img width="1296" alt="Screenshot 2025-01-15 at 15 09 39" src="https://github.com/user-attachments/assets/ecefc1e8-5f0a-4fe2-948d-5bb394c46376" />
