### PR TITLE
Réusinage de l’activation/désactivation du statut administrateur d’un membre d’une organisation

### DIFF
--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -110,6 +110,11 @@ class OrganizationAbstract(models.Model):
             )
         membership.is_admin = admin
         membership.updated_by = updated_by
+        membership.save(update_fields=["is_admin", "updated_by"])
+        if admin:
+            self.add_admin_email(membership.user).send()
+        else:
+            self.remove_admin_email(membership.user).send()
 
     @property
     def active_members(self):

--- a/itou/common_apps/organizations/views.py
+++ b/itou/common_apps/organizations/views.py
@@ -37,13 +37,13 @@ def update_org_admin_role(request, target_member, action):
 
     if request.method == "POST":
         if action == "add":
-            membership.set_admin_role(is_admin=True, updated_by=request.user)
+            request.current_organization.set_admin_role(membership, admin=True, updated_by=request.user)
             messages.success(
                 request, f"{target_member.get_full_name()} a été ajouté(e) aux administrateurs de cette structure."
             )
             request.current_organization.add_admin_email(target_member).send()
         if action == "remove":
-            membership.set_admin_role(is_admin=False, updated_by=request.user)
+            request.current_organization.set_admin_role(membership, admin=False, updated_by=request.user)
             messages.success(
                 request, f"{target_member.get_full_name()} a été retiré(e) des administrateurs de cette structure."
             )

--- a/itou/common_apps/organizations/views.py
+++ b/itou/common_apps/organizations/views.py
@@ -36,18 +36,21 @@ def update_org_admin_role(request, target_member, action):
         raise PermissionDenied
 
     if request.method == "POST":
-        if action == "add":
-            request.current_organization.set_admin_role(membership, admin=True, updated_by=request.user)
-            messages.success(
-                request, f"{target_member.get_full_name()} a été ajouté(e) aux administrateurs de cette structure."
-            )
-            request.current_organization.add_admin_email(target_member).send()
-        if action == "remove":
-            request.current_organization.set_admin_role(membership, admin=False, updated_by=request.user)
-            messages.success(
-                request, f"{target_member.get_full_name()} a été retiré(e) des administrateurs de cette structure."
-            )
-            request.current_organization.remove_admin_email(target_member).send()
+        match action:
+            case "add":
+                request.current_organization.set_admin_role(membership, admin=True, updated_by=request.user)
+                messages.success(
+                    request, f"{target_member.get_full_name()} a été ajouté(e) aux administrateurs de cette structure."
+                )
+                request.current_organization.add_admin_email(target_member).send()
+            case "remove":
+                request.current_organization.set_admin_role(membership, admin=False, updated_by=request.user)
+                messages.success(
+                    request, f"{target_member.get_full_name()} a été retiré(e) des administrateurs de cette structure."
+                )
+                request.current_organization.remove_admin_email(target_member).send()
+            case _:
+                raise ValueError(f"Unknown {action=}")
         membership.save()
         return True
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter les mises à jour futures.
