### PR TITLE
[GEN-2208] Changement d’intitulé pour le filtre des candidatures archivées

### DIFF
--- a/itou/templates/apply/includes/job_applications_filters/offcanvas_body.html
+++ b/itou/templates/apply/includes/job_applications_filters/offcanvas_body.html
@@ -29,7 +29,7 @@
             <input type="hidden" name="{{ filters_form.job_seeker.name }}" value="{{ filters_form.job_seeker.value }}">
         {% endif %}
         <hr>
-        {% include "apply/includes/job_applications_filters/field_collapse.html" with field=filters_form.archived legend="Type de candidature" only %}
+        {% include "apply/includes/job_applications_filters/field_collapse.html" with field=filters_form.archived legend="Candidatures archivées" only %}
     {% endif %}
     {% include "apply/includes/job_applications_filters/dates.html" %}
 </div>

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -3290,7 +3290,7 @@
   
   <fieldset>
       <legend>
-          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Type de candidature</button>
+          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Candidatures archivées</button>
       </legend>
       <div class="mt-3 collapse" id="collapse-archived"><div class="form-group"><div class="" id="id_archived">
       
@@ -3560,7 +3560,7 @@
   
   <fieldset>
       <legend>
-          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Type de candidature</button>
+          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Candidatures archivées</button>
       </legend>
       <div class="mt-3 collapse" id="collapse-archived"><div class="form-group"><div class="" id="id_archived">
       
@@ -3804,7 +3804,7 @@
   
   <fieldset>
       <legend>
-          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Type de candidature</button>
+          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Candidatures archivées</button>
       </legend>
       <div class="mt-3 collapse" id="collapse-archived"><div class="form-group"><div class="" id="id_archived">
       

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -2396,7 +2396,7 @@
   
   <fieldset>
       <legend>
-          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Type de candidature</button>
+          <button aria-controls="collapse-archived" aria-expanded="false" class="btn btn-outline-transparent has-collapse-caret collapsed" data-bs-target="#collapse-archived" data-bs-toggle="collapse" type="button">Candidatures archivées</button>
       </legend>
       <div class="mt-3 collapse" id="collapse-archived"><div class="form-group"><div class="" id="id_archived">
       


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à des retours utilisateurs, nous voulons changer le wording du filtre

## :cake: Comment ? <!-- optionnel -->

<img width="210" alt="image" src="https://github.com/user-attachments/assets/63161920-d7bc-4f8c-bd85-3aa0e8a846df" />

## :desert_island: Comment tester ?

login employeur > candidatures > tous les filtres

## :computer: Captures d'écran <!-- optionnel -->

Avant, en démo :

![image](https://github.com/user-attachments/assets/042afaa7-c642-45da-9dc4-25e39edf359b)

Après, en local :

![image](https://github.com/user-attachments/assets/47f1d19f-e851-4d13-98af-3f422164d144)

