### PR TITLE
Tableau de bord (équipe support uniquement) : modifier le nom “comité technique d’animation” par “export des prescripteurs et employeurs” [GEN-2209]

### DIFF
--- a/itou/templates/dashboard/includes/staff_export_card.html
+++ b/itou/templates/dashboard/includes/staff_export_card.html
@@ -19,7 +19,7 @@
             <p class="mb-3 mb-lg-5">
                 <a href="{% url 'itou_staff_views:export_cta' %}" class="btn-link btn-ico">
                     <i class="ri-download-line ri-lg fw-normal" aria-hidden="true"></i>
-                    <span>Comités Techniques d'Animation</span>
+                    <span>Export des prescripteurs et employeurs</span>
                 </a>
             </p>
         </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Problème : le titre comité technique d’animation n’est pas explicite

## :cake: Comment ? <!-- optionnel -->

en le remplaçant par “ Export des prescripteurs et employeurs”

## :computer: Captures d'écran <!-- optionnel -->

Avant :

![image](https://github.com/user-attachments/assets/3bdc85bb-8491-40c4-b869-456b382721eb)

Après :

![image](https://github.com/user-attachments/assets/5be41585-f050-4f6e-8354-88d931a520eb)


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
