### PR TITLE
[GEN-557] Candidature : préparation à la certification AAH

### DIFF
--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -20,7 +20,7 @@ logger = logging.getLogger("APIParticulierClient")
 def certify_criteria(eligibility_diagnosis):
     job_seeker = eligibility_diagnosis.job_seeker
     if not api_particulier.has_required_info(job_seeker):
-        logger.info("Skipping {job_seeker.pk=}, missing required information.")
+        logger.info("Skipping job seeker %s, missing required information.", job_seeker.pk)
         return
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
     criteria = (

--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from huey.contrib.djhuey import task
 from huey.exceptions import RetryTask
 
-from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, AdministrativeCriteriaKind
+from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS
 from itou.utils.apis import api_particulier
 from itou.utils.types import InclusiveDateRange
 
@@ -33,55 +33,55 @@ def certify_criteria(eligibility_diagnosis):
     )
     with api_particulier.client() as client:
         for criterion in criteria:
-            if criterion.administrative_criteria.kind == AdministrativeCriteriaKind.RSA:
-                try:
-                    data = api_particulier.certify_criteria(criterion.administrative_criteria.kind, client, job_seeker)
-                except httpx.HTTPStatusError as exc:
-                    criterion.data_returned_by_api = exc.response.json()
-                    logger.error(
-                        "Error certifying criterion %r: code=%d json=%s",
-                        criterion,
-                        exc.response.status_code,
-                        criterion.data_returned_by_api,
+            try:
+                data = api_particulier.certify_criteria(criterion.administrative_criteria.kind, client, job_seeker)
+            except httpx.HTTPStatusError as exc:
+                criterion.data_returned_by_api = exc.response.json()
+                logger.error(
+                    "Error certifying criterion %r: code=%d json=%s",
+                    criterion,
+                    exc.response.status_code,
+                    criterion.data_returned_by_api,
+                )
+                match exc.response.status_code:
+                    case 400 | 404:
+                        # Job seeker not found or missing profile information.
+                        criterion.certified_at = timezone.now()
+                    case 429:
+                        # https://particulier.api.gouv.fr/developpeurs#respecter-la-volumétrie
+                        raise RetryTask(delay=int(exc.response.headers["Retry-After"])) from exc
+                    case 503:
+                        # TODO: Use the error code instead the message when switching to API v3.
+                        if criterion.data_returned_by_api["message"] == (
+                            "Erreur de fournisseur de donnée : "
+                            "Trop de requêtes effectuées, veuillez réessayer plus tard."
+                        ):
+                            # The data provider for API particulier returned a 429.
+                            # Let’s hope the data provider rate limit has been reset by then.
+                            raise RetryTask(delay=3600) from exc
+                        else:
+                            # The data provider for API particulier likely returned a 500.
+                            # According to the API particulier team, it often means integrity
+                            # errors on the beneficiary case. The data provider itself aggregates data
+                            # from other providers (e.g. regional information systems). When the data
+                            # sources aren’t consistent with each other, the data provider cannot
+                            # answer.
+                            # Retrying won’t fix the issue, and the error has been logged already.
+                            pass
+                    case _:
+                        raise
+            else:
+                criterion.certified = data["is_certified"]
+                criterion.certified_at = timezone.now()
+                criterion.data_returned_by_api = data["raw_response"]
+                criterion.certification_period = None
+                if criterion.certified:
+                    start_at = data["start_at"]
+                    end_at = timezone.localdate(criterion.certified_at) + datetime.timedelta(
+                        days=criterion.CERTIFICATION_GRACE_PERIOD_DAYS
                     )
-                    match exc.response.status_code:
-                        case 400 | 404:
-                            # Job seeker not found or missing profile information.
-                            criterion.certified_at = timezone.now()
-                        case 429:
-                            # https://particulier.api.gouv.fr/developpeurs#respecter-la-volumétrie
-                            raise RetryTask(delay=int(exc.response.headers["Retry-After"])) from exc
-                        case 503:
-                            # TODO: Use the error code instead the message when switching to API v3.
-                            if criterion.data_returned_by_api["message"] == (
-                                "Erreur de fournisseur de donnée : "
-                                "Trop de requêtes effectuées, veuillez réessayer plus tard."
-                            ):
-                                # The data provider for API particulier returned a 429.
-                                # Let’s hope the data provider rate limit has been reset by then.
-                                raise RetryTask(delay=3600) from exc
-                            else:
-                                # The data provider for API particulier likely returned a 500.
-                                # According to the API particulier team, it often means integrity
-                                # errors on the beneficiary case. The data provider itself aggregates data
-                                # from other providers (e.g. regional information systems). When the data
-                                # sources aren’t consistent with each other, the data provider cannot
-                                # answer.
-                                # Retrying won’t fix the issue, and the error has been logged already.
-                                pass
-                        case _:
-                            raise
-                else:
-                    criterion.certified = data["is_certified"]
-                    criterion.certified_at = timezone.now()
-                    criterion.data_returned_by_api = data["raw_response"]
-                    criterion.certification_period = None
-                    if criterion.certified:
-                        start_at = data["start_at"]
-                        end_at = timezone.localdate(criterion.certified_at) + datetime.timedelta(
-                            days=criterion.CERTIFICATION_GRACE_PERIOD_DAYS
-                        )
-                        criterion.certification_period = InclusiveDateRange(start_at, end_at)
+                    criterion.certification_period = InclusiveDateRange(start_at, end_at)
+
     SelectedAdministrativeCriteria.objects.bulk_update(
         criteria,
         fields=[

--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -51,7 +51,7 @@ def certify_criteria(eligibility_diagnosis):
                         # https://particulier.api.gouv.fr/developpeurs#respecter-la-volumétrie
                         raise RetryTask(delay=int(exc.response.headers["Retry-After"])) from exc
                     case 503:
-                        # TODO: Use the error code instead the message when switching to API v3.
+                        # TODO: Use the error code instead of the message when switching to API v3.
                         if criterion.data_returned_by_api["message"] == (
                             "Erreur de fournisseur de donnée : "
                             "Trop de requêtes effectuées, veuillez réessayer plus tard."

--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -33,11 +33,9 @@ def certify_criteria(eligibility_diagnosis):
     )
     with api_particulier.client() as client:
         for criterion in criteria:
-            # Only the RSA criterion is certifiable at the moment,
-            # but this may change soon with the addition of `parent isolé` and `allocation adulte handicapé`.
             if criterion.administrative_criteria.kind == AdministrativeCriteriaKind.RSA:
                 try:
-                    data = api_particulier.revenu_solidarite_active(client, job_seeker)
+                    data = api_particulier.certify_criteria(criterion.administrative_criteria.kind, client, job_seeker)
                 except httpx.HTTPStatusError as exc:
                     criterion.data_returned_by_api = exc.response.json()
                     logger.error(

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -424,7 +424,6 @@ class TestJobApplicationQuerySet:
         )
         eligibility_diagnosis = IAEEligibilityDiagnosisFactory(
             from_prescriber=True,
-            with_not_certifiable_criteria=True,
             job_seeker=job_application.job_seeker,
         )
 
@@ -440,7 +439,6 @@ class TestJobApplicationQuerySet:
         eligibility_diagnosis = IAEEligibilityDiagnosisFactory(
             from_employer=True,
             author_siae=job_application.sender_company,
-            with_not_certifiable_criteria=True,
             job_seeker=job_application.job_seeker,
         )
 
@@ -455,7 +453,6 @@ class TestJobApplicationQuerySet:
         )
         IAEEligibilityDiagnosisFactory(
             from_employer=True,
-            with_not_certifiable_criteria=True,
             job_seeker=job_application.job_seeker,
         )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

A l’instar du critère BRSA on veut interroger l’API Particuliers pour certifier le critère AAH.
AAH est un critère pour lequel on demande un justificatif de < de 3 mois.

## :cake: Comment ? <!-- optionnel -->
Règles identiques au critère RSA.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

En tant que SIAE, réaliser une auto-prescription avec un critère AAH.

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
