### PR TITLE
UX/UI: Mise a jour du thème vers la v2.6.1

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -259,27 +259,6 @@ an input field being invalid, generating an uncontrolled red box-shadow. */
     min-height: 11rem;
 }
 
-/* HTMX button indicator */
-.has-btn-with-spinner-loading-text.has-spinner-loading {
-    pointer-events: none;
-}
-
-.has-btn-with-spinner-loading-text.has-spinner-loading::after {
-    display: none;
-}
-
-.has-btn-with-spinner-loading-text.has-spinner-loading .stable-text {
-    display: none;
-}
-
-.has-btn-with-spinner-loading-text .loading-text {
-    display: none;
-}
-
-.has-btn-with-spinner-loading-text.has-spinner-loading .loading-text {
-    display: block;
-}
-
 /* step 1/5 */
 .progress-bar-20 {
     width: 20%;

--- a/itou/templates/apply/includes/accept_section.html
+++ b/itou/templates/apply/includes/accept_section.html
@@ -15,8 +15,7 @@
                 {% include "companies/includes/_company_info.html" with company=company show_cta=True extra_box_class="mb-3 mb-lg-5" open_in_tab=True only %}
             </div>
             <div class="modal-footer">
-                <form class="has-btn-with-spinner-loading-text"
-                      hx-post="{{ request.path }}"
+                <form hx-post="{{ request.path }}"
                       hx-target="#acceptFormDiv"
                       hx-swap="outerHTML"
                       hx-vals='{"confirmed": "True"}'

--- a/itou/templates/apply/includes/buttons/rdv_insertion_invite.html
+++ b/itou/templates/apply/includes/buttons/rdv_insertion_invite.html
@@ -5,7 +5,7 @@
         {% if job_application %}
             <form {% if for_detail %} hx-target="#rdvi-invitation-requests" hx-post="{% url "apply:rdv_insertion_invite_for_detail" job_application.pk %}" {% else %} hx-post="{% url "apply:rdv_insertion_invite" job_application.pk %}" {% endif %}
                   hx-swap="outerHTML"
-                  class="d-inline-flex has-btn-with-spinner-loading-text">
+                  class="d-inline-flex">
                 {% csrf_token %}
                 <button class="btn btn-danger btn-ico w-100 w-md-auto"
                         data-bs-toggle="tooltip"
@@ -42,7 +42,7 @@
     {% else %}
         <form {% if for_detail %} hx-target="#rdvi-invitation-requests" hx-post="{% url "apply:rdv_insertion_invite_for_detail" job_application.pk %}" {% else %} hx-post="{% url "apply:rdv_insertion_invite" job_application.pk %}" {% endif %}
               hx-swap="outerHTML"
-              class="d-inline-flex has-btn-with-spinner-loading-text">
+              class="d-inline-flex">
             {% csrf_token %}
             <button class="btn btn-secondary btn-ico w-100 w-md-auto" aria-label="Proposer un rendez-vous à {{ job_application.job_seeker.get_full_name }}" {% matomo_event "candidature" "clic" "proposer-rdv" %}>
                 <div class="stable-text">

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -219,11 +219,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.5.7.zip",
-            "sha256": "78930e93a7e8604fbd9236f40f687fd65f4a378c62dba05be9b7120c04c6dc28",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.6.1.zip",
+            "sha256": "c377ced35245a972b9286f50ba8e3b8994d39142637af446e09b9d787acf51c0",
         },
         "extract": {
-            "origin": "itou-theme-2.5.7/dist",
+            "origin": "itou-theme-2.6.1/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",

--- a/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
+++ b/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
@@ -1116,7 +1116,7 @@
   
   
       
-          <form class="d-inline-flex has-btn-with-spinner-loading-text" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
+          <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button aria-label="Proposer un rendez-vous à Jacques HENRY" class="btn btn-secondary btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
                   <div class="stable-text">
@@ -1148,7 +1148,7 @@
   
   
       
-          <form class="d-inline-flex has-btn-with-spinner-loading-text" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
+          <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
               <button aria-label="Proposer un rendez-vous à Jacques HENRY" class="btn btn-secondary btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
                   <div class="stable-text">

--- a/tests/www/apply/__snapshots__/test_list_rdv_insertion.ambr
+++ b/tests/www/apply/__snapshots__/test_list_rdv_insertion.ambr
@@ -45,7 +45,7 @@
 # ---
 # name: TestRdvInsertionView.test_rdv_insertion_configured_with_failed_rdv_insertion_exchange
   '''
-  <form class="d-inline-flex has-btn-with-spinner-loading-text" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv-insertion-invite" hx-swap="outerHTML">
+  <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv-insertion-invite" hx-swap="outerHTML">
                   <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                   <button aria-label="Proposer un rendez-vous à Jacques HENRY" class="btn btn-danger btn-ico w-100 w-md-auto" data-bs-title="Une erreur s’est produite, l’envoi n’a pas abouti." data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
                       <div class="stable-text">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mise a jour du thème pour :
- corriger un problème z-index des `.tooltip` dans les `.dropdown`
- modifier le fonctionnement de la classe utilitaire `.has-spinner-loading` afin qu'elle se comporte différemment selon qu'elle est appliquée sur un `<div>` ou sur un `.btn`. (Sur une idée de @leo-naeka ) [Plus de précisions dans le ZeroHeight](https://zeroheight.com/85c89893b/p/02df01-spinner)
- suppression des règles et de la classe `.has-btn-with-spinner-loading-text`, maintenant inutile car gérée dans le thème 
