### PR TITLE
API: amélioration de notre réponse d'erreur

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -534,6 +534,7 @@ REST_FRAMEWORK = {
         "anon": "12/minute",
         "user": "120/minute",
     },
+    "EXCEPTION_HANDLER": "itou.api.errors.custom_exception_handler",
 }
 
 SPECTACULAR_SETTINGS = {

--- a/itou/api/errors.py
+++ b/itou/api/errors.py
@@ -1,0 +1,20 @@
+import logging
+
+from rest_framework.response import Response
+from rest_framework.views import exception_handler, set_rollback
+
+
+logger = logging.getLogger(__name__)
+
+
+def custom_exception_handler(exc, context):
+    # Call REST framework's default exception handler first,
+    # to get the standard error response.
+    response = exception_handler(exc, context)
+
+    if response is None:
+        logger.exception("API Error: %s", exc)
+        set_rollback()
+        response = Response(data={"detail": "Something went wrong, sorry. We've been notified."}, status=500)
+
+    return response

--- a/tests/api/test_error.py
+++ b/tests/api/test_error.py
@@ -1,0 +1,14 @@
+from django.urls import reverse
+
+
+def failing_function(*args):
+    raise Exception("Something bad")
+
+
+def test_error_handling(client, mocker):
+    some_api_url = reverse("v1:siaes-list")
+    mocker.patch("itou.api.siae_api.viewsets.SiaeViewSet.get_queryset", failing_function)
+
+    response = client.get(some_api_url)
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Something went wrong, sorry. We've been notified."}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand notre API plante, rien ne sert de renvoyer une page HTML. D'autant plus quand elle plante: https://inclusion.sentry.io/issues/29358189/

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
