### PR TITLE
Admin: Amélioration de la gestion des appartenances aux organisations

### DIFF
--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -71,6 +71,13 @@ class AuthorizationValidationRequired(admin.SimpleListFilter):
 
 class PrescriberOrganizationMembersInline(MembersInline):
     model = PrescriberOrganization.members.through
+    MEMBERSHIP_RO_LIMIT = 200
+
+    def has_change_permission(self, request, obj=None):
+        # A few organizations have more than 250 members, which causes the form
+        # to have more than 1000 fields (the limit set in DATA_UPLOAD_MAX_NUMBER_FIELDS)
+        # we believe that with 200+ members, there's no need to ask the support team to manually add a member
+        return not bool(obj and obj.prescribermembership_set.count() > self.MEMBERSHIP_RO_LIMIT)
 
 
 @admin.register(PrescriberOrganization)

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -84,7 +84,6 @@ class DisabledNotificationsMixin:
 class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
     model = CompanyMembership
     extra = 0
-    raw_id_fields = ("company",)
     readonly_fields = (
         "company_siret_link",
         "joined_at",
@@ -96,15 +95,15 @@ class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
         "updated_by",
     )
     fields = readonly_fields
-    can_delete = True
+    can_delete = False
     show_change_link = True
     fk_name = "user"
 
     def has_change_permission(self, request, obj=None):
-        return True
+        return False
 
     def has_add_permission(self, request, obj=None):
-        return True
+        return False
 
     @admin.display(description="Entreprise")
     def company_siret_link(self, obj):
@@ -114,7 +113,6 @@ class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
 class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
     model = PrescriberMembership
     extra = 0
-    raw_id_fields = ("organization",)
     readonly_fields = (
         "organization_id_link",
         "joined_at",
@@ -126,14 +124,14 @@ class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
         "updated_by",
     )
     fields = readonly_fields
-    can_delete = True
+    can_delete = False
     fk_name = "user"
 
     def has_change_permission(self, request, obj=None):
-        return True
+        return False
 
     def has_add_permission(self, request, obj=None):
-        return True
+        return False
 
     def organization_id_link(self, obj):
         return get_structure_view_link(obj.organization)
@@ -142,11 +140,6 @@ class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline):
 class InstitutionMembershipInline(ItouTabularInline):
     model = InstitutionMembership
     extra = 0
-    raw_id_fields = (
-        "institution",
-        "user",
-        "updated_by",
-    )
     readonly_fields = (
         "institution_id_link",
         "joined_at",
@@ -157,14 +150,14 @@ class InstitutionMembershipInline(ItouTabularInline):
         "updated_by",
     )
     fields = readonly_fields
-    can_delete = True
+    can_delete = False
     fk_name = "user"
 
     def has_change_permission(self, request, obj=None):
-        return True
+        return False
 
     def has_add_permission(self, request, obj=None):
-        return True
+        return False
 
     def institution_id_link(self, obj):
         return get_structure_view_link(obj.institution)

--- a/tests/prescribers/tests.py
+++ b/tests/prescribers/tests.py
@@ -1045,6 +1045,19 @@ def test_add_admin(admin_client, caplog, mailoutbox):
     ) in caplog.messages
 
 
+def test_admin_more_than_100_memberships(admin_client, mocker):
+    organization = PrescriberOrganizationWith2MembershipFactory()
+
+    change_url = reverse("admin:prescribers_prescriberorganization_change", args=[organization.pk])
+    response = admin_client.get(change_url)
+    membership_form_field_id = '"id_prescribermembership_set-0-user"'
+    assertContains(response, membership_form_field_id)
+
+    mocker.patch("itou.prescribers.admin.PrescriberOrganizationMembersInline.MEMBERSHIP_RO_LIMIT", 1)
+    response = admin_client.get(change_url)
+    assertNotContains(response, membership_form_field_id)
+
+
 def test_prescriber_kinds_are_alphabetically_sorted():
     assert PrescriberOrganizationKind.choices == sorted(
         PrescriberOrganizationKind.choices,

--- a/tests/users/__snapshots__/test_admin_views.ambr
+++ b/tests/users/__snapshots__/test_admin_views.ambr
@@ -311,6 +311,60 @@
       }),
       dict({
         'origin': list([
+          'PrescriberMembershipFormFormSet.initial_form_count[<site-packages>/django/forms/models.py]',
+          'PrescriberMembershipFormFormSet.initial_form_count[<site-packages>/django/forms/models.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login"
+          FROM "prescribers_prescribermembership"
+          LEFT OUTER JOIN "users_user" T3 ON ("prescribers_prescribermembership"."updated_by_id" = T3."id")
+          WHERE "prescribers_prescribermembership"."user_id" = %s
+          ORDER BY "prescribers_prescribermembership"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'JobApplicationFormFormSet.initial_form_count[<site-packages>/django/forms/models.py]',
           'JobApplicationFormFormSet.initial_form_count[<site-packages>/django/forms/models.py]',
         ]),
@@ -435,60 +489,6 @@
           INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
           WHERE "job_applications_jobapplication"."sender_id" = %s
           ORDER BY "job_applications_jobapplication"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'PrescriberMembershipFormFormSet.initial_form_count[<site-packages>/django/forms/models.py]',
-          'PrescriberMembershipFormFormSet.initial_form_count[<site-packages>/django/forms/models.py]',
-        ]),
-        'sql': '''
-          SELECT "prescribers_prescribermembership"."id",
-                 "prescribers_prescribermembership"."user_id",
-                 "prescribers_prescribermembership"."joined_at",
-                 "prescribers_prescribermembership"."is_admin",
-                 "prescribers_prescribermembership"."is_active",
-                 "prescribers_prescribermembership"."created_at",
-                 "prescribers_prescribermembership"."updated_at",
-                 "prescribers_prescribermembership"."organization_id",
-                 "prescribers_prescribermembership"."updated_by_id",
-                 T3."id",
-                 T3."password",
-                 T3."last_login",
-                 T3."is_superuser",
-                 T3."username",
-                 T3."first_name",
-                 T3."last_name",
-                 T3."is_staff",
-                 T3."is_active",
-                 T3."date_joined",
-                 T3."address_line_1",
-                 T3."address_line_2",
-                 T3."post_code",
-                 T3."city",
-                 T3."department",
-                 T3."coords",
-                 T3."geocoding_score",
-                 T3."geocoding_updated_at",
-                 T3."ban_api_resolved_address",
-                 T3."insee_city_id",
-                 T3."title",
-                 T3."full_name_search_vector",
-                 T3."email",
-                 T3."phone",
-                 T3."kind",
-                 T3."identity_provider",
-                 T3."has_completed_welcoming_tour",
-                 T3."created_by_id",
-                 T3."external_data_source_history",
-                 T3."last_checked_at",
-                 T3."public_id",
-                 T3."address_filled_at",
-                 T3."first_login"
-          FROM "prescribers_prescribermembership"
-          LEFT OUTER JOIN "users_user" T3 ON ("prescribers_prescribermembership"."updated_by_id" = T3."id")
-          WHERE "prescribers_prescribermembership"."user_id" = %s
-          ORDER BY "prescribers_prescribermembership"."id" ASC
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

This way, we only allow it on the organization page.

We now need to handle the following issue : for organization with more than 250 members, we have more than DATA_UPLOAD_MAX_NUMBER_FIELDS limit of 1000.


We could make all the inlined memberships readonly ig there are too many and allow to change them from the user detail page ?
Or handle the memberships from a dedicated page that we filter from the url (?user=X or ?company=Y)


## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
