### PR TITLE
Notifications : correction du contenu de l'email envoyé aux prescripteurs lors du refus d'une candidature

### DIFF
--- a/itou/templates/apply/email/refuse_body_for_proxy.txt
+++ b/itou/templates/apply/email/refuse_body_for_proxy.txt
@@ -7,11 +7,9 @@ La candidature de {{ job_application.job_seeker.get_full_name }} envoyée par {{
 Pour l'instant cette SIAE n'est plus habilitée à recevoir de candidatures.
 {% endif %}
 
-{% if job_application.refusal_reason_shared_with_job_seeker %}
-*Motif de refus* :
+*Motif de refus {{ job_application.refusal_reason_shared_with_job_seeker|yesno:"transmis,non transmis" }} au candidat* :
 
 {{ job_application.get_refusal_reason_display }}
-{% endif %}
 
 {% if job_application.answer %}
 *Réponse de l'entreprise transmise au candidat* :

--- a/tests/job_applications/__snapshots__/tests.ambr
+++ b/tests/job_applications/__snapshots__/tests.ambr
@@ -1,0 +1,117 @@
+# serializer version: 1
+# name: TestJobApplicationNotifications.test_refuse[False-False][job_seeker_email]
+  '''
+  Votre candidature chez Acme inc. n'a malheureusement pas pu aboutir.
+  
+  Nous vous souhaitons bon courage dans votre recherche et sommes persuadés que votre démarche aboutira ailleurs.
+  
+  *Message de l'entreprise* :
+  
+  Pas venu
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestJobApplicationNotifications.test_refuse[False-True][job_seeker_email]
+  '''
+  Votre candidature chez Acme inc. n'a malheureusement pas pu aboutir.
+  
+  Nous vous souhaitons bon courage dans votre recherche et sommes persuadés que votre démarche aboutira ailleurs.
+  
+  *Message de l'entreprise* :
+  
+  Pas venu
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestJobApplicationNotifications.test_refuse[False-True][prescriber_email]
+  '''
+  La candidature de Jane DOE envoyée par Pierre DUPONT chez Acme inc. n'a malheureusement pas pu aboutir.
+  
+  *Motif de refus non transmis au candidat* :
+  
+  Candidat ne s’étant pas présenté à l’entretien
+  
+  *Réponse de l'entreprise transmise au candidat* :
+  
+  Pas venu
+  
+  *Message privé de l'entreprise (non transmis au candidat)* :
+  
+  Le candidat n'est pas venu.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestJobApplicationNotifications.test_refuse[True-False][job_seeker_email]
+  '''
+  Votre candidature chez Acme inc. n'a malheureusement pas pu aboutir.
+  
+  Nous vous souhaitons bon courage dans votre recherche et sommes persuadés que votre démarche aboutira ailleurs.
+  
+  *Motif de refus* :
+  
+  Candidat ne s’étant pas présenté à l’entretien
+  
+  *Message de l'entreprise* :
+  
+  Pas venu
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestJobApplicationNotifications.test_refuse[True-True][job_seeker_email]
+  '''
+  Votre candidature chez Acme inc. n'a malheureusement pas pu aboutir.
+  
+  Nous vous souhaitons bon courage dans votre recherche et sommes persuadés que votre démarche aboutira ailleurs.
+  
+  *Motif de refus* :
+  
+  Candidat ne s’étant pas présenté à l’entretien
+  
+  *Message de l'entreprise* :
+  
+  Pas venu
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestJobApplicationNotifications.test_refuse[True-True][prescriber_email]
+  '''
+  La candidature de Jane DOE envoyée par Pierre DUPONT chez Acme inc. n'a malheureusement pas pu aboutir.
+  
+  *Motif de refus transmis au candidat* :
+  
+  Candidat ne s’étant pas présenté à l’entretien
+  
+  *Réponse de l'entreprise transmise au candidat* :
+  
+  Pas venu
+  
+  *Message privé de l'entreprise (non transmis au candidat)* :
+  
+  Le candidat n'est pas venu.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car c'était une pâle copie de celui envoyé au candidat : si l'on ne partageait pas le motif avec le candidat (choix par défaut), le prescripteur ne l'avait jamais dans le mail.

## :cake: Comment ? <!-- optionnel -->

- Le prescripteur a toujours le motif indiqué dans son mail à présent
- On indique en plus si c'est partagé ou non avec le candidat (comme les autres items du mail)
- En reprenant les tests et couvrant mieux ce cas d'usage

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?