### PR TITLE
Préférer des emails en @inclusion.gouv.fr

### DIFF
--- a/itou/api/README-FS-SSII.md
+++ b/itou/api/README-FS-SSII.md
@@ -10,7 +10,7 @@ Ceci est une documentation publique à destination des logiciels SSII pour la r�
 
 - L'endpoint `api/v1/employee-records` n'est pas encore disponible mais en attendant vous pouvez déjà utiliser l'endpoint similaire `api/v1/dummy-employee-records` pour faire vos premiers tests.
 
-- L'endpoint `api/v1/dummy-employee-records` renvoit systématiquement 25 fiches salarié sur 2 pages avec des données factices mais réalistes, peu importe le compte employeur utilisé. Si vous ne disposez pas d'un compte employeur en production, nous vous invitons à utiliser le compte employeur `test+etti@inclusion.beta.gouv.fr` (mot de passe `password`) pour faire vos tests sur la démo (https://demo.emplois.inclusion.beta.gouv.fr/) au lieu de la production (https://emplois.inclusion.beta.gouv.fr/). Merci de ne pas créer de compte factice en production.
+- L'endpoint `api/v1/dummy-employee-records` renvoit systématiquement 25 fiches salarié sur 2 pages avec des données factices mais réalistes, peu importe le compte employeur utilisé. Si vous ne disposez pas d'un compte employeur en production, nous vous invitons à utiliser le compte employeur `test+etti@inclusion.gouv.fr` (mot de passe `password`) pour faire vos tests sur la démo (https://demo.emplois.inclusion.beta.gouv.fr/) au lieu de la production (https://emplois.inclusion.beta.gouv.fr/). Merci de ne pas créer de compte factice en production.
 
 ## Points importants
 
@@ -31,7 +31,7 @@ curl -H 'Accept: application/json; indent=4' -d "username=john.doe@mail.com&pass
 Exemple en démo avec le compte de test :
 
 ```
-curl -H 'Accept: application/json; indent=4' -d "username=test%2Betti@inclusion.beta.gouv.fr&password=password" https://demo.emplois.inclusion.beta.gouv.fr/api/v1/token-auth/
+curl -H 'Accept: application/json; indent=4' -d "username=test%2Betti@inclusion.gouv.fr&password=password" https://demo.emplois.inclusion.beta.gouv.fr/api/v1/token-auth/
 ```
 
 Réponse :
@@ -203,7 +203,3 @@ Tous les référentiels utiles mentionnés dans le JSON ci-dessous sont [disponi
     }
 }
 ```
-
-
-
-

--- a/itou/fixtures/django/05_test_users.json
+++ b/itou/fixtures/django/05_test_users.json
@@ -49,7 +49,7 @@
       "created_by": null,
       "date_joined": "2019-09-30T13:42:09Z",
       "department": "",
-      "email": "test+de@inclusion.beta.gouv.fr",
+      "email": "test+de@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Jacques",
@@ -72,7 +72,7 @@
       "public_id": "46d882ce-39b9-4969-ac33-e8e6db3f2270",
       "title": "",
       "user_permissions": [],
-      "username": "test+de@inclusion.beta.gouv.fr"
+      "username": "test+de@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 2
@@ -88,7 +88,7 @@
       "created_by": null,
       "date_joined": "2019-09-30T13:42:57Z",
       "department": "",
-      "email": "test+prescripteur@inclusion.beta.gouv.fr",
+      "email": "test+prescripteur@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "André",
@@ -111,7 +111,7 @@
       "public_id": "ee0606e0-638e-408e-9a3d-1323a67ee0bd",
       "title": "",
       "user_permissions": [],
-      "username": "test+prescripteur@inclusion.beta.gouv.fr"
+      "username": "test+prescripteur@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 3
@@ -127,7 +127,7 @@
       "created_by": null,
       "date_joined": "2019-09-30T13:43:26Z",
       "department": "",
-      "email": "test+etti@inclusion.beta.gouv.fr",
+      "email": "test+etti@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Daphnée",
@@ -150,7 +150,7 @@
       "public_id": "96bf0bfd-d9b6-4c3e-a9da-93ba6f508ebf",
       "title": "",
       "user_permissions": [],
-      "username": "test+etti@inclusion.beta.gouv.fr"
+      "username": "test+etti@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 4
@@ -166,7 +166,7 @@
       "created_by": null,
       "date_joined": "2019-09-30T13:44:15Z",
       "department": "",
-      "email": "test+orienteur-solo@inclusion.beta.gouv.fr",
+      "email": "test+orienteur-solo@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Emmanuelle",
@@ -189,7 +189,7 @@
       "public_id": "1a2a1479-f4f8-4e2a-a707-358b8aed1d87",
       "title": "",
       "user_permissions": [],
-      "username": "test+orienteur-solo@inclusion.beta.gouv.fr"
+      "username": "test+orienteur-solo@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 5
@@ -205,7 +205,7 @@
       "created_by": null,
       "date_joined": "2020-04-09T13:36:52Z",
       "department": "",
-      "email": "test+ei@inclusion.beta.gouv.fr",
+      "email": "test+ei@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Victor",
@@ -228,7 +228,7 @@
       "public_id": "d9e0b843-fc23-4d9c-9909-5c1cb43ef6bf",
       "title": "",
       "user_permissions": [],
-      "username": "test+ei@inclusion.beta.gouv.fr"
+      "username": "test+ei@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 6
@@ -244,7 +244,7 @@
       "created_by": null,
       "date_joined": "2020-04-09T13:48:41Z",
       "department": "",
-      "email": "test+orienteur@inclusion.beta.gouv.fr",
+      "email": "test+orienteur@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Olivier",
@@ -267,7 +267,7 @@
       "public_id": "d0c8253d-9d47-4fa0-8714-d4aac51a26c2",
       "title": "",
       "user_permissions": [],
-      "username": "test+orienteur@inclusion.beta.gouv.fr"
+      "username": "test+orienteur@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 7
@@ -283,7 +283,7 @@
       "created_by": 3,
       "date_joined": "2020-04-09T14:06:40Z",
       "department": "37",
-      "email": "test+de-proxy@inclusion.beta.gouv.fr",
+      "email": "test+de-proxy@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Sylvie",
@@ -306,7 +306,7 @@
       "public_id": "7feb3b2e-8c62-482e-8681-ed7a5e95abf1",
       "title": "",
       "user_permissions": [],
-      "username": "test+de-proxy@inclusion.beta.gouv.fr"
+      "username": "test+de-proxy@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 8
@@ -322,7 +322,7 @@
       "created_by": null,
       "date_joined": "2020-04-14T16:10:12Z",
       "department": "",
-      "email": "test+geiq@inclusion.beta.gouv.fr",
+      "email": "test+geiq@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Laura",
@@ -345,7 +345,7 @@
       "public_id": "72ba065b-6a9a-47c1-9e77-b7563b3d55d7",
       "title": "",
       "user_permissions": [],
-      "username": "test+geiq@inclusion.beta.gouv.fr"
+      "username": "test+geiq@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 9
@@ -595,7 +595,7 @@
       "created_by": null,
       "date_joined": "2021-02-22T15:02:19Z",
       "department": "",
-      "email": "test+ea@inclusion.beta.gouv.fr",
+      "email": "test+ea@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Alphonse",
@@ -829,7 +829,7 @@
       "created_by": null,
       "date_joined": "2021-07-13T15:33:29Z",
       "department": "",
-      "email": "test+dreets@inclusion.beta.gouv.fr",
+      "email": "test+dreets@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Joseph",
@@ -852,7 +852,7 @@
       "public_id": "f55fe9f1-abe2-42ab-b4cd-782097401192",
       "title": "",
       "user_permissions": [],
-      "username": "test+dreets@inclusion.beta.gouv.fr"
+      "username": "test+dreets@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 24
@@ -868,7 +868,7 @@
       "created_by": null,
       "date_joined": "2021-11-23T13:43:26Z",
       "department": "",
-      "email": "test+ai@inclusion.beta.gouv.fr",
+      "email": "test+ai@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Jean-Claude",
@@ -891,7 +891,7 @@
       "public_id": "c5e7eeb7-0a8d-4645-bda9-16a6f1e57210",
       "title": "",
       "user_permissions": [],
-      "username": "test+ai@inclusion.beta.gouv.fr"
+      "username": "test+ai@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 25
@@ -946,7 +946,7 @@
       "created_by": null,
       "date_joined": "2023-06-02T09:35:44.525Z",
       "department": "",
-      "email": "test+ddets@inclusion.beta.gouv.fr",
+      "email": "test+ddets@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Georges",
@@ -969,7 +969,7 @@
       "public_id": "d95b438f-53c0-4d18-93aa-60fce8d25a24",
       "title": "",
       "user_permissions": [],
-      "username": "test+ddets@inclusion.beta.gouv.fr"
+      "username": "test+ddets@inclusion.gouv.fr"
     },
     "model": "users.user",
     "pk": 27
@@ -985,7 +985,7 @@
       "created_by": null,
       "date_joined": "2023-06-21T13:49:22.935Z",
       "department": "",
-      "email": "test+cap@inclusion.beta.gouv.fr",
+      "email": "test+cap@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Georges",
@@ -1024,7 +1024,7 @@
       "created_by": null,
       "date_joined": "2023-06-21T13:49:22.935Z",
       "department": "",
-      "email": "test+institution@inclusion.beta.gouv.fr",
+      "email": "test+institution@inclusion.gouv.fr",
       "external_data_source_history": null,
       "first_login": null,
       "first_name": "Gustave",

--- a/itou/fixtures/django/06_confirmed_emails.json
+++ b/itou/fixtures/django/06_confirmed_emails.json
@@ -11,7 +11,7 @@
   },
   {
     "fields": {
-      "email": "test+de@inclusion.beta.gouv.fr",
+      "email": "test+de@inclusion.gouv.fr",
       "primary": true,
       "user": 2,
       "verified": true
@@ -21,7 +21,7 @@
   },
   {
     "fields": {
-      "email": "test+prescripteur@inclusion.beta.gouv.fr",
+      "email": "test+prescripteur@inclusion.gouv.fr",
       "primary": true,
       "user": 3,
       "verified": true
@@ -31,7 +31,7 @@
   },
   {
     "fields": {
-      "email": "test+etti@inclusion.beta.gouv.fr",
+      "email": "test+etti@inclusion.gouv.fr",
       "primary": true,
       "user": 4,
       "verified": true
@@ -41,7 +41,7 @@
   },
   {
     "fields": {
-      "email": "test+orienteur-solo@inclusion.beta.gouv.fr",
+      "email": "test+orienteur-solo@inclusion.gouv.fr",
       "primary": true,
       "user": 5,
       "verified": true
@@ -51,7 +51,7 @@
   },
   {
     "fields": {
-      "email": "test+ei@inclusion.beta.gouv.fr",
+      "email": "test+ei@inclusion.gouv.fr",
       "primary": true,
       "user": 6,
       "verified": true
@@ -61,7 +61,7 @@
   },
   {
     "fields": {
-      "email": "test+orienteur@inclusion.beta.gouv.fr",
+      "email": "test+orienteur@inclusion.gouv.fr",
       "primary": true,
       "user": 7,
       "verified": true
@@ -71,7 +71,7 @@
   },
   {
     "fields": {
-      "email": "test+de-proxy@inclusion.beta.gouv.fr",
+      "email": "test+de-proxy@inclusion.gouv.fr",
       "primary": true,
       "user": 8,
       "verified": true
@@ -81,7 +81,7 @@
   },
   {
     "fields": {
-      "email": "test+geiq@inclusion.beta.gouv.fr",
+      "email": "test+geiq@inclusion.gouv.fr",
       "primary": true,
       "user": 9,
       "verified": true
@@ -151,7 +151,7 @@
   },
   {
     "fields": {
-      "email": "test+ea@inclusion.beta.gouv.fr",
+      "email": "test+ea@inclusion.gouv.fr",
       "primary": true,
       "user": 16,
       "verified": true
@@ -161,7 +161,7 @@
   },
   {
     "fields": {
-      "email": "test+dreets@inclusion.beta.gouv.fr",
+      "email": "test+dreets@inclusion.gouv.fr",
       "primary": true,
       "user": 24,
       "verified": true
@@ -171,7 +171,7 @@
   },
   {
     "fields": {
-      "email": "test+ai@inclusion.beta.gouv.fr",
+      "email": "test+ai@inclusion.gouv.fr",
       "primary": true,
       "user": 25,
       "verified": true
@@ -191,7 +191,7 @@
   },
   {
     "fields": {
-      "email": "test+ddets@inclusion.beta.gouv.fr",
+      "email": "test+ddets@inclusion.gouv.fr",
       "primary": true,
       "user": 27,
       "verified": true
@@ -201,7 +201,7 @@
   },
   {
     "fields": {
-      "email": "test+cap@inclusion.beta.gouv.fr",
+      "email": "test+cap@inclusion.gouv.fr",
       "primary": true,
       "user": 28,
       "verified": true
@@ -211,7 +211,7 @@
   },
   {
     "fields": {
-      "email": "test+institution@inclusion.beta.gouv.fr",
+      "email": "test+institution@inclusion.gouv.fr",
       "primary": true,
       "user": 29,
       "verified": true

--- a/itou/siae_evaluations/fixtures.py
+++ b/itou/siae_evaluations/fixtures.py
@@ -1,8 +1,8 @@
 """
 Generate fake data based on global Itou's fixtures.
 You can use it with the quick login accounts located on the header banner.
-Employer's account: test+cap@inclusion.beta.gouv.fr
-Labor inspector's account: test+ddets@inclusion.beta.gouv.fr
+Employer's account: test+cap@inclusion.gouv.fr
+Labor inspector's account: test+ddets@inclusion.gouv.fr
 """
 
 import random
@@ -62,7 +62,7 @@ def load_data():
 
     created_job_applications_pks = []
 
-    employer = User.objects.get(email="test+cap@inclusion.beta.gouv.fr")
+    employer = User.objects.get(email="test+cap@inclusion.gouv.fr")
     controlled_siaes = employer.company_set.all()
     assert controlled_siaes.count() == 5
     total_administrative_criteria = AdministrativeCriteria.objects.count()

--- a/itou/utils/mocks/rdv_insertion.py
+++ b/itou/utils/mocks/rdv_insertion.py
@@ -1,10 +1,10 @@
 RDV_INSERTION_AUTH_SUCCESS_BODY = {
     "data": {
-        "email": "tech@inclusion.beta.gouv.fr",
+        "email": "tech.emplois@inclusion.gouv.fr",
         "first_name": "Jean",
         "last_name": "Teste",
         "provider": "email",
-        "uid": "tech@inclusion.beta.gouv.fr",
+        "uid": "tech.emplois@inclusion.gouv.fr",
         "id": 1,
         "deleted_at": None,
         "email_original": None,
@@ -29,7 +29,7 @@ RDV_INSERTION_AUTH_SUCCESS_BODY = {
 RDV_INSERTION_AUTH_SUCCESS_HEADERS = {
     "access-token": "V60eQsbHA6m2hTIsHzD-Jw",
     "client": "KhtrOXm0US_kCq79JhJAyA",
-    "uid": "tech@inclusion.beta.gouv.fr",
+    "uid": "tech.emplois@inclusion.gouv.fr",
 }
 
 RDV_INSERTION_AUTH_FAILURE_BODY = {
@@ -53,7 +53,7 @@ RDV_INSERTION_CREATE_AND_INVITE_SUCCESS_BODY = {
         "title": "monsieur",
         "address": "112 Quai de Jemmapes, 75010 Paris",
         "phone_number": None,
-        "email": "tech@inclusion.beta.gouv.fr",
+        "email": "tech.emplois@inclusion.gouv.fr",
         "birth_date": "1970-01-01",
         "rights_opening_date": "2024-06-22",
         "birth_name": None,
@@ -99,7 +99,7 @@ RDV_INSERTION_WEBHOOK_INVITATION_BODY = {
             "id": 3432,
             "uid": None,
             "role": "demandeur",
-            "email": "tech@inclusion.beta.gouv.fr",
+            "email": "tech.emplois@inclusion.gouv.fr",
             "title": "madame",
             "address": "102 Quai de Jemmapes, 75010 Paris 10ème",
             "last_name": "Test",
@@ -157,7 +157,7 @@ RDV_INSERTION_WEBHOOK_APPOINTMENT_BODY = {
                 "id": 3432,
                 "uid": None,
                 "role": "demandeur",
-                "email": "tech@inclusion.beta.gouv.fr",
+                "email": "tech.emplois@inclusion.gouv.fr",
                 "title": "madame",
                 "address": "102 Quai de Jemmapes, 75010 Paris 10ème",
                 "last_name": "Test",
@@ -176,7 +176,7 @@ RDV_INSERTION_WEBHOOK_APPOINTMENT_BODY = {
         "agents": [
             {
                 "id": 370,
-                "email": "tech@inclusion.beta.gouv.fr",
+                "email": "tech.emplois@inclusion.gouv.fr",
                 "last_name": "Itou",
                 "first_name": "Tech",
                 "rdv_solidarites_agent_id": 1791,
@@ -204,7 +204,7 @@ RDV_INSERTION_WEBHOOK_APPOINTMENT_BODY = {
                     "id": 3432,
                     "uid": None,
                     "role": "demandeur",
-                    "email": "tech@inclusion.beta.gouv.fr",
+                    "email": "tech.emplois@inclusion.gouv.fr",
                     "title": "madame",
                     "address": "102 Quai de Jemmapes, 75010 Paris 10ème",
                     "last_name": "Test",

--- a/itou/utils/templatetags/demo_accounts.py
+++ b/itou/utils/templatetags/demo_accounts.py
@@ -10,7 +10,7 @@ def employers_accounts_tag():
     action_url = reverse("login:employer")
     return [
         {
-            "email": "test+etti@inclusion.beta.gouv.fr",
+            "email": "test+etti@inclusion.gouv.fr",
             "description": "1 poste ouvert au recrutement",
             "image": "etti.svg",
             "location": "Beaucaire (30)",
@@ -18,7 +18,7 @@ def employers_accounts_tag():
             "action_url": action_url,
         },
         {
-            "email": "test+ei@inclusion.beta.gouv.fr",
+            "email": "test+ei@inclusion.gouv.fr",
             "description": "2 postes ouverts au recrutement",
             "image": "ei.svg",
             "location": "St-Etienne du Grès (13)",
@@ -26,7 +26,7 @@ def employers_accounts_tag():
             "action_url": action_url,
         },
         {
-            "email": "test+geiq@inclusion.beta.gouv.fr",
+            "email": "test+geiq@inclusion.gouv.fr",
             "description": "1 poste ouvert au recrutement",
             "image": "geiq.svg",
             "location": "Tarascon (13)",
@@ -34,7 +34,7 @@ def employers_accounts_tag():
             "action_url": action_url,
         },
         {
-            "email": "test+ea@inclusion.beta.gouv.fr",
+            "email": "test+ea@inclusion.gouv.fr",
             "description": "1 poste ouvert au recrutement",
             "image": "ea.svg",
             "location": "Fontvieille (13)",
@@ -42,7 +42,7 @@ def employers_accounts_tag():
             "action_url": action_url,
         },
         {
-            "email": "test+ai@inclusion.beta.gouv.fr",
+            "email": "test+ai@inclusion.gouv.fr",
             "description": "1 poste ouvert au recrutement",
             "image": "ai.svg",
             "location": "Tours (37)",
@@ -58,19 +58,19 @@ def prescribers_accounts_tag():
     return [
         {
             "title": "Prescripteur habilité",
-            "email": "test+prescripteur@inclusion.beta.gouv.fr",
+            "email": "test+prescripteur@inclusion.gouv.fr",
             "image": "prescripteur_habilite.svg",
             "action_url": action_url,
         },
         {
             "title": "Orienteur <br>(prescripteur non habilité)",
-            "email": "test+orienteur@inclusion.beta.gouv.fr",
+            "email": "test+orienteur@inclusion.gouv.fr",
             "image": "prescripteur_non_habilite.svg",
             "action_url": action_url,
         },
         {
             "title": "Orienteur seul,<br> sans organisation",
-            "email": "test+orienteur-solo@inclusion.beta.gouv.fr",
+            "email": "test+orienteur-solo@inclusion.gouv.fr",
             "image": "prescripteur_solo.svg",
             "action_url": action_url,
         },
@@ -80,4 +80,4 @@ def prescribers_accounts_tag():
 @register.simple_tag
 def job_seekers_accounts_tag():
     action_url = reverse("login:job_seeker")
-    return [{"email": "test+de@inclusion.beta.gouv.fr", "image": "de.svg", "action_url": action_url}]
+    return [{"email": "test+de@inclusion.gouv.fr", "image": "de.svg", "action_url": action_url}]

--- a/scripts/mkchangelog
+++ b/scripts/mkchangelog
@@ -164,7 +164,7 @@ def main(publish):
             "-c",
             "user.name=Changelog Bot",
             "-c",
-            "user.email=noreply@inclusion.beta.gouv.fr",
+            "user.email=tech.emplois@inclusion.gouv.fr",
             "commit",
         ]
         title = f"changelog: From {sprint_start} to {sprint_end}"

--- a/tests/rdv_insertion/tests.py
+++ b/tests/rdv_insertion/tests.py
@@ -36,7 +36,7 @@ class TestRDVInsertionTokenRenewal:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings):
         settings.RDV_SOLIDARITES_API_BASE_URL = "https://rdv-solidarites.fake/api/v1/"
-        settings.RDV_SOLIDARITES_EMAIL = "tech@inclusion.beta.gouv.fr"
+        settings.RDV_SOLIDARITES_EMAIL = "tech.emplois@inclusion.gouv.fr"
         settings.RDV_SOLIDARITES_PASSWORD = "password"
         settings.RDV_SOLIDARITES_TOKEN_EXPIRY = 86000
         settings.RDV_INSERTION_API_BASE_URL = "https://rdv-insertion.fake/api/v1/"

--- a/tests/www/apply/test_detail_rdv_insertion.py
+++ b/tests/www/apply/test_detail_rdv_insertion.py
@@ -22,7 +22,7 @@ from tests.utils.test import parse_response_to_soup
 @pytest.fixture(autouse=True)
 def mock_rdvs_api(settings):
     settings.RDV_SOLIDARITES_API_BASE_URL = "https://rdv-solidarites.fake/api/v1/"
-    settings.RDV_SOLIDARITES_EMAIL = "tech@inclusion.beta.gouv.fr"
+    settings.RDV_SOLIDARITES_EMAIL = "tech.emplois@inclusion.gouv.fr"
     settings.RDV_SOLIDARITES_PASSWORD = "password"
     settings.RDV_INSERTION_API_BASE_URL = "https://rdv-insertion.fake/api/v1/"
     settings.RDV_INSERTION_INVITE_HOLD_DURATION = datetime.timedelta(days=2)

--- a/tests/www/apply/test_list_rdv_insertion.py
+++ b/tests/www/apply/test_list_rdv_insertion.py
@@ -24,7 +24,7 @@ from tests.utils.test import parse_response_to_soup
 @pytest.fixture(autouse=True)
 def mock_rdvs_api(settings):
     settings.RDV_SOLIDARITES_API_BASE_URL = "https://rdv-solidarites.fake/api/v1/"
-    settings.RDV_SOLIDARITES_EMAIL = "tech@inclusion.beta.gouv.fr"
+    settings.RDV_SOLIDARITES_EMAIL = "tech.emplois@inclusion.gouv.fr"
     settings.RDV_SOLIDARITES_PASSWORD = "password"
     settings.RDV_INSERTION_API_BASE_URL = "https://rdv-insertion.fake/api/v1/"
     settings.RDV_INSERTION_INVITE_HOLD_DURATION = datetime.timedelta(days=2)


### PR DESCRIPTION
## :thinking: Pourquoi ?
Les emails en @inclusion.beta.gouv.fr disparaitront bientôt.