### PR TITLE
Renommer PrescriberWithOrg{Sent,}InvitationFactory

### DIFF
--- a/tests/invitations/factories.py
+++ b/tests/invitations/factories.py
@@ -29,7 +29,7 @@ class EmployerInvitationFactory(factory.django.DjangoModelFactory):
     sender = factory.LazyAttribute(lambda o: o.company.members.first())
 
 
-class PrescriberWithOrgSentInvitationFactory(factory.django.DjangoModelFactory):
+class PrescriberWithOrgInvitationFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.PrescriberWithOrgInvitation
 

--- a/tests/invitations/tests.py
+++ b/tests/invitations/tests.py
@@ -6,7 +6,7 @@ from itou.users.enums import KIND_EMPLOYER
 from tests.companies.factories import CompanyMembershipFactory
 from tests.invitations.factories import (
     EmployerInvitationFactory,
-    PrescriberWithOrgSentInvitationFactory,
+    PrescriberWithOrgInvitationFactory,
 )
 from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.users.factories import EmployerFactory, PrescriberFactory
@@ -97,7 +97,7 @@ class TestInvitationEmails:
 
 class TestPrescriberWithOrgInvitation:
     def test_add_or_activate_membership_to_organization(self):
-        invitation = PrescriberWithOrgSentInvitationFactory(email="hey@you.com")
+        invitation = PrescriberWithOrgInvitationFactory(email="hey@you.com")
         PrescriberFactory(email=invitation.email)
         org_members = invitation.organization.members.count()
         invitation.add_invited_user_to_organization()
@@ -105,7 +105,7 @@ class TestPrescriberWithOrgInvitation:
         assert org_members + 1 == org_members_after
 
     def test_add_inactive_member_back_to_organization(self):
-        invitation = PrescriberWithOrgSentInvitationFactory(email="hey@you.com")
+        invitation = PrescriberWithOrgInvitationFactory(email="hey@you.com")
         PrescriberMembershipFactory(
             organization=invitation.organization, user__email=invitation.email, is_active=False
         )
@@ -120,7 +120,7 @@ class TestPrescriberWithOrgInvitation:
 
 class TestPrescriberWithOrgInvitationEmails:
     def test_accepted_notif_sender(self):
-        invitation = PrescriberWithOrgSentInvitationFactory()
+        invitation = PrescriberWithOrgInvitationFactory()
         email = invitation.notifications_accepted_notif_sender.build()
 
         # Subject
@@ -137,7 +137,7 @@ class TestPrescriberWithOrgInvitationEmails:
         assert invitation.sender.email in email.to
 
     def test_email_invitation(self):
-        invitation = PrescriberWithOrgSentInvitationFactory()
+        invitation = PrescriberWithOrgInvitationFactory()
         email = invitation.email_invitation
 
         # Subject

--- a/tests/www/invitations_views/test_helpers.py
+++ b/tests/www/invitations_views/test_helpers.py
@@ -7,7 +7,7 @@ from itou.www.invitations_views.helpers import accept_all_pending_invitations
 from tests.invitations.factories import (
     EmployerInvitationFactory,
     LaborInspectorInvitationFactory,
-    PrescriberWithOrgSentInvitationFactory,
+    PrescriberWithOrgInvitationFactory,
 )
 from tests.users.factories import EmployerFactory, LaborInspectorFactory, PrescriberFactory
 from tests.utils.tests import get_response_for_middlewaremixin
@@ -31,11 +31,11 @@ def test_accept_prescriber_invitations():
     prescriber = PrescriberFactory()
     request.user = prescriber
 
-    valid_invitation_1 = PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
-    valid_invitation_2 = PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+    valid_invitation_1 = PrescriberWithOrgInvitationFactory(email=prescriber.email)
+    valid_invitation_2 = PrescriberWithOrgInvitationFactory(email=prescriber.email)
     # non pending invitations
-    PrescriberWithOrgSentInvitationFactory(email=prescriber.email, expired=True)
-    PrescriberWithOrgSentInvitationFactory(email=prescriber.email, accepted=True)
+    PrescriberWithOrgInvitationFactory(email=prescriber.email, expired=True)
+    PrescriberWithOrgInvitationFactory(email=prescriber.email, accepted=True)
     # other user kind invitations
     EmployerInvitationFactory(email=prescriber.email)
     LaborInspectorInvitationFactory(email=prescriber.email)
@@ -54,7 +54,7 @@ def test_accept_employer_invitations():
     EmployerInvitationFactory(email=prescriber.email, expired=True)
     EmployerInvitationFactory(email=prescriber.email, accepted=True)
     # other user kind invitations
-    PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+    PrescriberWithOrgInvitationFactory(email=prescriber.email)
     LaborInspectorInvitationFactory(email=prescriber.email)
 
     assert accept_all_pending_invitations(request) == [valid_invitation_1, valid_invitation_2]
@@ -72,6 +72,6 @@ def test_accept_labor_inspector_invitations():
     LaborInspectorInvitationFactory(email=prescriber.email, accepted=True)
     # other user kind invitations
     EmployerInvitationFactory(email=prescriber.email)
-    PrescriberWithOrgSentInvitationFactory(email=prescriber.email)
+    PrescriberWithOrgInvitationFactory(email=prescriber.email)
 
     assert accept_all_pending_invitations(request) == [valid_invitation_1, valid_invitation_2]

--- a/tests/www/invitations_views/test_prescriber_organization.py
+++ b/tests/www/invitations_views/test_prescriber_organization.py
@@ -23,7 +23,7 @@ from itou.utils import constants as global_constants
 from itou.utils.perms.prescriber import get_current_org_or_404
 from itou.utils.urls import add_url_params
 from tests.companies.factories import CompanyFactory
-from tests.invitations.factories import PrescriberWithOrgSentInvitationFactory
+from tests.invitations.factories import PrescriberWithOrgInvitationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory, PrescriberPoleEmploiFactory
 from tests.users.factories import DEFAULT_PASSWORD, JobSeekerFactory, PrescriberFactory
 from tests.utils.test import ItouClient, assert_previous_step
@@ -256,7 +256,7 @@ class TestAcceptPrescriberWithOrgInvitation:
 
     @respx.mock
     def test_accept_prescriber_org_invitation(self, client, mailoutbox, pro_connect):
-        invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
+        invitation = PrescriberWithOrgInvitationFactory(sender=self.sender, organization=self.organization)
         response = client.get(invitation.acceptance_link)
         pro_connect.assertContainsButton(response)
 
@@ -319,7 +319,7 @@ class TestAcceptPrescriberWithOrgInvitation:
 
     @respx.mock
     def test_accept_prescriber_org_invitation_returns_on_other_browser(self, client, mailoutbox, pro_connect):
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             email=pro_connect.oidc_userinfo["email"],
             sender=self.sender,
             organization=self.organization,
@@ -359,7 +359,7 @@ class TestAcceptPrescriberWithOrgInvitation:
     @respx.mock
     def test_accept_prescriber_org_invitation_without_link(self, client, mailoutbox, pro_connect):
         # The user's invitations are automatically accepted at login
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             email=pro_connect.oidc_userinfo["email"],
             sender=self.sender,
             organization=self.organization,
@@ -378,7 +378,7 @@ class TestAcceptPrescriberWithOrgInvitation:
 
     def test_accept_existing_user_is_prescriber_without_org(self, client, mailoutbox):
         user = PrescriberFactory(has_completed_welcoming_tour=True)
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             sender=self.sender,
             organization=self.organization,
             first_name=user.first_name,
@@ -394,7 +394,7 @@ class TestAcceptPrescriberWithOrgInvitation:
 
     def test_accept_existing_user_email_different_case(self, client, mailoutbox):
         user = PrescriberFactory(has_completed_welcoming_tour=True, email="HEY@example.com")
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             sender=self.sender,
             organization=self.organization,
             first_name=user.first_name,
@@ -410,7 +410,7 @@ class TestAcceptPrescriberWithOrgInvitation:
         user = PrescriberOrganizationWithMembershipFactory().members.first()
         user.has_completed_welcoming_tour = True
         user.save()
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             sender=self.sender,
             organization=self.organization,
             first_name=user.first_name,
@@ -424,7 +424,7 @@ class TestAcceptPrescriberWithOrgInvitation:
 
     @respx.mock
     def test_accept_existing_user_not_logged_in_using_PC(self, client, mailoutbox, pro_connect):
-        invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
+        invitation = PrescriberWithOrgInvitationFactory(sender=self.sender, organization=self.organization)
         user = PrescriberFactory(
             username=pro_connect.oidc_userinfo["sub"],
             email=pro_connect.oidc_userinfo["email"],
@@ -432,7 +432,7 @@ class TestAcceptPrescriberWithOrgInvitation:
         )
         # The user verified its email
         EmailAddress(user_id=user.pk, email=user.email, verified=True, primary=True).save()
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             sender=self.sender,
             organization=self.organization,
             first_name=user.first_name,
@@ -468,11 +468,11 @@ class TestAcceptPrescriberWithOrgInvitation:
         self.assert_invitation_is_accepted(response, user, invitation, mailoutbox, new_user=False)
 
     def test_accept_existing_user_not_logged_in_using_django_auth(self, client, mailoutbox):
-        invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
+        invitation = PrescriberWithOrgInvitationFactory(sender=self.sender, organization=self.organization)
         user = PrescriberFactory(has_completed_welcoming_tour=True, identity_provider="DJANGO")
         # The user verified its email
         EmailAddress(user_id=user.pk, email=user.email, verified=True, primary=True).save()
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             sender=self.sender,
             organization=self.organization,
             first_name=user.first_name,
@@ -501,7 +501,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions:
 
     def test_existing_user_is_not_prescriber(self, client):
         user = CompanyFactory(with_membership=True).members.first()
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             sender=self.sender,
             organization=self.organization,
             first_name=user.first_name,
@@ -516,7 +516,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions:
         assert not invitation.accepted_at
 
     def test_connected_user_is_not_the_invited_user(self, client):
-        invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
+        invitation = PrescriberWithOrgInvitationFactory(sender=self.sender, organization=self.organization)
         client.force_login(self.sender)
         response = client.get(invitation.acceptance_link, follow=True)
         assertRedirects(response, reverse("account_logout"))
@@ -525,7 +525,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions:
         assertContains(response, escape("Un utilisateur est déjà connecté."))
 
     def test_expired_invitation_with_new_user(self, client):
-        invitation = PrescriberWithOrgSentInvitationFactory(sender=self.sender, organization=self.organization)
+        invitation = PrescriberWithOrgInvitationFactory(sender=self.sender, organization=self.organization)
         invitation.sent_at -= timedelta(days=invitation.DEFAULT_VALIDITY_DAYS)
         invitation.save()
         assert invitation.has_expired
@@ -541,7 +541,7 @@ class TestAcceptPrescriberWithOrgInvitationExceptions:
 
     def test_expired_invitation_with_existing_user(self, client):
         user = PrescriberFactory()
-        invitation = PrescriberWithOrgSentInvitationFactory(
+        invitation = PrescriberWithOrgInvitationFactory(
             first_name=user.first_name,
             last_name=user.last_name,
             email=user.email,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suivre la convention établie pour les entreprises et institutions.
