### PR TITLE
Admin: sécurisation des urls de gestion des membres [GEN-2399]

### DIFF
--- a/itou/templates/includes/deactivate_member.html
+++ b/itou/templates/includes/deactivate_member.html
@@ -30,7 +30,7 @@
         <p>En cas d'erreur, vous pourrez toujours lui renvoyer une invitation pour rejoindre votre {{ org_display }}.</p>
     {% endwith %}
 
-    <form action="{% url base_url|add:":deactivate_member" target_member.pk %}" method="post">
+    <form action="{% url base_url|add:":deactivate_member" target_member.public_id %}" method="post">
         {% url base_url|add:":members" as reset_url %}
         {% csrf_token %}
         {% itou_buttons_form primary_label="Retirer l'utilisateur" reset_url=reset_url %}

--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -39,13 +39,13 @@
                                         <i class="ri-more-2-fill" aria-hidden="true"></i>
                                     </button>
                                     <div class="dropdown-menu" aria-labelledby="dropdown_{{ forloop.counter }}_action_menu">
-                                        <a href="{% url base_url|add:":deactivate_member" member.user.pk %}" class="dropdown-item">Retirer de la structure</a>
+                                        <a href="{% url base_url|add:":deactivate_member" member.user.public_id %}" class="dropdown-item">Retirer de la structure</a>
                                         {% if not member.user in active_admin_members %}
-                                            <a href="{% url base_url|add:":update_admin_role" "add" member.user.pk %}" class="dropdown-item">
+                                            <a href="{% url base_url|add:":update_admin_role" "add" member.user.public_id %}" class="dropdown-item">
                                                 Ajouter en tant qu'administrateur
                                             </a>
                                         {% else %}
-                                            <a href="{% url base_url|add:":update_admin_role" "remove" member.user.pk %}" class="dropdown-item">
+                                            <a href="{% url base_url|add:":update_admin_role" "remove" member.user.public_id %}" class="dropdown-item">
                                                 Retirer les droits d'administrateur
                                             </a>
                                         {% endif %}

--- a/itou/templates/includes/update_admin.html
+++ b/itou/templates/includes/update_admin.html
@@ -22,7 +22,7 @@
             <li>Cet utilisateur sera notifié par e-mail de la modification de son rôle.</li>
         </ul>
 
-        <form action="{% url base_url|add:":update_admin_role" action target_member.pk %}" method="post">
+        <form action="{% url base_url|add:":update_admin_role" action target_member.public_id %}" method="post">
             {% url base_url|add:":members" as reset_url %}
             {% csrf_token %}
             {% if action == "remove" %}

--- a/itou/www/companies_views/urls.py
+++ b/itou/www/companies_views/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from itou.www.companies_views import views
 
@@ -28,14 +28,10 @@ urlpatterns = [
     path("edit-company-description", views.edit_company_step_description, name="edit_company_step_description"),
     path("edit-company-preview", views.edit_company_step_preview, name="edit_company_step_preview"),
     path("colleagues", views.members, name="members"),
+    path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
+    # to be removed when old url is not used anymore
     path("deactivate_member/<int:user_id>", views.deactivate_member, name="deactivate_member"),
-    # Tricky: when using `re_path` you CAN'T mix re parts with non re ones
-    # here, user_id was defined as <int:user_id> and action as re
-    # as a result the eval of the url fails silently (404)
-    # ROT: if using `re_path`, use RE everywhere
-    re_path(
-        "admin_role/(?P<action>add|remove)/(?P<user_id>[0-9]+)", views.update_admin_role, name="update_admin_role"
-    ),
+    path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
     path("dora-services/<str:code_insee>", views.hx_dora_services, name="hx_dora_services"),
     path(
         "dora-service-redirect/<str:source>/<str:service_id>",

--- a/itou/www/institutions_views/urls.py
+++ b/itou/www/institutions_views/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from itou.www.institutions_views import views
 
@@ -8,9 +8,8 @@ app_name = "institutions_views"
 
 urlpatterns = [
     path("colleagues", views.member_list, name="members"),
+    path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
+    # to be removed when old url is not used anymore
     path("deactivate_member/<int:user_id>", views.deactivate_member, name="deactivate_member"),
-    # # Can't mix capture var syntaxes in `re_path`: all path vars expressed as RE
-    re_path(
-        "admin_role/(?P<action>add|remove)/(?P<user_id>[0-9]+)", views.update_admin_role, name="update_admin_role"
-    ),
+    path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
 ]

--- a/itou/www/prescribers_views/urls.py
+++ b/itou/www/prescribers_views/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path
 
 from itou.www.prescribers_views import views
 
@@ -10,10 +10,9 @@ urlpatterns = [
     path("edit_organization", views.edit_organization, name="edit_organization"),
     path("colleagues", views.member_list, name="members"),
     path("<int:org_id>/card", views.card, name="card"),
+    path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
+    # to be removed when old url is not used anymore
     path("deactivate_member/<int:user_id>", views.deactivate_member, name="deactivate_member"),
-    # Can't mix capture var syntaxes in `re_path`: all path vars expressed as RE
-    re_path(
-        "admin_role/(?P<action>add|remove)/(?P<user_id>[0-9]+)", views.update_admin_role, name="update_admin_role"
-    ),
+    path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
     path("list_accredited_organizations", views.list_accredited_organizations, name="list_accredited_organizations"),
 ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

> les urls des `companies_views`, `prescribers_views` et `institutions_views` permettent l'accès à la gestion des membres (ajout, mise à jour, suppression) à partir de l'`id` incrémental du `user`


## Catégories changelog

Employeur, Prescripteur, Institutions

## :cake: Comment ?

🦺  remplacer les `id` par les `public_id`
🦺 ajout de 3 routes temporaires pour le deploiement `zero downtime`
🦺 simplification de routes utilisant `re_path`, pour supprimer les `regex` sur les `uuid`

## :rotating_light: À vérifier

-  Mettre à jour le CHANGELOG_breaking_changes.md ? > Non

[ref notion](https://www.notion.so/plateforme-inclusion/IDOR-securiser-les-urls-de-gestion-des-membres-des-compagnies-prescripteurs-et-institutions-181e8fa5c35b809e856ff155eb792a75?pvs=4)
