### PR TITLE
S’assurer que le candidat a un diagnostic valide avant d’essayer de certifier les critères d’éligibilité

### DIFF
--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -96,7 +96,11 @@ def _accept(request, company, job_seeker, error_url, back_url, template_name, ex
             with transaction.atomic():
                 if form_personal_data:
                     form_personal_data.save()
-                    if settings.API_PARTICULIER_TOKEN:
+                    if (
+                        valid_diagnosis
+                        and valid_diagnosis.criteria_can_be_certified()
+                        and settings.API_PARTICULIER_TOKEN
+                    ):
                         valid_diagnosis.certify_criteria()
                 if form_user_address:
                     form_user_address.save()


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://inclusion.sentry.io/issues/23729495/?alert_rule_id=106033&alert_type=issue&notification_uuid=65c1809b-0bc0-42b6-b93f-d765d6428375&project=4508410589020240&referrer=slack
