### PR TITLE
[GEN-727] Rewording de l’onglet “Recrutement en cours” pour les entreprises sans fiche de poste afin de cesser de décourager les candidatures spontanées.

### DIFF
--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -154,7 +154,9 @@
                         <li class="nav-item" role="presentation">
                             <a id="recrutements-en-cours-tab" class="nav-link active" role="tab" href="#recrutements-en-cours" data-bs-toggle="tab" aria-selected="true" aria-controls="recrutements-en-cours">
                                 <span>Recrutement{{ active_job_descriptions|pluralizefr }} en cours</span>
-                                <span class="badge badge-sm rounded-pill ms-2">{{ active_job_descriptions|length }}</span>
+                                {% if active_job_descriptions %}
+                                    <span class="badge badge-sm rounded-pill ms-2">{{ active_job_descriptions|length }}</span>
+                                {% endif %}
                             </a>
                         </li>
                         {% if other_job_descriptions %}
@@ -175,7 +177,7 @@
                                     {% endfor %}
                                 </ul>
                             {% else %}
-                                <p class="mb-0">Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
+                                <p class="mb-0">Cet employeur accepte de recevoir des candidatures spontanées.</p>
                             {% endif %}
                         </div>
                         {% if other_job_descriptions %}

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -51,7 +51,7 @@
                     </div>
                 {% endif %}
             {% endif %}
-            {% if active_jobs_descriptions or other_jobs_descriptions %}
+            {% if active_job_descriptions or other_job_descriptions %}
                 <div class="form-group col-12 col-lg-auto">
                     <a href="#metiers" class="btn btn-lg btn-outline-white btn-block btn-ico">
                         <i class="ri-eye-line fw-medium" aria-hidden="true"></i>
@@ -153,24 +153,24 @@
                     <ul class="s-tabs-01__nav nav nav-tabs" role="tablist" data-it-sliding-tabs="true" aria-labelledby="metiers-title">
                         <li class="nav-item" role="presentation">
                             <a id="recrutements-en-cours-tab" class="nav-link active" role="tab" href="#recrutements-en-cours" data-bs-toggle="tab" aria-selected="true" aria-controls="recrutements-en-cours">
-                                <span>Recrutement{{ active_jobs_descriptions|pluralizefr }} en cours</span>
-                                <span class="badge badge-sm rounded-pill ms-2">{{ active_jobs_descriptions|length }}</span>
+                                <span>Recrutement{{ active_job_descriptions|pluralizefr }} en cours</span>
+                                <span class="badge badge-sm rounded-pill ms-2">{{ active_job_descriptions|length }}</span>
                             </a>
                         </li>
-                        {% if other_jobs_descriptions %}
+                        {% if other_job_descriptions %}
                             <li class="nav-item" role="presentation">
                                 <a id="autres-metiers-tab" class="nav-link" role="tab" href="#autres-metiers" data-bs-toggle="tab" aria-selected="false" aria-controls="autres-metiers">
-                                    <span>{{ other_jobs_descriptions|pluralizefr:"Autre métier exercé,Autres métiers exercés" }}</span>
-                                    <span class="badge badge-sm rounded-pill ms-2">{{ other_jobs_descriptions|length }}</span>
+                                    <span>{{ other_job_descriptions|pluralizefr:"Autre métier exercé,Autres métiers exercés" }}</span>
+                                    <span class="badge badge-sm rounded-pill ms-2">{{ other_job_descriptions|length }}</span>
                                 </a>
                             </li>
                         {% endif %}
                     </ul>
                     <div class="tab-content">
                         <div id="recrutements-en-cours" class="tab-pane fade active show" aria-labelledby="recrutements-en-cours-tab" role="tabpanel">
-                            {% if active_jobs_descriptions %}
+                            {% if active_job_descriptions %}
                                 <ul class="list-group list-group-flush list-group-link">
-                                    {% for job in active_jobs_descriptions %}
+                                    {% for job in active_job_descriptions %}
                                         {% include "companies/includes/_siae_jobdescription.html" %}
                                     {% endfor %}
                                 </ul>
@@ -178,10 +178,10 @@
                                 <p class="mb-0">Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
                             {% endif %}
                         </div>
-                        {% if other_jobs_descriptions %}
+                        {% if other_job_descriptions %}
                             <div id="autres-metiers" class="tab-pane fade" aria-labelledby="autres-metiers-tab" role="tabpanel">
                                 <ul class="list-group list-group-flush list-group-link">
-                                    {% for job in other_jobs_descriptions %}
+                                    {% for job in other_job_descriptions %}
                                         {% include "companies/includes/_siae_jobdescription.html" %}
                                     {% endfor %}
                                 </ul>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -76,7 +76,7 @@
                         </div>
                     {% endif %}
                 {% endif %}
-                {% if others_active_jobs and not siae.block_job_applications %}
+                {% if other_active_jobs and not siae.block_job_applications %}
                     <div class="form-group col-12 col-lg-auto">
                         <a href="#recrutements" class="btn btn-lg btn-outline-white btn-block btn-ico">
                             <i class="ri-eye-line fw-medium" aria-hidden="true"></i>
@@ -122,7 +122,7 @@
         </div>
     </section>
 
-    {% if others_active_jobs and not siae.block_job_applications %}
+    {% if other_active_jobs and not siae.block_job_applications %}
         <section id="recrutements" class="s-tabs-01 mt-0 pt-0">
             <div class="s-tabs-01__container container">
                 <div class="s-tabs-01__row row">
@@ -131,16 +131,16 @@
                         <ul class="s-tabs-01__nav nav nav-tabs" role="tablist" data-it-sliding-tabs="true" aria-labelledby="recrutements-title">
                             <li class="nav-item" role="presentation">
                                 <a id="recrutements-en-cours-tab" class="nav-link active" role="tab" href="#recrutements-en-cours" data-bs-toggle="tab" aria-selected="true" aria-controls="recrutements-en-cours">
-                                    <span>Recrutement{{ others_active_jobs|pluralizefr }} en cours dans cette structure</span>
-                                    <span class="badge badge-sm rounded-pill ms-2">{{ others_active_jobs|length }}</span>
+                                    <span>Recrutement{{ other_active_jobs|pluralizefr }} en cours dans cette structure</span>
+                                    <span class="badge badge-sm rounded-pill ms-2">{{ other_active_jobs|length }}</span>
                                 </a>
                             </li>
                         </ul>
                         <div class="tab-content">
                             <div id="recrutements-en-cours" class="tab-pane fade active show" aria-labelledby="recrutements-en-cours-tab" role="tabpanel">
-                                {% if others_active_jobs %}
+                                {% if other_active_jobs %}
                                     <ul class="list-group list-group-flush list-group-link">
-                                        {% for other_job in others_active_jobs %}
+                                        {% for other_job in other_active_jobs %}
                                             {% include "companies/includes/_siae_jobdescription.html" with job=other_job %}
                                         {% endfor %}
                                     </ul>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -138,15 +138,11 @@
                         </ul>
                         <div class="tab-content">
                             <div id="recrutements-en-cours" class="tab-pane fade active show" aria-labelledby="recrutements-en-cours-tab" role="tabpanel">
-                                {% if other_active_jobs %}
-                                    <ul class="list-group list-group-flush list-group-link">
-                                        {% for other_job in other_active_jobs %}
-                                            {% include "companies/includes/_siae_jobdescription.html" with job=other_job %}
-                                        {% endfor %}
-                                    </ul>
-                                {% else %}
-                                    <p class="mb-0">Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
-                                {% endif %}
+                                <ul class="list-group list-group-flush list-group-link">
+                                    {% for other_job in other_active_jobs %}
+                                        {% include "companies/includes/_siae_jobdescription.html" with job=other_job %}
+                                    {% endfor %}
+                                </ul>
                             </div>
                         </div>
                     </div>

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -141,7 +141,7 @@ class JobDescriptionCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, Temp
         )
 
         # select_related on company, location useful for _list_siae_actives_jobs_row.html template
-        others_active_jobs = (
+        other_active_jobs = (
             JobDescription.objects.select_related("appellation", "company", "location")
             .filter(is_active=True, company=company)
             .exclude(id=self.job_description.pk)
@@ -159,7 +159,7 @@ class JobDescriptionCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, Temp
             "job": self.job_description,
             "siae": company,
             "can_update_job_description": can_update_job_description,
-            "others_active_jobs": others_active_jobs,
+            "other_active_jobs": other_active_jobs,
             "back_url": back_url,
             "matomo_custom_title": "Détails de la fiche de poste",
             "code_insee": code_insee,
@@ -460,24 +460,24 @@ class CompanyCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, TemplateVie
 
     def get_context_data(self, **kwargs):
         back_url = get_safe_url(self.request, "back_url")
-        jobs_descriptions = JobDescription.objects.filter(company=self.company).select_related(
+        job_descriptions = JobDescription.objects.filter(company=self.company).select_related(
             "appellation", "location"
         )
-        active_jobs_descriptions = []
+        active_job_descriptions = []
         if self.company.block_job_applications:
-            other_jobs_descriptions = jobs_descriptions
+            other_job_descriptions = job_descriptions
         else:
-            other_jobs_descriptions = []
-            for job_desc in jobs_descriptions:
+            other_job_descriptions = []
+            for job_desc in job_descriptions:
                 if job_desc.is_active:
-                    active_jobs_descriptions.append(job_desc)
+                    active_job_descriptions.append(job_desc)
                 else:
-                    other_jobs_descriptions.append(job_desc)
+                    other_job_descriptions.append(job_desc)
 
         return super().get_context_data(**kwargs) | {
             "siae": self.company,
-            "active_jobs_descriptions": active_jobs_descriptions,
-            "other_jobs_descriptions": other_jobs_descriptions,
+            "active_job_descriptions": active_job_descriptions,
+            "other_job_descriptions": other_job_descriptions,
             "matomo_custom_title": "Fiche de la structure d'insertion",
             "code_insee": self.company.insee_city.code_insee if self.company.insee_city else None,
             "siae_card_absolute_url": get_absolute_url(

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -5,7 +5,7 @@
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
-                                  <span class="badge badge-sm rounded-pill ms-2">0</span>
+                                  
                               </a>
                           </li>
                           
@@ -24,7 +24,7 @@
   <div class="tab-content">
                           <div aria-labelledby="recrutements-en-cours-tab" class="tab-pane fade active show" id="recrutements-en-cours" role="tabpanel">
                               
-                                  <p class="mb-0">Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
+                                  <p class="mb-0">Cet employeur accepte de recevoir des candidatures spontanées.</p>
                               
                           </div>
                           
@@ -73,7 +73,9 @@
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
-                                  <span class="badge badge-sm rounded-pill ms-2">1</span>
+                                  
+                                      <span class="badge badge-sm rounded-pill ms-2">1</span>
+                                  
                               </a>
                           </li>
                           
@@ -182,7 +184,7 @@
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
-                                  <span class="badge badge-sm rounded-pill ms-2">0</span>
+                                  
                               </a>
                           </li>
                           
@@ -201,7 +203,7 @@
   <div class="tab-content">
                           <div aria-labelledby="recrutements-en-cours-tab" class="tab-pane fade active show" id="recrutements-en-cours" role="tabpanel">
                               
-                                  <p class="mb-0">Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
+                                  <p class="mb-0">Cet employeur accepte de recevoir des candidatures spontanées.</p>
                               
                           </div>
                           
@@ -396,7 +398,7 @@
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
-                                  <span class="badge badge-sm rounded-pill ms-2">0</span>
+                                  
                               </a>
                           </li>
                           
@@ -404,7 +406,7 @@
                       <div class="tab-content">
                           <div aria-labelledby="recrutements-en-cours-tab" class="tab-pane fade active show" id="recrutements-en-cours" role="tabpanel">
                               
-                                  <p class="mb-0">Pour le moment, il n’y a aucun recrutement en cours dans cette structure.</p>
+                                  <p class="mb-0">Cet employeur accepte de recevoir des candidatures spontanées.</p>
                               
                           </div>
                           
@@ -426,7 +428,9 @@
                           <li class="nav-item" role="presentation">
                               <a aria-controls="recrutements-en-cours" aria-selected="true" class="nav-link active" data-bs-toggle="tab" href="#recrutements-en-cours" id="recrutements-en-cours-tab" role="tab">
                                   <span>Recrutement en cours</span>
-                                  <span class="badge badge-sm rounded-pill ms-2">1</span>
+                                  
+                                      <span class="badge badge-sm rounded-pill ms-2">1</span>
+                                  
                               </a>
                           </li>
                           

--- a/tests/www/companies_views/test_card_views.py
+++ b/tests/www/companies_views/test_card_views.py
@@ -358,8 +358,8 @@ class TestJobDescriptionCardView:
         assertNotContains(response, OPEN_POSITION_TEXT)
 
         # Check other jobs
-        assert response.context["others_active_jobs"].count() == 3
-        for other_active_job in response.context["others_active_jobs"]:
+        assert response.context["other_active_jobs"].count() == 3
+        for other_active_job in response.context["other_active_jobs"]:
             assertContains(response, other_active_job.display_name, html=True)
 
         response = client.get(add_url_params(url, {"back_url": reverse("companies_views:job_description_list")}))


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'ancien wording décourage clairement les candidatures spontanées :

![image](https://github.com/user-attachments/assets/e1ff21ac-f00e-4d6d-a7c7-8fae9c0ef823)

## :cake: Comment ?

Avec ce nouveau wording qui :
- ne mentionne pas qu'il n'y a pas de fiche ouverte
- ne mentionne pas le chiffre zéro
- encourage explicitement la candidature spontanée
- est validé ✅ par le métier (Marion) ce jeudi 13 février ([lien de la négociation](https://gip-inclusion.slack.com/archives/CQ6C3LSAH/p1739457684705049))

![image](https://github.com/user-attachments/assets/5634a944-35c0-4ff7-85a0-d8ef1a01c587)

## :rotating_light: Notes

Pour les entreprises avec au moins une fiche de poste. le wording est inchangé :

![image](https://github.com/user-attachments/assets/5221562a-099f-450a-994c-5112acae1fe7)

## 🚨 Notes techniques

Un peu de nettoyage en passant.
