### PR TITLE
 Profil salarié : afficher l’encart Immersion Facilitée de la page de tous les salariés [GEN-355]

### DIFF
--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -41,7 +41,7 @@
                         {% include "approvals/includes/box.html" with approval=approval link_from_current_url=request.get_full_path extra_class='mb-3 mb-md-4' only %}
                     {% endif %}
                     {% if link_immersion_facile %}
-                        {# Immersion Facilitée proposal on expiring passes #}
+                        {# Immersion Facilitée proposal on all passes #}
                         <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
                             <div class="c-box__header--immersion-facile p-3 p-lg-4">
                                 <span class="h4 m-0">Trouver une immersion</span>
@@ -51,11 +51,14 @@
                                     {% if approval_expired %}
                                         Le pass de ce candidat est expiré.
                                         <br />
-                                    {% else %}
+                                        <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
+                                    {% elif approval_expires_soon %}
                                         Le pass IAE de ce candidat arrive bientôt à expiration.
                                         <br />
+                                        <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
+                                    {% else %}
+                                        <strong>Immersion Facilitée</strong> vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
                                     {% endif %}
-                                    <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                 </p>
                                 <a href="{{ link_immersion_facile }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)">
                                     Rechercher une immersion

--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -41,7 +41,7 @@
                         {% include "approvals/includes/box.html" with approval=approval link_from_current_url=request.get_full_path extra_class='mb-3 mb-md-4' only %}
                     {% endif %}
                     {% if link_immersion_facile %}
-                        {# Immersion Facilitée proposal on all passes #}
+                        {# Immersion Facilitée proposal #}
                         <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
                             <div class="c-box__header--immersion-facile p-3 p-lg-4">
                                 <span class="h4 m-0">Trouver une immersion</span>

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -119,9 +119,10 @@ class EmployeeDetailView(DetailView):
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
         context["link_immersion_facile"] = None
 
-        if approval and approval.remainder.days < 90 and self.request.user.is_employer:
+        if approval and self.request.user.is_employer:
             context["link_immersion_facile"] = immersion_search_url(approval.user)
             context["approval_expired"] = not approval.is_in_progress
+            context["approval_expires_soon"] = approval.remainder.days < 90
 
         context["all_job_applications"] = (
             JobApplication.objects.filter(

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -119,10 +119,9 @@ class EmployeeDetailView(DetailView):
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
         context["link_immersion_facile"] = None
 
-        if approval:
-            context["link_immersion_facile"] = immersion_search_url(approval.user)
-            context["approval_expired"] = not approval.is_in_progress
-            context["approval_expires_soon"] = approval.remainder.days < 90
+        context["link_immersion_facile"] = immersion_search_url(self.object)
+        context["approval_expired"] = approval and not approval.is_in_progress
+        context["approval_expires_soon"] = approval and approval.remainder.days < 90
 
         context["all_job_applications"] = (
             JobApplication.objects.filter(

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -119,7 +119,7 @@ class EmployeeDetailView(DetailView):
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
         context["link_immersion_facile"] = None
 
-        if approval and self.request.user.is_employer:
+        if approval:
             context["link_immersion_facile"] = immersion_search_url(approval.user)
             context["approval_expired"] = not approval.is_in_progress
             context["approval_expires_soon"] = approval.remainder.days < 90

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1479,6 +1479,46 @@
     ]),
   })
 # ---
+# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expirant bientôt]
+  '''
+  <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
+                              <div class="c-box__header--immersion-facile p-3 p-lg-4">
+                                  <span class="h4 m-0">Trouver une immersion</span>
+                              </div>
+                              <div class="p-3 p-lg-4">
+                                  <p>
+                                      
+                                          Le pass IAE de ce candidat arrive bientôt à expiration.
+                                          <br/>
+                                          <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
+                                      
+                                  </p>
+                                  <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                                      Rechercher une immersion
+                                  </a>
+                              </div>
+                          </div>
+  '''
+# ---
+# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expirant dans longtemps]
+  '''
+  <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
+                              <div class="c-box__header--immersion-facile p-3 p-lg-4">
+                                  <span class="h4 m-0">Trouver une immersion</span>
+                              </div>
+                              <div class="p-3 p-lg-4">
+                                  <p>
+                                      
+                                          <strong>Immersion Facilitée</strong> vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
+                                      
+                                  </p>
+                                  <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                                      Rechercher une immersion
+                                  </a>
+                              </div>
+                          </div>
+  '''
+# ---
 # name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expiré]
   '''
   <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
@@ -1490,29 +1530,8 @@
                                       
                                           Le pass de ce candidat est expiré.
                                           <br/>
+                                          <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                       
-                                      <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
-                                  </p>
-                                  <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
-                                      Rechercher une immersion
-                                  </a>
-                              </div>
-                          </div>
-  '''
-# ---
-# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile]
-  '''
-  <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
-                              <div class="c-box__header--immersion-facile p-3 p-lg-4">
-                                  <span class="h4 m-0">Trouver une immersion</span>
-                              </div>
-                              <div class="p-3 p-lg-4">
-                                  <p>
-                                      
-                                          Le pass IAE de ce candidat arrive bientôt à expiration.
-                                          <br/>
-                                      
-                                      <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                   </p>
                                   <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
                                       Rechercher une immersion

--- a/tests/www/employees_views/test_detail.py
+++ b/tests/www/employees_views/test_detail.py
@@ -196,7 +196,7 @@ class TestEmployeeDetailView:
         response = client.get(url)
         assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
-        assert str(alert) == snapshot(name="alerte à l'opportunité immersion facile")
+        assert str(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expirant bientôt")
 
         approval.end_at = today - datetime.timedelta(days=1)
         approval.save()
@@ -208,5 +208,6 @@ class TestEmployeeDetailView:
         approval.end_at = today + datetime.timedelta(days=90)
         approval.save()
         response = client.get(url)
-        assert response.status_code == 200
-        assert response.context["link_immersion_facile"] is None
+        assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
+        alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
+        assert str(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expirant dans longtemps")


### PR DESCRIPTION
## :thinking: Pourquoi ?

La mise en place de l’encart IF sur la page salarié ne semble pas avoir d’impact sur les sorties positives. Nombre de visites très faible. 243 depuis début octobre. Taux de conversion à 0,6% sur 2024. ( 1 demande d’immersion au total sur 2024)

## :cake: Comment ?

On l’affiche sur toutes les pages salarié et pas seulement celles dont les PASS arrivent à expiration dans moins de 90 jours.

Techniquement on passe de 2 à 3 cas, voir plus bas.

## :computer: Captures d'écran <!-- optionnel -->

### Cas 1 inchangé : pass expiré

![image](https://github.com/user-attachments/assets/6e042835-a1c8-4b50-8c91-eeebeae76f87)

### Cas 2 inchangé : pass expirant dans moins de 3 mois

![image](https://github.com/user-attachments/assets/0aaa29bc-8805-469f-a53c-aadb6e50c4f7)

### Cas 3 nouveau : pass expirant dans plus de 3 mois ou pas de pass => wording validé par Marion ✅ 

![image](https://github.com/user-attachments/assets/a2806107-347b-4790-928e-07e5ac09dc5c)

