### PR TITLE
Tech: amélioration de la détection des étapes précédentes manquantes

### DIFF
--- a/itou/www/apply/views/batch_views.py
+++ b/itou/www/apply/views/batch_views.py
@@ -375,6 +375,8 @@ class RefuseWizardView(UserPassesTestMixin, TemplateView):
         for previous_step in self.steps:
             if previous_step == step:
                 return None
+            if self.wizard_session.get(previous_step) is self.wizard_session.NOT_SET:
+                return previous_step
             form = self.get_form(previous_step, data=self.wizard_session.get(previous_step, {}))
             if not form.is_valid():
                 return previous_step

--- a/tests/www/apply/test_batch_views.py
+++ b/tests/www/apply/test_batch_views.py
@@ -1,6 +1,7 @@
 import random
 import uuid
 
+import pytest
 from django.contrib import messages
 from django.urls import reverse
 from django.utils import timezone
@@ -887,8 +888,13 @@ class TestBatchRefuse:
             [messages.Message(messages.SUCCESS, "2 candidatures ont bien été refusées.", extra_tags="toast")],
         )
 
-    def test_refuse_step_bypass(self, client):
-        company = CompanyFactory(with_membership=True)
+    # TODO(xfernandez): remove this parametrization when
+    # https://github.com/gip-inclusion/les-emplois/commit/829e972903b0bfa8801eaa801b3197f13193c87b
+    # is reverted (or extended to all departments)
+    @pytest.mark.parametrize("rhone", [True, False])
+    def test_refuse_step_bypass(self, client, rhone):
+        extra_kwargs = {"department": "69"} if rhone else {}
+        company = CompanyFactory(with_membership=True, **extra_kwargs)
         employer = company.members.first()
         next_url = add_url_params(reverse("apply:list_for_siae"), {"state": "PROCESSING"})
         client.force_login(employer)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour les champs optionnels, valider le formulaire n'est pas suffisant.
On vérifie donc d'abord l'existence des infos de l'étape.

Cela corrige un test flaky qui échouait quand le département du Rhone était tiré au sort.


## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
