### PR TITLE
suppression de la redirection temporaire approvals:redirect_to_employee vers employees:detail

### DIFF
--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -8,7 +8,6 @@ app_name = "approvals"
 
 urlpatterns = [
     # PASS IAE
-    path("detail/<int:pk>", views.approval_detail_redirect_to_employee_view, name="redirect_to_employee"),
     path("details/<int:pk>", views.ApprovalDetailView.as_view(), name="details"),
     path("display/<int:approval_id>", views.ApprovalPrintableDisplay.as_view(), name="display_printable_approval"),
     path("list", views.ApprovalListView.as_view(), name="list"),

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -10,7 +10,7 @@ from django.core.files.storage import default_storage
 from django.db import IntegrityError
 from django.db.models import Max, Prefetch
 from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
 from django.views import View
@@ -71,17 +71,6 @@ class ApprovalBaseViewMixin:
         context = super().get_context_data(**kwargs)
         context["siae"] = self.siae
         return context
-
-
-# TODO(xfernandez): remove this redirect view in a few weeks
-def approval_detail_redirect_to_employee_view(request, pk):
-    siae = get_current_company_or_404(request)
-
-    if not siae.is_subject_to_eligibility_rules:
-        raise PermissionDenied
-
-    approval = get_object_or_404(Approval.objects.select_related("user"), pk=pk)
-    return redirect("employees:detail", public_id=approval.user.public_id)
 
 
 class ApprovalListView(ApprovalBaseViewMixin, ListView):

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -28,25 +28,6 @@ from tests.users.factories import JobSeekerFactory, LaborInspectorFactory
 from tests.utils.test import assertSnapshotQueries, parse_response_to_soup
 
 
-class TestRedirectToEmployeeView:
-    def test_anonymous_user(self, client):
-        approval = ApprovalFactory()
-        url = reverse("approvals:redirect_to_employee", kwargs={"pk": approval.pk})
-        response = client.get(url)
-        assertRedirects(response, reverse("account_login") + f"?next={url}")
-
-    def test_redirect(self, client):
-        membership = CompanyMembershipFactory()
-        client.force_login(membership.user)
-        approval = ApprovalFactory()
-        response = client.get(reverse("approvals:redirect_to_employee", kwargs={"pk": approval.pk}))
-        assertRedirects(
-            response,
-            reverse("employees:detail", kwargs={"public_id": approval.user.public_id}),
-            fetch_redirect_response=False,
-        )
-
-
 class TestApprovalDetailView:
     def test_anonymous_user(self, client):
         approval = JobApplicationFactory(with_approval=True).approval


### PR DESCRIPTION
## :thinking: Pourquoi ?

> La redirection en objet n'est plus utile, il n'est donc pas nécessaire de la modifier dans la #5431 

## :cake: Comment ? <!-- optionnel -->

> suppression

## :rotating_light: À vérifier

NON : Mettre à jour le CHANGELOG_breaking_changes.md ?
NON : Ajouter l'étiquette « Bug » ?

# Catégories changelog

PASS IAE