### PR TITLE
Gabarit des PR : ajout d'une mention pour vérifier si l'étiquette Bug est nécessaire

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,21 @@
 
 > _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._
 
+## :cake: Comment ? <!-- optionnel -->
+
+> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._
+
+## :rotating_light: À vérifier
+
+- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
+- [ ] Ajouter l'étiquette « Bug » ?
+
+## :desert_island: Comment tester ?
+
+> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._
+
+## :computer: Captures d'écran <!-- optionnel -->
+
 <!--
 # Catégories changelog
 
@@ -24,18 +39,3 @@
  +--------------------------|--------------------------+
 
 -->
-
-## :cake: Comment ? <!-- optionnel -->
-
-> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._
-
-## :rotating_light: À vérifier
-
-- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
-- [ ] Ajouter l'étiquette « Bug » ?
-
-## :desert_island: Comment tester
-
-> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._
-
-## :computer: Captures d'écran <!-- optionnel -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,7 @@
 ## :rotating_light: À vérifier
 
 - [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
+- [ ] Ajouter l'étiquette « Bug » ?
 
 ## :desert_island: Comment tester
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour mieux mesurer le nombre de PR résolvant un bogue.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
