### PR TITLE
Fiches salarié : retirer la mention champs obligatoire de l’étape de sélection des Annexes financières  dans le parcours des fiches salarié [GEN-2213]

### DIFF
--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -21,7 +21,7 @@
                     {% url_add_query secondary_url status=request.GET.status as secondary_url %}
                     {% url_add_query reset_url status=request.GET.status as reset_url %}
                 {% endif %}
-                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url %}
+                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url show_mandatory_fields_mention=False %}
             </form>
         </div>
     </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La mention est affichée alors qu'il n'y a pas de champs obligatoire à cette étape.

## :cake: Comment ? <!-- optionnel -->

Avant :

![image](https://github.com/user-attachments/assets/b0c4abdc-1821-43b3-a44f-259493bf5401)

Après :

![image](https://github.com/user-attachments/assets/5b61efba-fe85-4c5a-8d63-25bdd0c5b661)
