### PR TITLE
GPS: utiliser le `tunnel` de la session et non un paramètre dans l'URL

### DIFF
--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -221,10 +221,7 @@ class GetOrCreateJobSeekerStartView(View):
         elif self.tunnel == "hire":
             view_name = "job_seekers_views:check_nir_for_hire"
 
-        return HttpResponseRedirect(
-            reverse(view_name, kwargs={"session_uuid": self.job_seeker_session.name})
-            + ("?gps=true" if self.tunnel == "gps" else "")
-        )
+        return HttpResponseRedirect(reverse(view_name, kwargs={"session_uuid": self.job_seeker_session.name}))
 
 
 class JobSeekerBaseView(TemplateView):
@@ -248,7 +245,7 @@ class JobSeekerBaseView(TemplateView):
             session_kind := self.job_seeker_session.get("config").get("session_kind")
         ) and session_kind != self.EXPECTED_SESSION_KIND:
             raise Http404
-        self.is_gps = "gps" in request.GET and request.GET["gps"] == "true"
+        self.is_gps = self.job_seeker_session.get("config", {}).get("tunnel") == "gps"
         if company_pk := self.job_seeker_session.get("apply", {}).get("company_pk"):
             self.company = (
                 get_object_or_404(Company.objects.with_has_active_members(), pk=company_pk)
@@ -395,7 +392,7 @@ class CheckNIRForSenderView(JobSeekerForSenderBaseView):
             if self.hire_process
             else "job_seekers_views:search_by_email_for_sender"
         )
-        return reverse(view_name, kwargs={"session_uuid": session_uuid}) + ("?gps=true" if self.is_gps else "")
+        return reverse(view_name, kwargs={"session_uuid": session_uuid})
 
     def post(self, request, *args, **kwargs):
         context = {}
@@ -476,10 +473,7 @@ class SearchByEmailForSenderView(JobSeekerForSenderBaseView):
                     else "job_seekers_views:create_job_seeker_step_1_for_sender"
                 )
 
-                return HttpResponseRedirect(
-                    reverse(view_name, kwargs={"session_uuid": self.job_seeker_session.name})
-                    + ("?gps=true" if self.is_gps else "")
-                )
+                return HttpResponseRedirect(reverse(view_name, kwargs={"session_uuid": self.job_seeker_session.name}))
 
             # Ask the sender to confirm the email we found is associated to the correct user
             if self.form.data.get("preview"):
@@ -551,14 +545,14 @@ class CreateJobSeekerForSenderBaseView(JobSeekerForSenderBaseView):
         return reverse(
             view_name,
             kwargs={"session_uuid": self.job_seeker_session.name},
-        ) + ("?gps=true" if self.is_gps else "")
+        )
 
     def get_next_url(self):
         view_name = self.next_hire_url if self.hire_process else self.next_apply_url
         return reverse(
             view_name,
             kwargs={"session_uuid": self.job_seeker_session.name},
-        ) + ("?gps=true" if self.is_gps else "")
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -6,7 +6,6 @@ from django.urls import resolve, reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects, assertTemplateNotUsed
 
 from itou.asp.models import Commune, Country, RSAAllocation
-from itou.companies import enums as companies_enums
 from itou.companies.enums import POLE_EMPLOI_SIRET
 from itou.companies.models import Company
 from itou.users.enums import LackOfPoleEmploiId, UserKind
@@ -32,7 +31,6 @@ from tests.utils.test import KNOWN_SESSION_KEYS
 )
 def test_create_job_seeker(_mock, client):
     [city] = create_test_cities(["67"], num_per_department=1)
-    singleton = Company.unfiltered_objects.get(siret=companies_enums.POLE_EMPLOI_SIRET)
 
     prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
     user = prescriber_organization.members.first()
@@ -78,7 +76,6 @@ def test_create_job_seeker(_mock, client):
             "from_url": reverse("gps:my_groups"),
             "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
-        "apply": {"company_pk": singleton.pk},
         "profile": {
             "nir": dummy_job_seeker.jobseeker_profile.nir,
         },
@@ -226,7 +223,6 @@ def test_existing_user_with_email(client):
     """
     A user with the same email already exists, create the group with this user
     """
-    singleton = Company.unfiltered_objects.get(siret=companies_enums.POLE_EMPLOI_SIRET)
     # Only authorized prescribers can add a NIR.
     # See User.can_add_nir
     prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
@@ -264,7 +260,6 @@ def test_existing_user_with_email(client):
             "from_url": reverse("gps:my_groups"),
             "session_kind": JobSeekerSessionKinds.GET_OR_CREATE,
         },
-        "apply": {"company_pk": singleton.pk},
         "profile": {
             "nir": nir,
         },

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -62,6 +62,7 @@ def test_create_job_seeker(_mock, client):
     assertNotContains(response, france_travail.display_name)
     assertNotContains(response, france_travail.siret)
     assertNotContains(response, france_travail.kind)
+    assertContains(response, "<h1>Enregistrer un nouveau bénéficiaire</h1>", html=True)
 
     response = client.post(next_url, data={"nir": dummy_job_seeker.jobseeker_profile.nir, "confirm": 1})
 
@@ -87,6 +88,9 @@ def test_create_job_seeker(_mock, client):
 
     # Step get job seeker e-mail.
     # ----------------------------------------------------------------------
+
+    response = client.get(next_url)
+    assertContains(response, "<h1>Enregistrer un nouveau bénéficiaire</h1>", html=True)
 
     response = client.post(next_url, data={"email": dummy_job_seeker.email, "confirm": "1"})
 
@@ -119,6 +123,7 @@ def test_create_job_seeker(_mock, client):
             kwargs={"session_uuid": job_seeker_session_name},
         ),
     )
+    assertContains(response, "<h1>Création du compte bénéficiaire</h1>", html=True)
 
     geispolsheim = create_city_geispolsheim()
     birthdate = dummy_job_seeker.jobseeker_profile.birthdate
@@ -147,6 +152,9 @@ def test_create_job_seeker(_mock, client):
     )
     assertRedirects(response, next_url)
 
+    response = client.get(next_url)
+    assertContains(response, "<h1>Création du compte bénéficiaire</h1>", html=True)
+
     post_data = {
         "ban_api_resolved_address": dummy_job_seeker.geocoding_address,
         "address_line_1": dummy_job_seeker.address_line_1,
@@ -167,6 +175,9 @@ def test_create_job_seeker(_mock, client):
         kwargs={"session_uuid": job_seeker_session_name},
     )
     assertRedirects(response, next_url)
+
+    response = client.get(next_url)
+    assertContains(response, "<h1>Création du compte bénéficiaire</h1>", html=True)
 
     post_data = {
         "education_level": dummy_job_seeker.jobseeker_profile.education_level,
@@ -200,6 +211,7 @@ def test_create_job_seeker(_mock, client):
     assertRedirects(response, next_url)
 
     response = client.get(next_url)
+    assertContains(response, '<h1 class="my-5">Création du bénéficiaire</h1>', html=True)
     assertContains(response, "Créer et suivre le bénéficiaire")
 
     response = client.post(next_url)

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -54,10 +54,7 @@ def test_create_job_seeker(_mock, client):
 
     response = client.get(create_beneficiary_url)
     [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
-    next_url = (
-        reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
-        + "?gps=true"
-    )
+    next_url = reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
     assertRedirects(response, next_url)
     response = client.get(next_url)
     france_travail = Company.unfiltered_objects.get(siret=POLE_EMPLOI_SIRET)
@@ -68,13 +65,10 @@ def test_create_job_seeker(_mock, client):
 
     response = client.post(next_url, data={"nir": dummy_job_seeker.jobseeker_profile.nir, "confirm": 1})
 
-    job_seeker_session_name = str(resolve(response.url.replace("?gps=true", "")).kwargs["session_uuid"])
-    next_url = (
-        reverse(
-            "job_seekers_views:search_by_email_for_sender",
-            kwargs={"session_uuid": job_seeker_session_name},
-        )
-        + "?gps=true"
+    job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
+    next_url = reverse(
+        "job_seekers_views:search_by_email_for_sender",
+        kwargs={"session_uuid": job_seeker_session_name},
     )
 
     expected_job_seeker_session = {
@@ -96,19 +90,16 @@ def test_create_job_seeker(_mock, client):
 
     response = client.post(next_url, data={"email": dummy_job_seeker.email, "confirm": "1"})
 
-    job_seeker_session_name = str(resolve(response.url.replace("?gps=true", "")).kwargs["session_uuid"])
+    job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
 
     expected_job_seeker_session |= {
         "user": {
             "email": dummy_job_seeker.email,
         },
     }
-    next_url = (
-        reverse(
-            "job_seekers_views:create_job_seeker_step_1_for_sender",
-            kwargs={"session_uuid": job_seeker_session_name},
-        )
-        + "?gps=true"
+    next_url = reverse(
+        "job_seekers_views:create_job_seeker_step_1_for_sender",
+        kwargs={"session_uuid": job_seeker_session_name},
     )
 
     assertRedirects(response, next_url)
@@ -150,12 +141,9 @@ def test_create_job_seeker(_mock, client):
     expected_job_seeker_session["user"] |= post_data
     assert client.session[job_seeker_session_name] == expected_job_seeker_session
 
-    next_url = (
-        reverse(
-            "job_seekers_views:create_job_seeker_step_2_for_sender",
-            kwargs={"session_uuid": job_seeker_session_name},
-        )
-        + "?gps=true"
+    next_url = reverse(
+        "job_seekers_views:create_job_seeker_step_2_for_sender",
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     assertRedirects(response, next_url)
 
@@ -174,12 +162,9 @@ def test_create_job_seeker(_mock, client):
     expected_job_seeker_session["user"] |= post_data | {"address_line_2": "", "address_for_autocomplete": None}
     assert client.session[job_seeker_session_name] == expected_job_seeker_session
 
-    next_url = (
-        reverse(
-            "job_seekers_views:create_job_seeker_step_3_for_sender",
-            kwargs={"session_uuid": job_seeker_session_name},
-        )
-        + "?gps=true"
+    next_url = reverse(
+        "job_seekers_views:create_job_seeker_step_3_for_sender",
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     assertRedirects(response, next_url)
 
@@ -208,12 +193,9 @@ def test_create_job_seeker(_mock, client):
     }
     assert client.session[job_seeker_session_name] == expected_job_seeker_session
 
-    next_url = (
-        reverse(
-            "job_seekers_views:create_job_seeker_step_end_for_sender",
-            kwargs={"session_uuid": job_seeker_session_name},
-        )
-        + "?gps=true"
+    next_url = reverse(
+        "job_seekers_views:create_job_seeker_step_end_for_sender",
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     assertRedirects(response, next_url)
 
@@ -250,10 +232,8 @@ def test_existing_user_with_email(client):
     # …until a job seeker has to be determined.
     assert response.status_code == 200
     last_url = response.redirect_chain[-1][0]
-    assert (
-        last_url
-        == reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
-        + "?gps=true"
+    assert last_url == reverse(
+        "job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name}
     )
 
     # Enter a non-existing NIR.
@@ -261,13 +241,10 @@ def test_existing_user_with_email(client):
     nir = "141068078200557"
     post_data = {"nir": nir, "confirm": 1}
     response = client.post(last_url, data=post_data)
-    job_seeker_session_name = str(resolve(response.url.replace("?gps=true", "")).kwargs["session_uuid"])
-    next_url = (
-        reverse(
-            "job_seekers_views:search_by_email_for_sender",
-            kwargs={"session_uuid": job_seeker_session_name},
-        )
-        + "?gps=true"
+    job_seeker_session_name = str(resolve(response.url).kwargs["session_uuid"])
+    next_url = reverse(
+        "job_seekers_views:search_by_email_for_sender",
+        kwargs={"session_uuid": job_seeker_session_name},
     )
     expected_job_seeker_session = {
         "config": {
@@ -328,10 +305,8 @@ def test_existing_user_with_nir(client):
     # …until a job seeker has to be determined.
     assert response.status_code == 200
     last_url = response.redirect_chain[-1][0]
-    assert (
-        last_url
-        == reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
-        + "?gps=true"
+    assert last_url == reverse(
+        "job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name}
     )
 
     # Enter an existing NIR.
@@ -378,8 +353,6 @@ def test_creation_by_user_kind(client, UserFactory, factory_args, expected_acces
     response = client.get(create_beneficiary_url)
     [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
     assert response.status_code == 302
-    assert (
-        response["Location"]
-        == reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
-        + "?gps=true"
+    assert response["Location"] == reverse(
+        "job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name}
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Depuis le travail effectué sur `job_seekers_views`, que GPS utilise pour créer un nouveau bénéficiaire, on remplit une session avec l'information `tunnel="gps"`. 
On n'a donc plus besoin de passer cette information dans l'URL.

---

Déploiement : on attend lundi pour que les sessions possèdent bien toutes un `tunnel`.

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :desert_island: Comment tester

- se rendre dans GPS (dashboard > Visualiser les bénéficiaires > Ajouter un bénéficiaire)
- taper n'importe quoi dans la barre de recherche de bénéficiaires, pour faire apparaître le lien "Enregistrer un nouveau bénéficiaire"
- cliquer sur ce lien
- vérifier que `?gps=true` n'apparaît dans aucune page tout au long de la création du bénéficiaire

