### PR TITLE
Recherche employeur : ne jamais afficher de bouton Postuler quand l'employeur a bloqué l'envoi de candidatures

### DIFF
--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -59,7 +59,7 @@
             {% endif %}
         </div>
     </div>
-    {% if siae.active_job_descriptions %}
+    {% if siae.active_job_descriptions and not siae.block_job_applications %}
         <hr class="m-0">
         {% if job_app_to_transfer|default:False %}
             <div class="c-box--results__body">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lorsque l'employeur bloque l'envoi de candidatures, les boutons "Postuler" ne sont pas affichés.
Tous, sauf dans un cas : dans la recherche employeur, si au moins une offre d'emploi n'est pas individuellement désactivée.

Ça mène à des incompréhensions : https://gip-inclusion.slack.com/archives/C0412CTV63D/p1737120766865729

## :desert_island: Comment tester

- en tant qu'administrateur d'une entreprise, bloquer l'envoi de canditatues (à la page /company/job_description_list)
- en tant qu'un autre utilisateur
  - chercher l'entreprise dans la recherche et cliquer sur Postuler
  - ou saisir directement l'adresse `/apply/<pk de l'entreprise>/start`

## :computer: Captures d'écran <!-- optionnel -->

Avant : 
![image](https://github.com/user-attachments/assets/6c28e4b8-19fb-48be-a6b4-6b78bcbd5542)

Après : 
![image](https://github.com/user-attachments/assets/dc232322-a6e9-415d-bcf1-b794a58eb9d8)


