### PR TITLE
UX/UI: Correction des attributs sur les tooltips

### DIFF
--- a/itou/templates/admin/job_applications/jobapplication_change_form.html
+++ b/itou/templates/admin/job_applications/jobapplication_change_form.html
@@ -21,7 +21,7 @@
                        class="danger js-with-confirm"
                        name="transition_cancel"
                        value="Annuler"
-                       {% if not original.can_be_cancelled %} disabled data-bs-toggle="tooltip" data-bs-placement="top" title=" Une fichie salarié doit probablement être supprimée avant de pouvoir annuler cette candidature " {% endif %}>
+                       {% if not original.can_be_cancelled %} disabled title="Une fiche salarié doit probablement être supprimée avant de pouvoir annuler cette candidature" {% endif %}>
             {% endif %}
             {% if original.state.is_obsolete %}
                 <input type='submit' class="danger js-with-confirm" name="transition_reset" value="Remettre au statut nouveau">

--- a/itou/templates/apply/includes/buttons/new_diagnosis.html
+++ b/itou/templates/apply/includes/buttons/new_diagnosis.html
@@ -3,7 +3,7 @@
         <button class="btn btn-lg btn-white btn-block btn-ico disabled"
                 data-bs-toggle="tooltip"
                 data-bs-placement="top"
-                title="Vous ne pouvez pas valider les critères d'éligibilité suite aux mesures prises dans le cadre du contrôle a posteriori. {{ suspension }}">
+                data-bs-title="Vous ne pouvez pas valider les critères d'éligibilité suite aux mesures prises dans le cadre du contrôle a posteriori. {{ suspension }}">
             <i class="ri-check-line fw-medium" aria-hidden="true"></i>
             <span>Accepter</span>
         </button>

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -18,7 +18,7 @@
             <i class="ri-information-line ri-xl text-info ms-1"
                data-bs-toggle="tooltip"
                data-bs-placement="top"
-               title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+               data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
         {% endif %}
     </div>
 </div>

--- a/itou/templates/apply/includes/transfer_job_application.html
+++ b/itou/templates/apply/includes/transfer_job_application.html
@@ -22,7 +22,7 @@
                 <strong>Une autre structure</strong>
             </a>
         {% else %}
-            <div data-bs-toggle="tooltip" data-bs-placement="bottom" title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur">
+            <div data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur">
                 <div class="dropdown-item disabled">
                     <i class="ri-home-smile-line"></i>
                     <strong>Une autre structure</strong>

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -99,10 +99,10 @@
                                                             <i class="ri-information-line ri-lg text-info ms-1"
                                                                data-bs-toggle="tooltip"
                                                                data-bs-placement="top"
-                                                               title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
+                                                               data-bs-title="L'embauche empêche l'atteinte des engagements contractuels avec les parties prenantes à la convention de financement mise en place par l'État."></i>
                                                         {% elif radio.data.value == RefusalReason.NO_POSITION %}
                                                             {{ radio.choice_label }}
-                                                            <i class="ri-information-line ri-lg text-info ms-1" data-bs-toggle="tooltip" data-bs-placement="right" title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
+                                                            <i class="ri-information-line ri-lg text-info ms-1" data-bs-toggle="tooltip" data-bs-placement="right" data-bs-title="Si vous choisissez ce motif, les fiches de postes associées seront dépubliées."></i>
                                                         {% elif radio.data.value == RefusalReason.OTHER %}
                                                             {{ radio.choice_label }}
                                                             {% if job_application.sender_kind == SenderKind.PRESCRIBER %}

--- a/itou/templates/approvals/details.html
+++ b/itou/templates/approvals/details.html
@@ -65,7 +65,7 @@
                                                 disabled
                                                 data-bs-toggle="tooltip"
                                                 data-bs-placement="top"
-                                                {% if approval.is_suspended %}title="La suspension n’est pas possible car une suspension est déjà en cours."{% elif not approval.is_valid %}title="Il est impossible de faire une suspension de PASS IAE expiré."{% elif not approval.is_in_progress %}title="La suspension n’est pas possible car le PASS IAE n’a pas encore démarré."{% else %}title="La suspension n’est pas possible car un autre employeur a embauché le candidat."{% endif %}>
+                                                {% if approval.is_suspended %}data-bs-title="La suspension n’est pas possible car une suspension est déjà en cours."{% elif not approval.is_valid %}data-bs-title="Il est impossible de faire une suspension de PASS IAE expiré."{% elif not approval.is_in_progress %}data-bs-title="La suspension n’est pas possible car le PASS IAE n’a pas encore démarré."{% else %}data-bs-title="La suspension n’est pas possible car un autre employeur a embauché le candidat."{% endif %}>
                                             <i class="ri-pause-circle-line fw-medium" aria-hidden="true"></i>
                                             <span>Suspendre</span>
                                         </button>
@@ -173,7 +173,7 @@
                                                 disabled
                                                 data-bs-toggle="tooltip"
                                                 data-bs-placement="top"
-                                                {% if not approval.is_valid %} title="Il est impossible de faire une prolongation de PASS IAE expiré." {% elif prolongation_request_pending %} title="Il ne peut y avoir qu’une seule demande de prolongation en attente à la fois." {% else %} title="Les prolongations ne sont possibles qu’entre le {{ approval.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END }}ème mois avant la fin d’un PASS IAE et jusqu’à son dernier jour de validité." {% endif %}>
+                                                {% if not approval.is_valid %} data-bs-title="Il est impossible de faire une prolongation de PASS IAE expiré." {% elif prolongation_request_pending %} data-bs-title="Il ne peut y avoir qu’une seule demande de prolongation en attente à la fois." {% else %} data-bs-title="Les prolongations ne sont possibles qu’entre le {{ approval.IS_OPEN_TO_PROLONGATION_BOUNDARIES_MONTHS_BEFORE_END }}ème mois avant la fin d’un PASS IAE et jusqu’à son dernier jour de validité." {% endif %}>
                                             <i class="ri-refresh-line fw-medium" aria-hidden="true"></i>
                                             <span>Prolonger</span>
                                         </button>

--- a/itou/templates/approvals/includes/box.html
+++ b/itou/templates/approvals/includes/box.html
@@ -34,9 +34,12 @@ Arguments:
                 <strong>{{ approval.remainder_as_date|date:"d/m/Y" }}</strong>
             </li>
             <li class="order-4{% if detail_view_version|default:False %} order-lg-3{% endif %}">
-                <small>Durée de validité <i class="ri-information-line ri-xl text-info"
-    data-bs-toggle="tooltip"
-    data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                <small>
+                    Durée de validité
+                    <i class="ri-information-line ri-xl text-info"
+                       data-bs-toggle="tooltip"
+                       data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                </small>
                 <strong {% if approval.state == "VALID" or approval.state == "FUTURE" %}class="text-success"{% endif %}>{{ approval.get_remainder_display }}</strong>
             </li>
         {% endif %}

--- a/itou/templates/approvals/includes/list_card.html
+++ b/itou/templates/approvals/includes/list_card.html
@@ -42,7 +42,8 @@
                     Durée de validité
                     <i class="ri-information-line text-info"
                        data-bs-toggle="tooltip"
-                       title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                       data-bs-title="Le reliquat est calculé sur la base d'un nombre de jours calendaires. Si le PASS IAE n'est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                </small>
                 <strong class="text-success">{{ approval.get_remainder_display }}</strong>
 
             </li>

--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -42,7 +42,7 @@
                                         <th scope="col">Demandée le</th>
                                         <th scope="col">
                                             Adressée à
-                                            <i class="ri-information-line text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                                            <i class="ri-information-line text-info" data-bs-toggle="tooltip" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
                                         </th>
                                         <th scope="col">Statut</th>
                                         <th scope="col" class="text-end w-50px"></th>

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -70,7 +70,7 @@
                         <hr>
                         <h3>
                             Adressé à
-                            <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                            <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
                         </h3>
                         <p>{{ prolongation_request.validated_by.get_full_name }} a été sollicité pour cette demande.</p>
                         <h3>Date de fin de PASS IAE demandée : {{ prolongation_request.end_at|date:"d/m/Y" }}</h3>

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -44,7 +44,7 @@
                     <span class="btn btn-lg btn-primary btn-ico disabled"
                           data-bs-toggle="tooltip"
                           data-bs-placement="top"
-                          title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
+                          data-bs-title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
                         <i class="ri-user-follow-line fw-medium"></i>
                         <span>Déclarer une embauche</span>
                     </span>

--- a/itou/templates/dashboard/includes/employer_job_applications_card.html
+++ b/itou/templates/dashboard/includes/employer_job_applications_card.html
@@ -25,7 +25,7 @@
                         <span class="btn-link btn-ico"
                               data-bs-toggle="tooltip"
                               data-bs-placement="top"
-                              title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
+                              data-bs-title="Vous ne pouvez pas déclarer d'embauche suite aux mesures prises dans le cadre du contrôle a posteriori. {{ siae_suspension_text_with_dates }}">
                             <i class="ri-user-follow-line ri-lg fw-normal disabled"></i>
                             <span class="disabled">Enregistrer une candidature</span>
                         </span>

--- a/itou/templates/geiq/assessment_info_for_employer.html
+++ b/itou/templates/geiq/assessment_info_for_employer.html
@@ -91,7 +91,7 @@
                                     {% bootstrap_form_errors submission_form type="non_fields" %}
                                     {% bootstrap_field submission_form.up_to_date_information %}
                                     <div class="form-group mb-0 col-6 col-lg-auto">
-                                        <button type="submit" class="btn btn-primary" {% if assessment.submitted_at %} disabled data-bs-toggle="tooltip" data-bs-placement="top" title="Votre dossier a déjà été envoyé." {% endif %}>
+                                        <button type="submit" class="btn btn-primary" {% if assessment.submitted_at %} disabled data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." {% endif %}>
                                             <span>Envoyer le bilan d’exécution</span>
                                         </button>
                                     </div>

--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -23,7 +23,7 @@
                         <td>
                             {{ member.user.get_full_name }}
                             {% if member.user in active_admin_members %}
-                                <span class="badge badge-xs rounded-pill bg-info" data-bs-toggle="tooltip" title="Administrateur de la structure">admin</span>
+                                <span class="badge badge-xs rounded-pill bg-info" data-bs-toggle="tooltip" data-bs-title="Administrateur de la structure">admin</span>
                             {% endif %}
                         </td>
                         <td>

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -47,7 +47,7 @@
                                    href="{{ url_query }}"
                                    {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %}
                                    {% if forloop.counter == 1 %}id="introJsBtnPostuler"{% endif %}>
-                                    <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip" title="Postuler pour ce candidat"></i>
+                                    <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip" data-bs-title="Postuler pour ce candidat"></i>
                                 </a>
                             </td>
                         </tr>

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -947,7 +947,7 @@
       <div aria-labelledby="transfer_to_button" class="dropdown-menu w-100">
           
           
-              <div data-bs-placement="bottom" data-bs-toggle="tooltip" title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur">
+              <div data-bs-placement="bottom" data-bs-title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur" data-bs-toggle="tooltip">
                   <div class="dropdown-item disabled">
                       <i class="ri-home-smile-line"></i>
                       <strong>Une autre structure</strong>

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -54,7 +54,9 @@ class TestApplyAsPrescriber:
                 data-matomo-option="postuler-pour-ce-candidat"
                 id="introJsBtnPostuler"
                 href="{next_url}">
-                <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip" title="Postuler pour ce candidat">
+                <i class="ri-draft-line" aria-hidden="true"
+                data-bs-toggle="tooltip"
+                data-bs-title="Postuler pour ce candidat">
                 </i>
             </a>
             """,
@@ -221,7 +223,9 @@ class TestApplyAsPrescriber:
                 data-matomo-option="postuler-pour-ce-candidat"
                 id="introJsBtnPostuler"
                 href="{next_url}">
-                <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip" title="Postuler pour ce candidat">
+                <i class="ri-draft-line" aria-hidden="true"
+                data-bs-toggle="tooltip"
+                data-bs-title="Postuler pour ce candidat">
                 </i>
             </a>
             """,

--- a/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
@@ -296,9 +296,12 @@
                   <strong>31/12/2026</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info"
-      data-bs-toggle="tooltip"
-      data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info"
+                         data-bs-toggle="tooltip"
+                         data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                  </small>
                   <strong class="text-success">730 jours (Environ 2 ans)</strong>
               </li>
           
@@ -344,9 +347,12 @@
                   <strong>04/12/2025</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info"
-      data-bs-toggle="tooltip"
-      data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info"
+                         data-bs-toggle="tooltip"
+                         data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                  </small>
                   <strong >486 jours (Environ 1 an et 3 mois)</strong>
               </li>
           
@@ -404,9 +410,12 @@
                   <strong>30/12/2025</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info"
-      data-bs-toggle="tooltip"
-      data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info"
+                         data-bs-toggle="tooltip"
+                         data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                  </small>
                   <strong class="text-success">512 jours (Environ 1 an et 4 mois)</strong>
               </li>
           
@@ -451,9 +460,12 @@
                   <strong>30/12/2025</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info"
-      data-bs-toggle="tooltip"
-      data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info"
+                         data-bs-toggle="tooltip"
+                         data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                  </small>
                   <strong class="text-success">512 jours (Environ 1 an et 4 mois)</strong>
               </li>
           
@@ -513,9 +525,12 @@
                   <strong>31/12/2025</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info"
-      data-bs-toggle="tooltip"
-      data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info"
+                         data-bs-toggle="tooltip"
+                         data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)."></i>
+                  </small>
                   <strong class="text-success">513 jours (Environ 1 an et 4 mois)</strong>
               </li>
           

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -48,7 +48,10 @@
                   <strong>02/01/2025</strong>
               </li>
               <li class="order-4 order-lg-3">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong class="text-success">2 jours</strong>
               </li>
           
@@ -83,7 +86,10 @@
                   <strong>01/01/3000</strong>
               </li>
               <li class="order-4 order-lg-3">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong class="text-success">356210 jours (Environ 975 ans et 3 mois)</strong>
               </li>
           
@@ -118,7 +124,10 @@
                   <strong>07/01/3000</strong>
               </li>
               <li class="order-4 order-lg-3">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong>356216 jours (Environ 975 ans et 3 mois)</strong>
               </li>
           
@@ -2181,7 +2190,7 @@
                               
                                   <div aria-label="Actions sur le PASS IAE" class="d-flex flex-column flex-md-row gap-3" role="group">
                                       
-                                          <button class="btn btn-block btn-outline-primary btn-ico" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Il ne peut y avoir qu’une seule demande de prolongation en attente à la fois." type="button">
+                                          <button class="btn btn-block btn-outline-primary btn-ico" data-bs-placement="top" data-bs-title="Il ne peut y avoir qu’une seule demande de prolongation en attente à la fois." data-bs-toggle="tooltip" disabled="" type="button">
                                               <i aria-hidden="true" class="ri-refresh-line fw-medium"></i>
                                               <span>Prolonger</span>
                                           </button>
@@ -4487,7 +4496,7 @@
                               
                                   <div aria-label="Actions sur le PASS IAE" class="d-flex flex-column flex-md-row gap-3" role="group">
                                       
-                                          <button class="btn btn-block btn-outline-primary btn-ico" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="La suspension n’est pas possible car une suspension est déjà en cours." type="button">
+                                          <button class="btn btn-block btn-outline-primary btn-ico" data-bs-placement="top" data-bs-title="La suspension n’est pas possible car une suspension est déjà en cours." data-bs-toggle="tooltip" disabled="" type="button">
                                               <i aria-hidden="true" class="ri-pause-circle-line fw-medium"></i>
                                               <span>Suspendre</span>
                                           </button>
@@ -4591,7 +4600,7 @@
                               
                                   <div aria-label="Actions sur le PASS IAE" class="d-flex flex-column flex-md-row gap-3" role="group">
                                       
-                                          <button class="btn btn-block btn-outline-primary btn-ico" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="La suspension n’est pas possible car une suspension est déjà en cours." type="button">
+                                          <button class="btn btn-block btn-outline-primary btn-ico" data-bs-placement="top" data-bs-title="La suspension n’est pas possible car une suspension est déjà en cours." data-bs-toggle="tooltip" disabled="" type="button">
                                               <i aria-hidden="true" class="ri-pause-circle-line fw-medium"></i>
                                               <span>Suspendre</span>
                                           </button>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -982,7 +982,7 @@
                                           <th scope="col">Demandée le</th>
                                           <th scope="col">
                                               Adressée à
-                                              <i class="ri-information-line text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                                              <i class="ri-information-line text-info" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande." data-bs-toggle="tooltip"></i>
                                           </th>
                                           <th scope="col">Statut</th>
                                           <th class="text-end w-50px" scope="col"></th>
@@ -1407,7 +1407,7 @@
                                           <th scope="col">Demandée le</th>
                                           <th scope="col">
                                               Adressée à
-                                              <i class="ri-information-line text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                                              <i class="ri-information-line text-info" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande." data-bs-toggle="tooltip"></i>
                                           </th>
                                           <th scope="col">Statut</th>
                                           <th class="text-end w-50px" scope="col"></th>
@@ -1458,7 +1458,7 @@
                           <hr/>
                           <h3>
                               Adressé à
-                              <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                              <i class="ri-information-line ri-xl text-info" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande." data-bs-toggle="tooltip"></i>
                           </h3>
                           <p>Pierre DUPONT a été sollicité pour cette demande.</p>
                           <h3>Date de fin de PASS IAE demandée : 31/01/2000</h3>
@@ -1574,7 +1574,7 @@
                           <hr/>
                           <h3>
                               Adressé à
-                              <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                              <i class="ri-information-line ri-xl text-info" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande." data-bs-toggle="tooltip"></i>
                           </h3>
                           <p>Pierre DUPONT a été sollicité pour cette demande.</p>
                           <h3>Date de fin de PASS IAE demandée : 31/01/2000</h3>
@@ -1643,7 +1643,10 @@
                   <strong>01/01/3000</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong class="text-success">356167 jours (Environ 975 ans et 1 mois)</strong>
               </li>
           
@@ -1817,7 +1820,7 @@
                           <hr/>
                           <h3>
                               Adressé à
-                              <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                              <i class="ri-information-line ri-xl text-info" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande." data-bs-toggle="tooltip"></i>
                           </h3>
                           <p>Pierre DUPONT a été sollicité pour cette demande.</p>
                           <h3>Date de fin de PASS IAE demandée : 31/01/2000</h3>
@@ -1886,7 +1889,10 @@
                   <strong>01/01/3000</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong class="text-success">356167 jours (Environ 975 ans et 1 mois)</strong>
               </li>
           
@@ -2073,7 +2079,7 @@
                           <hr/>
                           <h3>
                               Adressé à
-                              <i class="ri-information-line ri-xl text-info" data-bs-toggle="tooltip" title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande."></i>
+                              <i class="ri-information-line ri-xl text-info" data-bs-title="En cas d’absence du prescripteur sollicité, vous pouvez traiter cette demande." data-bs-toggle="tooltip"></i>
                           </h3>
                           <p>Pierre DUPONT a été sollicité pour cette demande.</p>
                           <h3>Date de fin de PASS IAE demandée : 31/01/2000</h3>
@@ -2142,7 +2148,10 @@
                   <strong>01/01/3000</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong class="text-success">356167 jours (Environ 975 ans et 1 mois)</strong>
               </li>
           

--- a/tests/www/geiq_views/__snapshots__/tests.ambr
+++ b/tests/www/geiq_views/__snapshots__/tests.ambr
@@ -883,7 +883,7 @@
                                       
                                       <div class="form-group form-group-required"><div class="form-check"><input checked="checked" class="form-check-input" disabled="disabled" id="id_up_to_date_information" name="up_to_date_information" required="" type="checkbox"/><label class="form-check-label" for="id_up_to_date_information">En cochant cette case, je certifie que les données de l’année concernée sont à jour.</label></div></div>
                                       <div class="form-group mb-0 col-6 col-lg-auto">
-                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Votre dossier a déjà été envoyé." type="submit">
+                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." data-bs-toggle="tooltip" disabled="" type="submit">
                                               <span>Envoyer le bilan d’exécution</span>
                                           </button>
                                       </div>
@@ -1237,7 +1237,7 @@
                                       
                                       <div class="form-group form-group-required"><div class="form-check"><input checked="checked" class="form-check-input" disabled="disabled" id="id_up_to_date_information" name="up_to_date_information" required="" type="checkbox"/><label class="form-check-label" for="id_up_to_date_information">En cochant cette case, je certifie que les données de l’année concernée sont à jour.</label></div></div>
                                       <div class="form-group mb-0 col-6 col-lg-auto">
-                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Votre dossier a déjà été envoyé." type="submit">
+                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." data-bs-toggle="tooltip" disabled="" type="submit">
                                               <span>Envoyer le bilan d’exécution</span>
                                           </button>
                                       </div>
@@ -1589,7 +1589,7 @@
                                       
                                       <div class="form-group form-group-required"><div class="form-check"><input checked="checked" class="form-check-input" disabled="disabled" id="id_up_to_date_information" name="up_to_date_information" required="" type="checkbox"/><label class="form-check-label" for="id_up_to_date_information">En cochant cette case, je certifie que les données de l’année concernée sont à jour.</label></div></div>
                                       <div class="form-group mb-0 col-6 col-lg-auto">
-                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Votre dossier a déjà été envoyé." type="submit">
+                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." data-bs-toggle="tooltip" disabled="" type="submit">
                                               <span>Envoyer le bilan d’exécution</span>
                                           </button>
                                       </div>
@@ -1943,7 +1943,7 @@
                                       
                                       <div class="form-group form-group-required"><div class="form-check"><input checked="checked" class="form-check-input" disabled="disabled" id="id_up_to_date_information" name="up_to_date_information" required="" type="checkbox"/><label class="form-check-label" for="id_up_to_date_information">En cochant cette case, je certifie que les données de l’année concernée sont à jour.</label></div></div>
                                       <div class="form-group mb-0 col-6 col-lg-auto">
-                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Votre dossier a déjà été envoyé." type="submit">
+                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." data-bs-toggle="tooltip" disabled="" type="submit">
                                               <span>Envoyer le bilan d’exécution</span>
                                           </button>
                                       </div>
@@ -2297,7 +2297,7 @@
                                       
                                       <div class="form-group form-group-required"><div class="form-check"><input checked="checked" class="form-check-input" disabled="disabled" id="id_up_to_date_information" name="up_to_date_information" required="" type="checkbox"/><label class="form-check-label" for="id_up_to_date_information">En cochant cette case, je certifie que les données de l’année concernée sont à jour.</label></div></div>
                                       <div class="form-group mb-0 col-6 col-lg-auto">
-                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Votre dossier a déjà été envoyé." type="submit">
+                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." data-bs-toggle="tooltip" disabled="" type="submit">
                                               <span>Envoyer le bilan d’exécution</span>
                                           </button>
                                       </div>
@@ -2643,7 +2643,7 @@
                                       
                                       <div class="form-group form-group-required"><div class="form-check"><input checked="checked" class="form-check-input" disabled="disabled" id="id_up_to_date_information" name="up_to_date_information" required="" type="checkbox"/><label class="form-check-label" for="id_up_to_date_information">En cochant cette case, je certifie que les données de l’année concernée sont à jour.</label></div></div>
                                       <div class="form-group mb-0 col-6 col-lg-auto">
-                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-toggle="tooltip" disabled="" title="Votre dossier a déjà été envoyé." type="submit">
+                                          <button class="btn btn-primary" data-bs-placement="top" data-bs-title="Votre dossier a déjà été envoyé." data-bs-toggle="tooltip" disabled="" type="submit">
                                               <span>Envoyer le bilan d’exécution</span>
                                           </button>
                                       </div>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -77,7 +77,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -308,7 +308,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -517,7 +517,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -684,7 +684,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -1876,7 +1876,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -2109,7 +2109,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -2322,7 +2322,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -2489,7 +2489,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -2700,7 +2700,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -2867,7 +2867,7 @@
               <span>Modifier</span>
           </a>
           
-              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-toggle="tooltip" title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
+              <i class="ri-information-line ri-xl text-info ms-1" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip"></i>
           
       </div>
   </div>
@@ -2970,7 +2970,10 @@
                   <strong>01/01/3000</strong>
               </li>
               <li class="order-4">
-                  <small>Durée de validité <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i></small>
+                  <small>
+                      Durée de validité
+                      <i class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip"></i>
+                  </small>
                   <strong class="text-success">356252 jours (Environ 975 ans et 4 mois)</strong>
               </li>
           

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -466,7 +466,7 @@
                                       
                                   
                                   <a aria-label="Postuler pour ce candidat" class="btn btn-sm btn-link btn-ico-only" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=11111111-1111-1111-1111-111111111111&amp;city=brest-29" id="introJsBtnPostuler">
-                                      <i aria-hidden="true" class="ri-draft-line" data-bs-toggle="tooltip" title="Postuler pour ce candidat"></i>
+                                      <i aria-hidden="true" class="ri-draft-line" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip"></i>
                                   </a>
                               </td>
                           </tr>
@@ -495,7 +495,7 @@
                                       
                                   
                                   <a aria-label="Postuler pour ce candidat" class="btn btn-sm btn-link btn-ico-only" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=22222222-2222-2222-2222-222222222222&amp;city=brest-29">
-                                      <i aria-hidden="true" class="ri-draft-line" data-bs-toggle="tooltip" title="Postuler pour ce candidat"></i>
+                                      <i aria-hidden="true" class="ri-draft-line" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip"></i>
                                   </a>
                               </td>
                           </tr>
@@ -524,7 +524,7 @@
                                       
                                   
                                   <a aria-label="Postuler pour ce candidat" class="btn btn-sm btn-link btn-ico-only" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=33333333-3333-3333-3333-333333333333&amp;city=brest-29">
-                                      <i aria-hidden="true" class="ri-draft-line" data-bs-toggle="tooltip" title="Postuler pour ce candidat"></i>
+                                      <i aria-hidden="true" class="ri-draft-line" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip"></i>
                                   </a>
                               </td>
                           </tr>
@@ -553,7 +553,7 @@
                                       
                                   
                                   <a aria-label="Postuler pour ce candidat" class="btn btn-sm btn-link btn-ico-only" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=44444444-4444-4444-4444-444444444444">
-                                      <i aria-hidden="true" class="ri-draft-line" data-bs-toggle="tooltip" title="Postuler pour ce candidat"></i>
+                                      <i aria-hidden="true" class="ri-draft-line" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip"></i>
                                   </a>
                               </td>
                           </tr>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -112,7 +112,7 @@ def test_multiple(client, snapshot):
                     {introjs_id}
                     href="{reverse("search:employers_results")}?job_seeker={application.job_seeker.public_id}&city={application.job_seeker.city_slug}">
                     <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip"
-                    title="Postuler pour ce candidat">
+                    data-bs-title="Postuler pour ce candidat">
                     </i>
                 </a>
                 """,
@@ -129,7 +129,7 @@ def test_multiple(client, snapshot):
                     data-matomo-option="postuler-pour-ce-candidat"
                     href="{reverse("search:employers_results")}?job_seeker={job_app4.job_seeker.public_id}">
                     <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip"
-                    title="Postuler pour ce candidat">
+                    data-bs-title="Postuler pour ce candidat">
                     </i>
                 </a>
                 """,
@@ -150,7 +150,7 @@ def test_multiple(client, snapshot):
                 id="introJsBtnPostuler"
                 href="{reverse("search:employers_results")}?job_seeker={job_app5.job_seeker.public_id}">
                 <i class="ri-draft-line" aria-hidden="true" data-bs-toggle="tooltip"
-                title="Postuler pour ce candidat">
+                data-bs-title="Postuler pour ce candidat">
                 </i>
             </a>
             """,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les attributs de data-bs-tooltip étaient souvent pas complets

## :cake: Comment ? <!-- optionnel -->
En remplacant les `title="blabla..."` par des `data-bs-title="blabla..."` afin que le js de BS puisse correctement associer (avec un `aria-labelledby=""`) les `data-bs-toggle="tooltip"` avec l'élément contenant le texte du `data-bs-title` lors de l'activation du tooltip