### PR TITLE
Notifications: Masquer le champ email de la structure dans l’email de désactivation de compte inspecteur du travail

### DIFF
--- a/itou/templates/common/emails/member_deactivation_email_body.txt
+++ b/itou/templates/common/emails/member_deactivation_email_body.txt
@@ -8,7 +8,9 @@ Organisation :
 
 - Nom : {{ structure.display_name }}
 - Type : {{ structure.kind }}
+{% if structure.email %}
 - Email de contact : {{ structure.email }}
+{% endif %}
 
 Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
 

--- a/tests/www/companies_views/__snapshots__/test_members_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_members_views.ambr
@@ -1,0 +1,20 @@
+# serializer version: 1
+# name: TestUserMembershipDeactivation.test_deactivate_user
+  '''
+  Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+  
+  Organisation :
+  
+  - Nom : Les petits paniers
+  - Type : EI
+  
+  - Email de contact : petitspaniers@mailinator.com
+  
+  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---

--- a/tests/www/companies_views/test_members_views.py
+++ b/tests/www/companies_views/test_members_views.py
@@ -94,12 +94,12 @@ class TestUserMembershipDeactivation:
         membership.refresh_from_db()
         assert membership.is_active
 
-    def test_deactivate_user(self, client, mailoutbox):
+    def test_deactivate_user(self, client, mailoutbox, snapshot):
         """
         Standard use case of user deactivation.
         Everything should be fine ...
         """
-        company = CompanyWith2MembershipsFactory()
+        company = CompanyWith2MembershipsFactory(name="Les petits paniers", email="petitspaniers@mailinator.com")
         admin = company.members.filter(companymembership__is_admin=True).first()
         guest = company.members.filter(companymembership__is_admin=False).first()
 
@@ -125,6 +125,7 @@ class TestUserMembershipDeactivation:
         assert f"[DEV] [Désactivation] Vous n'êtes plus membre de {company.display_name}" == email.subject
         assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
         assert email.to[0] == guest.email
+        assert email.body == snapshot
 
     def test_deactivate_with_no_perms(self, client):
         """

--- a/tests/www/institutions_views/__snapshots__/test_views.ambr
+++ b/tests/www/institutions_views/__snapshots__/test_views.ambr
@@ -1,0 +1,18 @@
+# serializer version: 1
+# name: TestMembers.test_deactivate_user
+  '''
+  Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+  
+  Organisation :
+  
+  - Nom : DDETS 14
+  - Type : DDETS IAE
+  
+  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -93,8 +93,8 @@ class TestMembers:
         institution.refresh_from_db()
         assert_set_admin_role__creation(guest, institution, mailoutbox)
 
-    def test_deactivate_user(self, client, mailoutbox):
-        institution = InstitutionFactory()
+    def test_deactivate_user(self, client, mailoutbox, snapshot):
+        institution = InstitutionFactory(name="DDETS 14")
         admin_membership = InstitutionMembershipFactory(institution=institution, is_admin=True)
         guest_membership = InstitutionMembershipFactory(institution=institution, is_admin=False)
         guest_id = guest_membership.user_id
@@ -115,6 +115,7 @@ class TestMembers:
         assert f"[DEV] [Désactivation] Vous n'êtes plus membre de {institution.display_name}" == email.subject
         assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
         assert email.to == [guest_membership.user.email]
+        assert email.body == snapshot
 
     def test_remove_admin(self, client, mailoutbox):
         """

--- a/tests/www/prescribers_views/__snapshots__/test_members.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_members.ambr
@@ -1,0 +1,20 @@
+# serializer version: 1
+# name: TestUserMembershipDeactivation.test_deactivate_user
+  '''
+  Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion
+  
+  Organisation :
+  
+  - Nom : Mission locale
+  - Type : PE
+  
+  - Email de contact : ml@mailinator.com
+  
+  Si vous estimez qu'il peut s'agir d'une erreur, contactez un des administrateurs cette structure sur les emplois de l'inclusion.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -93,12 +93,12 @@ class TestUserMembershipDeactivation:
         membership.refresh_from_db()
         assert membership.is_active
 
-    def test_deactivate_user(self, client, mailoutbox):
+    def test_deactivate_user(self, client, mailoutbox, snapshot):
         """
         Standard use case of user deactivation.
         Everything should be fine ...
         """
-        organization = PrescriberOrganizationWith2MembershipFactory()
+        organization = PrescriberOrganizationWith2MembershipFactory(name="Mission locale", email="ml@mailinator.com")
         admin = organization.members.filter(prescribermembership__is_admin=True).first()
         guest = organization.members.filter(prescribermembership__is_admin=False).first()
 
@@ -123,6 +123,7 @@ class TestUserMembershipDeactivation:
         assert f"[DEV] [Désactivation] Vous n'êtes plus membre de {organization.display_name}" == email.subject
         assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
         assert email.to[0] == guest.email
+        assert email.body == snapshot
 
     def test_deactivate_with_no_perms(self, client):
         """


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les institutions n’ont pas d’email.
