### PR TITLE
Tech: migrations d'autres commandes aux logs

### DIFF
--- a/itou/analytics/management/commands/collect_analytics_data.py
+++ b/itou/analytics/management/commands/collect_analytics_data.py
@@ -1,6 +1,5 @@
 import datetime
 
-import sentry_sdk
 from django import db
 from django.db import transaction
 from django.forms import models
@@ -22,10 +21,10 @@ class Command(BaseCommand):
         before = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0) - datetime.timedelta(
             days=options["offset"]
         )
-        self.stderr.write(f"Collecting analytics data before '{before!s}'.")
+        self.logger.info(f"Collecting analytics data before '{before!s}'.")
 
         data = self._get_data(before)
-        self.stderr.write("Analytics data computed.")
+        self.logger.info("Analytics data computed.")
 
         self.show_data(data)
         if options["save"]:
@@ -43,11 +42,11 @@ class Command(BaseCommand):
 
     def show_data(self, data):
         for code, value in data.items():
-            self.stdout.write(f"{code.label} ({code.value}): {value}")
+            self.logger.info(f"{code.label} ({code.value}): {value}")
 
     def save_data(self, data, before):
         bucket = (before.date() - datetime.timedelta(days=1)).isoformat()
-        self.stderr.write(f"Saving analytics data in bucket '{bucket}'.")
+        self.logger.info(f"Saving analytics data in bucket '{bucket}'.")
         for code, value in data.items():
             datum = Datum(
                 code=code.value,
@@ -58,13 +57,12 @@ class Command(BaseCommand):
                 with transaction.atomic():
                     datum.save()
             except db.IntegrityError:
-                self.stderr.write(f"Failed to save code={code.value} for bucket={bucket} because it already exists.")
+                self.logger.warning(f"Failed to save code={code.value} for bucket={bucket} because it already exists.")
             except models.ValidationError as error:
                 message = (
                     f"Failed to save code={code.value} for bucket={bucket} because of a ValidationError: "
                     f"{error.message}"
                 )
-                sentry_sdk.capture_message(message, "error")
-                self.stderr.write(message)
+                self.logger.error(message)
             else:
-                self.stdout.write(f"Successfully saved code={code.value} bucket={bucket} value={value}.")
+                self.logger.info(f"Successfully saved code={code.value} bucket={bucket} value={value}.")

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -34,8 +34,8 @@ class Command(BaseCommand):
             if emails:
                 send_email_messages(emails)
                 evaluated_siaes.update(reminder_sent_at=timezone.now())
-                self.stdout.write(
-                    f"Emailed first reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
+                self.logger.info(
+                    "Emailed first reminders to %d SIAE which did not submit proofs to %s", len(emails), campaign
                 )
 
         for campaign in campaigns.filter(calendar__adversarial_stage_start__lte=today - relativedelta(days=30)):
@@ -58,8 +58,8 @@ class Command(BaseCommand):
             if emails:
                 send_email_messages(emails)
                 evaluated_siaes.update(reminder_sent_at=timezone.now())
-                self.stdout.write(
-                    f"Emailed second reminders to {len(emails)} SIAE which did not submit proofs to {campaign}."
+                self.logger.info(
+                    "Emailed second reminders to %d SIAE which did not submit proofs to %s", len(emails), campaign
                 )
 
         # When a campaign is frozen, a notification is sent to institutions synchronously
@@ -72,4 +72,4 @@ class Command(BaseCommand):
             send_email_messages([CampaignEmailFactory(campaign).submission_frozen_reminder()])
             campaign.submission_freeze_notified_at = timezone.now()
             campaign.save(update_fields=["submission_freeze_notified_at"])
-            self.stdout.write(f"Reminded “{campaign.institution}” to control SIAE during the submission freeze.")
+            self.logger.info("Reminded “%s” to control SIAE during the submission freeze.", campaign.institution)

--- a/tests/analytics/test_collect_analytics_data_management_command.py
+++ b/tests/analytics/test_collect_analytics_data_management_command.py
@@ -1,5 +1,4 @@
 import datetime
-import io
 import unittest.mock
 
 import pytest
@@ -20,7 +19,7 @@ class CodeTest(models.TextChoices):
 
 @pytest.fixture(name="command")
 def command_fixture(mocker):
-    command = collect_analytics_data.Command(io.StringIO(), io.StringIO())
+    command = collect_analytics_data.Command()
     mocker.patch.object(command, "_get_data", return_value={})
     mocker.spy(command, "show_data")
     mocker.spy(command, "save_data")
@@ -29,7 +28,7 @@ def command_fixture(mocker):
 
 
 @freeze_time("2022-01-01")
-def test_handle_default_options(command):
+def test_handle_default_options(command, caplog):
     command.handle(save=False, offset=0)
 
     assert command._get_data.call_args_list == [
@@ -37,10 +36,9 @@ def test_handle_default_options(command):
     ]
     assert command.show_data.call_args_list == [unittest.mock.call({})]
     assert command.save_data.call_args_list == []
-    assert command.stderr.getvalue().split("\n") == [
+    assert caplog.messages == [
         "Collecting analytics data before '2022-01-01 00:00:00+00:00'.",
         "Analytics data computed.",
-        "",
     ]
 
 
@@ -54,27 +52,25 @@ def test_handle_save_option(command):
 
 
 @freeze_time("2022-01-01")
-def test_handle_offset_option(command):
+def test_handle_offset_option(command, caplog):
     command.handle(save=False, offset=7)
 
-    assert command.stderr.getvalue().split("\n") == [
+    assert caplog.messages == [
         "Collecting analytics data before '2021-12-25 00:00:00+00:00'.",
         "Analytics data computed.",
-        "",
     ]
 
 
-def test_show_data(command):
+def test_show_data(command, caplog):
     command.show_data({CodeTest.CODE_001: 42, CodeTest.CODE_002: 21})
 
-    assert command.stdout.getvalue().split("\n") == [
+    assert caplog.messages == [
         "Premier code de test (CODE-001): 42",
         "Second code de test (CODE-002): 21",
-        "",
     ]
 
 
-def test_save_data(command):
+def test_save_data(command, caplog):
     command.save_data(
         {CodeTest.CODE_001: 42, CodeTest.CODE_002: 21},
         datetime.datetime(2022, 1, 1, tzinfo=datetime.UTC),
@@ -86,15 +82,14 @@ def test_save_data(command):
     assert objects[0].value == 42
     assert objects[1].code == CodeTest.CODE_002
     assert objects[1].value == 21
-    assert command.stderr.getvalue() == "Saving analytics data in bucket '2021-12-31'.\n"
-    assert command.stdout.getvalue().split("\n") == [
+    assert caplog.messages == [
+        "Saving analytics data in bucket '2021-12-31'.",
         "Successfully saved code=CODE-001 bucket=2021-12-31 value=42.",
         "Successfully saved code=CODE-002 bucket=2021-12-31 value=21.",
-        "",
     ]
 
 
-def test_save_data_with_an_integrity_error(command):
+def test_save_data_with_an_integrity_error(command, caplog):
     factories.DatumFactory(code=CodeTest.CODE_001, bucket="2021-12-31")
 
     command.save_data(
@@ -106,15 +101,14 @@ def test_save_data_with_an_integrity_error(command):
     assert len(objects) == 2
     assert objects[1].code == CodeTest.CODE_002
     assert objects[1].value == 21
-    assert command.stderr.getvalue().split("\n") == [
+    assert caplog.messages == [
         "Saving analytics data in bucket '2021-12-31'.",
         "Failed to save code=CODE-001 for bucket=2021-12-31 because it already exists.",
-        "",
+        "Successfully saved code=CODE-002 bucket=2021-12-31 value=21.",
     ]
-    assert command.stdout.getvalue() == "Successfully saved code=CODE-002 bucket=2021-12-31 value=21.\n"
 
 
-def test_save_data_with_a_float(command):
+def test_save_data_with_a_float(command, caplog):
     command.save_data(
         {CodeTest.CODE_001: 42.5, CodeTest.CODE_002: 21},
         datetime.datetime(2022, 1, 1, tzinfo=datetime.UTC),
@@ -123,12 +117,11 @@ def test_save_data_with_a_float(command):
     assert len(objects) == 1
     assert objects[0].code == CodeTest.CODE_002
     assert objects[0].value == 21
-    assert command.stderr.getvalue().split("\n") == [
+    assert caplog.messages == [
         "Saving analytics data in bucket '2021-12-31'.",
         "Failed to save code=CODE-001 for bucket=2021-12-31 because of a ValidationError: 42.5 is not an integer.",
-        "",
+        "Successfully saved code=CODE-002 bucket=2021-12-31 value=21.",
     ]
-    assert command.stdout.getvalue() == "Successfully saved code=CODE-002 bucket=2021-12-31 value=21.\n"
 
 
 @freeze_time("2024-12-03")

--- a/tests/approvals/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/approvals/__snapshots__/test_prolongation_requests.ambr
@@ -1,17 +1,15 @@
 # serializer version: 1
 # name: test_chores_send_reminder_to_prescriber_organization_other_members[False-0]
-  '''
-  2 prolongation requests can be reminded
-  0/2 prolongation requests reminded
-  
-  '''
+  list([
+    '2 prolongation requests can be reminded',
+    '0/2 prolongation requests reminded',
+  ])
 # ---
 # name: test_chores_send_reminder_to_prescriber_organization_other_members[True-2]
-  '''
-  2 prolongation requests can be reminded
-  2/2 prolongation requests reminded
-  
-  '''
+  list([
+    '2 prolongation requests can be reminded',
+    '2/2 prolongation requests reminded',
+  ])
 # ---
 # name: test_chores_send_reminder_to_prescriber_organization_other_members_copy_limit[body]
   '''

--- a/tests/approvals/test_prolongation_requests.py
+++ b/tests/approvals/test_prolongation_requests.py
@@ -1,5 +1,4 @@
 import contextlib
-import io
 import itertools
 
 import pytest
@@ -17,7 +16,7 @@ from tests.users.factories import PrescriberFactory
 
 @pytest.fixture(name="command")
 def command_fixture():
-    return prolongation_requests_chores.Command(stdout=io.StringIO(), stderr=io.StringIO())
+    return prolongation_requests_chores.Command()
 
 
 def test_unique_approval_for_pending_constraint():
@@ -95,7 +94,7 @@ def test_deny(django_capture_on_commit_callbacks, mailoutbox):
     ],
 )
 def test_chores_send_reminder_to_prescriber_organization_other_members(
-    snapshot, mailoutbox, command, django_capture_on_commit_callbacks, wet_run, expected
+    snapshot, mailoutbox, caplog, command, django_capture_on_commit_callbacks, wet_run, expected
 ):
     parameters = itertools.product(
         ProlongationRequestStatus,
@@ -114,7 +113,7 @@ def test_chores_send_reminder_to_prescriber_organization_other_members(
             command.handle(command="email_reminder", wet_run=wet_run)
         assert len(mailoutbox) == expected
         assert ProlongationRequest.objects.filter(reminder_sent_at=timezone.now()).count() == expected
-    assert command.stdout.getvalue() == snapshot
+    assert caplog.messages == snapshot()
 
 
 def test_chores_send_reminder_to_prescriber_organization_other_members_every_ten_days_for_thirty_days(

--- a/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
@@ -1,10 +1,7 @@
 # serializer version: 1
 # name: test_missed_notifications_limit
-  '''
-  * Checking missing employee records notifications:
-   - found 3 missing notification(s)
-   - 2 notification(s) created
-   - done!
-  
-  '''
+  list([
+    'found 3 missed employee records notifications',
+    '2/3 notifications created',
+  ])
 # ---

--- a/tests/users/__snapshots__/test_management_commands.ambr
+++ b/tests/users/__snapshots__/test_management_commands.ambr
@@ -108,39 +108,45 @@
   '''
 # ---
 # name: test_pe_certify_users
-  '''
-  > about to resolve first_name and last_name for count=1 users.
-  > only count=1 users have the necessary data to be resolved.
-  ! could not find a match for pk=424242 error=PoleEmploiAPIBadResponse(code=R010)
-  ! no match found either for pk=424242 when swapping last and first names exc=PoleEmploiAPIBadResponse(code=R010)
-  > count=1 users have been examined.
-  > count=0 users have been certified.
-  > count=1 users could not be certified.
-  > count=0 users have been swapped.
-  
-  '''
+  list([
+    'about to resolve first_name and last_name for count=1 users',
+    'only count=1 users have the necessary data to be resolved',
+    'HTTP Request: POST https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire "HTTP/1.1 200 OK"',
+    'HTTP Request: POST https://pe.fake/rechercheindividucertifie/v1/rechercheIndividuCertifie "HTTP/1.1 200 OK"',
+    'could not find a match for pk=424242 error=PoleEmploiAPIBadResponse(code=R010)',
+    'HTTP Request: POST https://pe.fake/rechercheindividucertifie/v1/rechercheIndividuCertifie "HTTP/1.1 200 OK"',
+    'no match found either for pk=424242 when swapping last and first names exc=PoleEmploiAPIBadResponse(code=R010)',
+    'count=1 users have been examined.',
+    'count=0 users have been certified',
+    'count=1 users could not be certified.',
+    'count=0 users have been swapped',
+  ])
 # ---
 # name: test_pe_certify_users.1
   list([
-    '> about to resolve first_name and last_name for count=1 users.',
-    '> only count=1 users have the necessary data to be resolved.',
-    '> certified user pk=424242 id_certifie=ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ',
-    '> count=1 users have been examined.',
-    '> count=1 users have been certified.',
-    '> count=0 users could not be certified.',
-    '> count=0 users have been swapped.',
+    'about to resolve first_name and last_name for count=1 users',
+    'only count=1 users have the necessary data to be resolved',
+    'HTTP Request: POST https://pe.fake/rechercheindividucertifie/v1/rechercheIndividuCertifie "HTTP/1.1 200 OK"',
+    'certified user pk=424242',
+    'count=1 users have been examined.',
+    'count=1 users have been certified',
+    'count=0 users could not be certified.',
+    'count=0 users have been swapped',
   ])
 # ---
 # name: test_pe_certify_users_with_swap
   list([
-    '> about to resolve first_name and last_name for count=1 users.',
-    '> only count=1 users have the necessary data to be resolved.',
-    '! could not find a match for pk=424243 error=PoleEmploiAPIBadResponse(code=R010)',
-    '> SWAP DETECTED! user pk=424243 id_certifie=ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ',
-    '> certified user pk=424243 id_certifie=ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ',
-    '> count=1 users have been examined.',
-    '> count=1 users have been certified.',
-    '> count=0 users could not be certified.',
-    '> count=1 users have been swapped.',
+    'about to resolve first_name and last_name for count=1 users',
+    'only count=1 users have the necessary data to be resolved',
+    'HTTP Request: POST https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire "HTTP/1.1 200 OK"',
+    'HTTP Request: POST https://pe.fake/rechercheindividucertifie/v1/rechercheIndividuCertifie "HTTP/1.1 200 OK"',
+    'could not find a match for pk=424243 error=PoleEmploiAPIBadResponse(code=R010)',
+    'HTTP Request: POST https://pe.fake/rechercheindividucertifie/v1/rechercheIndividuCertifie "HTTP/1.1 200 OK"',
+    'SWAP DETECTED: user pk=424243',
+    'certified user pk=424243',
+    'count=1 users have been examined.',
+    'count=1 users have been certified',
+    'count=0 users could not be certified.',
+    'count=1 users have been swapped',
   ])
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Toutes ces commandes sont principalement lancées par cron.

@rsebille J'ai un peu modifié les messages de `sanitize_employee_records`, dis moi si ça te semble moins clair (voir même faux :sweat_smile: ).

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
