### PR TITLE
Tests : vérifier le contenu de la modale confirmant un candidat trouvé par son NIR ou son email

### DIFF
--- a/itou/templates/job_seekers_views/step_search_job_seeker_by_email.html
+++ b/itou/templates/job_seekers_views/step_search_job_seeker_by_email.html
@@ -66,28 +66,26 @@
                             </p>
                             {% if can_add_nir %}
                                 <p>
-                                    En cliquant sur « Continuer », <b>vous acceptez que le numéro de sécurité sociale {{ nir|format_nir }} soit associé à ce
-                                    {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}
-                                .</b>
-                            </p>
-                        {% endif %}
-                    </div>
-                    <div class="modal-footer">
+                                    En cliquant sur « Continuer », <b>vous acceptez que le numéro de sécurité sociale {{ nir|format_nir }} soit associé à ce {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}.</b>
+                                </p>
+                            {% endif %}
+                        </div>
+                        <div class="modal-footer">
 
-                        {# Reload this page with a new form. #}
-                        {% if is_gps|default:False %}
-                            {% bootstrap_button "Suivre un autre bénéficiaire" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
-                        {% else %}
-                            {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
-                        {% endif %}
-                        {# Go to the next step. #}
-                        {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
+                            {# Reload this page with a new form. #}
+                            {% if is_gps|default:False %}
+                                {% bootstrap_button "Suivre un autre bénéficiaire" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                            {% else %}
+                                {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                            {% endif %}
+                            {# Go to the next step. #}
+                            {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    {% endif %}
-</form>
+        {% endif %}
+    </form>
 {% endblock %}
 
 {% block script %}

--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -51,7 +51,7 @@ def assert_contains_gps_email_modal(response, job_seeker, nir_to_add=None):
         f"""
         <p>
             En cliquant sur « Continuer », <b>vous acceptez que le numéro de sécurité sociale
-            {format_nir(nir_to_add)} soit associé à ce bénéficiaire .</b>
+            {format_nir(nir_to_add)} soit associé à ce bénéficiaire.</b>
         </p>
         """
         if nir_to_add is not None

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -106,7 +106,7 @@ def assert_contains_apply_email_modal(response, job_seeker, with_personal_inform
         f"""
         <p>
             En cliquant sur « Continuer », <b>vous acceptez que le numéro de sécurité sociale
-            {format_nir(nir_to_add)} soit associé à ce candidat .</b>
+            {format_nir(nir_to_add)} soit associé à ce candidat.</b>
         </p>
         """
         if nir_to_add is not None


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une modale s'affiche lorsqu'on trouve un compte candidat à partir de son NIR ou de son adresse email.
Cette modale s'affiche dans différents contextes (candidature, GPS, …) et devient assez complexe.
Testons son contenu.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
