### PR TITLE
Inscription: Bug lors d'un conflit d'email avec un utilisateur non-candidat pendant inscription

### DIFF
--- a/itou/www/signup/errors.py
+++ b/itou/www/signup/errors.py
@@ -34,8 +34,9 @@ class JobSeekerSignupConflictModalResolver:
 
     def __init__(self, cleaned_data, errors, nir, email):
         self.errors = errors
-        email_conflict_user = User.objects.filter(email=email).first() if email is not None else None
-        nir_conflict_user = User.objects.filter(jobseeker_profile__nir=nir).first() if nir is not None else None
+        job_seekers = User.objects.filter(kind=UserKind.JOB_SEEKER)
+        email_conflict_user = job_seekers.filter(email=email).first() if email is not None else None
+        nir_conflict_user = job_seekers.filter(jobseeker_profile__nir=nir).first() if nir is not None else None
 
         # A guess of identity is made (in order of priority) on NIR, email, and birth details
         # The final fallback is included because users will sometimes create one account with a temporary NIR,
@@ -45,8 +46,7 @@ class JobSeekerSignupConflictModalResolver:
             or email_conflict_user
             or (
                 all(key in cleaned_data for key in ["birthdate", "first_name", "last_name"])
-                and User.objects.filter(
-                    kind=UserKind.JOB_SEEKER,
+                and job_seekers.filter(
                     jobseeker_profile__birthdate=cleaned_data["birthdate"],
                     first_name__unaccent__iexact=cleaned_data["first_name"],
                     last_name__unaccent__iexact=cleaned_data["last_name"],


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://inclusion.sentry.io/issues/15287176

Un utilisateur a tenté s'inscrire en tant que candidat, en utilisant un e-mail déjà lié au compte employeur ou prescripteur.

## :cake: Comment ?

J'ai proposé ne pas afficher le choix de se connecter avec le compte employeur/prescripteur dans ce cas. J'aime que c'est une solution simple, et je pense que c'est logique quand l'utilisateur a démandé inscrire en tant que candidat. Pour arriver ici, il a mis un NIR parmis des autres champs candidats.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

* Créer un compte employeur
* Réutiliser l'adresse e-mail associée avec ce compte pour s'inscrire à nouveau en tant que candidat.
