### PR TITLE
Correction des vues deactivate_member

### DIFF
--- a/itou/common_apps/organizations/views.py
+++ b/itou/common_apps/organizations/views.py
@@ -11,7 +11,7 @@ def deactivate_org_member(request, target_member):
         raise PermissionDenied
 
     try:
-        membership = request.current_organization.memberships.get(user=target_member)
+        membership = request.current_organization.memberships.get(user=target_member, is_active=True)
     except ObjectDoesNotExist:
         raise PermissionDenied
 

--- a/itou/common_apps/organizations/views.py
+++ b/itou/common_apps/organizations/views.py
@@ -4,16 +4,14 @@ Functions used in organization views.
 
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
+from django.shortcuts import get_object_or_404
 
 
 def deactivate_org_member(request, target_member):
     if not request.is_current_organization_admin or request.user == target_member:
         raise PermissionDenied
 
-    try:
-        membership = request.current_organization.memberships.get(user=target_member, is_active=True)
-    except ObjectDoesNotExist:
-        raise PermissionDenied
+    membership = get_object_or_404(request.current_organization.memberships, user=target_member, is_active=True)
 
     if request.method == "POST":
         if membership.is_active:

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -23,7 +23,7 @@ from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.apis.data_inclusion import DataInclusionApiClient, DataInclusionApiException
 from itou.utils.apis.exceptions import GeocodingDataError
-from itou.utils.auth import LoginNotRequiredMixin
+from itou.utils.auth import LoginNotRequiredMixin, check_user
 from itou.utils.pagination import pager
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.urls import add_url_params, get_absolute_url, get_safe_url
@@ -635,19 +635,14 @@ def members(request, template_name="companies/members.html"):
     return render(request, template_name, context)
 
 
+@check_user(lambda user: user.is_employer)
 def deactivate_member(request, user_id, template_name="companies/deactivate_member.html"):
-    company = get_current_company_or_404(request)
-    target_member = User.objects.get(pk=user_id)
-
-    if deactivate_org_member(request=request, target_member=target_member):
-        return HttpResponseRedirect(reverse("companies_views:members"))
-
-    context = {
-        "structure": company,
-        "target_member": target_member,
-    }
-
-    return render(request, template_name, context)
+    return deactivate_org_member(
+        request,
+        user_id,
+        success_url=reverse("companies_views:members"),
+        template_name=template_name,
+    )
 
 
 def update_admin_role(request, action, user_id, template_name="companies/update_admins.html"):

--- a/itou/www/institutions_views/views.py
+++ b/itou/www/institutions_views/views.py
@@ -5,6 +5,7 @@ from django.urls import reverse_lazy
 
 from itou.common_apps.organizations.views import deactivate_org_member, update_org_admin_role
 from itou.users.models import User
+from itou.utils.auth import check_user
 from itou.utils.perms.institution import get_current_institution_or_404
 
 
@@ -37,19 +38,14 @@ def member_list(request, template_name="institutions/members.html"):
     return render(request, template_name, context)
 
 
+@check_user(lambda user: user.is_labor_inspector)
 def deactivate_member(request, user_id, template_name="institutions/deactivate_member.html"):
-    institution = get_current_institution_or_404(request)
-    target_member = User.objects.get(pk=user_id)
-
-    if deactivate_org_member(request=request, target_member=target_member):
-        return HttpResponseRedirect(reverse_lazy("institutions_views:members"))
-
-    context = {
-        "structure": institution,
-        "target_member": target_member,
-    }
-
-    return render(request, template_name, context)
+    return deactivate_org_member(
+        request,
+        user_id,
+        success_url=reverse_lazy("institutions_views:members"),
+        template_name=template_name,
+    )
 
 
 def update_admin_role(request, action, user_id, template_name="institutions/update_admins.html"):

--- a/itou/www/prescribers_views/views.py
+++ b/itou/www/prescribers_views/views.py
@@ -11,6 +11,7 @@ from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.models import User
 from itou.utils.apis.exceptions import GeocodingDataError
+from itou.utils.auth import check_user
 from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.urls import get_safe_url
 from itou.www.prescribers_views.forms import EditPrescriberOrganizationForm
@@ -72,19 +73,14 @@ def member_list(request, template_name="prescribers/members.html"):
     return render(request, template_name, context)
 
 
+@check_user(lambda user: user.is_prescriber)
 def deactivate_member(request, user_id, template_name="prescribers/deactivate_member.html"):
-    organization = get_current_org_or_404(request)
-    target_member = User.objects.get(pk=user_id)
-
-    if deactivate_org_member(request=request, target_member=target_member):
-        return HttpResponseRedirect(reverse_lazy("prescribers_views:members"))
-
-    context = {
-        "structure": organization,
-        "target_member": target_member,
-    }
-
-    return render(request, template_name, context)
+    return deactivate_org_member(
+        request,
+        user_id,
+        success_url=reverse("prescribers_views:members"),
+        template_name=template_name,
+    )
 
 
 def update_admin_role(request, action, user_id, template_name="prescribers/update_admins.html"):

--- a/tests/www/companies_views/test_members_views.py
+++ b/tests/www/companies_views/test_members_views.py
@@ -153,7 +153,7 @@ class TestUserMembershipDeactivation:
             ),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 404
         other_membership.refresh_from_db()
         assert other_membership.is_active is True
 
@@ -166,7 +166,7 @@ class TestUserMembershipDeactivation:
         client.force_login(admin_membership.user)
         request = getattr(client, method)
         response = request(reverse("companies_views:deactivate_member", kwargs={"user_id": guest_membership.user_id}))
-        assert response.status_code == 403
+        assert response.status_code == 404
         guest_membership.refresh_from_db()
         assert guest_membership.is_active is False
         assert mailoutbox == []
@@ -179,7 +179,7 @@ class TestUserMembershipDeactivation:
         client.force_login(admin_membership.user)
         request = getattr(client, method)
         response = request(reverse("companies_views:deactivate_member", kwargs={"user_id": other_user.pk}))
-        assert response.status_code == 403
+        assert response.status_code == 404
         assert mailoutbox == []
 
     def test_user_with_no_company_left(self, client):

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -133,7 +133,7 @@ class TestMembers:
             ),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 404
         other_membership.refresh_from_db()
         assert other_membership.is_active is True
 
@@ -148,7 +148,7 @@ class TestMembers:
         response = request(
             reverse("institutions_views:deactivate_member", kwargs={"user_id": guest_membership.user_id})
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
         guest_membership.refresh_from_db()
         assert guest_membership.is_active is False
         assert mailoutbox == []
@@ -161,7 +161,7 @@ class TestMembers:
         client.force_login(admin_membership.user)
         request = getattr(client, method)
         response = request(reverse("institutions_views:deactivate_member", kwargs={"user_id": other_user.pk}))
-        assert response.status_code == 403
+        assert response.status_code == 404
         assert mailoutbox == []
 
     def test_remove_admin(self, client, mailoutbox):

--- a/tests/www/prescribers_views/test_members.py
+++ b/tests/www/prescribers_views/test_members.py
@@ -140,7 +140,7 @@ class TestUserMembershipDeactivation:
             ),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 404
         other_membership.refresh_from_db()
         assert other_membership.is_active is True
         assert mailoutbox == []
@@ -169,7 +169,7 @@ class TestUserMembershipDeactivation:
         response = request(
             reverse("prescribers_views:deactivate_member", kwargs={"user_id": guest_membership.user_id})
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
         guest_membership.refresh_from_db()
         assert guest_membership.is_active is False
         assert mailoutbox == []
@@ -182,7 +182,7 @@ class TestUserMembershipDeactivation:
         client.force_login(admin_membership.user)
         request = getattr(client, method)
         response = request(reverse("prescribers_views:deactivate_member", kwargs={"user_id": other_user.pk}))
-        assert response.status_code == 403
+        assert response.status_code == 404
         assert mailoutbox == []
 
     def test_deactivated_prescriber_is_orienter(self, client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin d’éviter des cas limite, l’application indique maintenant 404 si le membership de l’utilisateur à désactiver n’est pas actif.

Petit réusinage nécessaire pour partager le code entre les différentes vues, indiquer le résultat d’une opération par un booléen a ses limites.
