### PR TITLE
[GEN-2186] Correctif d'une anomalie d’affichage des puces pour les critères admin quand le diag est d’origine prescripteur habilité

### DIFF
--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -36,19 +36,23 @@
                 {% regroup selected_administrative_criteria|dictsort:"administrative_criteria.level" by administrative_criteria.get_level_display as levels_list %}
                 <ul>
                     {% for level, criteria in levels_list %}
-                        <li>
-                            {% comment %}
-                            Les candidatures envoyées par des prescripteurs habilités ne sont pas affichées de manière
-                            hiérarchisée afin de ne pas induire les employeurs en erreur.
-                            Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critères de niveau 2 par exemple.
-                            {% endcomment %}
-                            {% if not is_sent_by_authorized_prescriber %}<span class="fw-bold">{{ level }}</span>{% endif %}
-                            <ul>
+                        {% comment %}
+                        Les candidatures envoyées par des prescripteurs habilités ne sont pas affichées de manière
+                        hiérarchisée afin de ne pas induire les employeurs en erreur.
+                        Avec des critères hiérarchisés, ils ont tendance à penser que le candidat n'est pas éligible car pas suffisamment de critères de niveau 2 par exemple.
+                        {% endcomment %}
+                        {% if not is_sent_by_authorized_prescriber %}
+                            <li>
+                                <span class="fw-bold">{{ level }}</span>
+                                <ul>
+                                {% endif %}
                                 {% for criterion in criteria %}
                                     {% include "apply/includes/selected_administrative_criteria_display.html" with diagnosis=eligibility_diagnosis criterion=criterion %}
                                 {% endfor %}
-                            </ul>
-                        </li>
+                                {% if not is_sent_by_authorized_prescriber %}
+                                </ul>
+                            </li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
             {% endwith %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Quand un diagnostic n'est pas d'origine PH, ses critères sont affichés correctement ainsi :

![image](https://github.com/user-attachments/assets/0b077b91-71c5-440f-aeb6-a32ed334091b)

mais s'il est d'origine PH alors cette liste est mise à plat ainsi :

![image](https://github.com/user-attachments/assets/872f79d6-6a4d-40b5-bff2-83866996c7ce)

avec des doubles puces perturbantes.

## :cake: Comment ? <!-- optionnel -->

En mettant à plat proprement la liste en une simple `ul` (unordered list) au lieu d'une `ul` de plusieurs `ul`. Ce qui donne :

![image](https://github.com/user-attachments/assets/1e9dbc55-615f-4617-87d6-69a1c58ef1ae)

