### PR TITLE
API: commentaire temporaire des scopes de l'API Rome en maintenance

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -50,8 +50,9 @@ AUTHORIZED_SCOPES = [
     "api_maj-pass-iaev1",
     "api_offresdemploiv2",
     "api_rechercheindividucertifiev1",
-    "api_romev1",
-    "nomenclatureRome",
+    # TODO: check if those 2 ROME-related scopes are again valid in a few days and uncomment them
+    # "api_romev1",
+    # "nomenclatureRome",
     "o2dsoffre",
     "passIAE",
     "rechercherIndividuCertifie",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ces 2 scopes font que toutes les demandes de token échouent avec comme erreur `invalid_scope`.

Cela empêche toutes les utilisations des APIs FranceTravail.

Cette PR débloque la situation mais idéalement je pense qu'il faudrait que chaque commande ne demande que les scopes dont elle a besoin.

Je n'ai pas commenté la commande `sync_romes_and_appellations`: son échec dans Sentry nous rappellera peut-être d'aller dé-commenter ces scopes si on ne l'a pas encore fait.
<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
