### PR TITLE
Réutiliser JobSeekerProfileForm dans EditJobSeekerInfoForm [GEN-1380]

### DIFF
--- a/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_job_seeker_info.ambr
@@ -572,6 +572,7 @@
       dict({
         'origin': list([
           'EditJobSeekerInfoForm.__init__[users/forms.py]',
+          'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
@@ -593,6 +594,7 @@
       }),
       dict({
         'origin': list([
+          'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',

--- a/tests/www/dashboard/__snapshots__/test_edit_user_info.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_user_info.ambr
@@ -69,6 +69,7 @@
       dict({
         'origin': list([
           'EditJobSeekerInfoForm.__init__[users/forms.py]',
+          'EditJobSeekerInfoForm.__init__[users/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',
           'EditJobSeekerInfoForm.__init__[common_apps/nir/forms.py]',
           'EditJobSeekerInfoForm.__init__[www/dashboard/forms.py]',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mutualiser les comportements et simplifier.
