### PR TITLE
Pilotage: Correction de crash sur les TdBs ETP quand un utilisateur est aussi membre des non-SIAEs

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -242,7 +242,7 @@ def stats_siae_etp(request):
             mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [
                 str(membership.company.convention.asp_id)
                 for membership in request.user.active_or_in_grace_period_company_memberships()
-                if membership.is_admin
+                if membership.is_admin and membership.company.convention is not None
             ]
         },
     )
@@ -266,7 +266,9 @@ def stats_siae_orga_etp(request):
         request=request,
         context=context,
         params={
-            mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [org.convention.asp_id for org in request.organizations],
+            mb.ASP_SIAE_FILTER_KEY_FLAVOR3: [
+                org.convention.asp_id for org in request.organizations if org.convention is not None
+            ],
         },
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Deux vues qui tentent de transmettre toutes les entreprises d'un utilisateur au TB peuvent essayer d'inclure des entreprises non SIAE, ce qui entraîne une `AttributeError` sur`company.convention` pour les utilisateurs affiliés à des non-SIAEs.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

J'ai testé à la main avec le processus suivant :
* Ajouter un utilisateur employeur de SIAE à une enterprise adaptée, en tant que administrateur.
* Se connecter à ce compte
* Visiter http://localhost:8000/stats/siae/orga_etp, avant et après l'application du fix
* Visiter http://localhost:8000/stats/siae/etp où le bug est également possible