### PR TITLE
Empêcher les membres d’une structure de s’y maintenir via des invitations

### DIFF
--- a/itou/common_apps/organizations/admin.py
+++ b/itou/common_apps/organizations/admin.py
@@ -1,46 +1,44 @@
-import logging
-
 from django.contrib import admin, messages
 from django.db.models import Count
-from django.forms import BaseInlineFormSet, ModelForm
+from django.forms import BaseInlineFormSet
 
 from itou.utils.admin import ItouModelAdmin, ItouTabularInline
 
 
-logger = logging.getLogger(__name__)
-
-
-def get_membership_structure(membership):
-    if hasattr(membership, "institution"):
-        return membership.institution
-    elif hasattr(membership, "organization"):
-        return membership.organization
-    elif hasattr(membership, "company"):
-        return membership.company
-    else:
-        logger.error("Invalid membership kind : %s", membership)
-
-
-class MembersInlineForm(ModelForm):
-    def save(self, commit=True):
-        instance = super().save(commit=commit)
-        if "is_admin" in self.changed_data:
-            structure = get_membership_structure(instance)
-            if structure is not None:
-                if instance.is_admin:
-                    structure.add_admin_email(instance.user).send()
-                else:
-                    structure.remove_admin_email(instance.user).send()
-        return instance
-
-
 class MembersInlineFormSet(BaseInlineFormSet):
+    def __init__(self, *args, acting_user, **kwargs):
+        self.acting_user = acting_user
+        return super().__init__(*args, **kwargs)
+
+    def _handle_save(self, form):
+        if form.instance.pk:
+            membership = form.instance
+            if "is_admin" in form.changed_data:
+                self.instance.set_admin_role(
+                    membership,
+                    form.cleaned_data["is_admin"],
+                    updated_by=self.acting_user,
+                )
+        else:
+            membership = self.instance.add_or_activate_membership(
+                form.cleaned_data["user"],
+                force_admin=form.cleaned_data["is_admin"],
+            )
+        return membership
+
+    def save_new(self, form, commit=True):
+        if commit:
+            return self._handle_save(form)
+        return super().save_new(form, commit=commit)
+
+    def save_existing(self, form, obj, commit=True):
+        if commit:
+            return self._handle_save(form)
+        return super().save_existing(form, obj, commit=commit)
+
     def delete_existing(self, obj, commit=True):
-        if obj.is_admin is True:
-            structure = get_membership_structure(obj)
-            if structure is not None:
-                structure.remove_admin_email(obj.user).send()
-        super().delete_existing(obj, commit=commit)
+        if commit:
+            self.instance.deactivate_membership(obj, updated_by=self.acting_user)
 
 
 class MembersInline(ItouTabularInline):
@@ -49,7 +47,6 @@ class MembersInline(ItouTabularInline):
     extra = 1
     raw_id_fields = ("user",)
     readonly_fields = ("is_active", "created_at", "updated_at", "updated_by", "joined_at")
-    form = MembersInlineForm
     formset = MembersInlineFormSet
 
 
@@ -76,6 +73,12 @@ class OrganizationAdmin(ItouModelAdmin):
 
     def get_queryset(self, request):
         return super().get_queryset(request).annotate(_member_count=Count("members", distinct=True))
+
+    def get_formset_kwargs(self, request, obj, inline, prefix):
+        kwargs = super().get_formset_kwargs(request, obj, inline, prefix)
+        if isinstance(inline, MembersInline):
+            kwargs["acting_user"] = request.user
+        return kwargs
 
     def save_related(self, request, form, formsets, change):
         had_admin = change and form.instance.active_admin_members.exists()

--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -126,6 +126,8 @@ class OrganizationAbstract(models.Model):
                 "is_admin": membership.is_admin,
             },
         )
+        if membership.is_admin:
+            self.add_admin_email(membership.user).send()
 
     def deactivate_membership(self, membership, *, updated_by):
         """

--- a/itou/invitations/migrations/0001_initial.py
+++ b/itou/invitations/migrations/0001_initial.py
@@ -98,7 +98,7 @@ class Migration(migrations.Migration):
                     "institution",
                     models.ForeignKey(
                         on_delete=django.db.models.deletion.CASCADE,
-                        related_name="labor_inspectors_invitations",
+                        related_name="invitations",
                         to="institutions.institution",
                     ),
                 ),

--- a/itou/invitations/models.py
+++ b/itou/invitations/models.py
@@ -292,9 +292,7 @@ class LaborInspectorInvitation(InvitationAbstract):
         on_delete=models.CASCADE,
         related_name="institution_invitations",
     )
-    institution = models.ForeignKey(
-        "institutions.Institution", on_delete=models.CASCADE, related_name="labor_inspectors_invitations"
-    )
+    institution = models.ForeignKey("institutions.Institution", on_delete=models.CASCADE, related_name="invitations")
 
     class Meta:
         verbose_name = "invitation inspecteurs du travail"

--- a/itou/www/institutions_views/views.py
+++ b/itou/www/institutions_views/views.py
@@ -25,7 +25,7 @@ def member_list(request, template_name="institutions/members.html"):
     # Institution members can only be labor inspectors for the moment,
     # but this is likely to change in the future.
     if request.user.is_labor_inspector:
-        pending_invitations = institution.labor_inspectors_invitations.pending()
+        pending_invitations = institution.invitations.pending()
 
     context = {
         "institution": institution,

--- a/tests/prescribers/tests.py
+++ b/tests/prescribers/tests.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.db import IntegrityError
 from django.urls import reverse
-from django.utils.timezone import get_current_timezone
+from django.utils import timezone
 from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertRedirects
 
 from itou.job_applications import models as job_applications_models
@@ -276,7 +276,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
         )
 
         url = reverse("admin:prescribers_prescriberorganization_change", args=[prescriber_organization.pk])
@@ -311,7 +311,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
         )
         PrescriberOrganizationFactory(
             kind=PrescriberOrganizationKind.OTHER,
@@ -360,7 +360,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
             authorization_status=PrescriberAuthorizationStatus.NOT_SET,
             is_authorized=False,
         )
@@ -396,7 +396,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
         )
 
         url = reverse("admin:prescribers_prescriberorganization_change", args=[prescriber_organization.pk])
@@ -430,7 +430,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
         )
 
         url = reverse("admin:prescribers_prescriberorganization_change", args=[prescriber_organization.pk])
@@ -464,7 +464,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
             authorization_status=PrescriberAuthorizationStatus.NOT_SET,
             is_authorized=False,
         )
@@ -500,7 +500,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
             authorization_status=PrescriberAuthorizationStatus.REFUSED,
             is_authorized=False,
         )
@@ -536,7 +536,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
         )
 
         url = reverse("admin:prescribers_prescriberorganization_change", args=[prescriber_organization.pk])
@@ -598,7 +598,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
             authorization_status=PrescriberAuthorizationStatus.NOT_SET,
             kind=PrescriberOrganizationKind.ODC,
             is_authorized=False,
@@ -638,7 +638,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
             authorization_status=PrescriberAuthorizationStatus.NOT_SET,
             is_authorized=False,
             kind=PrescriberOrganizationKind.OTHER,
@@ -694,7 +694,7 @@ class TestPrescriberOrganizationAdmin:
             siret="83987278500010",
             department="14",
             post_code="14000",
-            authorization_updated_at=datetime.now(tz=get_current_timezone()),
+            authorization_updated_at=datetime.now(tz=timezone.get_current_timezone()),
         )
 
         url = reverse("admin:prescribers_prescriberorganization_change", args=[prescriber_organization.pk])

--- a/tests/prescribers/tests.py
+++ b/tests/prescribers/tests.py
@@ -935,7 +935,7 @@ def test_deactivate_last_admin(admin_client, mailoutbox):
     assert_set_admin_role__removal(membership.user, organization, mailoutbox)
 
 
-def test_delete_admin(admin_client, mailoutbox):
+def test_delete_admin(admin_client, caplog, mailoutbox):
     organization = PrescriberOrganizationWithMembershipFactory()
     membership = organization.memberships.first()
     assert membership.is_admin
@@ -978,10 +978,18 @@ def test_delete_admin(admin_client, mailoutbox):
     assertRedirects(response, change_url, fetch_redirect_response=False)
     response = admin_client.get(change_url)
 
-    assert_set_admin_role__removal(membership.user, organization, mailoutbox)
+    assert membership.user not in organization.active_admin_members
+    [email] = mailoutbox
+    assert f"[DEV] [Désactivation] Vous n'êtes plus membre de {organization.display_name}" == email.subject
+    assert "Un administrateur vous a retiré d'une structure" in email.body
+    assert email.to == [membership.user.email]
+    assert (
+        f"User {admin_client.session['_auth_user_id']} deactivated prescribers.PrescriberMembership "
+        f"of organization_id={organization.pk} for user_id={membership.user_id} is_admin=True."
+    ) in caplog.messages
 
 
-def test_add_admin(admin_client, mailoutbox):
+def test_add_admin(admin_client, caplog, mailoutbox):
     organization = PrescriberOrganizationWithMembershipFactory()
     membership = organization.memberships.first()
     prescriber = PrescriberFactory()
@@ -1028,6 +1036,10 @@ def test_add_admin(admin_client, mailoutbox):
     response = admin_client.get(change_url)
 
     assert_set_admin_role__creation(prescriber, organization, mailoutbox)
+    assert (
+        f"Creating prescribers.PrescriberMembership of organization_id={organization.pk} "
+        f"for user_id={prescriber.pk} is_admin=True."
+    ) in caplog.messages
 
 
 def test_prescriber_kinds_are_alphabetically_sorted():

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
 
+from tests.invitations.factories import PrescriberWithOrgInvitationFactory
 from tests.prescribers.factories import (
     PrescriberFactory,
     PrescriberMembershipFactory,
@@ -94,7 +95,7 @@ class TestUserMembershipDeactivation:
         membership.refresh_from_db()
         assert membership.is_active
 
-    def test_deactivate_user(self, client, mailoutbox, snapshot):
+    def test_deactivate_user(self, caplog, client, mailoutbox, snapshot):
         """
         Standard use case of user deactivation.
         Everything should be fine ...
@@ -106,6 +107,10 @@ class TestUserMembershipDeactivation:
         memberships = guest.prescribermembership_set.all()
         membership = memberships.first()
 
+        received_invitation = PrescriberWithOrgInvitationFactory(email=guest.email, organization=organization)
+        sent_invitation = PrescriberWithOrgInvitationFactory(sender=guest, organization=organization)
+        sent_invitation_to_other = PrescriberWithOrgInvitationFactory(sender=guest)
+
         client.force_login(admin)
         url = reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest.id})
         response = client.post(url)
@@ -116,6 +121,14 @@ class TestUserMembershipDeactivation:
         assert not membership.is_active
         assert admin == membership.updated_by
         assert membership.updated_at is not None
+        assert (
+            f"Expired 1 invitations to prescribers.PrescriberOrganization {organization.pk} for user_id={guest.pk}."
+            in caplog.messages
+        )
+        assert (
+            f"Expired 1 invitations to prescribers.PrescriberOrganization {organization.pk} from user_id={guest.pk}."
+            in caplog.messages
+        )
 
         # Check mailbox
         # User must have been notified of deactivation (we're human after all)
@@ -125,6 +138,12 @@ class TestUserMembershipDeactivation:
         assert "Un administrateur vous a retiré d'une structure sur les emplois de l'inclusion" in email.body
         assert email.to[0] == guest.email
         assert email.body == snapshot
+        received_invitation.refresh_from_db()
+        assert received_invitation.has_expired is True
+        sent_invitation.refresh_from_db()
+        assert sent_invitation.has_expired is True
+        sent_invitation_to_other.refresh_from_db()
+        assert sent_invitation_to_other.has_expired is False
 
     def test_deactivate_user_from_another_organisation(self, client, mailoutbox):
         my_organization = PrescriberOrganizationFactory()

--- a/tests/www/signup/test_prescriber.py
+++ b/tests/www/signup/test_prescriber.py
@@ -140,8 +140,8 @@ class TestPrescriberSignup:
         assert user.prescribermembership_set.get().organization_id == organization.pk
         assert user.company_set.count() == 0
 
-        # No email has been sent to support (validation/refusal of authorisation not needed).
-        assert len(mailoutbox) == 0
+        [email] = mailoutbox
+        assert email.subject == "[DEV] Votre rôle d’administrateur"
 
     @respx.mock
     def test_create_user_prescriber_with_authorized_org_returns_on_other_browser(
@@ -217,9 +217,9 @@ class TestPrescriberSignup:
         assert membership.is_admin
 
         # Check email has been sent to support (validation/refusal of authorisation needed).
-        assert len(mailoutbox) == 1
-        subject = mailoutbox[0].subject
-        assert "Vérification de l'habilitation d'une nouvelle organisation" in subject
+        [authorization_email, administrator_email] = mailoutbox
+        assert "Vérification de l'habilitation d'une nouvelle organisation" in authorization_email.subject
+        assert administrator_email.subject == "[DEV] Votre rôle d’administrateur"
 
     @respx.mock
     def test_create_user_prescriber_with_authorized_org_of_known_kind(self, client, mocker, mailoutbox, pro_connect):
@@ -294,12 +294,13 @@ class TestPrescriberSignup:
         assert membership.is_admin
 
         # Check email has been sent to support (validation/refusal of authorisation needed).
-        [email] = mailoutbox
-        assert "Vérification de l'habilitation d'une nouvelle organisation" in email.subject
-        body_lines = email.body.splitlines()
+        [authorization_email, administrator_email] = mailoutbox
+        assert "Vérification de l'habilitation d'une nouvelle organisation" in authorization_email.subject
+        body_lines = authorization_email.body.splitlines()
         assert "- Nom : CENTRE COMMUNAL D'ACTION SOCIALE" in body_lines
         assert f"- ID : {org.pk}" in body_lines
         assert "- Type sélectionné par l’utilisateur : Cap emploi" in body_lines
+        assert administrator_email.subject == "[DEV] Votre rôle d’administrateur"
 
     @respx.mock
     def test_create_user_prescriber_with_authorized_org_of_unknown_kind(self, client, mocker, mailoutbox, pro_connect):
@@ -391,9 +392,9 @@ class TestPrescriberSignup:
         assert membership.is_admin
 
         # Check email has been sent to support (validation/refusal of authorisation needed).
-        assert len(mailoutbox) == 1
-        subject = mailoutbox[0].subject
-        assert "Vérification de l'habilitation d'une nouvelle organisation" in subject
+        [authorization_email, administrator_email] = mailoutbox
+        assert "Vérification de l'habilitation d'une nouvelle organisation" in authorization_email.subject
+        assert administrator_email.subject == "[DEV] Votre rôle d’administrateur"
 
     @respx.mock
     def test_create_user_prescriber_with_unauthorized_org(self, client, mocker, mailoutbox, pro_connect):
@@ -475,8 +476,8 @@ class TestPrescriberSignup:
         membership = user.prescribermembership_set.get(organization=org)
         assert membership.is_admin
 
-        # No email has been sent to support (validation/refusal of authorisation not needed).
-        assert len(mailoutbox) == 0
+        [email] = mailoutbox
+        assert email.subject == "[DEV] Votre rôle d’administrateur"
 
     def test_create_user_prescriber_with_existing_siren_other_department(self, client):
         """
@@ -604,7 +605,7 @@ class TestPrescriberSignup:
         # Check membership.
         assert 0 == user.prescriberorganization_set.count()
 
-        # No email has been sent to support (validation/refusal of authorisation not needed).
+        # No email has been sent.
         assert len(mailoutbox) == 0
 
     @respx.mock


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sécurité.

## :desert_island: Comment tester

https://yeswehack.com/vulnerability-center/reports/310822
