### PR TITLE
Prescripteur : amélioration de la modale confirmant qu'un candidat existe déjà avec ce NIR ou cet email [GEN-2198]

### DIFF
--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -88,28 +88,36 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body">
+                            {# djlint:off #}
                             <p>
-                                Le numéro {{ form.nir.value|format_nir }} est associé au compte de <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>.
+                                Le numéro {{ form.nir.value|format_nir }} est associé au compte de <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>{% if standalone_creation and is_job_seeker_in_list %} figurant dans votre liste de candidats{% endif %}.
                             </p>
+                            {# djlint:on #}
                             <p>
                                 {% if is_gps|default:False %}
                                     Si ce n'est pas le bénéficiaire que vous souhaitez suivre, cliquez sur « Suivre un autre bénéficiaire » afin de modifier le numéro de sécurité sociale.
-                                {% elif standalone_creation|default:False %}
+                                {% elif standalone_creation and not is_job_seeker_in_list %}
                                     Le compte de ce candidat sera ajouté à votre liste une fois que vous aurez postulé pour lui.
-                                {% else %}
+                                {% elif not is_job_seeker_in_list %}
                                     Si cette candidature n'est pas pour <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur « Ce n'est pas mon candidat » afin de modifier le numéro de sécurité sociale.
                                 {% endif %}
                             </p>
                         </div>
                         <div class="modal-footer">
-                            {# Reload this page with a new form. #}
-                            {% if is_gps|default:False %}
-                                {% bootstrap_button "Suivre un autre bénéficiaire" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                            {% if standalone_creation and is_job_seeker_in_list %}
+                                {% url "job_seekers_views:details" public_id=job_seeker.public_id as job_seeker_details %}
+                                {% bootstrap_button "Consulter le profil" button_type="link" href=job_seeker_details button_class="btn btn-sm btn-outline-primary" %}
+                                {% bootstrap_button "Postuler" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                             {% else %}
-                                {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% if is_gps|default:False %}
+                                    {% bootstrap_button "Suivre un autre bénéficiaire" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% else %}
+                                    {# Reload this page with a new form. #}
+                                    {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% endif %}
+                                {# Go to the next step. #}
+                                {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                             {% endif %}
-                            {# Go to the next step. #}
-                            {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                         </div>
                     </div>
                 </div>

--- a/itou/templates/job_seekers_views/step_search_job_seeker_by_email.html
+++ b/itou/templates/job_seekers_views/step_search_job_seeker_by_email.html
@@ -51,16 +51,18 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                         </div>
                         <div class="modal-body">
+                            {# djlint:off #}
                             <p>
-                                L'adresse {{ form.email.value }} est associée au compte de <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>.
+                                L'adresse {{ form.email.value }} est associée au compte de <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>{% if standalone_creation and is_job_seeker_in_list %} figurant dans votre liste de candidats{% endif %}.
                             </p>
+                            {# djlint:on #}
                             <p>
                                 {% if is_gps|default:False %}
                                     L'identité du candidat est une information clé pour la structure.
                                     Si vous ne souhaitez pas suivre <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur « Suivre un autre bénéficiaire » afin d'enregistrer ses informations personnelles.
-                                {% elif standalone_creation|default:False %}
+                                {% elif standalone_creation and not is_job_seeker_in_list %}
                                     Le compte de ce candidat sera ajouté à votre liste une fois que vous aurez postulé pour lui.
-                                {% else %}
+                                {% elif not standalone_creation %}
                                     L'identité du candidat est une information clé pour la structure.
                                     Si cette candidature n'est pas pour <b>{{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</b>, cliquez sur
                                     « Ce n'est pas mon candidat » afin d'enregistrer ses informations
@@ -75,14 +77,20 @@
                         </div>
                         <div class="modal-footer">
 
-                            {# Reload this page with a new form. #}
-                            {% if is_gps|default:False %}
-                                {% bootstrap_button "Suivre un autre bénéficiaire" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                            {% if standalone_creation and is_job_seeker_in_list %}
+                                {% url "job_seekers_views:details" public_id=job_seeker.public_id as job_seeker_details %}
+                                {% bootstrap_button "Consulter le profil" button_type="link" href=job_seeker_details button_class="btn btn-sm btn-outline-primary" %}
+                                {% bootstrap_button "Postuler" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                             {% else %}
-                                {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% if is_gps|default:False %}
+                                    {% bootstrap_button "Suivre un autre bénéficiaire" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% else %}
+                                    {# Reload this page with a new form. #}
+                                    {% bootstrap_button "Ce n'est pas mon candidat" button_type="submit" button_class="btn btn-sm btn-outline-primary" name="cancel" value="1" %}
+                                {% endif %}
+                                {# Go to the next step. #}
+                                {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                             {% endif %}
-                            {# Go to the next step. #}
-                            {% bootstrap_button "Continuer" button_type="submit" button_class="btn btn-sm btn-primary" name="confirm" value="1" %}
                         </div>
                     </div>
                 </div>

--- a/tests/www/job_seekers_views/__snapshots__/test_create_or_update.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_create_or_update.ambr
@@ -1,0 +1,267 @@
+# serializer version: 1
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_email[in_list_application]
+  '''
+  <div aria-labelledby="email-confirmation-label" aria-modal="true" class="modal" id="email-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="email-confirmation-label">Email existant</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  L'adresse jane.doe@test.local est associée au compte de <b>Jane DOE</b> figurant dans votre liste de candidats.
+                              </p>
+                              
+                              <p>
+                                  
+                              </p>
+                              
+                          </div>
+                          <div class="modal-footer">
+  
+                              
+                                  
+                                  <a class="btn btn-sm btn-outline-primary" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a" role="button">Consulter le profil</a>
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Postuler</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_email[in_list_organization]
+  '''
+  <div aria-labelledby="email-confirmation-label" aria-modal="true" class="modal" id="email-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="email-confirmation-label">Email existant</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  L'adresse jane.doe@test.local est associée au compte de <b>Jane DOE</b> figurant dans votre liste de candidats.
+                              </p>
+                              
+                              <p>
+                                  
+                              </p>
+                              
+                          </div>
+                          <div class="modal-footer">
+  
+                              
+                                  
+                                  <a class="btn btn-sm btn-outline-primary" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a" role="button">Consulter le profil</a>
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Postuler</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_email[in_list_user]
+  '''
+  <div aria-labelledby="email-confirmation-label" aria-modal="true" class="modal" id="email-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="email-confirmation-label">Email existant</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  L'adresse jane.doe@test.local est associée au compte de <b>Jane DOE</b> figurant dans votre liste de candidats.
+                              </p>
+                              
+                              <p>
+                                  
+                              </p>
+                              
+                          </div>
+                          <div class="modal-footer">
+  
+                              
+                                  
+                                  <a class="btn btn-sm btn-outline-primary" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a" role="button">Consulter le profil</a>
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Postuler</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_email[not_in_list]
+  '''
+  <div aria-labelledby="email-confirmation-label" aria-modal="true" class="modal" id="email-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="email-confirmation-label">Email existant</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  L'adresse jane.doe@test.local est associée au compte de <b>Jane DOE</b>.
+                              </p>
+                              
+                              <p>
+                                  
+                                      Le compte de ce candidat sera ajouté à votre liste une fois que vous aurez postulé pour lui.
+                                  
+                              </p>
+                              
+                          </div>
+                          <div class="modal-footer">
+  
+                              
+                                  
+                                      
+                                      <button class="btn btn-sm btn-outline-primary" name="cancel" type="submit" value="1">Ce n'est pas mon candidat</button>
+                                  
+                                  
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Continuer</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_nir[in_list_application]
+  '''
+  <div aria-labelledby="nir-confirmation-label" aria-modal="true" class="modal" id="nir-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="nir-confirmation-label">Utilisateur trouvé</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  Le numéro <span>2</span><span class="ms-1">90</span><span class="ms-1">01</span><span class="ms-1">01</span><span class="ms-1">010</span><span class="ms-1">101</span><span class="ms-1">25</span> est associé au compte de <b>Jane DOE</b> figurant dans votre liste de candidats.
+                              </p>
+                              
+                              <p>
+                                  
+                              </p>
+                          </div>
+                          <div class="modal-footer">
+                              
+                                  
+                                  <a class="btn btn-sm btn-outline-primary" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a" role="button">Consulter le profil</a>
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Postuler</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_nir[in_list_organization]
+  '''
+  <div aria-labelledby="nir-confirmation-label" aria-modal="true" class="modal" id="nir-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="nir-confirmation-label">Utilisateur trouvé</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  Le numéro <span>2</span><span class="ms-1">90</span><span class="ms-1">01</span><span class="ms-1">01</span><span class="ms-1">010</span><span class="ms-1">101</span><span class="ms-1">25</span> est associé au compte de <b>Jane DOE</b> figurant dans votre liste de candidats.
+                              </p>
+                              
+                              <p>
+                                  
+                              </p>
+                          </div>
+                          <div class="modal-footer">
+                              
+                                  
+                                  <a class="btn btn-sm btn-outline-primary" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a" role="button">Consulter le profil</a>
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Postuler</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_nir[in_list_user]
+  '''
+  <div aria-labelledby="nir-confirmation-label" aria-modal="true" class="modal" id="nir-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="nir-confirmation-label">Utilisateur trouvé</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  Le numéro <span>2</span><span class="ms-1">90</span><span class="ms-1">01</span><span class="ms-1">01</span><span class="ms-1">010</span><span class="ms-1">101</span><span class="ms-1">25</span> est associé au compte de <b>Jane DOE</b> figurant dans votre liste de candidats.
+                              </p>
+                              
+                              <p>
+                                  
+                              </p>
+                          </div>
+                          <div class="modal-footer">
+                              
+                                  
+                                  <a class="btn btn-sm btn-outline-primary" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a" role="button">Consulter le profil</a>
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Postuler</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---
+# name: TestStandaloneCreateAsPrescriber.test_standalone_creation_as_prescriber_existing_nir[not_in_list]
+  '''
+  <div aria-labelledby="nir-confirmation-label" aria-modal="true" class="modal" id="nir-confirmation-modal" role="dialog" tabindex="-1">
+                  <div class="modal-dialog modal-dialog-centered">
+                      <div class="modal-content">
+                          <div class="modal-header">
+                              <h3 class="modal-title" id="nir-confirmation-label">Utilisateur trouvé</h3>
+                              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button"></button>
+                          </div>
+                          <div class="modal-body">
+                              
+                              <p>
+                                  Le numéro <span>2</span><span class="ms-1">90</span><span class="ms-1">01</span><span class="ms-1">01</span><span class="ms-1">010</span><span class="ms-1">101</span><span class="ms-1">25</span> est associé au compte de <b>Jane DOE</b>.
+                              </p>
+                              
+                              <p>
+                                  
+                                      Le compte de ce candidat sera ajouté à votre liste une fois que vous aurez postulé pour lui.
+                                  
+                              </p>
+                          </div>
+                          <div class="modal-footer">
+                              
+                                  
+                                      
+                                      <button class="btn btn-sm btn-outline-primary" name="cancel" type="submit" value="1">Ce n'est pas mon candidat</button>
+                                  
+                                  
+                                  <button class="btn btn-sm btn-primary" name="confirm" type="submit" value="1">Continuer</button>
+                              
+                          </div>
+                      </div>
+                  </div>
+              </div>
+  '''
+# ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lorsqu'on insère un NIR ou une adresse mail au début du parcours de création de compte candidat, une modale apparaît lorsqu'un candidat correspond à ce NIR ou cette adresse email.

Dans le cas d'une création de compte candidat sans candidature, il a plusieurs sous-cas :
- le candidat existe déjà et est présent dans la liste "Mes candidats"
- le candidat existe déjà et n'est pas présent dans la liste

La présente PR ajoute ces deux cas à cette modale.

## :desert_island: Comment tester ?

- en tant que prescripteur (habilité ou non), créer un compte candidat depuis la liste de "Mes candidats" grâce au bouton dédié
- insérer le NIR d'un compte existant
    - soit absent de la liste Mes candidats
    - soit présent dans la liste parce que créé par l'utilisateur en cours
    - soit présent dans la liste parce que créé par un membre de l'organisation en cours
    - soit présent dans la liste parce que l'utilisateur en cours a postulé pour lui
- même chose avec l'adresse email
- *Consulter le profil* ou *Postuler* et vérifier qu'on arrive au bon endroit

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/f0463ac4-3d1e-42ac-bed9-2420287cd5de)


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
