### PR TITLE
docs: Retirer des références aux variables Mailjet pour le compte principal

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -75,11 +75,6 @@ ProConnect, elles sont préfixées par `PRO_CONNECT_`.
 
 Identifiants Mailjet de l’applicatif, utilisé lors de l’envoi d’emails.
 
-#### `API_MAILJET_KEY_PRINCIPAL` & `API_MAILJET_SECRET_PRINCIPAL`
-
-Identifiants Mailjet du compte principal, utilisé pour alimenter les listes de
-diffusion pour les campagnes Mailjet.
-
 ### `MATOMO_BASE_URL`
 
 Connexion à l’instance Matomo du GIP de l’inclusion. Le site par défaut dans


### PR DESCRIPTION
## :thinking: Pourquoi ?

Inutilisées depuis 22dfb9f11516bc5159771b2e2b8578958b5e0474.
