### PR TITLE
Pilotage: Ajout du nom au extrait utilisateurs

### DIFF
--- a/itou/users/management/commands/extract_c2_users.py
+++ b/itou/users/management/commands/extract_c2_users.py
@@ -82,6 +82,7 @@ class Command(BaseCommand):
             "DateRattachement": membership.created_at.date(),
             "Département": DEPARTMENTS[org.department] if org.department else None,
             "Région": org.region,
+            "Organisation": org.display_name,
         }
 
         if isinstance(org, Company):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à https://github.com/gip-inclusion/les-emplois/pull/5498, on veut ajouter le nom de l'organisation à l'extrait

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

`python manage.py extract_c2_users --include-institutions --include-prescribers --include-siae`