### PR TITLE
A11Y: Ajout des attibuts aria sur tous les <i> remixicon

### DIFF
--- a/itou/templates/api/index.html
+++ b/itou/templates/api/index.html
@@ -21,7 +21,7 @@
                     <br />
                     Si vous désirez obtenir ces droits sur votre compte, ou de l’aide pour utiliser l’API, merci de
                     <a class="text-decoration-underline fw-bold text-white" href="mailto:{{ API_EMAIL_CONTACT }}" aria-label="Nous contacter par e-mail">nous contacter</a>
-                    <i class="ri-external-link-line"></i>.
+                    <i class="ri-external-link-line" aria-hidden="true"></i>.
                 </div>
             </div>
             <div class="row mt-5">

--- a/itou/templates/apply/includes/certification_info_box.html
+++ b/itou/templates/apply/includes/certification_info_box.html
@@ -12,7 +12,7 @@
             </div>
         </button>
         <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
-            <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg"></i>
+            <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg" aria-hidden="true"></i>
         </div>
     </div>
 {% endif %}

--- a/itou/templates/apply/includes/job_application_answers.html
+++ b/itou/templates/apply/includes/job_application_answers.html
@@ -59,20 +59,20 @@
                         {% if refused_by %}
                             <li class="d-flex justify-content-start align-items-center">
                                 <a href="{% url 'companies_views:card' siae_id=job_application.to_company.pk %}" class="btn-link btn-ico">
-                                    <i class="ri-user-line ri-lg fw-normal"></i>
+                                    <i class="ri-user-line ri-lg fw-normal" aria-hidden="true"></i>
                                     <span>{{ refused_by.get_full_name }}</span>
                                 </a>
                             </li>
                         {% endif %}
                         <li class="d-flex justify-content-start align-items-center">
                             <a href="{% url 'companies_views:card' siae_id=job_application.to_company.pk %}" class="btn-link btn-ico">
-                                <i class="ri-community-line ri-lg fw-normal"></i>
+                                <i class="ri-community-line ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>{{ job_application.to_company.display_name }}</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-start align-items-center">
                             <a href="mailto:{{ refusal_contact_email }}" class="btn-link btn-ico">
-                                <i class="ri-mail-line ri-lg fw-normal"></i>
+                                <i class="ri-mail-line ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>{{ refusal_contact_email }}</span>
                             </a>
                             {% matomo_event "candidature" "clic" "prescriber_copied_company_email" as matomo_event_attrs %}
@@ -80,7 +80,7 @@
                         </li>
                         <li class="d-flex justify-content-start align-items-center">
                             <a href="tel:{{ job_application.to_company.phone|cut:" " }}" class="btn-link btn-ico">
-                                <i class="ri-phone-line ri-lg fw-normal"></i>
+                                <i class="ri-phone-line ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>{{ job_application.to_company.phone }}</span>
                             </a>
                             {% matomo_event "candidature" "clic" "prescriber_copied_company_phone" as matomo_event_attrs %}

--- a/itou/templates/apply/includes/job_application_info.html
+++ b/itou/templates/apply/includes/job_application_info.html
@@ -34,7 +34,7 @@
                     </div>
                     <div class="d-inline ms-lg-auto">
                         <span class="fs-sm text-nowrap">
-                            <i class="ri-map-pin-2-line ri-sm"></i>
+                            <i class="ri-map-pin-2-line ri-sm" aria-hidden="true"></i>
                             {% if job.location %}
                                 {{ job.location }}
                             {% else %}

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -90,7 +90,7 @@
                 {% if job_application.resume_link %}
                     <a href="{{ job_application.resume_link }}" class="btn-link btn-ico" target="_blank" rel="noreferrer noopener">
                         <span>Télécharger le CV</span>
-                        <i class="ri-download-2-line"></i>
+                        <i class="ri-download-2-line" aria-hidden="true"></i>
                     </a>
                 {% else %}
                     <i class="text-disabled">Non renseigné</i>

--- a/itou/templates/apply/includes/list_job_applications.html
+++ b/itou/templates/apply/includes/list_job_applications.html
@@ -37,17 +37,17 @@
             </p>
             {% if job_applications_list_kind is JobApplicationsListKind.SENT %}
                 <a href="{% url 'search:employers_results' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
-                    <i class="ri-user-follow-line ri-lg fw-normal"></i>
+                    <i class="ri-user-follow-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Postuler pour un candidat</span>
                 </a>
             {% elif job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
                 <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
-                    <i class="ri-briefcase-line ri-lg fw-normal"></i>
+                    <i class="ri-briefcase-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Gérer les métiers et recrutements</span>
                 </a>
             {% elif job_applications_list_kind is JobApplicationsListKind.SENT_FOR_ME %}
                 <a href="{% url 'search:employers_home' %}" class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center">
-                    <i class="ri-briefcase-line ri-lg fw-normal"></i>
+                    <i class="ri-briefcase-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Rechercher un emploi inclusif</span>
                 </a>
             {% endif %}

--- a/itou/templates/apply/includes/list_tr.html
+++ b/itou/templates/apply/includes/list_tr.html
@@ -75,10 +75,10 @@
         {% elif job_application.sender_kind == SenderKind.JOB_SEEKER %}
             <i class="ri-user-line me-1" aria-hidden="true"></i>Le candidat lui-même
         {% elif job_application.sender_kind == SenderKind.EMPLOYER %}
-            <i class="ri-community-line"></i>
+            <i class="ri-community-line" aria-hidden="true"></i>
             {{ job_application.sender_company.display_name }}
         {% elif job_application.sender_kind == SenderKind.PRESCRIBER %}
-            <i class="ri-home-smile-2-line"></i>
+            <i class="ri-home-smile-2-line" aria-hidden="true"></i>
             {% if job_application.sender_prescriber_organization %}
                 {{ job_application.sender_prescriber_organization.display_name }}
             {% else %}

--- a/itou/templates/apply/includes/siae_actions.html
+++ b/itou/templates/apply/includes/siae_actions.html
@@ -91,7 +91,7 @@
                                                     {% matomo_event "candidature" "clic" "batch-transfer-applications-open-modal" %}
                                                     data-bs-toggle="modal"
                                                     data-bs-target="#transfer_confirmation_modal_{{ siae.pk }}">
-                                                <i class="ri-community-line"></i>
+                                                <i class="ri-community-line" aria-hidden="true"></i>
                                                 <span>{{ siae.kind }}</span>
                                                 <strong>{{ siae.display_name }}</strong>
                                             </button>

--- a/itou/templates/apply/includes/siae_hiring_actions.html
+++ b/itou/templates/apply/includes/siae_hiring_actions.html
@@ -53,7 +53,7 @@
                 <form method="post" action="{% url "apply:archive" job_application_id=job_application.pk %}">
                     {% csrf_token %}
                     <button class="btn btn-lg btn-outline-white btn-block btn-ico">
-                        <i class="ri-archive-line fw-medium"></i>
+                        <i class="ri-archive-line fw-medium" aria-hidden="true"></i>
                         <span>Archiver</span>
                     </button>
                 </form>

--- a/itou/templates/apply/includes/transfer_job_application.html
+++ b/itou/templates/apply/includes/transfer_job_application.html
@@ -8,7 +8,7 @@
             {% for siae in request.organizations %}
                 {% if siae != request.current_organization %}
                     <a class="dropdown-item dropdown-item__summary" data-bs-toggle="modal" data-bs-target="#transfer_confirmation_modal_{{ siae.pk }}">
-                        <i class="ri-community-line"></i>
+                        <i class="ri-community-line" aria-hidden="true"></i>
                         <span>{{ siae.kind }}</span>
                         <strong>{{ siae.display_name }}</strong>
                     </a>
@@ -18,13 +18,13 @@
         {% endif %}
         {% if job_application.state.is_refused %}
             <a class="dropdown-item" href="{% url 'apply:job_application_external_transfer_step_1' job_application_id=job_application.id %}">
-                <i class="ri-home-smile-line"></i>
+                <i class="ri-home-smile-line" aria-hidden="true"></i>
                 <strong>Une autre structure</strong>
             </a>
         {% else %}
             <div data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur" role="button" tabindex="0">
                 <div class="dropdown-item disabled">
-                    <i class="ri-home-smile-line"></i>
+                    <i class="ri-home-smile-line" aria-hidden="true"></i>
                     <strong>Une autre structure</strong>
                 </div>
             </div>

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -43,7 +43,7 @@
                             <div class="c-box mb-4">
                                 <div class="mb-2">
                                     <span class="badge badge-base rounded-pill bg-light text-primary">
-                                        <i class="ri-archive-line"></i>
+                                        <i class="ri-archive-line" aria-hidden="true"></i>
                                         Candidature archivée
                                     </span>
                                 </div>
@@ -69,7 +69,7 @@
                                            rel="noopener"
                                            aria-label="En savoir plus sur l’archivage des candidatures (ouverture dans un nouvel onglet)">
                                             documentation
-                                            <i class="ri-external-link-line"></i>
+                                            <i class="ri-external-link-line" aria-hidden="true"></i>
                                         </a>
                                     </i>
                                 </p>
@@ -77,7 +77,7 @@
                                     <form method="post" action="{% url "apply:unarchive" job_application_id=job_application.pk %}" class="my-2">
                                         {% csrf_token %}
                                         <button class="btn btn-ico btn-outline-primary w-100">
-                                            <i class="ri-inbox-unarchive-line"></i>
+                                            <i class="ri-inbox-unarchive-line" aria-hidden="true"></i>
                                             <span>Désarchiver</span>
                                         </button>
                                     </form>

--- a/itou/templates/apply/process_external_transfer_resume.html
+++ b/itou/templates/apply/process_external_transfer_resume.html
@@ -17,7 +17,7 @@
                     Souhaitez-vous conserver le CV présent dans la candidature d’origine ?
                 </label>
                 <a href="{{ job_app_to_transfer.resume_link }}" class="btn-link btn-ico ms-3" target="_blank">
-                    <i class="ri-eye-line ri-lg fw-normal"></i>
+                    <i class="ri-eye-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Afficher</span>
                 </a>
             </div>

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -39,7 +39,7 @@
             {% if can_view_personal_information and not request.user.is_job_seeker %}
                 <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
             {% endif %}
-            {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning"></i>{% endif %}
+            {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>{% endif %}
         </p>
     {% endif %}
 {% endblock %}

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -39,12 +39,12 @@
                                     <h2 class="mb-0 flex-grow-1">{{ job_application.job_seeker.get_full_name }}</h2>
                                     {% if request.user.is_job_seeker %}
                                         <a class="btn btn-outline-primary btn-ico btn-sm" href="{% url 'dashboard:edit_user_info' %}">
-                                            <i class="ri-pencil-line"></i>
+                                            <i class="ri-pencil-line" aria-hidden="true"></i>
                                             <span>Modifier</span>
                                         </a>
                                     {% elif can_edit_personal_information %}
                                         <span class="btn btn-outline-primary btn-ico btn-sm" data-swap-element="#informations">
-                                            <i class="ri-pencil-line"></i>
+                                            <i class="ri-pencil-line" aria-hidden="true"></i>
                                             <span>Modifier</span>
                                         </span>
                                     {% endif %}

--- a/itou/templates/apply/submit/application/jobs.html
+++ b/itou/templates/apply/submit/application/jobs.html
@@ -19,12 +19,12 @@
                                 </label>
                                 {% if job_description.is_overwhelmed %}
                                     <div class="order-1 order-md-2">
-                                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>{{ job_description.OVERWHELMED_THRESHOLD }}+ candidatures</span>
+                                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line" aria-hidden="true"></i>{{ job_description.OVERWHELMED_THRESHOLD }}+ candidatures</span>
                                     </div>
                                 {% endif %}
                             </div>
                             <span class="fs-sm mt-1 d-flex align-items-center">
-                                <i class="ri-map-pin-2-line ri-sm me-1"></i>{{ job_description.display_location }}
+                                <i class="ri-map-pin-2-line ri-sm me-1" aria-hidden="true"></i>{{ job_description.display_location }}
                             </span>
                         </div>
                         <div class="mt-lg-0 ms-auto d-flex flex-column align-items-end justify-content-center">

--- a/itou/templates/approvals/includes/declaration_upload_panel.html
+++ b/itou/templates/approvals/includes/declaration_upload_panel.html
@@ -30,7 +30,7 @@
             {# HTMX: confirm prescriber organization if many #}
             {% include "approvals/includes/declaration_prescriber_email.html" %}
             <p>
-                <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank" aria-label="Rechercher des prescripteurs (ouverture dans une nouvelle fenêtre)">Rechercher des prescripteurs</a> <i class="ri-external-link-line ms-1"></i>
+                <a href="{% url 'search:prescribers_home' %}" rel="noopener" target="_blank" aria-label="Rechercher des prescripteurs (ouverture dans une nouvelle fenêtre)">Rechercher des prescripteurs</a> <i class="ri-external-link-line ms-1" aria-hidden="true"></i>
             </p>
         </div>
 

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -27,14 +27,14 @@
                     <form method="post" action="{% url "approvals:prolongation_request_grant" prolongation_request.pk %}">
                         {% csrf_token %}
                         <button class="btn btn-lg btn-white btn-block btn-ico justify-content-center">
-                            <i class="ri-check-line"></i>
+                            <i class="ri-check-line" aria-hidden="true"></i>
                             <span>Accepter</span>
                         </button>
                     </form>
                 </div>
                 <div class="form-group col-12 col-lg-auto">
                     <a class="btn btn-lg btn-outline-white btn-block btn-ico justify-content-center" href="{% url "approvals:prolongation_request_deny" prolongation_request.pk %}?reset=1">
-                        <i class="ri-close-line"></i>
+                        <i class="ri-close-line" aria-hidden="true"></i>
                         <span>Refuser</span>
                     </a>
                 </div>
@@ -90,7 +90,7 @@
                                 <a class="btn btn-secondary btn-ico"
                                    href="{% url "approvals:prolongation_request_report_file" prolongation_request_id=prolongation_request.pk %}"
                                    download="Bilan prolongation PASS IAE {{ prolongation_request.approval.number }} {{ prolongation_request.approval.user.get_full_name }}.xlsx">
-                                    <i class="ri-download-line ri-lg fw-normal"></i>
+                                    <i class="ri-download-line ri-lg fw-normal" aria-hidden="true"></i>
                                     <span>Télécharger le bilan</span>
                                 </a>
                             </p>
@@ -101,12 +101,12 @@
                                 L’employeur a fait une demande d'entretien téléphonique pour vous apporter des explications supplémentaires pour cette prolongation. Voici ses coordonnées :
                             </p>
                             <p>
-                                <i class="ri-mail-line"></i>
+                                <i class="ri-mail-line" aria-hidden="true"></i>
                                 <a class="btn-link me-3" href="mailto:{{ prolongation_request.contact_email }}">{{ prolongation_request.contact_email }}</a>
                                 {% include 'includes/copy_to_clipboard.html' with content=prolongation_request.contact_email css_classes="btn btn-ico btn-secondary" %}
                             </p>
                             <p>
-                                <i class="ri-phone-line"></i>
+                                <i class="ri-phone-line" aria-hidden="true"></i>
                                 <a class="btn-link" href="tel:{{ prolongation_request.contact_phone|cut:" " }}">{{ prolongation_request.contact_phone }}</a>
                             </p>
                         {% endif %}

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -124,7 +124,7 @@
                     <div class="c-box">
                         <h3 class="mb-2">Coordonnées</h3>
                         <div class="d-flex text-secondary fs-sm">
-                            <i class="ri-map-pin-2-line me-2"></i>
+                            <i class="ri-map-pin-2-line me-2" aria-hidden="true"></i>
                             <address class="m-0">{{ siae.address_on_one_line }}</address>
                         </div>
                         <hr class="my-3">
@@ -194,7 +194,7 @@
                                        href="{% url 'apply:job_application_external_transfer_step_2' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
                                        {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                                        aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line"></i>
+                                        <i class="ri-draft-line" aria-hidden="true"></i>
                                         <span>Transférer la candidature</span>
                                     </a>
                                 </div>
@@ -205,7 +205,7 @@
                                        href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" %}"
                                        {% matomo_event "candidature" "clic" "start_application" %}
                                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line"></i>
+                                        <i class="ri-draft-line" aria-hidden="true"></i>
                                         <span>Postuler</span>
                                     </a>
                                 </div>

--- a/itou/templates/companies/edit_siae.html
+++ b/itou/templates/companies/edit_siae.html
@@ -35,7 +35,7 @@
 
                         <div class="c-box c-box--structure mb-3 mb-lg-5">
                             <div class="c-box--structure__summary">
-                                <i class="ri-community-line"></i>
+                                <i class="ri-community-line" aria-hidden="true"></i>
                                 <div>
                                     <button type="button" data-bs-toggle="tooltip" data-bs-title="{{ siae.get_kind_display }}">{{ siae.kind }}</button>
                                     <h3>{{ siae.display_name }}</h3>

--- a/itou/templates/companies/edit_siae_preview.html
+++ b/itou/templates/companies/edit_siae_preview.html
@@ -59,21 +59,21 @@
                                 <ul class="list-unstyled">
                                     {% if siae.email %}
                                         <li>
-                                            <i class="ri-mail-line ri-xl me-2"></i>
+                                            <i class="ri-mail-line ri-xl me-2" aria-hidden="true"></i>
                                             <a aria-label="Contact par mail" href="mailto:{{ siae.email }}" class="fw-bold text-break">{{ siae.email }}</a>
                                         </li>
                                     {% endif %}
 
                                     {% if siae.phone %}
                                         <li>
-                                            <i class="ri-phone-line ri-xl me-2"></i>
+                                            <i class="ri-phone-line ri-xl me-2" aria-hidden="true"></i>
                                             <a aria-label="Contact téléphonique" href="tel:{{ siae.phone|cut:' ' }}" class="fw-bold">{{ siae.phone|format_phone }}</a>
                                         </li>
                                     {% endif %}
 
                                     {% if siae.website %}
                                         <li>
-                                            <i class="ri-global-line ri-xl me-2"></i>
+                                            <i class="ri-global-line ri-xl me-2" aria-hidden="true"></i>
                                             <a aria-label="Site web (ouverture dans un nouvel onglet)" href="{{ siae.website }}" rel="noopener" target="_blank" class="fw-bold">{{ siae.website }}</a>
                                         </li>
                                     {% endif %}

--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -45,11 +45,11 @@
                         {% endif %}
                         <ul class="c-box--results__list-contact flex-md-grow-1 mt-1">
                             <li class="d-block d-md-inline-flex">
-                                <i class="ri-navigation-line fw-normal me-1"></i>
+                                <i class="ri-navigation-line fw-normal me-1" aria-hidden="true"></i>
                                 à <strong class="text-info mx-md-1">{{ job_description.distance | floatformat:"-1" }}&nbsp;km</strong> de votre lieu de recherche
                             </li>
                             <li class="d-block d-md-inline-flex">
-                                <i class="ri-map-pin-2-line fw-normal me-1"></i>
+                                <i class="ri-map-pin-2-line fw-normal me-1" aria-hidden="true"></i>
                                 <address class="d-inline m-0">
                                     {% if job_description.location %}
                                         {{ job_description.location }}

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -30,7 +30,7 @@
         <div class="d-flex flex-column flex-md-row gap-2 align-items-md-end gap-md-3">
             <ul class="c-box--results__list-contact flex-md-grow-1 mt-2 mb-2 mb-md-0">
                 <li>
-                    <i class="ri-navigation-line fw-normal me-1"></i>
+                    <i class="ri-navigation-line fw-normal me-1" aria-hidden="true"></i>
                     à <strong class="text-info mx-1">{{ siae.distance|floatformat:"-1"|default:"12" }}&nbsp;km</strong> de votre lieu de recherche
                     {% comment %}
                     The "default" distance of 12 kms above seems a little weird.
@@ -41,7 +41,7 @@
                     {% endcomment %}
                 </li>
                 <li>
-                    <i class="ri-map-pin-2-line fw-normal me-1"></i>
+                    <i class="ri-map-pin-2-line fw-normal me-1" aria-hidden="true"></i>
                     <address class="m-0">{{ siae.address_on_one_line }}</address>
                 </li>
             </ul>

--- a/itou/templates/companies/includes/_company_info.html
+++ b/itou/templates/companies/includes/_company_info.html
@@ -8,7 +8,7 @@
          aria-expanded="{{ show|default:False|yesno:'true,false' }}"
          aria-controls="collapseBoxStructure"
          tabindex="0">
-        <i class="ri-community-line"></i>
+        <i class="ri-community-line" aria-hidden="true"></i>
         <div>
             <button type="button" data-bs-toggle="tooltip" data-bs-title="{{ company.get_kind_display }}">
                 {{ company.kind }}
@@ -20,7 +20,7 @@
         <hr class="my-4">
         <ul class="c-box--structure__list-contact">
             <li>
-                <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                <i class="ri-map-pin-2-line fw-normal me-2" aria-hidden="true"></i>
                 <address class="m-0">{{ company.address_on_one_line }}</address>
                 {% include 'includes/copy_to_clipboard.html' with content=company.address_on_one_line css_classes="btn-link fw-medium ms-1" only_icon=True %}
             </li>

--- a/itou/templates/companies/includes/_job_description_details.html
+++ b/itou/templates/companies/includes/_job_description_details.html
@@ -5,18 +5,18 @@
 <ul class="list-unstyled mb-5">
     {% if job.display_contract_type %}
         <li class="d-flex align-items-center mb-2">
-            <i class="ri-file-list-3-line me-1"></i>
+            <i class="ri-file-list-3-line me-1" aria-hidden="true"></i>
             {{ job.display_contract_type }}
         </li>
     {% endif %}
     {% if job.hours_per_week %}
         <li class="d-flex align-items-center mb-2">
-            <i class="ri-time-line me-1"></i>
+            <i class="ri-time-line me-1" aria-hidden="true"></i>
             {{ job.hours_per_week }}h / semaine
         </li>
     {% endif %}
     <li class="d-flex align-items-center mb-2">
-        <i class="ri-map-pin-line me-1"></i>
+        <i class="ri-map-pin-line me-1" aria-hidden="true"></i>
         {{ job.display_location }}
     </li>
 </ul>

--- a/itou/templates/companies/includes/_siae_jobdescription.html
+++ b/itou/templates/companies/includes/_siae_jobdescription.html
@@ -16,12 +16,12 @@
                 {% endif %}
                 {% if job.is_overwhelmed %}
                     <div class="order-1 order-md-2">
-                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line"></i>{{ job.OVERWHELMED_THRESHOLD }}+ candidatures</span>
+                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line" aria-hidden="true"></i>{{ job.OVERWHELMED_THRESHOLD }}+ candidatures</span>
                     </div>
                 {% endif %}
             </div>
             <span class="fs-sm mt-1 d-flex align-items-center">
-                <i class="ri-map-pin-2-line ri-sm me-1"></i>
+                <i class="ri-map-pin-2-line ri-sm me-1" aria-hidden="true"></i>
                 {% if job.location %}
                     {{ job.location }}
                 {% else %}

--- a/itou/templates/companies/show_financial_annexes.html
+++ b/itou/templates/companies/show_financial_annexes.html
@@ -63,7 +63,7 @@
                             {% if can_select_af %}
                                 <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les annexes financières">
                                     <a class="btn btn-primary btn-ico" href="{% url 'companies_views:select_financial_annex' %}">
-                                        <i class="ri-share-forward-box-line"></i>
+                                        <i class="ri-share-forward-box-line" aria-hidden="true"></i>
                                         <span>Sélectionner une autre annexe financière</span>
                                     </a>
                                 </div>

--- a/itou/templates/dashboard/includes/admin_card.html
+++ b/itou/templates/dashboard/includes/admin_card.html
@@ -6,7 +6,7 @@
         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'admin:index' %}" class="btn-link btn-ico">
-                    <i class="ri-key-2-line ri-lg fw-normal"></i>
+                    <i class="ri-key-2-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Admin</span>
                 </a>
             </p>

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -52,7 +52,7 @@
                     </button>
                 {% else %}
                     <a href="{% url 'apply:start_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
-                        <i class="ri-user-follow-line fw-medium"></i>
+                        <i class="ri-user-follow-line fw-medium" aria-hidden="true"></i>
                         <span>Déclarer une embauche</span>
                     </a>
                 {% endif %}

--- a/itou/templates/dashboard/includes/dora_card.html
+++ b/itou/templates/dashboard/includes/dora_card.html
@@ -7,23 +7,23 @@
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{{ DORA_BASE_URL }}?{{ tracker }}" rel="noopener" target="_blank" aria-label="Consulter les services d'insertion de votre territoire (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
-                        <i class="ri-search-eye-line ri-lg fw-normal align-self-start"></i>
+                        <i class="ri-search-eye-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                         <span>Consulter les services d'insertion de votre territoire</span>
                         <i class="ri-external-link-line fw-normal ms-2"></i>
                     </a>
                 </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{{ DORA_BASE_URL }}?siret={{ siret }}&{{ tracker }}" rel="noopener" target="_blank" aria-label="Référencer vos services (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
-                        <i class="ri-file-add-line ri-lg fw-normal"></i>
+                        <i class="ri-file-add-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Référencer vos services</span>
-                        <i class="ri-external-link-line fw-normal ms-2"></i>
+                        <i class="ri-external-link-line fw-normal ms-2" aria-hidden="true"></i>
                     </a>
                 </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{{ DORA_BASE_URL }}?{{ tracker }}" rel="noopener" target="_blank" aria-label="Suggérer un service partenaire (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
-                        <i class="ri-lightbulb-line ri-lg fw-normal"></i>
+                        <i class="ri-lightbulb-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Suggérer un service partenaire</span>
-                        <i class="ri-external-link-line fw-normal ms-2"></i>
+                        <i class="ri-external-link-line fw-normal ms-2" aria-hidden="true"></i>
                     </a>
                 </li>
             </ul>

--- a/itou/templates/dashboard/includes/employer_company_card.html
+++ b/itou/templates/dashboard/includes/employer_company_card.html
@@ -12,20 +12,20 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'companies_views:job_description_list' %}" class="btn btn-outline-primary btn-block btn-ico mb-3" {% matomo_event "employeurs" "clic" "voir-liste-metiers" %}>
-                <i class="ri-briefcase-line ri-lg fw-normal"></i>
+                <i class="ri-briefcase-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Gérer les métiers et recrutements</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{{ request.current_organization.get_card_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-infos-entreprise" %}>
-                        <i class="ri-eye-line ri-lg fw-normal"></i>
+                        <i class="ri-eye-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Voir la fiche publique</span>
                     </a>
                 </li>
                 {% if request.is_current_organization_admin %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'companies_views:edit_company_step_contact_infos' %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "modifier-infos-entreprise" %}>
-                            <i class="ri-pencil-line ri-lg fw-normal"></i>
+                            <i class="ri-pencil-line ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Modifier les informations</span>
                         </a>
                     </li>
@@ -33,7 +33,7 @@
                 {% if request.current_organization.is_active %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'companies_views:members' %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "gerer-collaborateurs" %}>
-                            <i class="ri-team-line ri-lg fw-normal"></i>
+                            <i class="ri-team-line ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Gérer les collaborateurs</span>
                         </a>
                     </li>
@@ -41,7 +41,7 @@
                 {% if can_create_siae_antenna %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'companies_views:create_company' %}" class="btn-link btn-ico">
-                            <i class="ri-add-line ri-lg fw-normal"></i>
+                            <i class="ri-add-line ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Créer/rejoindre une autre structure</span>
                         </a>
                     </li>
@@ -49,7 +49,7 @@
                 {% if can_show_financial_annexes %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'companies_views:show_financial_annexes' %}" class="btn-link btn-ico">
-                            <i class="ri-folder-chart-line ri-lg fw-normal"></i>
+                            <i class="ri-folder-chart-line ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Voir les annexes financières</span>
                         </a>
                         {% if not request.current_organization.is_active %}

--- a/itou/templates/dashboard/includes/employer_employees_card.html
+++ b/itou/templates/dashboard/includes/employer_employees_card.html
@@ -7,14 +7,14 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'approvals:list' %}"  class="btn btn-outline-primary btn-block btn-ico mb-3" {% matomo_event "employeurs" "clic" "voir-liste-agrements" %}>
-                <i class="ri-contacts-book-line ri-lg fw-normal"></i>
+                <i class="ri-contacts-book-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Gérer les salariés et PASS IAE</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 {% if can_show_employee_records %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'employee_record_views:list' %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-liste-fiches-salaries" %}>
-                            <i class="ri-article-line ri-lg fw-normal"></i>
+                            <i class="ri-article-line ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Fiches salarié ASP</span>
                         </a>
                         {% if num_rejected_employee_records %}

--- a/itou/templates/dashboard/includes/employer_evaluation_campaigns_card.html
+++ b/itou/templates/dashboard/includes/employer_evaluation_campaigns_card.html
@@ -11,7 +11,7 @@
                     {% for evaluated_siae in active_campaigns %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'siae_evaluations_views:siae_job_applications_list' evaluated_siae.pk %}" class="btn-link btn-ico">
-                                <i class="ri-list-check-3 ri-lg fw-normal"></i>
+                                <i class="ri-list-check-3 ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>Campagne en cours</span>
                             </a>
                             {% if evaluated_siae.should_display_pending_action_warning %}
@@ -22,7 +22,7 @@
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'siae_evaluations_views:campaign_calendar' evaluated_siae.evaluation_campaign.pk %}" class="btn-link btn-ico">
                                     {% comment %} TODO(cms): change icon {% endcomment %}
-                                    <i class="ri-calendar-line ri-lg fw-normal"></i>
+                                    <i class="ri-calendar-line ri-lg fw-normal" aria-hidden="true"></i>
                                     <span>Calendrier</span>
                                 </a>
                             </li>
@@ -32,15 +32,15 @@
             {% endif %}
             {% if evaluated_siae_notifications %}
                 <button class="btn btn-link btn-ico p-0" type="button" data-bs-toggle="collapse" data-bs-target="#closed_campaigns" aria-expanded="false" aria-controls="closed_campaigns">
-                    <i class="ri-history-line ri-lg fw-normal"></i>
+                    <i class="ri-history-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Historique</span>
-                    <i class="ri-arrow-drop-down-line ri-lg fw-normal"></i>
+                    <i class="ri-arrow-drop-down-line ri-lg fw-normal" aria-hidden="true"></i>
                 </button>
                 <ul class="collapse" id="closed_campaigns">
                     {% for evaluated_siae in evaluated_siae_notifications %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url "siae_evaluations_views:siae_sanction" evaluated_siae.pk %}" class="btn-link btn-ico">
-                                <i class="ri-file-copy-2-line ri-lg fw-normal"></i>
+                                <i class="ri-file-copy-2-line ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>{{ evaluated_siae.evaluation_campaign.name }}</span>
                             </a>
                         </li>
@@ -51,7 +51,7 @@
             <div class="d-flex justify-content-between align-items-center">
                 <a href="https://www.legifrance.gouv.fr/download/pdf/circ?id=45319" class="btn-link btn-ico" rel="noopener" target="_blank">
                     <span>Contexte législatif</span>
-                    <i class="ri-external-link-line fw-normal"></i>
+                    <i class="ri-external-link-line fw-normal" aria-hidden="true"></i>
                 </a>
             </div>
         </div>

--- a/itou/templates/dashboard/includes/employer_geiq_card.html
+++ b/itou/templates/dashboard/includes/employer_geiq_card.html
@@ -7,13 +7,13 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'geiq:assessment_info' assessment_pk=last_geiq_execution_assessment.pk %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
-                <i class="ri-file-chart-line ri-lg fw-normal"></i>
+                <i class="ri-file-chart-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Le bilan d’exécution</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'geiq:employee_list' assessment_pk=last_geiq_execution_assessment.pk info_type="personal-information" %}?back_url={% url 'dashboard:index' %}" class="btn-link btn-ico">
-                        <i class="ri-group-line ri-lg fw-normal"></i>
+                        <i class="ri-group-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Mes salariés</span>
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/employer_job_applications_card.html
+++ b/itou/templates/dashboard/includes/employer_job_applications_card.html
@@ -7,14 +7,14 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'apply:list_for_siae' %}" class="btn btn-outline-primary btn-block btn-ico mb-3" {% matomo_event "employeurs" "clic" "voir-liste-candidatures" %}>
-                <i class="ri-file-user-line ri-lg fw-normal"></i>
+                <i class="ri-file-user-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Voir toutes les candidatures</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 {% for category in job_applications_categories %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{{ category.url }}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-liste-candidatures-"|add:category.name %}>
-                            <i class="{{ category.icon }} ri-lg fw-normal"></i>
+                            <i class="{{ category.icon }} ri-lg fw-normal" aria-hidden="true"></i>
                             <span>{{ category.name }}</span>
                         </a>
                         <span class="badge rounded-pill badge-xs {{ category.badge }} text-info">{{ category.counter }}</span>
@@ -34,7 +34,7 @@
                     {% else %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'apply:start' company_pk=request.current_organization.pk %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "enregistrer-candidature" %}>
-                                <i class="ri-draft-line ri-lg fw-normal"></i>
+                                <i class="ri-draft-line ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>Enregistrer une candidature</span>
                             </a>
                         </li>
@@ -42,7 +42,7 @@
                 {% endif %}
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'apply:list_for_siae_exports' %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "export-candidatures" %}>
-                        <i class="ri-download-line ri-lg fw-normal"></i>
+                        <i class="ri-download-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Exporter toutes les candidatures</span>
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/employer_prescription_card.html
+++ b/itou/templates/dashboard/includes/employer_prescription_card.html
@@ -8,13 +8,13 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url "search:employers_results" %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
-                <i class="ri-draft-line ri-lg fw-normal"></i>
+                <i class="ri-draft-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Postuler pour un candidat</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url "apply:list_prescriptions" %}" class="btn-link btn-ico" {% matomo_event "employeurs" "clic" "voir-liste-candidatures-envoyées" %}>
-                        <i class="ri-folder-shared-line ri-lg fw-normal"></i>
+                        <i class="ri-folder-shared-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Candidatures envoyées</span>
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/gps_card.html
+++ b/itou/templates/dashboard/includes/gps_card.html
@@ -9,7 +9,7 @@
             <ul class="list-unstyled">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'gps:my_groups' %}" aria-label="Gérer les utilisateurs suivis dans votre groupe." class="btn-link btn-ico" {% matomo_event "gps" "clic" "tdb_liste_beneficiaires" %}>
-                        <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                        <i class="ri-article-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                         <span>Visualiser les bénéficiaires</span>
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/job_seeker_job_applications_card.html
+++ b/itou/templates/dashboard/includes/job_seeker_job_applications_card.html
@@ -9,13 +9,13 @@
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'apply:list_for_job_seeker' %}" class="btn-link btn-ico">
-                        <i class="ri-file-user-line ri-lg fw-normal"></i>
+                        <i class="ri-file-user-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Voir mes candidatures</span>
                     </a>
                 </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'search:employers_home' %}" class="btn-link btn-ico">
-                        <i class="ri-briefcase-line ri-lg fw-normal"></i>
+                        <i class="ri-briefcase-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Rechercher un emploi inclusif</span>
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_evaluation_campains_card.html
@@ -12,12 +12,12 @@
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             {% if active_campaign.evaluations_asked_at %}
                                 <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_list' active_campaign.pk %}" class="btn-link btn-ico">
-                                    <i class="ri-list-check-3 ri-lg fw-normal"></i>
+                                    <i class="ri-list-check-3 ri-lg fw-normal" aria-hidden="true"></i>
                                     <span>Campagne en cours</span>
                                 </a>
                             {% else %}
                                 <a href="{% url 'siae_evaluations_views:samples_selection' %}" class="btn-link btn-ico">
-                                    <i class="ri-list-check-3 ri-lg fw-normal"></i>
+                                    <i class="ri-list-check-3 ri-lg fw-normal" aria-hidden="true"></i>
                                     <span>Campagne en cours</span>
                                 </a>
                             {% endif %}
@@ -26,7 +26,7 @@
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'siae_evaluations_views:campaign_calendar' active_campaign.pk %}" class="btn-link btn-ico">
                                     {% comment %} TODO(cms): change icon {% endcomment %}
-                                    <i class="ri-calendar-line ri-lg fw-normal"></i>
+                                    <i class="ri-calendar-line ri-lg fw-normal" aria-hidden="true"></i>
                                     <span>Calendrier</span>
                                 </a>
                             </li>
@@ -38,15 +38,15 @@
             {% if closed_campaigns %}
                 <hr class="mb-0">
                 <button class="btn btn-link btn-ico p-0" type="button" data-bs-toggle="collapse" data-bs-target="#closed_campaigns" aria-expanded="false" aria-controls="closed_campaigns">
-                    <i class="ri-history-line ri-lg fw-normal"></i>
+                    <i class="ri-history-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Historique</span>
-                    <i class="ri-arrow-drop-down-line ri-lg fw-normal"></i>
+                    <i class="ri-arrow-drop-down-line ri-lg fw-normal" aria-hidden="true"></i>
                 </button>
                 <ul class="collapse" id="closed_campaigns">
                     {% for closed_campaign in closed_campaigns %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'siae_evaluations_views:institution_evaluated_siae_list' closed_campaign.pk %}" class="btn-link btn-ico">
-                                <i class="ri-file-copy-2-line ri-lg fw-normal"></i>
+                                <i class="ri-file-copy-2-line ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>{{ closed_campaign.name }}</span>
                             </a>
                         </li>
@@ -57,7 +57,7 @@
             <div class="d-flex justify-content-between align-items-center">
                 <a href="https://www.legifrance.gouv.fr/download/pdf/circ?id=45319" class="btn-link btn-ico" rel="noopener" target="_blank">
                     <span>Contexte législatif</span>
-                    <i class="ri-external-link-line fw-normal"></i>
+                    <i class="ri-external-link-line fw-normal" aria-hidden="true"></i>
                 </a>
             </div>
         </div>

--- a/itou/templates/dashboard/includes/labor_inspector_geiq_assessment_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_geiq_assessment_card.html
@@ -5,7 +5,7 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'geiq:geiq_list' institution_pk=request.current_organization.pk %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
-                <i class="ri-file-chart-line ri-lg fw-normal"></i>
+                <i class="ri-file-chart-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Rechercher un GEIQ</span>
             </a>
             {% if active_geiq_campaign %}

--- a/itou/templates/dashboard/includes/labor_inspector_organization_card.html
+++ b/itou/templates/dashboard/includes/labor_inspector_organization_card.html
@@ -11,7 +11,7 @@
         <div class="px-3 px-lg-4">
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'institutions_views:members' %}" class="btn-link btn-ico">
-                    <i class="ri-group-line ri-lg"></i>
+                    <i class="ri-group-line ri-lg" aria-hidden="true"></i>
                     <span>Gérer les collaborateurs</span>
                 </a>
             </p>

--- a/itou/templates/dashboard/includes/prescriber_job_applications_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_applications_card.html
@@ -5,19 +5,19 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'apply:list_prescriptions' %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
-                <i class="ri-file-user-line ri-lg fw-normal"></i>
+                <i class="ri-file-user-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Voir toutes les candidatures</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'search:employers_results' %}" class="btn-link btn-ico">
-                        <i class="ri-draft-line ri-lg fw-normal"></i>
+                        <i class="ri-draft-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Postuler pour un candidat</span>
                     </a>
                 </li>
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'apply:list_prescriptions_exports' %}" class="btn-link btn-ico">
-                        <i class="ri-download-line ri-lg fw-normal"></i>
+                        <i class="ri-download-line ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Exporter toutes les candidatures</span>
                     </a>
                 </li>

--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -5,13 +5,13 @@
         </div>
         <div class="px-3 px-lg-4">
             <a href="{% url 'job_seekers_views:list' %}" class="btn btn-outline-primary btn-block btn-ico mb-3">
-                <i class="ri-user-line ri-lg fw-normal"></i>
+                <i class="ri-user-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Liste de mes candidats</span>
             </a>
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'approvals:prolongation_requests_list' %}?only_pending=on" class="btn-link btn-ico">
-                        <i class="ri-list-check-3 ri-lg fw-normal"></i>
+                        <i class="ri-list-check-3 ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Gérer mes prolongations de PASS IAE</span>
                     </a>
                     {% if pending_prolongation_requests %}
@@ -21,7 +21,7 @@
                 {% if request.current_organization.kind == PrescriberOrganizationKind.FT %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="https://tally.so/r/w2Ex0M" aria-label="Suspendre un PASS IAE (ouverture dans un nouvel onglet)" target="_blank" class="btn-link btn-ico has-external-link">
-                            <i class="ri-pause-circle-line ri-lg fw-normal"></i>
+                            <i class="ri-pause-circle-line ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Suspendre un PASS IAE</span>
                         </a>
                     </li>

--- a/itou/templates/dashboard/includes/prescriber_organisation_card.html
+++ b/itou/templates/dashboard/includes/prescriber_organisation_card.html
@@ -15,7 +15,7 @@
                     {% if request.is_current_organization_admin %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'prescribers_views:edit_organization' %}" class="btn-link btn-ico">
-                                <i class="ri-pencil-line ri-lg ri-lg fw-normal"></i>
+                                <i class="ri-pencil-line ri-lg ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>Modifier cette organisation</span>
                             </a>
                         </li>
@@ -23,7 +23,7 @@
                     {% if card_url %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{{ card_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
-                                <i class="ri-eye-line ri-lg ri-lg fw-normal"></i>
+                                <i class="ri-eye-line ri-lg ri-lg fw-normal" aria-hidden="true"></i>
                                 <span>Voir la fiche publique</span>
                             </a>
                         </li>
@@ -31,14 +31,14 @@
                 {% endwith %}
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{% url 'prescribers_views:members' %}" class="btn-link btn-ico">
-                        <i class="ri-team-line ri-lg ri-lg fw-normal"></i>
+                        <i class="ri-team-line ri-lg ri-lg fw-normal" aria-hidden="true"></i>
                         <span>Gérer les collaborateurs</span>
                     </a>
                 </li>
                 {% if request.current_organization.kind == PrescriberOrganizationKind.DEPT and request.is_current_organization_admin %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'prescribers_views:list_accredited_organizations' %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link btn-ico">
-                            <i class="ri-list-unordered ri-lg ri-lg fw-normal"></i>
+                            <i class="ri-list-unordered ri-lg ri-lg fw-normal" aria-hidden="true"></i>
                             <span>Voir la liste des organisations conventionnées</span>
                         </a>
                     </li>

--- a/itou/templates/dashboard/includes/staff_actions_card.html
+++ b/itou/templates/dashboard/includes/staff_actions_card.html
@@ -6,7 +6,7 @@
         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'itou_staff_views:merge_users' %}" class="btn-link btn-ico">
-                    <i class="ri-key-2-line ri-lg fw-normal"></i>
+                    <i class="ri-key-2-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Fusion de comptes</span>
                 </a>
             </p>

--- a/itou/templates/dashboard/includes/staff_export_card.html
+++ b/itou/templates/dashboard/includes/staff_export_card.html
@@ -6,19 +6,19 @@
         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'itou_staff_views:export_job_applications_unknown_to_ft' %}" class="btn-link btn-ico">
-                    <i class="ri-key-2-line ri-lg fw-normal"></i>
+                    <i class="ri-key-2-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Candidatures inconnues de France Travail</span>
                 </a>
             </p>
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'itou_staff_views:export_ft_api_rejections' %}" class="btn-link btn-ico">
-                    <i class="ri-download-line ri-lg fw-normal"></i>
+                    <i class="ri-download-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Rejets de l'API FranceTravail</span>
                 </a>
             </p>
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'itou_staff_views:export_cta' %}" class="btn-link btn-ico">
-                    <i class="ri-download-line ri-lg fw-normal"></i>
+                    <i class="ri-download-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>Comités Techniques d'Animation</span>
                 </a>
             </p>

--- a/itou/templates/dashboard/includes/staff_stats_card.html
+++ b/itou/templates/dashboard/includes/staff_stats_card.html
@@ -6,7 +6,7 @@
         <div class="px-3 px-lg-4 pt-3 pt-lg-4">
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'stats:stats_staff_service_indicators' %}" class="btn-link btn-ico">
-                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                     <span>Indicateurs à suivre</span>
                 </a>
             </p>

--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -19,7 +19,7 @@
                     {% if can_view_stats_siae_aci %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_aci' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre le cofinancement de mon ACI</span>
                             </a>
                         </li>
@@ -27,7 +27,7 @@
                     {% if can_view_stats_siae_etp %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre les effectifs annuels et mensuels en ETP de ma ou mes structures</span>
                             </a>
                         </li>
@@ -35,32 +35,32 @@
                     {% if can_view_stats_siae %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_orga_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_hiring' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_auto_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Auto-prescription réalisées par ma ou mes structures</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_follow_siae_evaluation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_siae_hiring_report' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -69,26 +69,26 @@
                     {% if can_view_stats_cd %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_cd_iae' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Données IAE de mon département</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_cd_hiring' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Données facilitation à l'embauche des structures de mon département</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_cd_brsa' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_cd_orga_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -97,7 +97,7 @@
                     {% if can_view_stats_cd_aci %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_cd_aci' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi du cofinancement des ACI de mon département</span>
                             </a>
                         </li>
@@ -109,31 +109,31 @@
                                target="_blank"
                                aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)"
                                class="btn-link btn-ico">
-                                <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-article-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Voir le guide d’analyse France Travail</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ft_state_main' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Traitement et résultat des candidatures orientées par mes agences</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ft_conversion_main' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Taux de transformation de mes agences</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ft_tension' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Fiches de poste en tension de mon territoire</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ft_delay_main' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Délai d'entrée en IAE pour mon territoire</span>
                             </a>
                         </li>
@@ -141,7 +141,7 @@
                     {% if can_view_stats_ph %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ph_state_main' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                             </a>
                         </li>
@@ -149,58 +149,58 @@
                     {% if can_view_stats_ddets_iae %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_auto_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Focus auto-prescription des structures de mon département</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_ph_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_follow_siae_evaluation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_follow_prolongation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi des demandes de prolongation de mon département</span>
                             </a>
                         </li>
                         <!-- Stats temporarily suspended until we stabilize them
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'stats:stats_ddets_iae_iae' %}" class="btn-link btn-ico">
-                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                     <span>Données IAE de mon département</span>
                                 </a>
                             </li>
                         -->
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_tension' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Fiches de poste en tension des structures de mon département</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_hiring' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Données facilitation à l'embauche de mon département</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_state' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des acteurs AHI de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_iae_orga_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -208,7 +208,7 @@
                         {% if can_view_stats_ddets_iae_aci %}
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'stats:stats_ddets_iae_aci' %}" class="btn-link btn-ico">
-                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                     <span>Suivi du cofinancement des ACI de mon département</span>
                                 </a>
                             </li>
@@ -217,7 +217,7 @@
                     {% if can_view_stats_ddets_log %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_ddets_log_state' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des acteurs AHI de ma région</span>
                             </a>
                         </li>
@@ -225,58 +225,58 @@
                     {% if can_view_stats_dreets_iae %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_auto_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Les auto-prescription des structures de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_ph_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_follow_siae_evaluation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi du contrôle à posteriori des structures de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_follow_prolongation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi des demandes de prolongation de ma région</span>
                             </a>
                         </li>
                         <!-- Stats temporarily suspended until we stabilize them
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'stats:stats_dreets_iae_iae' %}" class="btn-link btn-ico">
-                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                    <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                     <span>Données IAE de ma région</span>
                                 </a>
                             </li>
                         -->
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_tension' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Fiches de poste en tension des structures de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_hiring' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Données facilitation à l'embauche des structures de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_state' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des acteurs AHI de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dreets_iae_orga_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre les effectifs annuels et mensuels en ETP des structures de ma région</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -285,19 +285,19 @@
                     {% if can_view_stats_dgefp_iae %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_auto_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Focus auto-prescription</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_follow_siae_evaluation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi du contrôle à posteriori</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_follow_prolongation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi des demandes de prolongation</span>
                             </a>
                         </li>
@@ -305,44 +305,44 @@
                             Which should happen once the dgefp starts working with us properly
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_iae' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Données IAE France entière</span>
                             </a>
                         </li>
                         -->
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_siae_evaluation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Voir les données du contrôle a posteriori (version bêta)</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_tension' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Fiches de poste en tension</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_hiring' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Données facilitation à l'embauche</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_state' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des acteurs AHI</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_ph_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_orga_etp' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -351,7 +351,7 @@
                     {% if can_view_stats_dihal %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dihal_state' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des acteurs AHI</span>
                             </a>
                         </li>
@@ -359,7 +359,7 @@
                     {% if can_view_stats_drihl %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_drihl_state' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions des acteurs AHI de ma région</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -368,7 +368,7 @@
                     {% if can_view_stats_iae_network %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_iae_network_hiring' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
                             </a>
                             {% include "dashboard/includes/stats_new_badge.html" %}
@@ -377,13 +377,13 @@
                     {% if can_view_stats_convergence %}
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_convergence_prescription' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Prescriptions et parcours</span>
                             </a>
                         </li>
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_convergence_job_application' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                 <span>Traitement et résultats des candidatures émises</span>
                             </a>
                         </li>
@@ -402,9 +402,9 @@
             <ul class="list-unstyled mb-lg-5">
                 <li class="d-flex justify-content-between align-items-center mb-3">
                     <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico">
-                        <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                        <i class="ri-dashboard-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                         <span>Accéder aux tableaux de bord publics</span>
-                        <i class="ri-external-link-line fw-normal ms-2"></i>
+                        <i class="ri-external-link-line fw-normal ms-2" aria-hidden="true"></i>
                     </a>
                 </li>
             </ul>

--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -25,7 +25,7 @@
                         </ul>
                         {% if profile.hexa_address_filled %}
                             <p class="mb-0">
-                                <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
+                                <i class="ri-error-warning-line ri-lg me-1" aria-hidden="true"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
                             </p>
                         {% else %}
                             <div class="alert alert-danger" role="status">

--- a/itou/templates/employee_record/includes/create_step_5.html
+++ b/itou/templates/employee_record/includes/create_step_5.html
@@ -19,7 +19,7 @@
                     de la fiche salarié sur la liste récapitulative accessible depuis le tableau de bord.
                 </p>
                 <p class="mb-0">
-                    <i class="ri-error-warning-line ri-lg me-1"></i><strong>Après validation de la fiche salarié, la modification de la date de début du PASS IAE n'est plus possible.</strong>
+                    <i class="ri-error-warning-line ri-lg me-1" aria-hidden="true"></i><strong>Après validation de la fiche salarié, la modification de la date de début du PASS IAE n'est plus possible.</strong>
                 </p>
             </div>
 

--- a/itou/templates/geiq/includes/_experiment_info_alert.html
+++ b/itou/templates/geiq/includes/_experiment_info_alert.html
@@ -19,7 +19,7 @@
                aria-label="Plus d’informations sur l’expérimentation"
                target="_blank">
                 <span>En savoir plus</span>
-                <i class="ri-external-link-line ri-lg"></i>
+                <i class="ri-external-link-line ri-lg" aria-hidden="true"></i>
             </a>
         </div>
     </div>

--- a/itou/templates/geiq/includes/labor_inspector_assessment_state_badge_for_list.html
+++ b/itou/templates/geiq/includes/labor_inspector_assessment_state_badge_for_list.html
@@ -1,7 +1,7 @@
 {% if not assessment.submitted_at %}
-    <span class="badge badge-xs rounded-pill text-nowrap bg-warning"><i class="ri-close-line"></i>En attente</span>
+    <span class="badge badge-xs rounded-pill text-nowrap bg-warning"><i class="ri-close-line" aria-hidden="true"></i>En attente</span>
 {% elif not assessment.reviewed_at %}
-    <span class="badge badge-xs rounded-pill text-nowrap bg-info"><i class="ri-loader-2-line"></i>À valider</span>
+    <span class="badge badge-xs rounded-pill text-nowrap bg-info"><i class="ri-loader-2-line" aria-hidden="true"></i>À valider</span>
 {% else %}
-    <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line"></i>Validé</span>
+    <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line" aria-hidden="true"></i>Validé</span>
 {% endif %}

--- a/itou/templates/gps/includes/group_members.html
+++ b/itou/templates/gps/includes/group_members.html
@@ -26,7 +26,7 @@
                                     {% if membership.is_referent %}
                                         <div>
                                             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
-                                                <i class="ri-map-pin-user-line"></i>
+                                                <i class="ri-map-pin-user-line" aria-hidden="true"></i>
                                                 Référent⸱e
                                             </span>
                                         </div>

--- a/itou/templates/gps/my_groups.html
+++ b/itou/templates/gps/my_groups.html
@@ -27,7 +27,7 @@
             <a href="{{ request_new_beneficiary_form_url }}" id="request-new-beneficiary-link" class="btn btn-lg btn-ico btn-primary mt-3 mt-md-0">
                 <i class="ri-user-add-line" aria-hidden="true"></i>
                 <span>Demander l'ajout d'un bénéficiaire</span>
-                <i class="ri-external-link-line ms-2"></i>
+                <i class="ri-external-link-line ms-2" aria-hidden="true"></i>
             </a>
         </div>
     </div>

--- a/itou/templates/includes/demo_accounts.html
+++ b/itou/templates/includes/demo_accounts.html
@@ -48,7 +48,7 @@
                                         <div class="p-3 text-center">
                                             <p class="card-text">{{ account.description }}</p>
                                             <p class="m-auto card-text">
-                                                <i class="ri-map-line me-1"></i>
+                                                <i class="ri-map-line me-1" aria-hidden="true"></i>
                                                 {{ account.location }}
                                             </p>
                                         </div>

--- a/itou/templates/includes/email_li.html
+++ b/itou/templates/includes/email_li.html
@@ -1,5 +1,5 @@
 <li>
-    <i class="ri-mail-line fw-normal me-2"></i>
+    <i class="ri-mail-line fw-normal me-2" aria-hidden="true"></i>
     <a href="mailto:{{ email }}" aria-label="Contact par mail" class="text-break">{{ email }}</a>
     {% include 'includes/copy_to_clipboard.html' with content=email css_classes="btn-link fw-medium ms-1" only_icon=True %}
 </li>

--- a/itou/templates/includes/phone_li.html
+++ b/itou/templates/includes/phone_li.html
@@ -1,6 +1,6 @@
 {% load format_filters %}
 <li>
-    <i class="ri-phone-line fw-normal me-2"></i>
+    <i class="ri-phone-line fw-normal me-2" aria-hidden="true"></i>
     {{ phonenumber|format_phone }}
     {% include 'includes/copy_to_clipboard.html' with content=phonenumber|cut:" " css_classes="btn-link fw-medium ms-1" only_icon=True %}
 </li>

--- a/itou/templates/includes/website_li.html
+++ b/itou/templates/includes/website_li.html
@@ -1,5 +1,5 @@
 <li>
-    <i class="ri-global-line fw-normal me-2"></i>
+    <i class="ri-global-line fw-normal me-2" aria-hidden="true"></i>
     <a href="{{ website }}" rel="noopener" target="_blank" class="btn-link fw-medium has-external-link" aria-label="Site web (ouverture dans un nouvel onglet)">
         {{ website }}
     </a>

--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -38,7 +38,7 @@
                                 {% endfor %}
                             </fieldset>
                             <button type="button" class="btn btn-link btn-ico justify-content-center mb-3 ps-0 pt-0 add-form-row">
-                                <i class="ri-user-add-line ri-lg"></i>
+                                <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
                                 <span>Ajouter un autre collaborateur</span>
                             </button>
 

--- a/itou/templates/layout/_header_user_dropdown_menu.html
+++ b/itou/templates/layout/_header_user_dropdown_menu.html
@@ -1,7 +1,7 @@
 <ul class="list-unstyled">
     <li class="dropdown-item">
         <div class="d-flex align-items-center">
-            <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+            <span class="flex-shrink-0"><i class="ri-user-line ri-2x" aria-hidden="true"></i></span>
             <div class="flex-grow-1 ms-2 lh-sm{% if mobile %} w-75{% endif %}">
                 {% if user.get_full_name %}
                     <span>{{ user.get_full_name }}</span>

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -42,7 +42,7 @@
                     <div class="c-box">
                         <h3 class="mb-2">Coordonnées</h3>
                         <div class="d-flex text-secondary fs-sm">
-                            <i class="ri-map-pin-2-line me-2"></i>
+                            <i class="ri-map-pin-2-line me-2" aria-hidden="true"></i>
                             <address class="m-0">{{ prescriber_org.address_on_one_line }}</address>
                         </div>
                         <hr class="my-3">

--- a/itou/templates/search/includes/prescribers_search_results.html
+++ b/itou/templates/search/includes/prescribers_search_results.html
@@ -14,11 +14,11 @@
                 <div class="d-flex flex-column flex-md-row gap-2 align-items-md-end gap-md-3">
                     <ul class="c-box--results__list-contact flex-md-grow-1 mt-2 mb-2 mb-md-0">
                         <li>
-                            <i class="ri-navigation-line fw-normal me-1"></i>
+                            <i class="ri-navigation-line fw-normal me-1" aria-hidden="true"></i>
                             à <strong class="text-info mx-1">{{ prescriber_org.distance.km|floatformat:"-1" }} km</strong> de votre lieu de recherche
                         </li>
                         <li>
-                            <i class="ri-map-pin-2-line fw-normal me-1"></i>
+                            <i class="ri-map-pin-2-line fw-normal me-1" aria-hidden="true"></i>
                             <address class="m-0">{{ prescriber_org.address_on_one_line }}</address>
                         </li>
                     </ul>

--- a/itou/templates/siae_evaluations/includes/criterion_infos.html
+++ b/itou/templates/siae_evaluations/includes/criterion_infos.html
@@ -1,8 +1,8 @@
 {% if review_state == "ACCEPTED" %}
-    <strong class="text-success"><i class="ri-check-line"></i> Validé</strong>
+    <strong class="text-success"><i class="ri-check-line" aria-hidden="true"></i> Validé</strong>
     <br>
 {% elif review_state == "REFUSED" or review_state == "REFUSED_2" %}
-    <strong class="text-danger"><i class="ri-close-line"></i> Refusé</strong>
+    <strong class="text-danger"><i class="ri-close-line" aria-hidden="true"></i> Refusé</strong>
     <br>
 {% endif %}
 <strong class="fs-sm">{{ criteria.name }}</strong>

--- a/itou/templates/siae_evaluations/includes/evaluation_data.html
+++ b/itou/templates/siae_evaluations/includes/evaluation_data.html
@@ -21,7 +21,7 @@
                 {% else %}
                     les {{ job_apps_count }} auto-prescriptions
                 {% endif %}
-                <i class="ri-external-link-line"></i></a>
+                <i class="ri-external-link-line" aria-hidden="true"></i></a>
             <hr class="my-4">
             <h3>Historique des campagnes de contrôle</h3>
             <ul class="list-unstyled">

--- a/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step2.html
+++ b/itou/templates/siae_evaluations/institution_evaluated_siae_notify_step2.html
@@ -37,7 +37,7 @@
                                 Vous pouvez vous appuyer sur les données présentes sur cette
                                 page et <a target="_blank" href="{% url 'siae_evaluations_views:sanctions_helper' %}">les sanctions
                                 prévues par l’instruction de la DGEFP
-                                <i class="ri-external-link-line"></i></a>.
+                                <i class="ri-external-link-line" aria-hidden="true"></i></a>.
                                 </p>
                                 <form method="post">
                                     {% csrf_token %}

--- a/itou/templates/siae_evaluations/siae_upload_doc.html
+++ b/itou/templates/siae_evaluations/siae_upload_doc.html
@@ -35,7 +35,7 @@
                                         <div class="mt-3 alert alert-info small" role="status">
                                             <div class="row">
                                                 <div class="col-auto pe-0">
-                                                    <i class="ri-information-line ri-xl text-info"></i>
+                                                    <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
                                                 </div>
                                                 <div class="col">
                                                     <p class="mb-0">

--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -54,21 +54,21 @@
                                     <li>Si non, faire une demande d’enregistrement de l’annexe financière dans l’ASP auprès de votre DDETS.</li>
                                 </ul>
                                 En cas de nécessité, contacter l’<a href="{{ ITOU_HELP_CENTER_URL }}/requests/new" target="_blank" rel="noopener" aria-label="lien de contact pour votre DDETS (ouverture dans un nouvel onglet)">Aide & Assistance</a>.
-                                <i class="ri-external-link-line ri-xl"></i>
+                                <i class="ri-external-link-line ri-xl" aria-hidden="true"></i>
                             </p>
 
                             <p>
                                 <strong>Une Entreprise Adaptée & GEIQ</strong> :
                                 <br>
                                 Complétez <a href="{% tally_form_url "wA799W" %}" target="_blank" rel="noopener" aria-label="lien pour une Entreprise Adaptée ou un GEIQ (ouverture dans un nouvel onglet)">ce formulaire de demande d'inscription</a>.
-                                <i class="ri-external-link-line ri-xl"></i>
+                                <i class="ri-external-link-line ri-xl" aria-hidden="true"></i>
                             </p>
 
                             <p class="mb-0">
                                 <strong>Si votre organisation est porteuse de la clause sociale</strong> :
                                 <br>
                                 Complétez <a href="{% url "signup:facilitator_search" %}" rel="noopener" aria-label="lien pour une organisation porteuse de la clause sociale">ce formulaire de demande d'inscription</a>.
-                                <i class="ri-external-link-line ri-xl"></i>
+                                <i class="ri-external-link-line ri-xl" aria-hidden="true"></i>
                             </p>
                         </div>
                     {% endif %}

--- a/itou/templates/utils/modal_includes/sso_email_conflict_registration_failure.html
+++ b/itou/templates/utils/modal_includes/sso_email_conflict_registration_failure.html
@@ -6,7 +6,7 @@
     <div class="modal-content">
         <div class="modal-header">
             <h3 class="modal-title text-danger" id="message-modal-{{ forloop.counter }}-label">
-                <i class="ri-xl ri-alert-line"></i>
+                <i class="ri-xl ri-alert-line" aria-hidden="true"></i>
                 L’inscription a échoué
             </h3>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>

--- a/itou/templates/utils/widgets/file_input.html
+++ b/itou/templates/utils/widgets/file_input.html
@@ -3,13 +3,13 @@
 
     <div class="file-dropzone-selector">
         <p class="mb-1 text-nuance-06" aria-hidden="true">
-            <i class="ri-upload-cloud-2-line ri-2x"></i>
+            <i class="ri-upload-cloud-2-line ri-2x" aria-hidden="true"></i>
         </p>
         <p class="mb-2">
             Glissez votre fichier ici ou <strong>rechercher</strong> dans vos fichiers
         </p>
         <label for="{{ widget.attrs.id }}" class="btn btn-link btn-sm btn-ico mb-2 stretched-link">
-            <i class="ri-folder-line ri-xl"></i>
+            <i class="ri-folder-line ri-xl" aria-hidden="true"></i>
             <span>Rechercher dans vos fichiers</span>
         </label>
         <p class="small text-nuance-06 mb-0">
@@ -30,7 +30,7 @@
             <strong class="file-dropzone-filename"></strong>
         </div>
         <button type="button" class="btn btn-sm btn-ico btn-secondary file-dropzone-clear">
-            <i class="ri-delete-bin-line ri-xl"></i>
+            <i class="ri-delete-bin-line ri-xl" aria-hidden="true"></i>
             <span>Supprimer</span>
         </button>
     </div>

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -191,7 +191,7 @@
                                       
                                           <div>
                                               <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
-                                                  <i class="ri-map-pin-user-line"></i>
+                                                  <i aria-hidden="true" class="ri-map-pin-user-line"></i>
                                                   Référent⸱e
                                               </span>
                                           </div>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -110,7 +110,7 @@
                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm w-75">
                   
                       <span>John DOE</span>
@@ -211,7 +211,7 @@
                                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm">
                   
                       <span>John DOE</span>
@@ -390,7 +390,7 @@
                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm w-75">
                   
                       <span>John DOE</span>
@@ -496,7 +496,7 @@
                                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm">
                   
                       <span>John DOE</span>
@@ -622,7 +622,7 @@
                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm w-75">
                   
                       <span>John DOE</span>
@@ -726,7 +726,7 @@
                                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm">
                   
                       <span>John DOE</span>
@@ -864,7 +864,7 @@
                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm w-75">
                   
                       <span>John DOE</span>
@@ -963,7 +963,7 @@
                                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm">
                   
                       <span>John DOE</span>
@@ -1116,7 +1116,7 @@
                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm w-75">
                   
                       <span>John DOE</span>
@@ -1213,7 +1213,7 @@
                                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm">
                   
                       <span>John DOE</span>
@@ -1343,7 +1343,7 @@
                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm w-75">
                   
                       <span>John DOE</span>
@@ -1440,7 +1440,7 @@
                                       <ul class="list-unstyled">
       <li class="dropdown-item">
           <div class="d-flex align-items-center">
-              <span class="flex-shrink-0"><i class="ri-user-line ri-2x"></i></span>
+              <span class="flex-shrink-0"><i aria-hidden="true" class="ri-user-line ri-2x"></i></span>
               <div class="flex-grow-1 ms-2 lh-sm">
                   
                       <span>John DOE</span>

--- a/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
@@ -382,7 +382,7 @@
       </td>
       <td>
           
-              <i class="ri-home-smile-2-line"></i>
+              <i aria-hidden="true" class="ri-home-smile-2-line"></i>
               
                   Pres. Org.
               
@@ -432,7 +432,7 @@
       </td>
       <td>
           
-              <i class="ri-community-line"></i>
+              <i aria-hidden="true" class="ri-community-line"></i>
               Acme inc.
           
       </td>
@@ -533,7 +533,7 @@
               </p>
               
                   <a class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center" href="/search/employers">
-                      <i class="ri-briefcase-line ri-lg fw-normal"></i>
+                      <i aria-hidden="true" class="ri-briefcase-line ri-lg fw-normal"></i>
                       <span>Rechercher un emploi inclusif</span>
                   </a>
               

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -2634,7 +2634,7 @@
                                       
                                           
                                               <button class="dropdown-item dropdown-item__summary" data-bs-target="#transfer_confirmation_modal_2222" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="batch-transfer-applications-open-modal" type="button">
-                                                  <i class="ri-community-line"></i>
+                                                  <i aria-hidden="true" class="ri-community-line"></i>
                                                   <span>EI</span>
                                                   <strong>Acme inc.</strong>
                                               </button>
@@ -2644,7 +2644,7 @@
                                       
                                           
                                               <button class="dropdown-item dropdown-item__summary" data-bs-target="#transfer_confirmation_modal_3333" data-bs-toggle="modal" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="batch-transfer-applications-open-modal" type="button">
-                                                  <i class="ri-community-line"></i>
+                                                  <i aria-hidden="true" class="ri-community-line"></i>
                                                   <span>EITI</span>
                                                   <strong>Superbe snapshot</strong>
                                               </button>
@@ -2684,7 +2684,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-lg-5">
       <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
                   EI
@@ -2696,7 +2696,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2707,7 +2707,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2721,7 +2721,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2790,7 +2790,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-lg-5">
       <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
                   EI
@@ -2802,7 +2802,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2813,7 +2813,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2827,7 +2827,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -3219,7 +3219,7 @@
       </td>
       <td>
           
-              <i class="ri-home-smile-2-line"></i>
+              <i aria-hidden="true" class="ri-home-smile-2-line"></i>
               
                   Pres. Org.
               
@@ -3438,7 +3438,7 @@
               </p>
               
                   <a class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center" href="/company/job_description_list">
-                      <i class="ri-briefcase-line ri-lg fw-normal"></i>
+                      <i aria-hidden="true" class="ri-briefcase-line ri-lg fw-normal"></i>
                       <span>Gérer les métiers et recrutements</span>
                   </a>
               

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -3005,7 +3005,7 @@
               </p>
               
                   <a class="btn btn-outline-primary btn-ico w-100 w-md-auto justify-content-center" href="/search/employers/results">
-                      <i class="ri-user-follow-line ri-lg fw-normal"></i>
+                      <i aria-hidden="true" class="ri-user-follow-line ri-lg fw-normal"></i>
                       <span>Postuler pour un candidat</span>
                   </a>
               

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -976,7 +976,7 @@
           
               <div data-bs-placement="bottom" data-bs-title="Vous devez d’abord décliner la candidature pour pouvoir la transférer à un autre employeur" data-bs-toggle="tooltip" role="button" tabindex="0">
                   <div class="dropdown-item disabled">
-                      <i class="ri-home-smile-line"></i>
+                      <i aria-hidden="true" class="ri-home-smile-line"></i>
                       <strong>Une autre structure</strong>
                   </div>
               </div>
@@ -995,7 +995,7 @@
           
           
               <a class="dropdown-item" href="/apply/[PK of JobApplication]/siae/external-transfer/1">
-                  <i class="ri-home-smile-line"></i>
+                  <i aria-hidden="true" class="ri-home-smile-line"></i>
                   <strong>Une autre structure</strong>
               </a>
           

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -1468,7 +1468,7 @@
                               </p>
                               <p>
                                   <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 Jane DOE.xlsx" href="/approvals/prolongation/request/666/report-file/">
-                                      <i class="ri-download-line ri-lg fw-normal"></i>
+                                      <i aria-hidden="true" class="ri-download-line ri-lg fw-normal"></i>
                                       <span>Télécharger le bilan</span>
                                   </a>
                               </p>
@@ -1479,7 +1479,7 @@
                                   L’employeur a fait une demande d'entretien téléphonique pour vous apporter des explications supplémentaires pour cette prolongation. Voici ses coordonnées :
                               </p>
                               <p>
-                                  <i class="ri-mail-line"></i>
+                                  <i aria-hidden="true" class="ri-mail-line"></i>
                                   <a class="btn-link me-3" href="mailto:email@example.com">email@example.com</a>
                                   <button class="btn btn-ico btn-secondary" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="email@example.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1488,7 +1488,7 @@
   
                               </p>
                               <p>
-                                  <i class="ri-phone-line"></i>
+                                  <i aria-hidden="true" class="ri-phone-line"></i>
                                   <a class="btn-link" href="tel:+33123456789">+33123456789</a>
                               </p>
                           
@@ -1586,7 +1586,7 @@
                               </p>
                               <p>
                                   <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 Jane DOE.xlsx" href="/approvals/prolongation/request/666/report-file/">
-                                      <i class="ri-download-line ri-lg fw-normal"></i>
+                                      <i aria-hidden="true" class="ri-download-line ri-lg fw-normal"></i>
                                       <span>Télécharger le bilan</span>
                                   </a>
                               </p>
@@ -1597,7 +1597,7 @@
                                   L’employeur a fait une demande d'entretien téléphonique pour vous apporter des explications supplémentaires pour cette prolongation. Voici ses coordonnées :
                               </p>
                               <p>
-                                  <i class="ri-mail-line"></i>
+                                  <i aria-hidden="true" class="ri-mail-line"></i>
                                   <a class="btn-link me-3" href="mailto:email@example.com">email@example.com</a>
                                   <button class="btn btn-ico btn-secondary" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="email@example.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1606,7 +1606,7 @@
   
                               </p>
                               <p>
-                                  <i class="ri-phone-line"></i>
+                                  <i aria-hidden="true" class="ri-phone-line"></i>
                                   <a class="btn-link" href="tel:+33123456789">+33123456789</a>
                               </p>
                           
@@ -1675,7 +1675,7 @@
   
   <div class="c-box c-box--structure">
       <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
                   EI
@@ -1687,7 +1687,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1698,7 +1698,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1712,7 +1712,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1840,7 +1840,7 @@
                               </p>
                               <p>
                                   <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 Jane DOE.xlsx" href="/approvals/prolongation/request/666/report-file/">
-                                      <i class="ri-download-line ri-lg fw-normal"></i>
+                                      <i aria-hidden="true" class="ri-download-line ri-lg fw-normal"></i>
                                       <span>Télécharger le bilan</span>
                                   </a>
                               </p>
@@ -1851,7 +1851,7 @@
                                   L’employeur a fait une demande d'entretien téléphonique pour vous apporter des explications supplémentaires pour cette prolongation. Voici ses coordonnées :
                               </p>
                               <p>
-                                  <i class="ri-mail-line"></i>
+                                  <i aria-hidden="true" class="ri-mail-line"></i>
                                   <a class="btn-link me-3" href="mailto:email@example.com">email@example.com</a>
                                   <button class="btn btn-ico btn-secondary" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="email@example.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1860,7 +1860,7 @@
   
                               </p>
                               <p>
-                                  <i class="ri-phone-line"></i>
+                                  <i aria-hidden="true" class="ri-phone-line"></i>
                                   <a class="btn-link" href="tel:+33123456789">+33123456789</a>
                               </p>
                           
@@ -1929,7 +1929,7 @@
   
   <div class="c-box c-box--structure">
       <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
                   EI
@@ -1941,7 +1941,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1952,7 +1952,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1966,7 +1966,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2052,14 +2052,14 @@
                       <form action="/approvals/prolongation/request/666/grant" method="post">
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <button class="btn btn-lg btn-white btn-block btn-ico justify-content-center">
-                              <i class="ri-check-line"></i>
+                              <i aria-hidden="true" class="ri-check-line"></i>
                               <span>Accepter</span>
                           </button>
                       </form>
                   </div>
                   <div class="form-group col-12 col-lg-auto">
                       <a class="btn btn-lg btn-outline-white btn-block btn-ico justify-content-center" href="/approvals/prolongation/request/666/deny?reset=1">
-                          <i class="ri-close-line"></i>
+                          <i aria-hidden="true" class="ri-close-line"></i>
                           <span>Refuser</span>
                       </a>
                   </div>
@@ -2107,7 +2107,7 @@
                               </p>
                               <p>
                                   <a class="btn btn-secondary btn-ico" download="Bilan prolongation PASS IAE 999999999999 Jane DOE.xlsx" href="/approvals/prolongation/request/666/report-file/">
-                                      <i class="ri-download-line ri-lg fw-normal"></i>
+                                      <i aria-hidden="true" class="ri-download-line ri-lg fw-normal"></i>
                                       <span>Télécharger le bilan</span>
                                   </a>
                               </p>
@@ -2118,7 +2118,7 @@
                                   L’employeur a fait une demande d'entretien téléphonique pour vous apporter des explications supplémentaires pour cette prolongation. Voici ses coordonnées :
                               </p>
                               <p>
-                                  <i class="ri-mail-line"></i>
+                                  <i aria-hidden="true" class="ri-mail-line"></i>
                                   <a class="btn-link me-3" href="mailto:email@example.com">email@example.com</a>
                                   <button class="btn btn-ico btn-secondary" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="email@example.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2127,7 +2127,7 @@
   
                               </p>
                               <p>
-                                  <i class="ri-phone-line"></i>
+                                  <i aria-hidden="true" class="ri-phone-line"></i>
                                   <a class="btn-link" href="tel:+33123456789">+33123456789</a>
                               </p>
                           
@@ -2206,7 +2206,7 @@
   
   <div class="c-box c-box--structure">
       <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
                   EI
@@ -2218,7 +2218,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2229,7 +2229,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2243,7 +2243,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -44,7 +44,7 @@
                   
               </div>
               <span class="fs-sm mt-1 d-flex align-items-center">
-                  <i class="ri-map-pin-2-line ri-sm me-1"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1"></i>
                   
                       Vannes (56)
                   
@@ -107,7 +107,7 @@
                   
               </div>
               <span class="fs-sm mt-1 d-flex align-items-center">
-                  <i class="ri-map-pin-2-line ri-sm me-1"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1"></i>
                   
                       Vannes (56)
                   
@@ -143,7 +143,7 @@
                   
               </div>
               <span class="fs-sm mt-1 d-flex align-items-center">
-                  <i class="ri-map-pin-2-line ri-sm me-1"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1"></i>
                   
                       Vannes (56)
                   
@@ -167,7 +167,7 @@
                                   <div class="d-flex justify-content-end mt-3">
                                       
                                       <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start">
-                                          <i class="ri-draft-line"></i>
+                                          <i aria-hidden="true" class="ri-draft-line"></i>
                                           <span>Postuler</span>
                                       </a>
                                   </div>
@@ -221,7 +221,7 @@
                   
               </div>
               <span class="fs-sm mt-1 d-flex align-items-center">
-                  <i class="ri-map-pin-2-line ri-sm me-1"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1"></i>
                   
                       Vannes (56)
                   
@@ -245,7 +245,7 @@
                                   <div class="d-flex justify-content-end mt-3">
                                       
                                       <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start">
-                                          <i class="ri-draft-line"></i>
+                                          <i aria-hidden="true" class="ri-draft-line"></i>
                                           <span>Postuler</span>
                                       </a>
                                   </div>
@@ -349,14 +349,14 @@
                       <div class="c-box">
                           <h3 class="mb-2">Coordonnées</h3>
                           <div class="d-flex text-secondary fs-sm">
-                              <i class="ri-map-pin-2-line me-2"></i>
+                              <i aria-hidden="true" class="ri-map-pin-2-line me-2"></i>
                               <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                           </div>
                           <hr class="my-3"/>
                           <ul class="fs-sm list-unstyled mb-0">
                               
                                   <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -369,7 +369,7 @@
                               
                                   
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -453,7 +453,7 @@
                   
               </div>
               <span class="fs-sm mt-1 d-flex align-items-center">
-                  <i class="ri-map-pin-2-line ri-sm me-1"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line ri-sm me-1"></i>
                   
                       Vannes (56)
                   
@@ -478,7 +478,7 @@
                                   <div class="d-flex justify-content-end mt-3">
                                       
                                       <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start">
-                                          <i class="ri-draft-line"></i>
+                                          <i aria-hidden="true" class="ri-draft-line"></i>
                                           <span>Postuler</span>
                                       </a>
                                   </div>

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -509,7 +509,7 @@
               <ul class="list-unstyled">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Gérer les utilisateurs suivis dans votre groupe." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_liste_beneficiaires" href="/gps/groups">
-                          <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                           <span>Visualiser les bénéficiaires</span>
                       </a>
                   </li>
@@ -534,7 +534,7 @@
               <ul class="list-unstyled">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Gérer les utilisateurs suivis dans votre groupe." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_liste_beneficiaires" href="/gps/groups">
-                          <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                           <span>Visualiser les bénéficiaires</span>
                       </a>
                   </li>
@@ -559,7 +559,7 @@
               <ul class="list-unstyled">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Gérer les utilisateurs suivis dans votre groupe." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_liste_beneficiaires" href="/gps/groups">
-                          <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                           <span>Visualiser les bénéficiaires</span>
                       </a>
                   </li>
@@ -584,7 +584,7 @@
               <ul class="list-unstyled">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Gérer les utilisateurs suivis dans votre groupe." class="btn-link btn-ico" data-matomo-action="clic" data-matomo-category="gps" data-matomo-event="true" data-matomo-option="tdb_liste_beneficiaires" href="/gps/groups">
-                          <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                           <span>Visualiser les bénéficiaires</span>
                       </a>
                   </li>

--- a/tests/www/dashboard/__snapshots__/test_dashboard_stats.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard_stats.ambr
@@ -23,7 +23,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -50,9 +50,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -87,7 +87,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -114,9 +114,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -151,7 +151,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -178,9 +178,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -215,7 +215,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -242,9 +242,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -287,9 +287,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -324,7 +324,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -351,9 +351,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -396,9 +396,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -441,9 +441,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -486,9 +486,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -523,7 +523,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -550,9 +550,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -595,9 +595,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -640,9 +640,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -674,7 +674,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/iae">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données IAE de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -682,19 +682,19 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/brsa">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -704,7 +704,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/aci">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du cofinancement des ACI de mon département</span>
                               </a>
                           </li>
@@ -733,9 +733,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -767,7 +767,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/iae">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données IAE de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -775,19 +775,19 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/brsa">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -819,9 +819,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -853,7 +853,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/iae">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données IAE de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -861,19 +861,19 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/brsa">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -883,7 +883,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/aci">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du cofinancement des ACI de mon département</span>
                               </a>
                           </li>
@@ -912,9 +912,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -946,7 +946,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/iae">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données IAE de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -954,19 +954,19 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/brsa">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des accompagnateurs des publics allocataires du RSA de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/cd/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -998,9 +998,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1034,31 +1034,31 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
-                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir le guide d’analyse France Travail</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultat des candidatures orientées par mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Taux de transformation de mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension de mon territoire</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/delay/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Délai d'entrée en IAE pour mon territoire</span>
                               </a>
                           </li>
@@ -1086,9 +1086,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1122,31 +1122,31 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
-                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir le guide d’analyse France Travail</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultat des candidatures orientées par mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Taux de transformation de mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension de mon territoire</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/delay/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Délai d'entrée en IAE pour mon territoire</span>
                               </a>
                           </li>
@@ -1174,9 +1174,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1210,31 +1210,31 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
-                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir le guide d’analyse France Travail</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultat des candidatures orientées par mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Taux de transformation de mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension de mon territoire</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/delay/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Délai d'entrée en IAE pour mon territoire</span>
                               </a>
                           </li>
@@ -1262,9 +1262,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1298,31 +1298,31 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a aria-label="Accéder au guide d'analyse France Travail (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://plateforme-inclusion.notion.site/Guide-d-utilisation-et-d-analyse-des-tableaux-de-bord-France-Travail-dad8530e64af47bd99787a6d4e81f6b9" rel="noopener" target="_blank">
-                                  <i class="ri-article-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-article-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir le guide d’analyse France Travail</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultat des candidatures orientées par mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/conversion/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Taux de transformation de mes agences</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension de mon territoire</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/pe/delay/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Délai d'entrée en IAE pour mon territoire</span>
                               </a>
                           </li>
@@ -1350,9 +1350,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1387,7 +1387,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -1414,9 +1414,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1451,7 +1451,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -1478,9 +1478,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1515,7 +1515,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -1542,9 +1542,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1579,7 +1579,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -1606,9 +1606,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1651,9 +1651,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1688,7 +1688,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -1715,9 +1715,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1760,9 +1760,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1805,9 +1805,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1850,9 +1850,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1887,7 +1887,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ph/state/main">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mon organisation</span>
                               </a>
                           </li>
@@ -1914,9 +1914,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -1959,9 +1959,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2004,9 +2004,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2037,7 +2037,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2045,25 +2045,25 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Auto-prescription réalisées par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2096,9 +2096,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2129,7 +2129,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2137,25 +2137,25 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Auto-prescription réalisées par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2188,9 +2188,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2221,7 +2221,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2229,25 +2229,25 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Auto-prescription réalisées par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2280,9 +2280,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2313,7 +2313,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2321,25 +2321,25 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Auto-prescription réalisées par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2372,9 +2372,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2405,7 +2405,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2413,25 +2413,25 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Auto-prescription réalisées par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2464,9 +2464,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2497,7 +2497,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP de ma structure</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2505,25 +2505,25 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures reçues par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Auto-prescription réalisées par ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle a posteriori pour ma ou mes structures</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/siae/hiring_report">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Déclarations d’embauche réalisées par ma ou mes structures sur le service des emplois</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -2556,9 +2556,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2601,9 +2601,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2646,9 +2646,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2691,9 +2691,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2736,13 +2736,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/convergence/prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions et parcours</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/convergence/job_application">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures émises</span>
                               </a>
                           </li>
@@ -2761,9 +2761,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2806,13 +2806,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/convergence/prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions et parcours</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/convergence/job_application">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures émises</span>
                               </a>
                           </li>
@@ -2831,9 +2831,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2876,13 +2876,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/convergence/prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions et parcours</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/convergence/job_application">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures émises</span>
                               </a>
                           </li>
@@ -2901,9 +2901,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2946,9 +2946,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -2991,9 +2991,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3036,9 +3036,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3074,13 +3074,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Focus auto-prescription des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3088,45 +3088,45 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation de mon département</span>
                               </a>
                           </li>
                           <!-- Stats temporarily suspended until we stabilize them
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a href="/stats/ddets/iae" class="btn-link btn-ico">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                       <span>Données IAE de mon département</span>
                                   </a>
                               </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3135,7 +3135,7 @@
                           
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a class="btn-link btn-ico" href="/stats/ddets/aci">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                       <span>Suivi du cofinancement des ACI de mon département</span>
                                   </a>
                               </li>
@@ -3162,9 +3162,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3200,13 +3200,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Focus auto-prescription des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3214,45 +3214,45 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation de mon département</span>
                               </a>
                           </li>
                           <!-- Stats temporarily suspended until we stabilize them
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a href="/stats/ddets/iae" class="btn-link btn-ico">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                       <span>Données IAE de mon département</span>
                                   </a>
                               </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3261,7 +3261,7 @@
                           
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a class="btn-link btn-ico" href="/stats/ddets/aci">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                       <span>Suivi du cofinancement des ACI de mon département</span>
                                   </a>
                               </li>
@@ -3288,9 +3288,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3326,13 +3326,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Focus auto-prescription des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3340,45 +3340,45 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori pour les structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation de mon département</span>
                               </a>
                           </li>
                           <!-- Stats temporarily suspended until we stabilize them
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a href="/stats/ddets/iae" class="btn-link btn-ico">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                       <span>Données IAE de mon département</span>
                                   </a>
                               </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension des structures de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche de mon département</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de mon département</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3407,9 +3407,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3446,7 +3446,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets_log/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
@@ -3471,9 +3471,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3510,7 +3510,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets_log/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
@@ -3535,9 +3535,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3574,7 +3574,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/ddets_log/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
@@ -3599,9 +3599,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3644,9 +3644,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3689,9 +3689,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3734,9 +3734,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3775,19 +3775,19 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Focus auto-prescription</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation</span>
                               </a>
                           </li>
@@ -3795,44 +3795,44 @@
                               Which should happen once the dgefp starts working with us properly
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a href="/stats/dgefp/iae" class="btn-link btn-ico">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                   <span>Données IAE France entière</span>
                               </a>
                           </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir les données du contrôle a posteriori (version bêta)</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3857,9 +3857,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -3898,19 +3898,19 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Focus auto-prescription</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation</span>
                               </a>
                           </li>
@@ -3918,44 +3918,44 @@
                               Which should happen once the dgefp starts working with us properly
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a href="/stats/dgefp/iae" class="btn-link btn-ico">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                   <span>Données IAE France entière</span>
                               </a>
                           </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir les données du contrôle a posteriori (version bêta)</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -3980,9 +3980,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4021,19 +4021,19 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Focus auto-prescription</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation</span>
                               </a>
                           </li>
@@ -4041,44 +4041,44 @@
                               Which should happen once the dgefp starts working with us properly
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a href="/stats/dgefp/iae" class="btn-link btn-ico">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                   <span>Données IAE France entière</span>
                               </a>
                           </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Voir les données du contrôle a posteriori (version bêta)</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4103,9 +4103,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4145,7 +4145,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dihal/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI</span>
                               </a>
                           </li>
@@ -4167,9 +4167,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4209,7 +4209,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dihal/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI</span>
                               </a>
                           </li>
@@ -4231,9 +4231,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4273,7 +4273,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dihal/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI</span>
                               </a>
                           </li>
@@ -4295,9 +4295,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4340,9 +4340,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4385,9 +4385,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4430,9 +4430,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4470,13 +4470,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Les auto-prescription des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4484,45 +4484,45 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation de ma région</span>
                               </a>
                           </li>
                           <!-- Stats temporarily suspended until we stabilize them
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a href="/stats/dreets/iae" class="btn-link btn-ico">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                       <span>Données IAE de ma région</span>
                                   </a>
                               </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4548,9 +4548,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4588,13 +4588,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Les auto-prescription des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4602,45 +4602,45 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation de ma région</span>
                               </a>
                           </li>
                           <!-- Stats temporarily suspended until we stabilize them
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a href="/stats/dreets/iae" class="btn-link btn-ico">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                       <span>Données IAE de ma région</span>
                                   </a>
                               </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4666,9 +4666,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4706,13 +4706,13 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/auto_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Les auto-prescription des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/ph_prescription">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4720,45 +4720,45 @@
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/follow_siae_evaluation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi du contrôle à posteriori des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/follow_prolongation">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivi des demandes de prolongation de ma région</span>
                               </a>
                           </li>
                           <!-- Stats temporarily suspended until we stabilize them
                               <li class="d-flex justify-content-between align-items-center mb-3">
                                   <a href="/stats/dreets/iae" class="btn-link btn-ico">
-                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                      <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
                                       <span>Données IAE de ma région</span>
                                   </a>
                               </li>
                           -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/tension">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Fiches de poste en tension des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Données facilitation à l'embauche des structures de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                           </li>
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dreets/orga_etp">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Suivre les effectifs annuels et mensuels en ETP des structures de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4784,9 +4784,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4827,7 +4827,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/drihl/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4850,9 +4850,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4893,7 +4893,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/drihl/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4916,9 +4916,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -4959,7 +4959,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/drihl/state">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Prescriptions des acteurs AHI de ma région</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -4982,9 +4982,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -5026,7 +5026,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/iae_network/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -5048,9 +5048,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -5092,7 +5092,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/iae_network/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -5114,9 +5114,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -5158,7 +5158,7 @@
                       
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/iae_network/hiring">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
+                                  <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
                                   <span>Traitement et résultats des candidatures orientées par mes adhérents</span>
                               </a>
                               <span class="badge badge-sm rounded-pill bg-important">Nouveau</span>
@@ -5180,9 +5180,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>
@@ -5225,9 +5225,9 @@
               <ul class="list-unstyled mb-lg-5">
                   <li class="d-flex justify-content-between align-items-center mb-3">
                       <a aria-label="Accéder aux tableaux de bord publics (ouverture dans un nouvel onglet)" class="btn-link btn-ico" href="https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord" rel="noopener" target="_blank">
-                          <i class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
+                          <i aria-hidden="true" class="ri-dashboard-line ri-lg fw-normal align-self-start"></i>
                           <span>Accéder aux tableaux de bord publics</span>
-                          <i class="ri-external-link-line fw-normal ms-2"></i>
+                          <i aria-hidden="true" class="ri-external-link-line fw-normal ms-2"></i>
                       </a>
                   </li>
               </ul>

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -8,11 +8,7 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
-from pytest_django.asserts import (
-    assertContains,
-    assertNotContains,
-    assertRedirects,
-)
+from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
 from itou.companies.enums import CompanyKind
 from itou.employee_record.enums import Status
@@ -214,7 +210,7 @@ class TestDashboardView:
                    data-matomo-category="employeurs"
                    data-matomo-action="clic"
                    data-matomo-option="voir-liste-candidatures-À traiter">
-                    <i class="ri-notification-4-line ri-lg fw-normal"></i>
+                    <i class="ri-notification-4-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>À traiter</span>
                 </a>
                 <span class="badge rounded-pill badge-xs bg-info-lighter text-info">1</span>
@@ -234,7 +230,7 @@ class TestDashboardView:
                    data-matomo-category="employeurs"
                    data-matomo-action="clic"
                    data-matomo-option="voir-liste-candidatures-En attente">
-                    <i class="ri-time-line ri-lg fw-normal"></i>
+                    <i class="ri-time-line ri-lg fw-normal" aria-hidden="true"></i>
                     <span>En attente</span>
                 </a>
                 <span class="badge rounded-pill badge-xs bg-info-lighter text-info">1</span>
@@ -475,7 +471,7 @@ class TestDashboardView:
             f"""
             <a href="/siae_evaluation/evaluated_siae_sanction/{evaluated_siae_with_final_decision.pk}/"
              class="btn-link btn-ico">
-                <i class="ri-file-copy-2-line ri-lg fw-normal"></i>
+                <i class="ri-file-copy-2-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>Final decision reached</span>
             </a>
             """,
@@ -487,7 +483,7 @@ class TestDashboardView:
             f"""
             <a href="/siae_evaluation/evaluated_siae_sanction/{evaluated_siae_campaign_closed.pk}/"
              class="btn-link btn-ico">
-                <i class="ri-file-copy-2-line ri-lg fw-normal"></i>
+                <i class="ri-file-copy-2-line ri-lg fw-normal" aria-hidden="true"></i>
                 <span>{just_closed_name}</span>
             </a>
             """,

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -21,7 +21,7 @@
                           </ul>
                           
                               <p class="mb-0">
-                                  <i class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
+                                  <i aria-hidden="true" class="ri-error-warning-line ri-lg me-1"></i><strong>Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié.</strong>
                               </p>
                           
                       </div>

--- a/tests/www/geiq_views/__snapshots__/tests.ambr
+++ b/tests/www/geiq_views/__snapshots__/tests.ambr
@@ -466,7 +466,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line"></i>Validé</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i aria-hidden="true" class="ri-check-line"></i>Validé</span>
   
   
                                               </td>
@@ -486,7 +486,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line"></i>Validé</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i aria-hidden="true" class="ri-check-line"></i>Validé</span>
   
   
                                               </td>
@@ -506,7 +506,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line"></i>Validé</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i aria-hidden="true" class="ri-check-line"></i>Validé</span>
   
   
                                               </td>
@@ -526,7 +526,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line"></i>Validé</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i aria-hidden="true" class="ri-check-line"></i>Validé</span>
   
   
                                               </td>
@@ -546,7 +546,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i class="ri-check-line"></i>Validé</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-success"><i aria-hidden="true" class="ri-check-line"></i>Validé</span>
   
   
                                               </td>
@@ -567,7 +567,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-info"><i class="ri-loader-2-line"></i>À valider</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-info"><i aria-hidden="true" class="ri-loader-2-line"></i>À valider</span>
   
   
                                               </td>
@@ -587,7 +587,7 @@
                                           <tr>
                                               <td>
                                                   
-      <span class="badge badge-xs rounded-pill text-nowrap bg-warning"><i class="ri-close-line"></i>En attente</span>
+      <span class="badge badge-xs rounded-pill text-nowrap bg-warning"><i aria-hidden="true" class="ri-close-line"></i>En attente</span>
   
   
                                               </td>
@@ -693,7 +693,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -705,7 +705,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -716,7 +716,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -730,7 +730,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -821,7 +821,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -974,7 +974,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -1049,7 +1049,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -1061,7 +1061,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1072,7 +1072,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1086,7 +1086,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1177,7 +1177,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -1328,7 +1328,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -1403,7 +1403,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -1415,7 +1415,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1426,7 +1426,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1440,7 +1440,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1531,7 +1531,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -1684,7 +1684,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -1759,7 +1759,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -1771,7 +1771,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1782,7 +1782,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1796,7 +1796,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -1887,7 +1887,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2040,7 +2040,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2115,7 +2115,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -2127,7 +2127,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2138,7 +2138,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2152,7 +2152,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2243,7 +2243,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2394,7 +2394,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2465,7 +2465,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -2477,7 +2477,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2488,7 +2488,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2502,7 +2502,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2591,7 +2591,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2738,7 +2738,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2794,7 +2794,7 @@
   
   <div class="c-box c-box--structure mb-3 mb-md-4">
       <div aria-controls="collapseBoxStructure" aria-expanded="true" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
-          <i class="ri-community-line"></i>
+          <i aria-hidden="true" class="ri-community-line"></i>
           <div>
               <button data-bs-title="Groupement d'employeurs pour l'insertion et la qualification" data-bs-toggle="tooltip" type="button">
                   GEIQ
@@ -2806,7 +2806,7 @@
           <hr class="my-4"/>
           <ul class="c-box--structure__list-contact">
               <li>
-                  <i class="ri-map-pin-2-line fw-normal me-2"></i>
+                  <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-2"></i>
                   <address class="m-0">112 rue de la Croix-Nivert, 75015 Paris</address>
                   <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="112 rue de la Croix-Nivert, 75015 Paris">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2817,7 +2817,7 @@
               
                   
       <li>
-      <i class="ri-mail-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@acmeinc.com">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2831,7 +2831,7 @@
   
       
   <li>
-      <i class="ri-phone-line fw-normal me-2"></i>
+      <i aria-hidden="true" class="ri-phone-line fw-normal me-2"></i>
       06 12 34 56 78
       <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="0612345678">
       <i aria-hidden="true" class="ri-file-copy-line fw-normal"></i>
@@ -2920,7 +2920,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>
@@ -2961,13 +2961,13 @@
   
       <div class="file-dropzone-selector">
           <p aria-hidden="true" class="mb-1 text-nuance-06">
-              <i class="ri-upload-cloud-2-line ri-2x"></i>
+              <i aria-hidden="true" class="ri-upload-cloud-2-line ri-2x"></i>
           </p>
           <p class="mb-2">
               Glissez votre fichier ici ou <strong>rechercher</strong> dans vos fichiers
           </p>
           <label class="btn btn-link btn-sm btn-ico mb-2 stretched-link" for="id_activity_report_file">
-              <i class="ri-folder-line ri-xl"></i>
+              <i aria-hidden="true" class="ri-folder-line ri-xl"></i>
               <span>Rechercher dans vos fichiers</span>
           </label>
           <p class="small text-nuance-06 mb-0">
@@ -2985,7 +2985,7 @@
               <strong class="file-dropzone-filename"></strong>
           </div>
           <button class="btn btn-sm btn-ico btn-secondary file-dropzone-clear" type="button">
-              <i class="ri-delete-bin-line ri-xl"></i>
+              <i aria-hidden="true" class="ri-delete-bin-line ri-xl"></i>
               <span>Supprimer</span>
           </button>
       </div>
@@ -3112,7 +3112,7 @@
           <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
               <a aria-label="Plus d’informations sur l’expérimentation" class="btn btn-sm btn-primary btn-ico" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/25713585083409--Exp%C3%A9rimentation-du-bilan-d-ex%C3%A9cution-GEIQ" rel="noopener" target="_blank">
                   <span>En savoir plus</span>
-                  <i class="ri-external-link-line ri-lg"></i>
+                  <i aria-hidden="true" class="ri-external-link-line ri-lg"></i>
               </a>
           </div>
       </div>

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -1907,7 +1907,7 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
             f"""
             <a target="_blank" href="/siae_evaluation/evaluated_siae_detail/{evaluated_siae.pk}/">
              Revoir les 5 auto-prescriptions
-             <i class="ri-external-link-line">
+             <i class="ri-external-link-line" aria-hidden="true">
              </i>
             </a>""",
             html=True,
@@ -2066,7 +2066,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep1(InstitutionEvaluatedSiaeNotify
             f"""
             <a target="_blank" href="/siae_evaluation/evaluated_siae_detail/{evaluated_siae.pk}/">
              Revoir l’auto-prescription
-             <i class="ri-external-link-line">
+             <i class="ri-external-link-line" aria-hidden="true">
              </i>
             </a>""",
             html=True,
@@ -3545,7 +3545,9 @@ class TestInstitutionEvaluatedJobApplicationView:
         assertNotContains(response, accepte_url)
         assertContains(response, reinit_url)
         assertContains(
-            response, '<strong class="text-success"><i class="ri-check-line"></i> Validé</strong>', html=True
+            response,
+            '<strong class="text-success"><i class="ri-check-line" aria-hidden="true"></i> Validé</strong>',
+            html=True,
         )
 
         # refused
@@ -3557,7 +3559,9 @@ class TestInstitutionEvaluatedJobApplicationView:
         assertNotContains(response, accepte_url)
         assertContains(response, reinit_url)
         assertContains(
-            response, '<strong class="text-danger"><i class="ri-close-line"></i> Refusé</strong>', html=True
+            response,
+            '<strong class="text-danger"><i class="ri-close-line" aria-hidden="true"></i> Refusé</strong>',
+            html=True,
         )
 
         # reinited

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -263,7 +263,7 @@ class TestSiaeJobApplicationListView:
                 "XXXXX2412345",
                 '<span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>',
                 """
-                <strong class="text-success"><i class="ri-check-line"></i> Validé</strong>
+                <strong class="text-success"><i class="ri-check-line" aria-hidden="true"></i> Validé</strong>
                 <br>
                 <strong class="fs-sm">Bénéficiaire du RSA</strong>
                 """,
@@ -273,7 +273,7 @@ class TestSiaeJobApplicationListView:
                 "XXXXX2423456",
                 SIAE_JOB_APPLICATION_LIST_REFUSED_HTML,
                 """
-                <strong class="text-danger"><i class="ri-close-line"></i> Refusé</strong>
+                <strong class="text-danger"><i class="ri-close-line" aria-hidden="true"></i> Refusé</strong>
                 <br>
                 <strong class="fs-sm">Bénéficiaire du RSA</strong>
                 """,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour corriger les erreurs d'accessibilité potentielles 

## :cake: Comment ? <!-- optionnel -->

En harmonisant les règles. A savoir :

Comme les `<i class="ri-*></i>` ne contiennent généralement pas de contenu texte et ne sont là que comme une aide visuelle, elles doivent être ignorées par les lecteurs d'écran. Pour cela, le plus simple est d'ajouter un `aria-hidden="true"` sur ces `<i class="ri-*></i>` 

Cependant, parfois, les `<i class="ri-*></i>` se trouvent dans un `<parent>` qui ne contient ni texte, ni aria-label pour informer de son rôle/utilité/. Dans ce cas, il ne faut pas mettre d'`aria-hidden=true"` sur l'icone `<i class="ri-*></i>` mais un `aria-label="xxx"`.
