### PR TITLE
Création de compte candidat : gestion des permissions

### DIFF
--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -210,6 +210,12 @@ class GetOrCreateJobSeekerStartView(View):
         data |= {"apply": {"company_pk": company.pk}} if company else {}
         self.job_seeker_session = SessionNamespace.create_uuid_namespace(request.session, data)
 
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.kind not in [UserKind.PRESCRIBER, UserKind.EMPLOYER]:
+            raise PermissionDenied("Vous n'êtes pas autorisé à rechercher ou créer un compte candidat.")
+
+        return super().dispatch(request, *args, **kwargs)
+
     def get(self, request, *args, **kwargs):
         if self.tunnel == "sender" or self.tunnel == "gps":
             view_name = "job_seekers_views:check_nir_for_sender"

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -307,8 +307,7 @@ class JobSeekerForSenderBaseView(JobSeekerBaseView):
 
     def dispatch(self, request, *args, **kwargs):
         if self.sender.kind not in [UserKind.PRESCRIBER, UserKind.EMPLOYER]:
-            logger.info(f"dispatch ({request.path}) : {self.sender.kind} in sender tunnel")
-            return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
+            raise PermissionDenied()
         return super().dispatch(request, *args, **kwargs)
 
 
@@ -328,8 +327,7 @@ class CheckNIRForJobSeekerView(JobSeekerBaseView):
 
     def dispatch(self, request, *args, **kwargs):
         if not self.job_seeker.is_job_seeker:
-            logger.info(f"dispatch ({request.path}) : {request.user.kind} in jobseeker tunnel")
-            return HttpResponseRedirect(reverse("apply:start", kwargs={"company_pk": self.company.pk}))
+            raise PermissionDenied()
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3107,8 +3107,6 @@ class TestApplyAsOther:
     ROUTES = [
         "apply:start",
         "apply:start_hire",
-        "job_seekers_views:check_nir_for_job_seeker",
-        "job_seekers_views:check_nir_for_sender",
     ]
 
     def test_labor_inspectors_are_not_allowed_to_submit_application(self, client, subtests):
@@ -3119,18 +3117,7 @@ class TestApplyAsOther:
 
         for route in self.ROUTES:
             with subtests.test(route=route):
-                if route.startswith("apply"):
-                    response = client.get(reverse(route, kwargs={"company_pk": company.pk}), follow=True)
-                else:
-                    # Init session (as it would be in apply:start)
-                    session = client.session
-                    session_name = str(uuid.uuid4())
-                    session[session_name] = {
-                        "config": {},
-                        "apply": {"company_pk": company.pk},
-                    }
-                    session.save()
-                    response = client.get(reverse(route, kwargs={"session_uuid": session_name}), follow=True)
+                response = client.get(reverse(route, kwargs={"company_pk": company.pk}), follow=True)
                 assert response.status_code == 403
 
     def test_itou_staff_are_not_allowed_to_submit_application(self, client, subtests):
@@ -3140,18 +3127,7 @@ class TestApplyAsOther:
 
         for route in self.ROUTES:
             with subtests.test(route=route):
-                if route.startswith("apply"):
-                    response = client.get(reverse(route, kwargs={"company_pk": company.pk}), follow=True)
-                else:
-                    # Init session (as it would be in apply:start)
-                    session = client.session
-                    session_name = str(uuid.uuid4())
-                    session[session_name] = {
-                        "config": {},
-                        "apply": {"company_pk": company.pk},
-                    }
-                    session.save()
-                    response = client.get(reverse(route, kwargs={"session_uuid": session_name}), follow=True)
+                response = client.get(reverse(route, kwargs={"company_pk": company.pk}), follow=True)
                 assert response.status_code == 403
 
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -96,21 +96,8 @@ class TestApply:
             "apply:start",
             "apply:start_hire",
             "apply:pending_authorization_for_sender",
-            "job_seekers_views:check_nir_for_sender",
-            "job_seekers_views:check_nir_for_job_seeker",
         ):
-            if viewname.startswith("apply"):
-                url = reverse(viewname, kwargs={"company_pk": company.pk})
-            else:
-                # Init session (as it would be in apply:start)
-                session = client.session
-                session_name = str(uuid.uuid4())
-                session[session_name] = {
-                    "config": {},
-                    "apply": {"company_pk": company.pk},
-                }
-                session.save()
-                url = reverse(viewname, kwargs={"session_uuid": session_name})
+            url = reverse(viewname, kwargs={"company_pk": company.pk})
             response = client.get(url)
             assertRedirects(response, reverse("account_login") + f"?next={url}")
 
@@ -3834,10 +3821,6 @@ class UpdateJobSeekerTestMixin:
 class TestUpdateJobSeeker(UpdateJobSeekerTestMixin):
     FINAL_REDIRECT_VIEW_NAME = "apply:application_jobs"
 
-    def test_anonymous_start(self, client):
-        response = client.get(self.start_url)
-        assertRedirects(response, add_url_params(reverse("account_login"), {"next": self.start_url}))
-
     def test_as_job_seeker(self, client):
         self._check_nothing_permitted(client, self.job_seeker)
 
@@ -3975,10 +3958,6 @@ class TestUpdateJobSeeker(UpdateJobSeekerTestMixin):
 
 class TestUpdateJobSeekerForHire(UpdateJobSeekerTestMixin):
     FINAL_REDIRECT_VIEW_NAME = "job_seekers_views:check_job_seeker_info_for_hire"
-
-    def test_anonymous_start(self, client):
-        response = client.get(self.start_url)
-        assertRedirects(response, add_url_params(reverse("account_login"), {"next": self.start_url}))
 
     def test_as_job_seeker(self, client):
         self._check_nothing_permitted(client, self.job_seeker)

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -16,7 +16,7 @@ from tests.users.factories import JobSeekerFactory
 from tests.utils.test import KNOWN_SESSION_KEYS
 
 
-class TestCreateForJobSeeker:
+class TestGetOrCreateForJobSeeker:
     def test_check_nir_with_session(self, client):
         company = CompanyFactory(with_membership=True)
         user = JobSeekerFactory(jobseeker_profile__birthdate=None, jobseeker_profile__nir="")
@@ -68,7 +68,7 @@ class TestCreateForJobSeeker:
         )
 
 
-class TestCreateForSender:
+class TestGetOrCreateForSender:
     @pytest.mark.parametrize(
         "company_value, tunnel_value, from_url_value, expected_status_code",
         [
@@ -280,7 +280,7 @@ class TestCreateForSender:
         )
 
 
-class TestUpdateForJobSeekerStart:
+class TestUpdateForJobSeeker:
     def test_start_update_job_seeker_forbidden(self, client):
         job_seeker = JobSeekerFactory(jobseeker_profile__birthdate=None, jobseeker_profile__nir="")
         company = CompanyFactory(with_membership=True)
@@ -303,7 +303,7 @@ class TestUpdateForJobSeekerStart:
         assert response.status_code == 403
 
 
-class TestUpdateForSenderStart:
+class TestUpdateForSender:
     @pytest.mark.parametrize(
         "job_seeker_value, from_url_value, expected_status_code",
         [
@@ -397,12 +397,10 @@ class TestUpdateForSenderStart:
 
         assert response.status_code == 404
 
-
-class TestUpdateJobSeekerStep1:
     @pytest.mark.parametrize(
         "born_in_france", [pytest.param(True, id="born_in_france"), pytest.param(False, id="born_outside_france")]
     )
-    def test_create_step_1(self, born_in_france, client):
+    def test_update_step_1(self, born_in_france, client):
         company = CompanyFactory(with_membership=True)
         user = company.members.get()
         job_seeker = JobSeekerFactory(created_by=user, title=Title.M, jobseeker_profile__nir="111116411111144")


### PR DESCRIPTION
## :thinking: Pourquoi ?

En voulant nettoyer/migrer les tests de création de compte candidat depuis `apply` vers `job_seekers_views`, je me suis rendu compte qu'il manquait une vérification de permission/userkind : les inspecteurs du travail et le staff Itou ne devraient pas être capables de créer de compte candidat (commit n°2).

J'ai également un peu simplifié ce qu'il se passe quand un utilisateur d'un certain type arrive sur le tunnel d'un autre type (par exemple, un `job_seeker` sur `CheckNIRForSender` ou un employeur sur `CheckNIRForJobSeeker`).
En pratique, ceci ne devrait jamais arriver, pour deux raisons :
- j'avais mis un `logger.info` qui relève quand une redirection se produit (https://github.com/gip-inclusion/les-emplois/blob/master/itou/www/job_seekers_views/views.py#L305, https://github.com/gip-inclusion/les-emplois/blob/master/itou/www/job_seekers_views/views.py#L326), le logger n'a jamais rien donné
- maintenant qu'on a le système de session, une erreur 404 est levée quand le `session_kind` ne correspond pas à l'action qu'on essaie de faire

Mais au cas où, je laisse un garde-fou : une erreur 403 quand on accède au mauvais type (commit n°4).
À voir si on supprime ce garde-fou également.



