### PR TITLE
MàJ d’un setting pour django-allauth 65.4.0

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -333,7 +333,7 @@ AUTHENTICATION_BACKENDS = (
 # https://django-allauth.readthedocs.io/en/latest/advanced.html#custom-redirects
 ACCOUNT_ADAPTER = "itou.users.adapter.UserAdapter"
 
-ACCOUNT_AUTHENTICATION_METHOD = "email"
+ACCOUNT_LOGIN_METHODS = {"email"}
 ACCOUNT_CONFIRM_EMAIL_ON_GET = True
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un warning indique une migration à venir.

Doc correspondante :
https://docs.allauth.org/en/latest/release-notes/recent.html#:~:text=The%20setting%20ACCOUNT_AUTHENTICATION_METHOD:%20str,This%20change%20is%20performed%20in%20a%20backwards%20compatible%20manner.
