### PR TITLE
Fiches salarié : Améliorations pour le désarchivage et la création automatique des notifications

### DIFF
--- a/itou/approvals/migrations/0011_allow_more_status_for_employee_record_notifications.py
+++ b/itou/approvals/migrations/0011_allow_more_status_for_employee_record_notifications.py
@@ -1,0 +1,32 @@
+import pgtrigger.compiler
+import pgtrigger.migrations
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0010_alter_approval_origin_prescriber_organization_kind_and_more"),
+    ]
+
+    operations = [
+        pgtrigger.migrations.RemoveTrigger(
+            model_name="approval",
+            name="create_employee_record_notification",
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name="approval",
+            trigger=pgtrigger.compiler.Trigger(
+                name="create_employee_record_notification",
+                sql=pgtrigger.compiler.UpsertTriggerSql(
+                    condition='WHEN (OLD."end_at" IS DISTINCT FROM (NEW."end_at") OR OLD."start_at" IS DISTINCT FROM (NEW."start_at"))',  # noqa: E501
+                    declare="DECLARE current_employee_record_id INT;",
+                    func="\n                    -- If there is an \"UPDATE\" action on 'approvals_approval' table (Approval model object):\n                    -- create an `EmployeeRecordUpdateNotification` object for each PROCESSED `EmployeeRecord`\n                    -- linked to this approval\n                    IF (TG_OP = 'UPDATE') THEN\n                        -- Only for update operations:\n                        -- iterate through processed employee records linked to this approval\n                        FOR current_employee_record_id IN\n                            SELECT id FROM employee_record_employeerecord\n                            WHERE approval_number = NEW.number\n                            AND status IN (\n                                'PROCESSED', 'SENT', 'DISABLED'\n                            )\n                            LOOP\n                                -- Create `EmployeeRecordUpdateNotification` object\n                                -- with the correct type and status\n                                INSERT INTO employee_record_employeerecordupdatenotification\n                                    (employee_record_id, created_at, updated_at, status)\n                                SELECT current_employee_record_id, NOW(), NOW(), 'NEW'\n                                -- Update it if already created (UPSERT)\n                                -- On partial indexes conflict, the where clause of the index must be added here\n                                ON conflict(employee_record_id) WHERE status = 'NEW'\n                                DO\n                                -- Not exactly the same syntax as a standard update op\n                                UPDATE SET updated_at = NOW();\n                            END LOOP;\n                    END IF;\n                    RETURN NULL;\n                ",  # noqa: E501
+                    hash="45442e1728b9b05d5e386610f84a528e6426a5ba",
+                    operation='UPDATE OF "start_at", "end_at"',
+                    pgid="pgtrigger_create_employee_record_notification_0b059",
+                    table="approvals_approval",
+                    when="AFTER",
+                ),
+            ),
+        ),
+    ]

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -593,7 +593,9 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
                         FOR current_employee_record_id IN
                             SELECT id FROM employee_record_employeerecord
                             WHERE approval_number = NEW.number
-                            AND status = '{Status.PROCESSED.value}'
+                            AND status IN (
+                                '{Status.PROCESSED.value}', '{Status.SENT.value}', '{Status.DISABLED.value}'
+                            )
                             LOOP
                                 -- Create `EmployeeRecordUpdateNotification` object
                                 -- with the correct type and status

--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -97,15 +97,29 @@ class EmployeeRecordTransitionLogInline(ReadonlyMixin, ItouTabularInline):
     extra = 0
     fields = (
         "transition",
-        "from_state",
-        "to_state",
+        "from_state_display",
+        "to_state_display",
         "user",
         "timestamp",
-        "asp_processing_code",
-        "asp_processing_label",
+        "asp_processing_display",
         "asp_batch_file",
     )
+    readonly_fields = fields
     raw_id_fields = ("user",)
+
+    @admin.display(description="statut initial")
+    def from_state_display(self, obj):
+        return obj.get_modified_object().status.workflow.states[obj.from_state].title
+
+    @admin.display(description="statut final")
+    def to_state_display(self, obj):
+        return obj.get_modified_object().status.workflow.states[obj.to_state].title
+
+    @admin.display(description="traitement ASP")
+    def asp_processing_display(self, obj):
+        if obj.asp_processing_code or self.asp_processing_label:
+            return f"{obj.asp_processing_code}/{obj.asp_processing_label}"
+        return self.get_empty_value_display()
 
 
 @admin.register(models.EmployeeRecord)

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -359,11 +359,15 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
 
     @xworkflows.transition_check(EmployeeRecordTransition.UNARCHIVE_PROCESSED)
     def check_unarchive_processed(self):
-        return self.asp_processing_code in ["0000", "3436"]
+        return self.asp_processing_code in ["0000", self.ASP_DUPLICATE_ERROR_CODE]
 
     @xworkflows.transition_check(EmployeeRecordTransition.UNARCHIVE_REJECTED)
     def check_unarchive_rejected(self):
-        return self.asp_processing_code and self.asp_processing_code[:2] in ["32", "33", "34"]
+        return (
+            self.asp_processing_code
+            and self.asp_processing_code[:2] in ["32", "33", "34"]
+            and self.asp_processing_code != self.ASP_DUPLICATE_ERROR_CODE
+        )
 
     def unarchive(self):
         for transition_name in [

--- a/tests/employee_record/__snapshots__/test_admin.ambr
+++ b/tests/employee_record/__snapshots__/test_admin.ambr
@@ -55,3 +55,43 @@
           </div>
   '''
 # ---
+# name: test_available_transitions_for_unarchive[0000]
+  '''
+  <div class="submit-row" id="employee-record-transitions">
+              <p>Changer l'état de la fiche salarié :</p>
+              
+                  <input class="danger js-with-confirm" name="transition_unarchive_processed" type="submit" value="Intégrée"/>
+              
+          </div>
+  '''
+# ---
+# name: test_available_transitions_for_unarchive[32##]
+  '''
+  <div class="submit-row" id="employee-record-transitions">
+              <p>Changer l'état de la fiche salarié :</p>
+              
+                  <input class="danger js-with-confirm" name="transition_unarchive_rejected" type="submit" value="En erreur"/>
+              
+          </div>
+  '''
+# ---
+# name: test_available_transitions_for_unarchive[3436]
+  '''
+  <div class="submit-row" id="employee-record-transitions">
+              <p>Changer l'état de la fiche salarié :</p>
+              
+                  <input class="danger js-with-confirm" name="transition_unarchive_processed" type="submit" value="Intégrée"/>
+              
+          </div>
+  '''
+# ---
+# name: test_available_transitions_for_unarchive[]
+  '''
+  <div class="submit-row" id="employee-record-transitions">
+              <p>Changer l'état de la fiche salarié :</p>
+              
+                  <input class="danger js-with-confirm" name="transition_unarchive_new" type="submit" value="Nouvelle"/>
+              
+          </div>
+  '''
+# ---

--- a/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
@@ -3,7 +3,7 @@
   list([
     'found 1 missed employee records notifications',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
-    '1/1 notifications created',
+    '1/1 employee records were unarchived',
   ])
 # ---
 # name: test_missed_notifications_limit
@@ -11,6 +11,6 @@
     'found 3 missed employee records notifications',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
-    '2/3 notifications created',
+    '2/3 employee records were unarchived',
   ])
 # ---

--- a/tests/employee_record/test_admin.py
+++ b/tests/employee_record/test_admin.py
@@ -133,3 +133,11 @@ def test_available_transitions(snapshot, client, status):
     client.force_login(ro_user)
     response = client.get(url)
     assertNotContains(response, '<div class="submit-row" id="employee-record-transitions">')
+
+
+@pytest.mark.parametrize("code", ["", "0000", "32##", "3436"])
+def test_available_transitions_for_unarchive(faker, snapshot, admin_client, code):
+    employee_record = EmployeeRecordFactory(status=Status.ARCHIVED, asp_processing_code=faker.numerify(code))
+
+    response = admin_client.get(reverse("admin:employee_record_employeerecord_change", args=[employee_record.pk]))
+    assert str(parse_response_to_soup(response, "#employee-record-transitions")) == snapshot()

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -268,6 +268,22 @@ class TestEmployeeRecordModel:
         employee_record_after_approval.unarchive()
         assert employee_record_after_approval.update_notifications.all().count() == 0
 
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            (None, Status.NEW),
+            ("0000", Status.PROCESSED),
+            ("31", None),
+            ("32", Status.REJECTED),
+            ("33", Status.REJECTED),
+            ("34", Status.REJECTED),
+            ("3436", Status.PROCESSED),
+        ],
+    )
+    def test_status_based_on_asp_processing_code(self, code, expected):
+        employee_record = BareEmployeeRecordFactory(asp_processing_code=code)
+        assert employee_record.status_based_on_asp_processing_code is expected
+
 
 @pytest.mark.parametrize(
     "factory,expected",

--- a/tests/employee_record/test_notifications.py
+++ b/tests/employee_record/test_notifications.py
@@ -11,11 +11,12 @@ from tests.employee_record.factories import EmployeeRecordFactory
 
 
 class TestEmployeeRecordUpdateNotification:
-    def test_update_approval_start_date(self):
+    @pytest.mark.parametrize("status", [Status.PROCESSED, Status.SENT, Status.DISABLED])
+    def test_update_approval_start_date(self, status):
         # If a modification occurs on the `start_date` field of an approval linked to a processed employee record
         # then exactly *one* 'NEW' notification objects must be created.
         # A normal case
-        employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
+        employee_record = EmployeeRecordFactory(status=status)
         approval = employee_record.job_application.approval
         today = timezone.localdate()
 
@@ -26,11 +27,12 @@ class TestEmployeeRecordUpdateNotification:
         assert today + timedelta(days=1) == approval.start_at
         assert 1 == EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).count()
 
-    def test_update_approval_end_date(self):
+    @pytest.mark.parametrize("status", [Status.PROCESSED, Status.SENT, Status.DISABLED])
+    def test_update_approval_end_date(self, status):
         # If a modification occurs on the `end_date` field of an approval linked to a processed employee record
         # then exactly *one* 'NEW' notification objects must be created.
         # Another normal case
-        employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
+        employee_record = EmployeeRecordFactory(status=status)
         approval = employee_record.job_application.approval
         today = timezone.localdate()
 
@@ -41,11 +43,12 @@ class TestEmployeeRecordUpdateNotification:
         assert today + timedelta(days=2) == approval.end_at
         assert 1 == EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).count()
 
-    def test_update_approval_twice(self):
+    @pytest.mark.parametrize("status", [Status.PROCESSED, Status.SENT, Status.DISABLED])
+    def test_update_approval_twice(self, status):
         # If SEVERAL modifications occurs on a monitored field of an approval linked to a processed employee record
         # then exactly *one* 'NEW' notification objects must be created,
         # (which is the last one)
-        employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
+        employee_record = EmployeeRecordFactory(status=status)
         approval = employee_record.job_application.approval
         today = timezone.localdate()
 
@@ -62,11 +65,12 @@ class TestEmployeeRecordUpdateNotification:
         assert today == approval.start_at
         assert 1 == EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).count()
 
-    def test_update_non_monitored_fields(self):
+    @pytest.mark.parametrize("status", [Status.PROCESSED, Status.SENT, Status.DISABLED])
+    def test_update_non_monitored_fields(self, status):
         # If a modification occurs on an approval linked to any or no employee record,
         # And the target fields are not monitored
         # Then there is no creation of an EmployeeRecordUpdateNotification object.
-        employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
+        employee_record = EmployeeRecordFactory(status=status)
         approval = employee_record.job_application.approval
 
         approval.created_at = timezone.localtime()
@@ -86,7 +90,7 @@ class TestEmployeeRecordUpdateNotification:
 
         assert 0 == EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).count()
 
-    @pytest.mark.parametrize("status", [elt for elt in Status.values if elt != Status.PROCESSED])
+    @pytest.mark.parametrize("status", set(Status) - {Status.PROCESSED, Status.SENT, Status.DISABLED})
     def test_update_on_non_processed_employee_record(self, status):
         # If a date modification occurs on an approval linked to an employee record NOT in processed state,
         # then no notification object must be created.
@@ -122,10 +126,11 @@ class TestEmployeeRecordUpdateNotification:
             ordered=False,
         )
 
-    def test_update_with_suspension(self):
+    @pytest.mark.parametrize("status", [Status.PROCESSED, Status.SENT, Status.DISABLED])
+    def test_update_with_suspension(self, status):
         # Creation of a suspension on an approval linked to an employee record
         # must also create a new employee record update notification.
-        employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
+        employee_record = EmployeeRecordFactory(status=status)
         approval = employee_record.job_application.approval
         start_at = timezone.localdate()
 
@@ -137,10 +142,11 @@ class TestEmployeeRecordUpdateNotification:
         assert 1 == EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).count()
         assert employee_record.pk == EmployeeRecordUpdateNotification.objects.earliest("created_at").employee_record.pk
 
-    def test_update_with_prolongation(self):
+    @pytest.mark.parametrize("status", [Status.PROCESSED, Status.SENT, Status.DISABLED])
+    def test_update_with_prolongation(self, status):
         # Creation of a prolongation on an approval linked to an employee record
         # must also create a new employee record update notification.
-        employee_record = EmployeeRecordFactory(status=Status.PROCESSED)
+        employee_record = EmployeeRecordFactory(status=status)
         approval = employee_record.job_application.approval
 
         ProlongationFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Commits :
1. Plus simple pour les échanges et la compréhension général
2. On se retrouvais à avoir 2 boutons, autant blinder la chose et faire comme le système aurais fait
3. Évite une manipulation en plus quand on désarchive depuis l'admin
4. On est jamais à l’abri d'une surprise, donc autant qu'un changement sur les statuts soit visible là où ils sont utilisés
5. `SENT` car on peux tomber dans le cas où la FS est en cours d'envoi et que le PASS est modifié. `DISABLED` on suppose qu'elle a été intégrée, au pire on aura une erreur, mais l'idée est que c'est plus embêtant d'en rater une que d'en faire une de trop.
6. Car... Comment dire... J'ai été clenché, OK ! :angel: 

## :desert_island: Comment tester ?

La suite de test couvre les cas normalements
