### PR TITLE
Ajout d'une popup Tally sur la dashboard prescripteurs habilités et employeurs [GEN-2351]

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -258,4 +258,24 @@
 {% block script %}
     {{ block.super }}
     <script src="{% static 'js/sliding_tabs.js'%}"></script>
+
+    {% if user.is_employer or user.is_prescriber_with_authorized_org %}
+        <script async src="https://tally.so/widgets/embed.js"></script>
+        <script nonce="{{ CSP_NONCE }}">
+            window.TallyConfig = {
+                "formId": "{{ user.is_employer|yesno:'mKvOeK,mZvQpy' }}",
+                "popup": {
+                    "emoji": {
+                        "text": "👋",
+                        "animation": "wave"
+                    },
+                    "autoClose": 0,
+                    "showOnce": true,
+                    "hiddenFields": {
+                        "user_id": "{{ user.pk }}",
+                    },
+                }
+            };
+        </script>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour questionner les prescripteurs et employeurs s’ils souhaitent qu’on leur propose d’autres solutions que les offres existantes.

## :cake: Comment ? <!-- optionnel -->

Ajour d'un questionnaire Tally en popup

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
- ~**J'ai utilisé le `public_id` pour ne pas exposer la PK, qu'en pensez-vous ?**~ Finalement j'expose la PK (utilisée dans les traitements en interne) et j'affiche bien le titre
