### PR TITLE
UX/UI: Modifier l'alignement des badges et supprimer les .text-muted dans la section titre

### DIFF
--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -6,7 +6,7 @@
 {% block title_content %}
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-0 me-3 text-md-nowrap">
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
                 Candidature de
                 {% if with_job_seeker_detail_url|default:False %}
                     <a href="{% url "job_seekers_views:details" public_id=job_application.job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}</a>

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -31,7 +31,7 @@
 {% block title_content %}
     {% if not job_app_to_transfer|default:False %}
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-0 me-3 text-md-nowrap">{% include 'apply/includes/_submit_title.html' %}</h1>
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{% include 'apply/includes/_submit_title.html' %}</h1>
             {% include 'apply/includes/eligibility_badge.html' %}
         </div>
         <p>

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -5,11 +5,7 @@
 {% block title %}Déclarer une prolongation de PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        Déclarer une prolongation de PASS IAE
-        <br>
-        <span class="text-muted">{{ approval.user.get_full_name }}</span>
-    </h1>
+    <h1>Déclarer une prolongation de PASS IAE pour {{ approval.user.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -13,7 +13,7 @@
 {% block title_content %}
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-0 me-3 text-md-nowrap">
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
                 Demande de prolongation pour {{ prolongation_request.approval.user.get_full_name }}
             </h1>
             {% include "approvals/prolongation_requests/_status_badge.html" with badge_size="badge-base" %}

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -6,11 +6,7 @@
 {% block title %}Déclarer une suspension de PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        Déclarer une suspension de PASS IAE
-        <br>
-        <span class="text-muted">{{ approval.user.get_full_name }}</span>
-    </h1>
+    <h1>Déclarer une suspension de PASS IAE pour {{ approval.user.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_action_choice.html
+++ b/itou/templates/approvals/suspension_action_choice.html
@@ -5,11 +5,7 @@
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        Supprimer la suspension du PASS IAE de
-        <br>
-        <span class="text-muted">{{ suspension.approval.user.get_full_name }}</span>
-    </h1>
+    <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_delete.html
+++ b/itou/templates/approvals/suspension_delete.html
@@ -6,11 +6,7 @@
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        Supprimer la suspension du PASS IAE de
-        <br>
-        <span class="text-muted">{{ suspension.approval.user.get_full_name }}</span>
-    </h1>
+    <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -5,11 +5,7 @@
 {% block title %}Modifier la suspension de PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        Modifier la suspension de PASS IAE
-        <br>
-        <span class="text-muted">{{ suspension.approval.user.get_full_name }}</span>
-    </h1>
+    <h1>Modifier la suspension de PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_update_enddate.html
+++ b/itou/templates/approvals/suspension_update_enddate.html
@@ -5,11 +5,7 @@
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        Supprimer la suspension du PASS IAE de
-        <br>
-        <span class="text-muted">{{ suspension.approval.user.get_full_name }}</span>
-    </h1>
+    <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -26,15 +26,13 @@
         {% include "apply/includes/job_application_external_transfer_progress.html" with job_app_to_transfer=job_app_to_transfer step=1 only %}
     {% endif %}
 
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 mb-md-4 justify-content-md-between">
-        <div>
-            <h1 class="mb-0">{{ job.display_name }}</h1>
+    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
+        <div class="d-xl-flex align-items-xl-center">
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{{ job.display_name }}</h1>
             {% if job.is_active %}
-                <p class="mt-1 mb-0">
-                    <span class="badge rounded-pill bg-success">
-                        {{ job.open_positions }} {{ job.open_positions|pluralizefr:"poste ouvert,postes ouverts" }} au recrutement
-                    </span>
-                </p>
+                <span class="badge rounded-pill bg-success">
+                    {{ job.open_positions }} {{ job.open_positions|pluralizefr:"poste ouvert,postes ouverts" }} au recrutement
+                </span>
             {% endif %}
         </div>
         {% if can_update_job_description %}

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -16,11 +16,7 @@
     </div>
 {% endblock %}
 
-{% block title_content %}
-    <h1>
-        Informations personnelles de <span class="text-muted">{{ job_seeker.get_full_name }}</span>
-    </h1>
-{% endblock %}
+{% block title_content %}<h1>Informations personnelles de {{ job_seeker.get_full_name }}</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -3,17 +3,19 @@
 {% load format_filters %}
 {% load django_bootstrap5 %}
 
-{% block title %}
-    Détail fiche salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}
-{% endblock %}
+{% block title %}Fiche salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}{% endblock %}
 
 {% block title_prevstep %}
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
 {% block title_content %}
-    <h1>Détail fiche salarié ASP: {{ employee_record.job_application.job_seeker.get_full_name }}</h1>
-    <p>{% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}</p>
+    <div class="d-xl-flex align-items-xl-center">
+        <h1 class="mb-1 mb-xl-0 me-xl-3">
+            Fiche salarié ASP : {{ employee_record.job_application.job_seeker.get_full_name }}
+        </h1>
+        {% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}
+    </div>
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/geiq/assessment_info_for_employer.html
+++ b/itou/templates/geiq/assessment_info_for_employer.html
@@ -10,7 +10,7 @@
 {% block title_content %}
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - {{ assessment.campaign.year }}</h1>
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - {{ assessment.campaign.year }}</h1>
             {% if not assessment.submitted_at %}
                 <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
             {% elif not assessment.reviewed_at %}

--- a/itou/templates/geiq/assessment_info_for_labor_inspector.html
+++ b/itou/templates/geiq/assessment_info_for_labor_inspector.html
@@ -10,7 +10,7 @@
 {% block title_content %}
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - {{ assessment.campaign.year }}</h1>
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - {{ assessment.campaign.year }}</h1>
             {% include "geiq/includes/labor_inspector_assessment_state_badge.html" with assessment=assessment extra_class="" ReviewState=ReviewState only %}
         </div>
     </div>

--- a/itou/templates/geiq/assessment_review.html
+++ b/itou/templates/geiq/assessment_review.html
@@ -11,7 +11,7 @@
 {% block title_content %}
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-0 me-3 text-md-nowrap">Valider le bilan d’exécution - {{ assessment.campaign.year }}</h1>
+            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Valider le bilan d’exécution - {{ assessment.campaign.year }}</h1>
             {% include "geiq/includes/labor_inspector_assessment_state_badge.html" with assessment=assessment extra_class="" ReviewState=ReviewState only %}
         </div>
     </div>

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -4,7 +4,7 @@
 
 {% block title_content %}
     <div class="d-xl-flex align-items-xl-center">
-        <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Informations personnelles de {{ job_seeker.get_full_name|title }}</h1>
+        <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Informations personnelles de {{ job_seeker.get_full_name }}</h1>
         {% include 'apply/includes/eligibility_badge.html' %}
     </div>
     <p>Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}</p>

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -4,7 +4,7 @@
 
 {% block title_content %}
     <div class="d-xl-flex align-items-xl-center">
-        <h1 class="mb-0 me-3 text-md-nowrap">Informations personnelles de {{ job_seeker.get_full_name|title }}</h1>
+        <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Informations personnelles de {{ job_seeker.get_full_name|title }}</h1>
         {% include 'apply/includes/eligibility_badge.html' %}
     </div>
     <p>Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}</p>

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step1.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step1.html
@@ -4,11 +4,7 @@
 
 {% block title %}Notifier la sanction du contrôle pour {{ evaluated_siae }} {{ block.super }}{% endblock %}
 
-{% block title_content %}
-    <h1>
-        Notifier la sanction du contrôle pour <span class="text-muted">{{ evaluated_siae }}</span>
-    </h1>
-{% endblock %}
+{% block title_content %}<h1>Notifier la sanction du contrôle pour {{ evaluated_siae }}</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step2.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step2.html
@@ -4,11 +4,7 @@
 
 {% block title %}Notifier la sanction du contrôle pour {{ evaluated_siae }}{{ block.super }}{% endblock %}
 
-{% block title_content %}
-    <h1>
-        Notifier la sanction du contrôle pour <span class="text-muted">{{ evaluated_siae }}</span>
-    </h1>
-{% endblock %}
+{% block title_content %}<h1>Notifier la sanction du contrôle pour {{ evaluated_siae }}</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step3.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step3.html
@@ -4,11 +4,7 @@
 
 {% block title %}Notifier la sanction du contrôle pour {{ evaluated_siae }}{{ block.super }}{% endblock %}
 
-{% block title_content %}
-    <h1>
-        Notifier la sanction du contrôle pour <span class="text-muted">{{ evaluated_siae }}</span>
-    </h1>
-{% endblock %}
+{% block title_content %}<h1>Notifier la sanction du contrôle pour {{ evaluated_siae }}</h1>{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4870,7 +4870,7 @@ class TestCheckJobSeekerInformationsForHire:
         assertContains(
             response,
             """<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
-            Informations personnelles de Son Prénom Son Nom De Famille</h1>""",
+            Informations personnelles de Son Prénom SON NOM DE FAMILLE</h1>""",
             html=True,
         )
         assertTemplateNotUsed(response, "approvals/includes/box.html")
@@ -4915,7 +4915,7 @@ class TestCheckJobSeekerInformationsForHire:
         assertContains(
             response,
             """<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
-            Informations personnelles de Son Prénom Son Nom De Famille</h1>""",
+            Informations personnelles de Son Prénom SON NOM DE FAMILLE</h1>""",
             html=True,
         )
         assertTemplateNotUsed(response, "approvals/includes/box.html")

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -4869,7 +4869,8 @@ class TestCheckJobSeekerInformationsForHire:
         response = client.get(url_check_infos)
         assertContains(
             response,
-            '<h1 class="mb-0 me-3 text-md-nowrap">Informations personnelles de Son Prénom Son Nom De Famille</h1>',
+            """<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+            Informations personnelles de Son Prénom Son Nom De Famille</h1>""",
             html=True,
         )
         assertTemplateNotUsed(response, "approvals/includes/box.html")
@@ -4913,7 +4914,8 @@ class TestCheckJobSeekerInformationsForHire:
         response = client.get(url_check_infos)
         assertContains(
             response,
-            '<h1 class="mb-0 me-3 text-md-nowrap">Informations personnelles de Son Prénom Son Nom De Famille</h1>',
+            """<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+            Informations personnelles de Son Prénom Son Nom De Famille</h1>""",
             html=True,
         )
         assertTemplateNotUsed(response, "approvals/includes/box.html")

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -1519,7 +1519,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
                   Demande de prolongation pour Jane DOE
               </h1>
               
@@ -1765,7 +1765,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
                   Demande de prolongation pour Jane DOE
               </h1>
               
@@ -2011,7 +2011,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
                   Demande de prolongation pour Jane DOE
               </h1>
               

--- a/tests/www/geiq_views/__snapshots__/tests.ambr
+++ b/tests/www/geiq_views/__snapshots__/tests.ambr
@@ -786,7 +786,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       
           <span class="badge badge-base rounded-pill text-nowrap bg-warning">Bilan validé : demande de remboursement total</span>
@@ -940,7 +940,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   
                       <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement total</span>
@@ -1140,7 +1140,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       
           <span class="badge badge-base rounded-pill text-nowrap bg-success">Bilan validé</span>
@@ -1292,7 +1292,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   
                       <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : totalité de l’aide accordée</span>
@@ -1492,7 +1492,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       
           <span class="badge badge-base rounded-pill text-nowrap bg-success">Bilan validé : solde partiellement accordé</span>
@@ -1646,7 +1646,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   
                       <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : solde partiellement accordé</span>
@@ -1846,7 +1846,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       
           <span class="badge badge-base rounded-pill text-nowrap bg-warning">Bilan validé : demande de remboursement partiel</span>
@@ -2000,7 +2000,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   
                       <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement partiel</span>
@@ -2200,7 +2200,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       
           <span class="badge badge-base rounded-pill text-nowrap bg-warning">Bilan validé : solde refusé</span>
@@ -2352,7 +2352,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   
                       <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : solde refusé</span>
@@ -2548,7 +2548,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
   
@@ -2696,7 +2696,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
               
@@ -2875,7 +2875,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
       <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
   
@@ -3068,7 +3068,7 @@
                               
       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
           <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-0 me-3 text-md-nowrap">Bilan d’exécution - 2023</h1>
+              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
               
                   <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
               

--- a/tests/www/login/__snapshots__/tests.ambr
+++ b/tests/www/login/__snapshots__/tests.ambr
@@ -96,35 +96,6 @@
                       </div>
   '''
 # ---
-# name: TestExistingUserLogin.test_login[IC]
-  '''
-  <div class="c-form mb-5">
-                          
-                              
-                                  <div class="alert alert-important">
-                                      <p class="mb-0">Inclusion Connect devient ProConnect</p>
-                                  </div>
-                                  
-  
-  
-  
-  
-      <div class="text-center">
-          <a class="proconnect-button" data-matomo-action="clic" data-matomo-category="connexion prescripteur" data-matomo-event="true" data-matomo-option="se-connecter-avec-pro-connect" href="/pro_connect/authorize?user_kind=prescriber&amp;previous_url=%2Flogin%2Fexisting%2Fc0fee70e-cf34-4d37-919d-a1ae3e3bf7e5%3Fback_url%3D%2Fsignup%2F">
-          </a>
-          <p>
-              <a href="https://proconnect.gouv.fr/" rel="noopener noreferrer" target="_blank" title="Qu’est-ce que AgentConnect ? - nouvelle fenêtre">
-                  Qu’est-ce que ProConnect ?
-              </a>
-          </p>
-      </div>
-  
-  
-                              
-                          
-                      </div>
-  '''
-# ---
 # name: TestExistingUserLogin.test_login[PC]
   '''
   <div class="c-form mb-5">
@@ -239,31 +210,6 @@
                                   <div class="alert alert-info" role="status">
                                       <p class="mb-0">FranceConnect est désactivé.</p>
                                   </div>
-                              
-                          
-                      </div>
-  '''
-# ---
-# name: TestExistingUserLogin.test_login_disabled_provider[IC]
-  '''
-  <div class="c-form mb-5">
-                          
-                              
-                                  
-  
-  
-  
-  
-      <div class="alert alert-info" role="status">
-          <p class="mb-2">
-              <strong>Inclusion Connect est momentanément désactivé.</strong>
-          </p>
-          <p class="mb-0">
-              Afin de demander un PASS IAE en urgence, <a class="has-external-link" href="https://tally.so/r/nrj0V5" target="_blank">remplissez ce formulaire.</a>
-          </p>
-      </div>
-  
-  
                               
                           
                       </div>

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2058,7 +2058,9 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep1(InstitutionEvaluatedSiaeNotify
                 kwargs={"evaluated_siae_pk": evaluated_siae.pk},
             )
         )
-        assertContains(response, f"Notifier la sanction du contrôle pour {evaluated_siae.siae.name}", count=1)
+        assertContains(
+            response, f"Notifier la sanction du contrôle pour {evaluated_siae.siae.name}", html=True, count=1
+        )
         assertContains(
             response,
             f"""


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les badges sont maintenant à la droite des titres
Nous n'utilisons plus le `.text-muted` pour mettre en avant les noms des candidats/structures/etc dans les titres de pages 

https://www.notion.so/plateforme-inclusion/Passer-le-badge-de-la-section-titre-droite-dans-les-fiches-de-poste-et-les-fiches-salari-es-ASP-188e8fa5c35b80c6a676d4cf1da0a145?pvs=4

## :computer: Captures d'écran <!-- optionnel -->
**Avant**
![capture 2025-01-28 à 14 57 45](https://github.com/user-attachments/assets/6d494724-3b5c-48ce-a565-83b8d62d352d)

**Apres**
![capture 2025-01-28 à 14 57 09](https://github.com/user-attachments/assets/eebfb4d6-022e-46a3-8ca5-932b90df85f3)