### PR TITLE
Simplifier update_admin_role

### DIFF
--- a/itou/common_apps/organizations/views.py
+++ b/itou/common_apps/organizations/views.py
@@ -30,28 +30,28 @@ def deactivate_org_member(request, target_member):
 
 
 def update_org_admin_role(request, target_member, action):
-    if not request.is_current_organization_admin or target_member not in request.current_organization.active_members:
+    if not request.is_current_organization_admin or target_member == request.user:
         raise PermissionDenied
 
-    membership = request.current_organization.memberships.get(user=target_member)
+    try:
+        membership = request.current_organization.memberships.get(user=target_member, is_active=True)
+    except ObjectDoesNotExist:
+        raise PermissionDenied
 
     if request.method == "POST":
-        if request.user != target_member and request.is_current_organization_admin and membership.is_active:
-            if action == "add":
-                membership.set_admin_role(is_admin=True, updated_by=request.user)
-                messages.success(
-                    request, f"{target_member.get_full_name()} a été ajouté(e) aux administrateurs de cette structure."
-                )
-                request.current_organization.add_admin_email(target_member).send()
-            if action == "remove":
-                membership.set_admin_role(is_admin=False, updated_by=request.user)
-                messages.success(
-                    request, f"{target_member.get_full_name()} a été retiré(e) des administrateurs de cette structure."
-                )
-                request.current_organization.remove_admin_email(target_member).send()
-            membership.save()
-        else:
-            raise PermissionDenied
+        if action == "add":
+            membership.set_admin_role(is_admin=True, updated_by=request.user)
+            messages.success(
+                request, f"{target_member.get_full_name()} a été ajouté(e) aux administrateurs de cette structure."
+            )
+            request.current_organization.add_admin_email(target_member).send()
+        if action == "remove":
+            membership.set_admin_role(is_admin=False, updated_by=request.user)
+            messages.success(
+                request, f"{target_member.get_full_name()} a été retiré(e) des administrateurs de cette structure."
+            )
+            request.current_organization.remove_admin_email(target_member).send()
+        membership.save()
         return True
 
     return False


### PR DESCRIPTION
## :thinking: Pourquoi ?

Retirer des vérifications en doublon, et commencer la vue par les contrôles d’accès.
