### PR TITLE
Connexion: Rediriger les utilisateurs d'InclusionConnect vers ProConnect

### DIFF
--- a/itou/templates/account/login_existing_user.html
+++ b/itou/templates/account/login_existing_user.html
@@ -16,7 +16,14 @@
                 <div class="s-section__col col-12 col-lg-6">
                     <div class="c-form mb-5">
                         {% if login_provider == "IC" %}
-                            {% include "account/includes/login_inclusion_connect.html" %}
+                            {% if pro_connect_url %}
+                                <div class="alert alert-important">
+                                    <p class="mb-0">Inclusion Connect devient ProConnect</p>
+                                </div>
+                                {% include "account/includes/login_pro_connect.html" %}
+                            {% else %}
+                                {% include "account/includes/login_inclusion_connect.html" %}
+                            {% endif %}
                         {% elif login_provider == "PC" %}
                             {% include "account/includes/login_pro_connect.html" %}
                         {% elif login_provider == "FC" %}

--- a/tests/www/login/__snapshots__/tests.ambr
+++ b/tests/www/login/__snapshots__/tests.ambr
@@ -101,20 +101,26 @@
   <div class="c-form mb-5">
                           
                               
+                                  <div class="alert alert-important">
+                                      <p class="mb-0">Inclusion Connect devient ProConnect</p>
+                                  </div>
+                                  
   
   
   
   
       <div class="text-center">
-          <a class="btn-inclusion-connect" data-matomo-action="clic" data-matomo-category="connexion prescripteur" data-matomo-event="true" data-matomo-option="se-connecter-avec-inclusion-connect" href="/inclusion_connect/authorize?user_kind=prescriber&amp;previous_url=%2Flogin%2Fexisting%2Fc0fee70e-cf34-4d37-919d-a1ae3e3bf7e5%3Fback_url%3D%2Fsignup%2F">
-              <picture>
-                  <source height="14" media="(min-width: 30em)" srcset="/static/vendor/theme-inclusion/images/logo-inclusion-connect-one-line.svg" type="image/svg+xml" width="286"/>
-                  <img alt="Se connecter avec Inclusion Connect" height="37" src="/static/vendor/theme-inclusion/images/logo-inclusion-connect-two-lines.svg" width="142"/>
-              </picture>
+          <a class="proconnect-button" data-matomo-action="clic" data-matomo-category="connexion prescripteur" data-matomo-event="true" data-matomo-option="se-connecter-avec-pro-connect" href="/pro_connect/authorize?user_kind=prescriber&amp;previous_url=%2Flogin%2Fexisting%2Fc0fee70e-cf34-4d37-919d-a1ae3e3bf7e5%3Fback_url%3D%2Fsignup%2F">
           </a>
+          <p>
+              <a href="https://proconnect.gouv.fr/" rel="noopener noreferrer" target="_blank" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
+                  Qu’est-ce que ProConnect ?
+              </a>
+          </p>
       </div>
   
   
+                              
                           
                       </div>
   '''
@@ -184,6 +190,7 @@
   <div class="c-form mb-5">
                           
                               
+                                  
   
   
   
@@ -198,6 +205,7 @@
       </div>
   
   
+                              
                           
                       </div>
   '''


### PR DESCRIPTION
## :thinking: Pourquoi ?

InclusionConnect a été remplacé par ProConnect dans `login_generic.html`, mais `ExistingUserLogin` présente nos utilisateurs avec la mode de connexion active sur leur compte.

ExistingUserLogin est utilisé quand il y a un conflit des e-mails pendant une connexion avec un SSO, et dans le parcours de connexion candidat.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

* Se connecter avec un candidat où `identity_provider == "IC"`

## :computer: Captures d'écran

<img width="719" alt="Screenshot 2025-01-16 at 12 35 30" src="https://github.com/user-attachments/assets/61e0db5e-b1a3-4b9b-a1e5-adf30829f29a" />

<img width="765" alt="Screenshot 2025-01-16 at 12 35 16" src="https://github.com/user-attachments/assets/4352052c-e4e2-49a1-b0a8-5791784f185e" />
