### PR TITLE
Stabilité: Correction d'une redirection cassée après avoir annulé une embauche [GEN-2188]

### DIFF
--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -637,6 +637,12 @@ def cancel(request, job_application_id):
     check_waiting_period(job_application)
     next_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
 
+    session_key = JOB_APP_DETAILS_FOR_COMPANY_BACK_URL_KEY % job_application.pk
+    if back_url := request.session.get(session_key):
+        if back_url.startswith(reverse("employees:detail", args=(job_application.job_seeker.public_id,))):
+            # Don't keep this back_url as the job seeker won't be an employee anymore
+            request.session.pop(session_key)
+
     if not job_application.can_be_cancelled:
         messages.error(request, "Vous ne pouvez pas annuler cette embauche.")
         return HttpResponseRedirect(next_url)


### PR DESCRIPTION
## :thinking: Pourquoi ?

il n'est alors plus possible de rediriger vers l'espace candidat quand c'est de là que l'utilisateur est arrivé?

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
