### PR TITLE
Prescripteur : masquer le nom des candidats dans le filtre de la liste des candidats

### DIFF
--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -11,6 +11,7 @@ from itou.users.forms import JobSeekerProfileFieldsMixin, JobSeekerProfileModelF
 from itou.users.models import JobSeekerProfile, User
 from itou.utils import constants as global_constants
 from itou.utils.emails import redact_email_address
+from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.validators import validate_nir
 from itou.utils.widgets import DuetDatePickerWidget
 
@@ -26,10 +27,15 @@ class FilterForm(forms.Form):
         ),
     )
 
-    def __init__(self, job_seeker_qs, data, *args, **kwargs):
+    def __init__(self, job_seeker_qs, data, *args, request_user, **kwargs):
         super().__init__(data, *args, **kwargs)
         self.fields["job_seeker"].choices = [
-            (job_seeker.pk, job_seeker.get_full_name())
+            (
+                job_seeker.pk,
+                mask_unless(
+                    job_seeker.get_full_name(), predicate=request_user.can_view_personal_information(job_seeker)
+                ),
+            )
             for job_seeker in job_seeker_qs.order_by("first_name", "last_name")
             if job_seeker.get_full_name()
         ]

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -126,6 +126,7 @@ class JobSeekerListView(UserPassesTestMixin, ListView):
             self.form = FilterForm(
                 User.objects.filter(kind=UserKind.JOB_SEEKER).filter(Exists(self._get_user_job_applications())),
                 self.request.GET or None,
+                request_user=request.user,
             )
 
     def test_func(self):

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -259,6 +259,26 @@
       }),
       dict({
         'origin': list([
+          'User.is_prescriber_with_authorized_org[users/models.py]',
+          'User.can_edit_personal_information[users/models.py]',
+          'User.can_view_personal_information[users/models.py]',
+          'FilterForm.__init__[www/job_seekers_views/forms.py]',
+          'JobSeekerListView.setup[www/job_seekers_views/views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."user_id" = %s
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescriberorganization"."is_authorized"
+                 AND "users_user"."is_active")
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
           'ItouPaginator.count[<site-packages>/django/core/paginator.py]',
           'JobSeekerListView.get_context_data[www/job_seekers_views/views.py]',
         ]),
@@ -383,25 +403,6 @@
                                                    %s,
                                                    %s)
           ORDER BY "approvals_approval"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'User.is_prescriber_with_authorized_org[users/models.py]',
-          'User.can_edit_personal_information[users/models.py]',
-          'User.can_view_personal_information[users/models.py]',
-          'JobSeekerListView.get_context_data[www/job_seekers_views/views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "prescribers_prescribermembership"
-          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
-          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
-          WHERE ("prescribers_prescribermembership"."user_id" = %s
-                 AND "prescribers_prescribermembership"."is_active"
-                 AND "prescribers_prescriberorganization"."is_authorized"
-                 AND "users_user"."is_active")
-          LIMIT 1
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

On cache le nom des candidats qu'un prescripteur non habilité (= orienteur) n'a pas créé… sauf ici.

## :cake: Comment ? <!-- optionnel -->


## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?


## :computer: Captures d'écran <!-- optionnel -->

Avant :
![image](https://github.com/user-attachments/assets/d86e801f-1e4b-4cc1-a21a-a321110350f0)

Après : 
![image](https://github.com/user-attachments/assets/1d8d08ba-d909-4363-89f6-9ab3060fdff2)


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
