### PR TITLE
Candidature: Simplification du parcours de refus (expérimentation dans le Rhône) [GEN-1611]

### DIFF
--- a/itou/templates/apply/email/refuse_body_for_job_seeker.txt
+++ b/itou/templates/apply/email/refuse_body_for_job_seeker.txt
@@ -12,7 +12,7 @@ Nous vous souhaitons bon courage dans votre recherche et sommes persuadés que v
 {% if job_application.refusal_reason_shared_with_job_seeker %}
 *Motif de refus* :
 
-{{ job_application.get_refusal_reason_display }}
+{{ job_application.get_refusal_reason_display|default:"Non renseigné" }}
 {% endif %}
 
 {% if job_application.answer %}

--- a/itou/templates/apply/email/refuse_body_for_proxy.txt
+++ b/itou/templates/apply/email/refuse_body_for_proxy.txt
@@ -9,7 +9,7 @@ Pour l'instant cette SIAE n'est plus habilitée à recevoir de candidatures.
 
 *Motif de refus {{ job_application.refusal_reason_shared_with_job_seeker|yesno:"transmis,non transmis" }} au candidat* :
 
-{{ job_application.get_refusal_reason_display }}
+{{ job_application.get_refusal_reason_display|default:"Non renseigné" }}
 
 {% if job_application.answer %}
 *Réponse de l'entreprise transmise au candidat* :

--- a/itou/templates/apply/includes/job_application_answers.html
+++ b/itou/templates/apply/includes/job_application_answers.html
@@ -4,7 +4,7 @@
     <div class="c-box mb-4">
         <h3>Réponse de l'employeur</h3>
         <ul class="list-data mb-3">
-            {% if job_application.refusal_reason %}
+            {% if job_application.refusal_reason or job_application.to_company.department == "69" %}
                 {% if not request.user.is_job_seeker or job_application.refusal_reason_shared_with_job_seeker %}
                     <li>
                         <div>
@@ -13,7 +13,7 @@
                             {% else %}
                                 <small>Motif de refus {{ job_application.refusal_reason_shared_with_job_seeker|yesno:"partagé,non partagé" }} avec le candidat</small>
                             {% endif %}
-                            <strong>{{ job_application.get_refusal_reason_display }}</strong>
+                            <strong>{{ job_application.get_refusal_reason_display|default:"Non renseigné" }}</strong>
                         </div>
                     </li>
                 {% endif %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -176,6 +176,8 @@ class JobApplicationRefusalReasonForm(forms.Form):
                     job_applications_enums.RefusalReason.NON_ELIGIBLE,
                 ]
             )
+        if company.department == "69":
+            self.fields["refusal_reason"].required = False
 
 
 class JobApplicationRefusalJobSeekerAnswerForm(forms.Form):

--- a/itou/www/apply/views/batch_views.py
+++ b/itou/www/apply/views/batch_views.py
@@ -364,6 +364,8 @@ class RefuseWizardView(UserPassesTestMixin, TemplateView):
 
             if refusal_reason := reason_data.get("refusal_reason"):
                 context["refusal_reason_label"] = job_applications_enums.RefusalReason(refusal_reason).label
+            else:
+                context["refusal_reason_label"] = "Non renseigné"
             context["refusal_reason_shared_with_job_seeker"] = reason_data.get("refusal_reason_shared_with_job_seeker")
 
         return context

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -472,9 +472,12 @@ class JobApplicationRefuseView(NamedUrlSessionWizardView):
         context = super().get_context_data(**kwargs)
         if self.steps.current != RefuseViewStep.REASON:
             cleaned_data = self.get_cleaned_data_for_step(RefuseViewStep.REASON)
-            context["refusal_reason_label"] = job_applications_enums.RefusalReason(
-                cleaned_data["refusal_reason"]
-            ).label
+            if cleaned_data.get("refusal_reason"):
+                context["refusal_reason_label"] = job_applications_enums.RefusalReason(
+                    cleaned_data["refusal_reason"]
+                ).label
+            else:
+                context["refusal_reason_label"] = "Non renseigné"
             context["refusal_reason_shared_with_job_seeker"] = cleaned_data["refusal_reason_shared_with_job_seeker"]
         return context | {
             "job_applications": [self.job_application],


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les employeurs ne sont pas toujours à l’aise avec le fait de renseigner un motif de refus, ce qui explique des candidatures non traitées. C’est plus simple de ne rien faire. 

Si on leur permet de refuser un candidat en indiquant qu’ils ne souhaitent pas renseigner de motif, traiteront-ils plus de candidatures ?

## :cake: Comment ? <!-- optionnel -->

En rendant optionnel le motif de refus si l'entreprise se situe dans le Rhône, que ce soit dans le parcours unitaire ou traitement par lot.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
