### PR TITLE
Tech: mise à jour de notre code pour rester compatible avec l'API ROME de FranceTravail

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -52,9 +52,8 @@ AUTHORIZED_SCOPES = [
     "api_maj-pass-iaev1",
     "api_offresdemploiv2",
     "api_rechercheindividucertifiev1",
-    # TODO: check if those 2 ROME-related scopes are again valid in a few days and uncomment them
-    # "api_romev1",
-    # "nomenclatureRome",
+    "api_rome-metiersv1",
+    "nomenclatureRome",
     "o2dsoffre",
     "passIAE",
     "rechercherIndividuCertifie",
@@ -225,7 +224,10 @@ class PoleEmploiApiClient:
         return data["resultats"]
 
     def appellations(self):
-        return self._request(f"{self.base_url}/rome/v1/appellation?champs=code,libelle,metier(code)", method="GET")
+        return self._request(
+            f"{self.base_url}/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code)",
+            method="GET",
+        )
 
     def agences(self, safir=None):
         agences = self._request(f"{self.base_url}/referentielagences/v1/agences", method="GET")

--- a/tests/jobs/management/test_sync_romes_and_appellations.py
+++ b/tests/jobs/management/test_sync_romes_and_appellations.py
@@ -23,7 +23,7 @@ def test_sync_rome_appellation(caplog, respx_mock):
             {"code": "MET01", "libelle": "Edition"},
         ],
     )
-    respx_mock.get("https://pe.fake/rome/v1/appellation?champs=code,libelle,metier(code)").respond(
+    respx_mock.get("https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code)").respond(
         200,
         json=[
             {"code": "JOB32", "libelle": "Ecriveur de bouquins", "metier": {"code": "MET01"}},
@@ -54,7 +54,10 @@ def test_sync_rome_appellation(caplog, respx_mock):
         "\tREMOVED Métiers du corps (B001)",
         "\tREMOVED Arts de la table (F002)",  # not really removed though by our command, see docstring
         "len=2 ROME entries have been created or updated.",
-        'HTTP Request: GET https://pe.fake/rome/v1/appellation?champs=code,libelle,metier(code) "HTTP/1.1 200 OK"',
+        (
+            "HTTP Request: GET https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code) "
+            '"HTTP/1.1 200 OK"'
+        ),
         "count=2 label=Appellation had the same key in collection and queryset",
         "\tCHANGED name=Entraîneur sportif changed to value=Entraîneur sportif avéré",
         "\tCHANGED name=Chef cuistot d'élite changed to value=Chef cuistor d'élite",

--- a/tests/utils/apis/test_pole_emploi_api.py
+++ b/tests/utils/apis/test_pole_emploi_api.py
@@ -194,7 +194,7 @@ class TestPoleEmploiAPIClient:
 
     @respx.mock
     def test_appellations(self):
-        respx.get("https://pe.fake/rome/v1/appellation?champs=code,libelle,metier(code)").respond(
+        respx.get("https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code)").respond(
             200,
             json=pole_emploi_api_mocks.API_APPELLATIONS,
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'ancien scope `api_romev1` ne semble plus valide (cf https://francetravail.io/produits-partages/catalogue/rome-4-0-metiers/documentation#/api-reference/)
Et l'endpoint est maintenant sur un autre chemin: https://francetravail.io/produits-partages/catalogue/rome-4-0-metiers/documentation#/api-reference/operations/listerAppellations

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
