### PR TITLE
Tech: correction de configuration des logs `huey`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -311,6 +311,10 @@ LOGGING = {
         # Huey; async tasks
         "huey": {
             "level": os.getenv("HUEY_LOG_LEVEL", "WARNING"),
+            # Define a null handler to prevent huey from adding a StreamHandler:
+            # https://github.com/coleifer/huey/blob/2.5.2/huey/contrib/djhuey/management/commands/run_huey.py#L87-L88
+            # We'll still get the logs since they will propagate to root handlers
+            "handlers": ["null"],
         },
     },
 }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, `huey` rajoute un `StreamHandler` sur son logger, cf:

- https://github.com/coleifer/huey/blob/2.5.2/huey/contrib/djhuey/management/commands/run_huey.py#L87-L88
- https://github.com/coleifer/huey/blob/2.5.2/huey/consumer_options.py#L147-L170

alors même que les logs sont propagés au logger racine et ses handlers.

On se retrouve alors avec des logs en double dont l'un n'est pas du JSON [polluant fortement nos logs](https://app.datadoghq.eu/logs?query=service%3Aitou-prod&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1739304820000&to_ts=1739304840000&live=false) lorsqu'il y a des tracebacks.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
