### PR TITLE
Candidature: conserver le mode d'affichage (Tableau/Liste) quand on efface tous les filtres

### DIFF
--- a/itou/templates/apply/includes/list_reset_filters.html
+++ b/itou/templates/apply/includes/list_reset_filters.html
@@ -10,7 +10,7 @@
 {% if btn_dropdown_filter|default:False %}
     <div class="ms-md-auto" id="apply-list-filter-counter"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
         {% if filters_counter > 0 %}
-            <a href="{{ reset_url }}" class="btn btn-ico btn-dropdown-filter" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
+            <a href="{{ reset_url }}?display={{ display_kind }}" class="btn btn-ico btn-dropdown-filter" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
                 <i class="ri-eraser-line fw-medium" aria-hidden="true"></i>
                 <span>Effacer tout</span>
             </a>
@@ -18,7 +18,7 @@
     </div>
 {% else %}
     {% if filters_counter > 0 %}
-        <a href="{{ reset_url }}" class="btn btn-ico btn-block btn-outline-primary" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
+        <a href="{{ reset_url }}?display={{ display_kind }}" class="btn btn-ico btn-block btn-outline-primary" aria-label="Réinitialiser {{ filters_counter|pluralizefr:"le filtre actif,les filtres actifs" }}">
             <i class="ri-eraser-line fw-medium" aria-hidden="true"></i>
             <span>Effacer tout</span>
         </a>

--- a/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
@@ -536,3 +536,69 @@
   </section>
   '''
 # ---
+# name: test_reset_filter_button_snapshot[off-canvas buttons in list view]
+  '''
+  <div class="offcanvas-footer gap-3" id="offcanvasApplyFiltersButtons">
+      <button class="btn btn-block btn-primary" data-bs-dismiss="offcanvas" type="button">Voir</button>
+      
+  
+  
+      
+  
+  
+      
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/job_seeker/list">
+              <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+              <span>Effacer tout</span>
+          </a>
+      
+  
+  
+  </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[off-canvas buttons in table view]
+  '''
+  <div class="offcanvas-footer gap-3" id="offcanvasApplyFiltersButtons">
+      <button class="btn btn-block btn-primary" data-bs-dismiss="offcanvas" type="button">Voir</button>
+      
+  
+  
+      
+  
+  
+      
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/job_seeker/list">
+              <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+              <span>Effacer tout</span>
+          </a>
+      
+  
+  
+  </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[reset-filter button in list view]
+  '''
+  <div class="ms-md-auto" id="apply-list-filter-counter">
+          
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/job_seeker/list">
+                  <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+                  <span>Effacer tout</span>
+              </a>
+          
+      </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[reset-filter button in table view]
+  '''
+  <div class="ms-md-auto" id="apply-list-filter-counter">
+          
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/job_seeker/list">
+                  <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+                  <span>Effacer tout</span>
+              </a>
+          
+      </div>
+  '''
+# ---

--- a/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
@@ -547,7 +547,7 @@
   
   
       
-          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/job_seeker/list">
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/job_seeker/list?display=list">
               <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
               <span>Effacer tout</span>
           </a>
@@ -568,7 +568,7 @@
   
   
       
-          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/job_seeker/list">
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/job_seeker/list?display=table">
               <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
               <span>Effacer tout</span>
           </a>
@@ -582,7 +582,7 @@
   '''
   <div class="ms-md-auto" id="apply-list-filter-counter">
           
-              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/job_seeker/list">
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/job_seeker/list?display=list">
                   <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
                   <span>Effacer tout</span>
               </a>
@@ -594,7 +594,7 @@
   '''
   <div class="ms-md-auto" id="apply-list-filter-counter">
           
-              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/job_seeker/list">
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/job_seeker/list?display=table">
                   <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
                   <span>Effacer tout</span>
               </a>

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -2970,7 +2970,7 @@
   
   
       
-          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/siae/list">
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/siae/list?display=list">
               <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
               <span>Effacer tout</span>
           </a>
@@ -2991,7 +2991,7 @@
   
   
       
-          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/siae/list">
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/siae/list?display=table">
               <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
               <span>Effacer tout</span>
           </a>
@@ -3005,7 +3005,7 @@
   '''
   <div class="ms-md-auto" id="apply-list-filter-counter">
           
-              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/siae/list">
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/siae/list?display=list">
                   <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
                   <span>Effacer tout</span>
               </a>
@@ -3017,7 +3017,7 @@
   '''
   <div class="ms-md-auto" id="apply-list-filter-counter">
           
-              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/siae/list">
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/siae/list?display=table">
                   <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
                   <span>Effacer tout</span>
               </a>

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -2959,3 +2959,69 @@
   </section>
   '''
 # ---
+# name: test_reset_filter_button_snapshot[off-canvas buttons in list view]
+  '''
+  <div class="offcanvas-footer gap-3" id="offcanvasApplyFiltersButtons">
+      <button class="btn btn-block btn-primary" data-bs-dismiss="offcanvas" type="button">Voir</button>
+      
+  
+  
+      
+  
+  
+      
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/siae/list">
+              <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+              <span>Effacer tout</span>
+          </a>
+      
+  
+  
+  </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[off-canvas buttons in table view]
+  '''
+  <div class="offcanvas-footer gap-3" id="offcanvasApplyFiltersButtons">
+      <button class="btn btn-block btn-primary" data-bs-dismiss="offcanvas" type="button">Voir</button>
+      
+  
+  
+      
+  
+  
+      
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/siae/list">
+              <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+              <span>Effacer tout</span>
+          </a>
+      
+  
+  
+  </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[reset-filter button in list view]
+  '''
+  <div class="ms-md-auto" id="apply-list-filter-counter">
+          
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/siae/list">
+                  <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+                  <span>Effacer tout</span>
+              </a>
+          
+      </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[reset-filter button in table view]
+  '''
+  <div class="ms-md-auto" id="apply-list-filter-counter">
+          
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/siae/list">
+                  <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+                  <span>Effacer tout</span>
+              </a>
+          
+      </div>
+  '''
+# ---

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -3017,7 +3017,7 @@
   
   
       
-          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/prescriptions/list">
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/prescriptions/list?display=list">
               <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
               <span>Effacer tout</span>
           </a>
@@ -3038,7 +3038,7 @@
   
   
       
-          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/prescriptions/list">
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/prescriptions/list?display=table">
               <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
               <span>Effacer tout</span>
           </a>
@@ -3052,7 +3052,7 @@
   '''
   <div class="ms-md-auto" id="apply-list-filter-counter">
           
-              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/prescriptions/list">
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/prescriptions/list?display=list">
                   <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
                   <span>Effacer tout</span>
               </a>
@@ -3064,7 +3064,7 @@
   '''
   <div class="ms-md-auto" id="apply-list-filter-counter">
           
-              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/prescriptions/list">
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/prescriptions/list?display=table">
                   <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
                   <span>Effacer tout</span>
               </a>

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -3006,3 +3006,69 @@
   </section>
   '''
 # ---
+# name: test_reset_filter_button_snapshot[off-canvas buttons in list view]
+  '''
+  <div class="offcanvas-footer gap-3" id="offcanvasApplyFiltersButtons">
+      <button class="btn btn-block btn-primary" data-bs-dismiss="offcanvas" type="button">Voir</button>
+      
+  
+  
+      
+  
+  
+      
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/prescriptions/list">
+              <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+              <span>Effacer tout</span>
+          </a>
+      
+  
+  
+  </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[off-canvas buttons in table view]
+  '''
+  <div class="offcanvas-footer gap-3" id="offcanvasApplyFiltersButtons">
+      <button class="btn btn-block btn-primary" data-bs-dismiss="offcanvas" type="button">Voir</button>
+      
+  
+  
+      
+  
+  
+      
+          <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-block btn-outline-primary" href="/apply/prescriptions/list">
+              <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+              <span>Effacer tout</span>
+          </a>
+      
+  
+  
+  </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[reset-filter button in list view]
+  '''
+  <div class="ms-md-auto" id="apply-list-filter-counter">
+          
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/prescriptions/list">
+                  <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+                  <span>Effacer tout</span>
+              </a>
+          
+      </div>
+  '''
+# ---
+# name: test_reset_filter_button_snapshot[reset-filter button in table view]
+  '''
+  <div class="ms-md-auto" id="apply-list-filter-counter">
+          
+              <a aria-label="Réinitialiser le filtre actif" class="btn btn-ico btn-dropdown-filter" href="/apply/prescriptions/list">
+                  <i aria-hidden="true" class="ri-eraser-line fw-medium"></i>
+                  <span>Effacer tout</span>
+              </a>
+          
+      </div>
+  '''
+# ---

--- a/tests/www/apply/test_list_for_job_seeker.py
+++ b/tests/www/apply/test_list_for_job_seeker.py
@@ -224,3 +224,28 @@ def test_list_snapshot(client, snapshot):
         ),
     )
     assert str(page) == snapshot(name="applications table")
+
+
+def test_reset_filter_button_snapshot(client, snapshot):
+    job_application = JobApplicationFactory()
+    client.force_login(job_application.job_seeker)
+
+    filter_params = {"states": [job_application.state]}
+    response = client.get(reverse("apply:list_for_job_seeker"), filter_params)
+
+    assert str(parse_response_to_soup(response, selector="#apply-list-filter-counter")) == snapshot(
+        name="reset-filter button in list view"
+    )
+    assert str(parse_response_to_soup(response, selector="#offcanvasApplyFiltersButtons")) == snapshot(
+        name="off-canvas buttons in list view"
+    )
+
+    filter_params["display"] = JobApplicationsDisplayKind.TABLE
+    response = client.get(reverse("apply:list_for_job_seeker"), filter_params)
+
+    assert str(parse_response_to_soup(response, selector="#apply-list-filter-counter")) == snapshot(
+        name="reset-filter button in table view"
+    )
+    assert str(parse_response_to_soup(response, selector="#offcanvasApplyFiltersButtons")) == snapshot(
+        name="off-canvas buttons in table view"
+    )

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -933,3 +933,28 @@ def test_list_for_siae_badge(client, snapshot, job_app_kwargs):
     response = client.get(reverse("apply:list_for_siae"))
     badge = parse_response_to_soup(response, selector=".c-box--results__summary span.badge")
     assert str(badge) == snapshot
+
+
+def test_reset_filter_button_snapshot(client, snapshot):
+    job_application = JobApplicationFactory()
+    client.force_login(job_application.to_company.members.get())
+
+    filter_params = {"states": [job_application.state]}
+    response = client.get(reverse("apply:list_for_siae"), filter_params)
+
+    assert str(parse_response_to_soup(response, selector="#apply-list-filter-counter")) == snapshot(
+        name="reset-filter button in list view"
+    )
+    assert str(parse_response_to_soup(response, selector="#offcanvasApplyFiltersButtons")) == snapshot(
+        name="off-canvas buttons in list view"
+    )
+
+    filter_params["display"] = JobApplicationsDisplayKind.TABLE
+    response = client.get(reverse("apply:list_for_siae"), filter_params)
+
+    assert str(parse_response_to_soup(response, selector="#apply-list-filter-counter")) == snapshot(
+        name="reset-filter button in table view"
+    )
+    assert str(parse_response_to_soup(response, selector="#offcanvasApplyFiltersButtons")) == snapshot(
+        name="off-canvas buttons in table view"
+    )

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -525,3 +525,28 @@ def test_exports_download_by_month(client):
     )
     assert 200 == response.status_code
     assert "spreadsheetml" in response.get("Content-Type")
+
+
+def test_reset_filter_button_snapshot(client, snapshot):
+    job_application = JobApplicationFactory()
+    client.force_login(job_application.sender)
+
+    filter_params = {"states": [job_application.state]}
+    response = client.get(reverse("apply:list_prescriptions"), filter_params)
+
+    assert str(parse_response_to_soup(response, selector="#apply-list-filter-counter")) == snapshot(
+        name="reset-filter button in list view"
+    )
+    assert str(parse_response_to_soup(response, selector="#offcanvasApplyFiltersButtons")) == snapshot(
+        name="off-canvas buttons in list view"
+    )
+
+    filter_params["display"] = JobApplicationsDisplayKind.TABLE
+    response = client.get(reverse("apply:list_prescriptions"), filter_params)
+
+    assert str(parse_response_to_soup(response, selector="#apply-list-filter-counter")) == snapshot(
+        name="reset-filter button in table view"
+    )
+    assert str(parse_response_to_soup(response, selector="#offcanvasApplyFiltersButtons")) == snapshot(
+        name="off-canvas buttons in table view"
+    )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement, quand on se met en mode tableau et qu'on ajoute des filtres (ou dans l'autre sens), si on enlève ensuite les filtres avec le bouton "Effacer tout", on est rebasculé en mode liste.

Pas trop d'idée de test par contre...

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?

## :desert_island: Comment tester

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->
