### PR TITLE
Utiliser JobSeekerProfileFieldMixin pour JobSeekerPersonalDataForm

### DIFF
--- a/itou/common_apps/nir/forms.py
+++ b/itou/common_apps/nir/forms.py
@@ -14,9 +14,6 @@ class JobSeekerNIRUpdateMixin:
     nir & lack_of_nir_reason must be declared in the form's Meta.fields
     """
 
-    def get_user_instance(self):
-        return self.instance
-
     def __init__(self, *args, editor=None, tally_form_query=None, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -60,7 +57,7 @@ class JobSeekerNIRUpdateMixin:
             # Disable NIR editing altogether if the job seeker already has one
             self.fields["nir"].disabled = True
             self.fields["lack_of_nir"].widget = forms.HiddenInput()
-            user_instance = self.get_user_instance()
+            user_instance = self.instance
             if user_instance.pk:
                 # These messages should only appear when updating a job seeker
                 # and not when creating one

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -20,7 +20,8 @@ from itou.eligibility.models import AdministrativeCriteria
 from itou.files.forms import ItouFileField
 from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, PriorAction
-from itou.users.models import JobSeekerProfile
+from itou.users.forms import JobSeekerProfileFieldsMixin
+from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
 from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.types import InclusiveDateRange
@@ -578,27 +579,27 @@ class EditHiringDateForm(forms.ModelForm):
         return cleaned_data
 
 
-class JobSeekerPersonalDataForm(JobSeekerNIRUpdateMixin, forms.ModelForm):
+class JobSeekerPersonalDataForm(JobSeekerNIRUpdateMixin, JobSeekerProfileFieldsMixin, forms.ModelForm):
     """
     Info that will be used to search for an existing Pôle emploi approval.
     """
 
+    PROFILE_FIELDS = ["birthdate", "pole_emploi_id", "lack_of_pole_emploi_id_reason", "nir", "lack_of_nir_reason"]
+
     class Meta:
-        model = JobSeekerProfile
-        fields = ["birthdate", "pole_emploi_id", "lack_of_pole_emploi_id_reason", "nir", "lack_of_nir_reason"]
-        help_texts = {"birthdate": "Au format JJ/MM/AAAA, par exemple 20/12/1978."}
+        model = User
+        fields = []
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["birthdate"].widget = DuetDatePickerWidget(
+        birthdate = self.fields["birthdate"]
+        birthdate.help_text = "Au format JJ/MM/AAAA, par exemple 20/12/1978."
+        birthdate.widget = DuetDatePickerWidget(
             attrs={
                 "min": DuetDatePickerWidget.min_birthdate(),
                 "max": DuetDatePickerWidget.max_birthdate(),
             }
         )
-
-    def get_user_instance(self):
-        return self.instance.user
 
     def clean(self):
         super().clean()

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -47,15 +47,13 @@ def _accept(request, company, job_seeker, error_url, back_url, template_name, ex
         valid_diagnosis = EligibilityDiagnosis.objects.last_considered_valid(job_seeker=job_seeker, for_siae=company)
         # Info that will be used to search for an existing Pôle emploi approval.
         form_personal_data = JobSeekerPersonalDataForm(
-            instance=job_seeker.jobseeker_profile,
+            instance=job_seeker,
             data=request.POST or None,
             tally_form_query=f"jobapplication={job_application.pk}" if job_application else None,
         )
         forms.append(form_personal_data)
         try:
-            birthdate = JobSeekerPersonalDataForm.base_fields["birthdate"].clean(
-                form_personal_data.data.get("birthdate")
-            )
+            birthdate = form_personal_data.fields["birthdate"].clean(form_personal_data.data.get("birthdate"))
         except ValidationError:
             pass  # will be presented to user later
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Consolider l’implémentation de la modification du profil utilisateur.

## :cake: Comment ? <!-- optionnel -->

Voir le message de commit.
