### PR TITLE
RGPD: Ne pas mettre les adresses géolocalisées par les management commands dans la sortie standard

### DIFF
--- a/itou/companies/management/commands/update_companies_coords.py
+++ b/itou/companies/management/commands/update_companies_coords.py
@@ -37,10 +37,10 @@ class Command(BaseCommand):
             dest="wet_run",
         )
 
-    def handle(self, wet_run, **options):
+    def handle(self, wet_run, verbosity, **options):
         companies = Company.objects.all()
 
-        companies_to_save = list(geolocate_qs(companies, is_verbose=True))
+        companies_to_save = list(geolocate_qs(companies, is_verbose=verbosity > 1))
         if wet_run:
             Company.objects.bulk_update(
                 companies_to_save,

--- a/itou/users/management/commands/update_job_seeker_coords.py
+++ b/itou/users/management/commands/update_job_seeker_coords.py
@@ -38,10 +38,10 @@ class Command(BaseCommand):
             dest="wet_run",
         )
 
-    def handle(self, wet_run, **options):
+    def handle(self, wet_run, verbosity, **options):
         users = User.objects.filter(kind=UserKind.JOB_SEEKER, is_active=True)
 
-        users_to_save = list(geolocate_qs(users, is_verbose=True))
+        users_to_save = list(geolocate_qs(users, is_verbose=verbosity > 1))
         if wet_run:
             User.objects.bulk_update(
                 users_to_save,

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -176,7 +176,7 @@ def test_update_companies_coords(settings, capsys, respx_mock):
         ),
     )
 
-    management.call_command("update_companies_coords", wet_run=True)
+    management.call_command("update_companies_coords", wet_run=True, verbosity=2)
     stdout, stderr = capsys.readouterr()
     assert stderr == ""
     assert stdout.splitlines() == [

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -705,7 +705,7 @@ def test_update_job_seeker_coords(settings, capsys, respx_mock):
         ),
     )
 
-    call_command("update_job_seeker_coords", wet_run=True)
+    call_command("update_job_seeker_coords", wet_run=True, verbosity=2)
     stdout, stderr = capsys.readouterr()
     assert stderr == ""
     assert stdout.splitlines() == [


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à cette remontée: https://github.com/gip-inclusion/les-emplois/security/code-scanning/129

Seules ces 2 commandes utilise ce code, et effectivement c'est mieux que ça ne finisse pas en print dans les données collectées par clever.

Je le rend facultatif pour permettre d'afficher les données en local lors de tests manuels (qui on a priori permis à victor de faire ces stats à l'époque).

Je me demande si on ne peut pas désormais supprimer update_companies_coords maintenant que c'est fait automatiquement à chaque modification dans l'admin :thinking: 


## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
