### PR TITLE
Permettre l'autoconnection à proconnect sur les liens vers la communauté (DSP) [GEN-2389]

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -635,7 +635,7 @@ CSP_FRAME_SRC = [
     "https://tally.so",
     "https://stats.inclusion.beta.gouv.fr",
     "https://pilotage.inclusion.beta.gouv.fr",
-    "https://communaute.inclusion.beta.gouv.fr",
+    "https://communaute.inclusion.gouv.fr",
     "https://inclusion.beta.gouv.fr",
     "blob:",  # For downloading Metabase questions as CSV/XSLX/JSON on Firefox etc
     "data:",  # For downloading Metabase questions as PNG on Firefox etc

--- a/itou/templates/apply/includes/eligibility_section.html
+++ b/itou/templates/apply/includes/eligibility_section.html
@@ -1,3 +1,4 @@
+{% load url_add_query %}
 {# This template is shown only to SIAEs (*auto-prescription*). #}
 <div class="c-box mb-4">
     <h2 class="h1">Valider l'éligibilité IAE</h2>
@@ -6,7 +7,7 @@
 
     <ol>
         <li>
-            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
+            Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{% autologin_proconnect 'https://communaute.inclusion.gouv.fr/surveys/dsp/create/' user %}" target="_blank" rel="noreferrer noopener">document diagnostic socio-professionnel de référence</a>)
         </li>
         <li>
             Sélectionner le ou les critères administratifs

--- a/itou/templates/apply/submit/application/eligibility.html
+++ b/itou/templates/apply/submit/application/eligibility.html
@@ -1,5 +1,6 @@
 {% extends "apply/submit/application/base.html" %}
 {% load django_bootstrap5 %}
+{% load url_add_query %}
 
 
 {% block progress_title %}{{ block.super }} - Éligibilité IAE{% endblock %}
@@ -55,7 +56,7 @@
                                     Veuillez vous assurer d’avoir réalisé un diagnostic socio-professionnel dans le cadre d'un entretien individuel.
                                     Vous pouvez vous appuyer sur le document
                                     <a class="text-important"
-                                       href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
+                                       href="{% autologin_proconnect 'https://communaute.inclusion.gouv.fr/surveys/dsp/create/' user %}"
                                        target="_blank"
                                        rel="noreferrer noopener"
                                        aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.

--- a/itou/templates/apply/submit/application/resume.html
+++ b/itou/templates/apply/submit/application/resume.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load matomo %}
 {% load buttons_form %}
+{% load url_add_query %}
 
 {% block progress_title %}{{ block.super }} - Message & CV{% endblock %}
 {% block step_title %}Finaliser la candidature{% endblock %}
@@ -136,7 +137,7 @@
                     <p class="mb-0">
                         Vous pouvez vous appuyer sur le document
                         <a class="has-external-link"
-                           href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
+                           href="{% autologin_proconnect 'https://communaute.inclusion.gouv.fr/surveys/dsp/create/' user %}"
                            target="_blank"
                            rel="noreferrer noopener"
                            aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.
@@ -161,7 +162,7 @@
                     <p class="mb-0">
                         Vous pouvez vous appuyer sur le document
                         <a class="has-external-link"
-                           href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
+                           href="{% autologin_proconnect 'https://communaute.inclusion.gouv.fr/surveys/dsp/create/' user %}"
                            target="_blank"
                            rel="noreferrer noopener"
                            aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel de référence</a>.

--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -1,3 +1,4 @@
+{% load url_add_query %}
 <div class="col mb-3 mb-md-5">
     <div class="c-box p-0 h-100">
         <div class="d-flex p-3 p-lg-4">
@@ -47,7 +48,7 @@
                 <hr class="mb-3">
                 <p class="fs-sm mb-lg-5">
                     <i class="ri-award-line ri-lg fw-normal me-1" aria-hidden="true"></i>
-                    {{ request.current_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="https://communaute.inclusion.beta.gouv.fr/surveys/dsp/create/"
+                    {{ request.current_organization.display_name }} est une organisation habilitée. Vous pouvez réaliser le <a href="{% autologin_proconnect 'https://communaute.inclusion.gouv.fr/surveys/dsp/create/' user %}"
     target="_blank"
     class="has-external-link"
     aria-label="Diagnostic socio-professionnel des candidats (ouverture dans un nouvel onglet)">diagnostic socio-professionnel</a> des candidats que vous accompagnez.

--- a/itou/templates/search/siaes_search_home.html
+++ b/itou/templates/search/siaes_search_home.html
@@ -73,7 +73,7 @@
                             <img src="{% static_theme_images "logo-communaute-inclusion.svg" %}" loading="lazy" height="80" alt="">
                         </div>
                         <div>
-                            <a href="https://communaute.inclusion.beta.gouv.fr" class="btn btn-outline-primary has-external-link" target="_blank">Découvrir</a>
+                            <a href="https://communaute.inclusion.gouv.fr" class="btn btn-outline-primary has-external-link" target="_blank">Découvrir</a>
                         </div>
                     </div>
                 </div>

--- a/itou/utils/templatetags/url_add_query.py
+++ b/itou/utils/templatetags/url_add_query.py
@@ -7,6 +7,8 @@ from urllib.parse import urlsplit, urlunsplit
 from django import template
 from django.http import QueryDict
 
+from itou.users.enums import IdentityProvider
+
 
 register = template.Library()
 
@@ -31,3 +33,10 @@ def url_add_query(url, **kwargs):
             querystring.pop(item)
     querystring.update(cleaned_kwargs)
     return urlunsplit(parsed._replace(query=querystring.urlencode("/")))
+
+
+@register.simple_tag
+def autologin_proconnect(url, user):
+    if user.is_authenticated and user.identity_provider == IdentityProvider.PRO_CONNECT:
+        return url_add_query(url, proconnect_login="true")
+    return url

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -42,7 +42,7 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company, CompanyMembership
 from itou.job_applications.enums import JobApplicationState
 from itou.prescribers.enums import PrescriberOrganizationKind
-from itou.users.enums import UserKind
+from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants, pagination
 from itou.utils.emails import redact_email_address
@@ -673,6 +673,21 @@ class TestUtilsTemplateTags:
         expected = "/company/10/card"
         assert out_empty == expected
         assert out_none == expected
+
+    @pytest.mark.parametrize(
+        "user,expected_query_params",
+        [
+            (lambda: JobSeekerFactory(identity_provider=IdentityProvider.FRANCE_CONNECT), ""),
+            (
+                lambda: PrescriberFactory(identity_provider=IdentityProvider.PRO_CONNECT),
+                "?proconnect_login=true",
+            ),
+        ],
+    )
+    def test_autologin_proconnect(self, db, user, expected_query_params):
+        template = Template("{% load url_add_query %}{% autologin_proconnect url user %}")
+        out = template.render(Context({"url": "/test/", "user": user()}))
+        assert out == f"/test/{expected_query_params}"
 
     def test_redirection_url(self):
         base_url = reverse("dashboard:index")


### PR DESCRIPTION
## :thinking: Pourquoi ?

> Le site des emplois redirige vers le Diagnostique Parcours IAE de la communaute. Ce diagnostique necessite l'authentification de l'utilisateur. Nous pensons que les utilisateurs `pro_connect` lors du changement de site, pourraient ne pas être motivés à se reconnecter. Nous testons la mise en place de l'autoconnection sur ce lien des emplois vers la commu.

lien avec [l'issue communaute #846](https://github.com/gip-inclusion/itou-communaute-django/issues/846)

changelog : connexion

## :cake: Comment ? <!-- optionnel -->

> ajout d'un tag `autologin_proconnect`

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

>  se connecter avec un utilisateur `ProConnect`

