### PR TITLE
Tests : retrait des assertions dupliquées assertContains et assertRedirects

### DIFF
--- a/tests/gps/test_create_beneficiary.py
+++ b/tests/gps/test_create_beneficiary.py
@@ -325,7 +325,6 @@ def test_existing_user_with_email(client):
         },
     }
 
-    assert response.url == next_url
     assert client.session[job_seeker_session_name] == expected_job_seeker_session
     assertRedirects(response, next_url)
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -438,7 +438,6 @@ class TestApplyAsJobSeeker:
         # ----------------------------------------------------------------------
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url_company)
 
         nir = "178122978200508"
@@ -460,7 +459,6 @@ class TestApplyAsJobSeeker:
         # ----------------------------------------------------------------------
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url_company)
 
         post_data = {"birthdate": "20/12/1978", "phone": "0610203040", "pole_emploi_id": "1234567A"}
@@ -1319,7 +1317,6 @@ class TestApplyAsAuthorizedPrescriber:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         post_data = {
@@ -1344,7 +1341,6 @@ class TestApplyAsAuthorizedPrescriber:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         post_data = {
@@ -1425,7 +1421,6 @@ class TestApplyAsAuthorizedPrescriber:
             return_value=True,
         ):
             response = client.get(next_url)
-            assert response.status_code == 200
             assertContains(response, CONFIRM_RESET_MARKUP % reset_url_job_description)
             assert not EligibilityDiagnosis.objects.has_considered_valid(new_job_seeker, for_siae=company)
             assertTemplateUsed(response, "apply/includes/known_criteria.html", count=1)
@@ -1525,11 +1520,9 @@ class TestApplyAsAuthorizedPrescriber:
         assert response.status_code == 200
 
         response = client.post(email_url, data={"email": "toto@pole-emploi.fr", "confirm": "1"})
-        assert response.status_code == 200
         assertContains(response, "Vous ne pouvez pas utiliser un e-mail Pôle emploi pour un candidat.")
 
         response = client.post(email_url, data={"email": "titi@francetravail.fr", "confirm": "1"})
-        assert response.status_code == 200
         assertContains(response, "Vous ne pouvez pas utiliser un e-mail France Travail pour un candidat.")
 
     def test_apply_step_eligibility_does_not_show_employer_diagnosis(self, client):
@@ -1764,7 +1757,6 @@ class TestApplyAsPrescriber:
             "lack_of_nir_reason": "",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(response, JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_TITLE % "")
 
         post_data = {
@@ -1776,7 +1768,6 @@ class TestApplyAsPrescriber:
             "lack_of_nir_reason": "",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(response, JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_BIRTHDATE % "")
 
         # Resume to valid data and proceed with "normal" flow.
@@ -1808,7 +1799,6 @@ class TestApplyAsPrescriber:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         post_data = {
@@ -1832,7 +1822,6 @@ class TestApplyAsPrescriber:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         post_data = {
@@ -1905,7 +1894,6 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url_company)
 
         selected_job = company.job_description_through.first()
@@ -2008,7 +1996,6 @@ class TestApplyAsPrescriber:
             "pole_emploi_id": "3454471C",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(
             response,
             (
@@ -2367,7 +2354,6 @@ class TestApplyAsCompany:
             "lack_of_nir_reason": "",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(response, JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_TITLE % "")
 
         post_data = {
@@ -2379,7 +2365,6 @@ class TestApplyAsCompany:
             "lack_of_nir_reason": "",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(response, JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_BIRTHDATE % "")
 
         # Resume to valid data and proceed with "normal" flow.
@@ -2411,7 +2396,6 @@ class TestApplyAsCompany:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url)
 
         post_data = {
@@ -2436,7 +2420,6 @@ class TestApplyAsCompany:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url)
 
         post_data = {
@@ -2490,7 +2473,6 @@ class TestApplyAsCompany:
         # ----------------------------------------------------------------------
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url)
 
         selected_job = company.job_description_through.first()
@@ -2633,7 +2615,6 @@ class TestApplyAsCompany:
             "pole_emploi_id": "3454471C",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(
             response,
             (
@@ -2675,11 +2656,9 @@ class TestApplyAsCompany:
         assert response.status_code == 200
 
         response = client.post(email_url, data={"email": "toto@pole-emploi.fr", "confirm": "1"})
-        assert response.status_code == 200
         assertContains(response, "Vous ne pouvez pas utiliser un e-mail Pôle emploi pour un candidat.")
 
         response = client.post(email_url, data={"email": "titi@francetravail.fr", "confirm": "1"})
-        assert response.status_code == 200
         assertContains(response, "Vous ne pouvez pas utiliser un e-mail France Travail pour un candidat.")
 
 
@@ -2851,7 +2830,6 @@ class TestDirectHireFullProcess:
             "lack_of_nir_reason": "",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(response, JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_TITLE % "")
 
         post_data = {
@@ -2863,7 +2841,6 @@ class TestDirectHireFullProcess:
             "lack_of_nir_reason": "",
         }
         response = client.post(next_url, data=post_data)
-        assert response.status_code == 200
         assertContains(response, JobSeekerProfile.ERROR_JOBSEEKER_INCONSISTENT_NIR_BIRTHDATE % "")
 
         # Resume to valid data and proceed with "normal" flow.
@@ -2895,7 +2872,6 @@ class TestDirectHireFullProcess:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_dashboard)
 
         post_data = {
@@ -2921,7 +2897,6 @@ class TestDirectHireFullProcess:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_dashboard)
 
         post_data = {
@@ -2957,7 +2932,6 @@ class TestDirectHireFullProcess:
         assert response.url == next_url
 
         response = client.get(next_url)
-        assert response.status_code == 200
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_dashboard)
 
         response = client.post(next_url)
@@ -3092,7 +3066,6 @@ class TestDirectHireFullProcess:
         # Step determine the job seeker with a NIR. First: show modal
         # ----------------------------------------------------------------------
         response = client.get(check_nir_url)
-        assert response.status_code == 200
         assertContains(response, LINK_RESET_MARKUP % reset_url_dashboard)
 
         response = client.post(check_nir_url, data={"nir": job_seeker.jobseeker_profile.nir, "preview": 1})

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -43,7 +43,6 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:list"))
-        assert response.status_code == 200
         next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
         assertContains(
             response,
@@ -67,7 +66,6 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
-        assert response.status_code == 200
         next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
         assertContains(
             response,
@@ -211,7 +209,6 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:list"))
-        assert response.status_code == 200
         next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
         assertContains(response, "A… Z…")
         assertContains(
@@ -236,7 +233,6 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
-        assert response.status_code == 200
         next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
         assertContains(response, "A… Z…")
         assertContains(
@@ -414,7 +410,6 @@ class TestApplyAsCompany:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
-        assert response.status_code == 200
         next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
         assertContains(
             response,

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -1,7 +1,7 @@
 from urllib.parse import quote
 
 from django.urls import reverse
-from pytest_django.asserts import assertContains
+from pytest_django.asserts import assertContains, assertRedirects
 
 from itou.companies.enums import CompanyKind
 from itou.eligibility.models import EligibilityDiagnosis
@@ -109,13 +109,12 @@ class TestApplyAsPrescriber:
             reverse("apply:start", kwargs={"company_pk": guerande_company.pk}) + f"?job_seeker={job_seeker.public_id}"
         )
         response = client.get(apply_company_url)
-        assert response.status_code == 302
 
         next_url = reverse(
             "apply:application_jobs",
             kwargs={"company_pk": guerande_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step apply to job
         # ----------------------------------------------------------------------
@@ -125,7 +124,6 @@ class TestApplyAsPrescriber:
 
         selected_job = guerande_company.job_description_through.first()
         response = client.post(next_url, data={"selected_jobs": [selected_job.pk]})
-        assert response.status_code == 302
 
         assert client.session[f"job_application-{guerande_company.pk}"] == {"selected_jobs": [selected_job.pk]}
 
@@ -133,14 +131,13 @@ class TestApplyAsPrescriber:
             "apply:application_eligibility",
             kwargs={"company_pk": guerande_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step application's eligibility
         # ----------------------------------------------------------------------
 
         # job seeker is getting RSA
         response = client.post(next_url, {"level_1_1": True})
-        assert response.status_code == 302
 
         assert EligibilityDiagnosis.objects.has_considered_valid(job_seeker, for_siae=guerande_company)
 
@@ -148,7 +145,7 @@ class TestApplyAsPrescriber:
             "apply:application_resume",
             kwargs={"company_pk": guerande_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step application's resume.
         # ----------------------------------------------------------------------
@@ -162,7 +159,6 @@ class TestApplyAsPrescriber:
                 "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             },
         )
-        assert response.status_code == 302
 
         job_application = JobApplication.objects.get(sender=prescriber, to_company=guerande_company)
         assert job_application.job_seeker == job_seeker
@@ -178,7 +174,7 @@ class TestApplyAsPrescriber:
         next_url = reverse(
             "apply:application_end", kwargs={"company_pk": guerande_company.pk, "application_pk": job_application.pk}
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
     def test_apply_as_prescriber_without_seeing_personal_info(self, client):
         guerande = create_city_guerande()
@@ -276,13 +272,12 @@ class TestApplyAsPrescriber:
             reverse("apply:start", kwargs={"company_pk": guerande_company.pk}) + f"?job_seeker={job_seeker.public_id}"
         )
         response = client.get(apply_company_url)
-        assert response.status_code == 302
 
         next_url = reverse(
             "apply:application_jobs",
             kwargs={"company_pk": guerande_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step apply to job
         # ----------------------------------------------------------------------
@@ -292,7 +287,6 @@ class TestApplyAsPrescriber:
 
         selected_job = guerande_company.job_description_through.first()
         response = client.post(next_url, data={"selected_jobs": [selected_job.pk]})
-        assert response.status_code == 302
 
         assert client.session[f"job_application-{guerande_company.pk}"] == {"selected_jobs": [selected_job.pk]}
 
@@ -300,14 +294,13 @@ class TestApplyAsPrescriber:
             "apply:application_eligibility",
             kwargs={"company_pk": guerande_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url, target_status_code=302, fetch_redirect_response=False)
 
         # Step application's eligibility
         # ----------------------------------------------------------------------
 
         # job seeker is getting RSA
         response = client.post(next_url, {"level_1_1": True})
-        assert response.status_code == 302
 
         assert EligibilityDiagnosis.objects.has_considered_valid(job_seeker, for_siae=guerande_company)
 
@@ -315,7 +308,7 @@ class TestApplyAsPrescriber:
             "apply:application_resume",
             kwargs={"company_pk": guerande_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step application's resume.
         # ----------------------------------------------------------------------
@@ -329,7 +322,6 @@ class TestApplyAsPrescriber:
                 "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             },
         )
-        assert response.status_code == 302
 
         job_application = JobApplication.objects.get(sender=prescriber, to_company=guerande_company)
         assert job_application.job_seeker == job_seeker
@@ -345,7 +337,7 @@ class TestApplyAsPrescriber:
         next_url = reverse(
             "apply:application_end", kwargs={"company_pk": guerande_company.pk, "application_pk": job_application.pk}
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
     def test_cannot_apply_as_prescriber_with_incorrect_public_id(self, client):
         company = CompanyWithMembershipAndJobsFactory()
@@ -452,13 +444,12 @@ class TestApplyAsCompany:
             reverse("apply:start", kwargs={"company_pk": other_company.pk}) + f"?job_seeker={job_seeker.public_id}"
         )
         response = client.get(apply_company_url)
-        assert response.status_code == 302
 
         next_url = reverse(
             "apply:application_jobs",
             kwargs={"company_pk": other_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step application's jobs.
         # ----------------------------------------------------------------------
@@ -468,7 +459,6 @@ class TestApplyAsCompany:
 
         selected_job = other_company.job_description_through.first()
         response = client.post(next_url, data={"selected_jobs": [selected_job.pk]})
-        assert response.status_code == 302
 
         assert client.session[f"job_application-{other_company.pk}"] == {"selected_jobs": [selected_job.pk]}
 
@@ -476,7 +466,7 @@ class TestApplyAsCompany:
             "apply:application_eligibility",
             kwargs={"company_pk": other_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url, target_status_code=302, fetch_redirect_response=False)
 
         # Step application's eligibility
         # ----------------------------------------------------------------------
@@ -486,7 +476,7 @@ class TestApplyAsCompany:
             "apply:application_resume",
             kwargs={"company_pk": other_company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
         # Step application's resume.
         # ----------------------------------------------------------------------
@@ -499,7 +489,6 @@ class TestApplyAsCompany:
                 "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             },
         )
-        assert response.status_code == 302
 
         job_application = JobApplication.objects.get(sender=employer, to_company=other_company)
         assert job_application.job_seeker == job_seeker
@@ -515,7 +504,7 @@ class TestApplyAsCompany:
         next_url = reverse(
             "apply:application_end", kwargs={"company_pk": other_company.pk, "application_pk": job_application.pk}
         )
-        assert response.url == next_url
+        assertRedirects(response, next_url)
 
     def test_cannot_apply_as_company_with_incorrect_public_id(self, client):
         company = CompanyWithMembershipAndJobsFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

`assertContains` teste également le `status_code`, pas besoin de rappeler `assert response.status_code == 200`.

De même, `assertRedirects` vérifie que `status_code == 302`, et il est inutile de rappeler `assert response.url == next_url`.

Nettoyage effectué dans `apply`,  `job_seekers_views` et `gps`.
