### PR TITLE
tech: typage manquants d'arguments des urls de `employee_record_views` [GEN-2416]

### DIFF
--- a/itou/www/employee_record_views/urls.py
+++ b/itou/www/employee_record_views/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     path("create_step_3/<uuid:job_application_id>", views.create_step_3, name="create_step_3"),
     path("create_step_4/<uuid:job_application_id>", views.create_step_4, name="create_step_4"),
     path("create_step_5/<uuid:job_application_id>", views.create_step_5, name="create_step_5"),
-    path("summary/<employee_record_id>", views.summary, name="summary"),
-    path("disable/<employee_record_id>", views.disable, name="disable"),
-    path("reactivate/<employee_record_id>", views.reactivate, name="reactivate"),
+    path("summary/<int:employee_record_id>", views.summary, name="summary"),
+    path("disable/<int:employee_record_id>", views.disable, name="disable"),
+    path("reactivate/<int:employee_record_id>", views.reactivate, name="reactivate"),
 ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

> cf titre


## :rotating_light: À vérifier

Mettre à jour le CHANGELOG_breaking_changes.md > NON


[notion](https://www.notion.so/plateforme-inclusion/tech-typage-manquants-dans-des-url-de-employee_record_views-183e8fa5c35b80a39475ea8b59564422?pvs=4)
