### PR TITLE
Tech: ajout d'un attribut `command.run_uid` commun aux logs venant d'une même commande

### DIFF
--- a/itou/utils/command.py
+++ b/itou/utils/command.py
@@ -1,8 +1,23 @@
+import collections
 import contextlib
 import logging
 import time
+import uuid
 
+from asgiref.local import Local  # NOQA
 from django.core.management import base
+
+
+local = Local()
+
+CommandInfo = collections.namedtuple("CommandInfo", ["run_uid", "name"])
+
+
+def get_current_command_info():
+    try:
+        return local.command_info
+    except AttributeError:
+        return None
 
 
 def _log_command_result(command, duration_in_ns, result):
@@ -29,13 +44,26 @@ def _command_duration_logger(command):
     _log_command_result(command, time.perf_counter_ns() - before, "succeeded")
 
 
+@contextlib.contextmanager
+def _command_info_manager(command):
+    command_info_before = get_current_command_info()
+    if command_info_before is None:
+        local.command_info = CommandInfo(str(command.run_uid), command.__class__.__module__)
+    try:
+        yield
+    finally:
+        if command_info_before is None:
+            del local.command_info
+
+
 class LoggedCommandMixin:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.run_uid = uuid.uuid4()
         self.logger = logging.getLogger(self.__class__.__module__)
 
     def execute(self, *args, **kwargs):
-        with _command_duration_logger(self):
+        with _command_info_manager(self), _command_duration_logger(self):
             try:
                 return super().execute(*args, **kwargs)
             except Exception:

--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -2,6 +2,8 @@ import logging
 
 from django_datadog_logger.formatters import datadog
 
+from itou.utils.command import get_current_command_info
+
 
 logger = logging.getLogger(__name__)
 
@@ -36,4 +38,7 @@ class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):
                         logger.warning(
                             "Request using token (%r) without datadog_info() method: please define one", token
                         )
+        if (command_info := get_current_command_info()) is not None:
+            log_entry_dict["command.run_uid"] = command_info.run_uid
+            log_entry_dict["command.name"] = command_info.name
         return log_entry_dict

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -87,6 +87,9 @@ xlrd==2.0.*  # https://pypi.org/project/xlrd/
 # Third-party applications
 # ------------------------------------------------------------------------------
 
+# Django dependency that we directly use for a future-proof threading.local equivalent
+asgiref  # https://github.com/django/asgiref/
+
 # Huey for async processing
 # https://huey.readthedocs.io/en/latest/
 huey  # https://github.com/coleifer/huey

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,6 +8,7 @@ asgiref==3.8.1 \
     --hash=sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47 \
     --hash=sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590
     # via
+    #   -r requirements/base.in
     #   django
     #   django-allauth
     #   django-htmx


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour facilement les retrouver & regrouper.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
