### PR TITLE
Sentry: ignorer le logger `django_datadog_logger.middleware.request_log`

### DIFF
--- a/config/sentry.py
+++ b/config/sentry.py
@@ -69,3 +69,4 @@ def sentry_init():
         # and is silently ignored when used in `context_processors.py` to get access to `request.user`.
     )
     ignore_logger("django.security.DisallowedHost")
+    ignore_logger("django_datadog_logger.middleware.request_log")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car il envoie toutes les requêtes se terminant en 500 à Sentry:
https://github.com/namespace-ee/django-datadog-logger/blob/v0.7.3/django_datadog_logger/middleware/request_log.py#L41-L44

ce qui cause des rapports en double vu que Sentry aura déjà envoyé le soucis ayant causé la 500.

Cf:
https://inclusion.sentry.io/issues/14187836/
&
https://inclusion.sentry.io/issues/14187834/

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
