### PR TITLE
Demandeur d’emploi: Unifier les formulaires de gestion de données personnelles

### DIFF
--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -13,7 +13,7 @@
 
         {% csrf_token %}
 
-        {% if form_user_address or form_personal_data or form_certified_criteria %}<h2>Candidat</h2>{% endif %}
+        {% if form_user_address or form_personal_data or form_birth_place %}<h2>Candidat</h2>{% endif %}
 
         {% if form_personal_data %}
             {% if form_personal_data.nir_error %}{{ form_personal_data.nir_error|safe }}{% endif %}
@@ -26,10 +26,12 @@
             {% bootstrap_field form_personal_data.pole_emploi_id %}
             {% bootstrap_field form_personal_data.lack_of_pole_emploi_id_reason %}
             {% bootstrap_field form_personal_data.birthdate %}
+            {% bootstrap_field form_personal_data.birth_place %}
+            {% bootstrap_field form_personal_data.birth_country %}
         {% endif %}
 
-        {% if form_certified_criteria %}
-            {% bootstrap_form form_certified_criteria %}
+        {% if form_birth_place %}
+            {% bootstrap_form form_birth_place %}
         {% endif %}
 
         {% if form_user_address %}

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.text import slugify
 
-from itou.asp.forms import BirthPlaceAndCountryMixin
+from itou.asp.forms import BirthPlaceWithBirthdateModelForm
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
 from itou.communications import registry as notification_registry
@@ -31,12 +31,11 @@ class SSOReadonlyMixin:
 # SSOReadonlyMixin needs to be before JobSeekerProfileFieldsMixin here
 # since it disables the birthdate field that is added by JobSeekerProfileFieldsMixin
 class EditJobSeekerInfoForm(
-    BirthPlaceAndCountryMixin,
     JobSeekerNIRUpdateMixin,
     SSOReadonlyMixin,
     JobSeekerProfileFieldsMixin,
     JobSeekerAddressForm,
-    forms.ModelForm,
+    BirthPlaceWithBirthdateModelForm,
 ):
     """
     Edit a job seeker profile.

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -14,6 +14,7 @@ from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
+from itou.users.forms import JobSeekerProfileModelForm
 from itou.users.models import User
 from itou.utils.pagination import pager
 from itou.utils.perms.company import get_current_company_or_404
@@ -24,7 +25,6 @@ from itou.www.employee_record_views.forms import (
     AddEmployeeRecordChooseApprovalForm,
     AddEmployeeRecordChooseEmployeeForm,
     EmployeeRecordFilterForm,
-    NewEmployeeRecordStep1Form,
     NewEmployeeRecordStep2Form,
     NewEmployeeRecordStep3ForEITIForm,
     NewEmployeeRecordStep3Form,
@@ -222,7 +222,7 @@ def create(request, job_application_id, template_name="employee_record/create.ht
     Step 1: Name and birth date / place / country of the jobseeker
     """
     job_application = can_create_employee_record(request, job_application_id)
-    form = NewEmployeeRecordStep1Form(data=request.POST or None, instance=job_application.job_seeker)
+    form = JobSeekerProfileModelForm(data=request.POST or None, instance=job_application.job_seeker)
     query_param = f"?status={request.GET.get('status')}" if request.GET.get("status") else ""
 
     if request.method == "POST" and form.is_valid():

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -4,11 +4,10 @@ from django.utils.html import format_html
 from django_select2.forms import Select2Widget
 
 from itou.asp import models as asp_models
-from itou.asp.forms import BirthPlaceAndCountryMixin
 from itou.common_apps.address.forms import JobSeekerAddressForm
 from itou.common_apps.nir.forms import JobSeekerNIRUpdateMixin
 from itou.users.enums import LackOfPoleEmploiId, UserKind
-from itou.users.forms import JobSeekerProfileFieldsMixin
+from itou.users.forms import JobSeekerProfileFieldsMixin, JobSeekerProfileModelForm
 from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
 from itou.utils.emails import redact_email_address
@@ -135,38 +134,11 @@ class JobSeekerExistsForm(forms.Form):
         return self.user
 
 
-class CreateOrUpdateJobSeekerStep1Form(
-    JobSeekerNIRUpdateMixin, BirthPlaceAndCountryMixin, JobSeekerProfileFieldsMixin, forms.ModelForm
-):
-    REQUIRED_FIELDS = [
-        "title",
-        "first_name",
-        "last_name",
-        "birthdate",
-    ]
-
+class CreateOrUpdateJobSeekerStep1Form(JobSeekerNIRUpdateMixin, JobSeekerProfileModelForm):
     PROFILE_FIELDS = ["birth_country", "birthdate", "birth_place", "nir", "lack_of_nir_reason"]
 
-    class Meta:
-        model = User
-        fields = [
-            "title",
-            "first_name",
-            "last_name",
-        ]
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        for field_name in self.REQUIRED_FIELDS:
-            self.fields[field_name].required = True
-
-        self.fields["birthdate"].widget = DuetDatePickerWidget(
-            {
-                "min": DuetDatePickerWidget.min_birthdate(),
-                "max": DuetDatePickerWidget.max_birthdate(),
-            }
-        )
+    class Meta(JobSeekerProfileModelForm.Meta):
+        pass
 
     def clean(self):
         super().clean()

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from itou.asp.forms import BirthPlaceAndCountryMixin
+from itou.asp.forms import BirthPlaceWithBirthdateModelForm
 from itou.common_apps.address.departments import DEPARTMENTS
 from itou.prescribers.enums import CHOOSABLE_PRESCRIBER_KINDS
 from itou.prescribers.models import PrescriberOrganization
@@ -101,7 +101,7 @@ class JobSeekerSituationForm(forms.Form):
     )
 
 
-class JobSeekerSignupForm(BirthPlaceAndCountryMixin, FullnameFormMixin, BaseSignupForm):
+class JobSeekerSignupForm(FullnameFormMixin, BirthPlaceWithBirthdateModelForm, BaseSignupForm):
     birthdate = forms.DateField(
         label="Date de naissance",
         required=True,
@@ -129,6 +129,10 @@ class JobSeekerSignupForm(BirthPlaceAndCountryMixin, FullnameFormMixin, BaseSign
 
     _nir_submitted = None
     _email_submitted = None
+
+    class Meta:
+        model = JobSeekerProfile
+        fields = ["birthdate", "birth_place", "birth_country"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestProcessAcceptViews.test_select_job_description_for_job_application[accept view SQL queries]
   dict({
-    'num_queries': 15,
+    'num_queries': 16,
     'queries': list([
       dict({
         'origin': list([
@@ -928,6 +928,31 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/includes/job_application_accept_form.html]',
+          'IfNode[apply/includes/job_application_accept_form.html]',
+          'IncludeNode[apply/includes/accept_section.html]',
+          'IncludeNode[apply/process_accept.html]',
+          'BlockNode[apply/process_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/process_base.html]',
+          'ExtendsNode[apply/process_accept.html]',
+          '_accept[www/apply/views/common.py]',
+          'accept[www/apply/views/process_views.py]',
+          '_check_user_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestHireConfirmation.test_as_company[view queries]
   dict({
-    'num_queries': 20,
+    'num_queries': 24,
     'queries': list([
       dict({
         'origin': list([
@@ -802,6 +802,46 @@
       }),
       dict({
         'origin': list([
+          'JobSeekerPersonalDataForm.__init__[users/forms.py]',
+          'JobSeekerPersonalDataForm.__init__[users/forms.py]',
+          'JobSeekerPersonalDataForm.__init__[common_apps/nir/forms.py]',
+          '_accept[www/apply/views/common.py]',
+          'hire_confirmation[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobSeekerPersonalDataForm.__init__[users/forms.py]',
+          'JobSeekerPersonalDataForm.__init__[users/forms.py]',
+          'JobSeekerPersonalDataForm.__init__[common_apps/nir/forms.py]',
+          '_accept[www/apply/views/common.py]',
+          'hire_confirmation[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          WHERE "asp_country"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
           'AcceptForm.__init__[www/apply/forms.py]',
           '_accept[www/apply/views/common.py]',
           'hire_confirmation[www/apply/views/submit_views.py]',
@@ -908,6 +948,58 @@
           FROM "eligibility_selectedadministrativecriteria"
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
           ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'RemoteAutocompleteSelect2Widget.optgroups[utils/widgets.py]',
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/includes/job_application_accept_form.html]',
+          'IfNode[apply/includes/job_application_accept_form.html]',
+          'IncludeNode[apply/includes/accept_section.html]',
+          'IncludeNode[apply/submit/hire_confirmation.html]',
+          'BlockNode[apply/submit_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit_base.html]',
+          'ExtendsNode[apply/submit/hire_confirmation.html]',
+          '_accept[www/apply/views/common.py]',
+          'hire_confirmation[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'CustomFieldRenderer.render[utils/custom_renderer.py]',
+          'SimpleNode[apply/includes/job_application_accept_form.html]',
+          'IfNode[apply/includes/job_application_accept_form.html]',
+          'IncludeNode[apply/includes/accept_section.html]',
+          'IncludeNode[apply/submit/hire_confirmation.html]',
+          'BlockNode[apply/submit_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit_base.html]',
+          'ExtendsNode[apply/submit/hire_confirmation.html]',
+          '_accept[www/apply/views/common.py]',
+          'hire_confirmation[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          ORDER BY "asp_country"."name" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
@@ -11,9 +11,6 @@ from tests.cities.factories import create_test_cities
 from tests.companies.factories import JobDescriptionFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
-from tests.users.factories import (
-    JobSeekerFactory,
-)
 
 
 class TestAcceptForm:
@@ -345,29 +342,3 @@ class TestJobApplicationAcceptFormWithGEIQFields:
         for kind in (CompanyKind.EA, CompanyKind.EATT, CompanyKind.GEIQ, CompanyKind.OPCS):
             assertNotContains(_response(kind), self.HELP_START_AT)
             assertNotContains(_response(kind), self.HELP_END_AT)
-
-
-class TestCertifiedCriteriaInfoRequiredForm:
-    def test_submit_valid(self):
-        job_seeker = JobSeekerFactory(
-            with_ban_api_mocked_address=True,
-            born_in_france=True,
-        )
-
-        birth_place = job_seeker.jobseeker_profile.birth_place
-        valid_birthdate = birth_place.start_date + timedelta(days=1)
-
-        form_data = {
-            "address_line_1": job_seeker.address_line_1,
-            "address_line_2": job_seeker.address_line_2,
-            "post_code": job_seeker.post_code,
-            "city": job_seeker.city,
-            "insee_code": job_seeker.insee_code,
-            "ban_api_resolved_address": job_seeker.geocoding_address,
-            "birth_country": job_seeker.jobseeker_profile.birth_country.id,
-            "birth_place": job_seeker.jobseeker_profile.birth_place.id,
-        }
-        form = apply_forms.CertifiedCriteriaInfoRequiredForm(
-            data=form_data, birthdate=valid_birthdate, with_birthdate_field=False
-        )
-        assert form.is_valid()

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -2668,6 +2668,8 @@ class TestDirectHireFullProcess:
             "first_name": dummy_job_seeker.first_name,
             "last_name": dummy_job_seeker.last_name,
             "birthdate": birthdate,
+            "birth_place": Commune.objects.by_insee_code_and_period("64483", birthdate).pk,
+            "birth_country": Country.objects.get(code=Country.INSEE_CODE_FRANCE).pk,
             "lack_of_nir": False,
             "lack_of_nir_reason": "",
         }
@@ -2858,6 +2860,7 @@ class TestDirectHireFullProcess:
             # Select the first and only one option
             "address_for_autocomplete": "0",
             # BRSA criterion certification.
+            "birthdate": birthdate,
             "birth_place": birth_place.pk,
             "birth_country": birth_country.pk,
         }
@@ -5104,7 +5107,11 @@ class TestHireConfirmation:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings, mocker):
         self.job_seeker = JobSeekerFactory(
-            first_name="Clara", last_name="Sion", with_pole_emploi_id=True, with_ban_geoloc_address=True
+            first_name="Clara",
+            last_name="Sion",
+            with_pole_emploi_id=True,
+            with_ban_geoloc_address=True,
+            born_in_france=True,
         )
         # This is the city matching with_ban_geoloc_address trait
         self.city = create_city_geispolsheim()
@@ -5136,6 +5143,9 @@ class TestHireConfirmation:
             "hiring_end_at": "",
             "pole_emploi_id": self.job_seeker.jobseeker_profile.pole_emploi_id,
             "lack_of_pole_emploi_id_reason": self.job_seeker.jobseeker_profile.lack_of_pole_emploi_id_reason,
+            "birthdate": self.job_seeker.jobseeker_profile.birthdate.isoformat(),
+            "birth_place": self.job_seeker.jobseeker_profile.birth_place.pk,
+            "birth_country": self.job_seeker.jobseeker_profile.birth_country.pk,
             "answer": "",
             "ban_api_resolved_address": self.job_seeker.geocoding_address,
             "address_line_1": self.job_seeker.address_line_1,

--- a/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
@@ -572,7 +572,6 @@
           'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',
-          'EditJobSeekerInfoForm.__init__[asp/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'edit_job_seeker_info[www/dashboard/views.py]',
         ]),

--- a/tests/www/dashboard/__snapshots__/test_edit_user_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_user_info.ambr
@@ -71,7 +71,6 @@
           'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',
-          'EditJobSeekerInfoForm.__init__[asp/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'edit_user_info[www/dashboard/views.py]',
         ]),

--- a/tests/www/job_seekers_views/test_forms.py
+++ b/tests/www/job_seekers_views/test_forms.py
@@ -53,9 +53,3 @@ class TestCheckJobSeekerNirForm:
             "Vous ne pouvez postuler pour cet utilisateur car ce numéro de sécurité sociale "
             "n'est pas associé à un compte candidat."
         ) == form.errors["__all__"][0]
-
-
-class TestCreateOrUpdateJobSeekerStep1Form:
-    def test_commune_birthdate_dependency(self):
-        form = job_seekers_forms.CreateOrUpdateJobSeekerStep1Form()
-        assert form.with_birthdate_field


### PR DESCRIPTION
## :thinking: Pourquoi ?

Préambule à [empêcher la modification des informations d’un candidat qui a au moins un critère administratif certifié](https://www.notion.so/plateforme-inclusion/Emp-cher-la-modification-des-informations-d-un-candidat-qui-a-au-moins-un-crit-re-administratif-cert-47724fdc4b0a48e9ace2c305376bd21f). Centraliser la gestion de ces champs permettra de centraliser la logique de désactivation.

## :cake: Comment ? <!-- optionnel -->

Voir le message de commit.

Les informations candidats demandées pour une embauche GEIQ diffèrent de l’IAE, pour des raisons historiques. Ces informations seront harmonisées bientôt.
https://www.notion.so/plateforme-inclusion/Pr-requis-Certification-Refonte-du-parcours-d-acceptation-de-candidature-158e8fa5c35b80959d71c3642d33512e

## :desert_island: Comment tester

Vérifier la modification des données demandeur d’emploi dans les parcours suivants:
- Inscription demandeur d’emploi
- Création du demandeur d’emploi par un tiers
- mise à jour profil demandeur d’emploi
- création de fiche salarié
- embauche IAE
- embauche GEIQ
