### PR TITLE
Tech: simplification du code de mise à jour de l'état de synchronisation d'un PASS IAE vers France Travail

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -295,7 +295,7 @@ class PENotificationMixin(models.Model):
         return self.end_at.strftime(DATE_FORMAT)
 
     def _pe_notification_update(
-        self, status: api_enums.PEApiNotificationStatus, at=None, endpoint=None, exit_code=None
+        self, status: api_enums.PEApiNotificationStatus, at: datetime.datetime, endpoint=None, exit_code=None
     ) -> api_enums.PEApiNotificationStatus:
         """A helper method to update the fields of the mixin:
         - whatever the destination class (Approval, PoleEmploiApproval)
@@ -305,7 +305,7 @@ class PENotificationMixin(models.Model):
         """
         update_dict = {
             "pe_notification_status": status,
-            "pe_notification_time": at if at else timezone.now(),
+            "pe_notification_time": at,
             "pe_notification_endpoint": endpoint,
             "pe_notification_exit_code": exit_code,
         }

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -340,7 +340,7 @@ class PENotificationMixin(models.Model):
     def pe_log_err(self, fmt, *args, **kwargs):
         self._pe_log("!", fmt, *args, **kwargs)
 
-    def pe_maj_pass(self, id_national_pe, siae_siret, siae_kind, sender_kind, prescriber_kind=None, at=None):
+    def pe_maj_pass(self, *, id_national_pe, siae_siret, siae_kind, sender_kind, prescriber_kind, at):
         pe_client = pole_emploi_api_client()
 
         typologie_prescripteur = None

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -303,14 +303,13 @@ class PENotificationMixin(models.Model):
 
         This will become useless when we will stop managing the PoleEmploiApproval that much.
         """
-        update_dict = {
-            "pe_notification_status": status,
-            "pe_notification_time": at,
-            "pe_notification_endpoint": endpoint,
-            "pe_notification_exit_code": exit_code,
-        }
-        queryset = self.__class__.objects.filter(pk=self.pk)
-        queryset.update(**{key: value for key, value in update_dict.items() if value})
+        self.__class__.objects.filter(pk=self.pk).update(
+            pe_notification_status=status,
+            pe_notification_time=at,
+            pe_notification_endpoint=endpoint,
+            pe_notification_exit_code=exit_code,
+        )
+
         return status
 
     def pe_save_pending(self, at, *, reason):

--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -313,16 +313,16 @@ class PENotificationMixin(models.Model):
         queryset.update(**{key: value for key, value in update_dict.items() if value})
         return status
 
-    def pe_save_pending(self, reason, at=None):
+    def pe_save_pending(self, reason, at):
         return self._pe_notification_update(api_enums.PEApiNotificationStatus.PENDING, at, None, reason)
 
-    def pe_save_error(self, endpoint, exit_code, at=None):
+    def pe_save_error(self, endpoint, exit_code, at):
         return self._pe_notification_update(api_enums.PEApiNotificationStatus.ERROR, at, endpoint, exit_code)
 
-    def pe_save_should_retry(self, at=None):
+    def pe_save_should_retry(self, at):
         return self._pe_notification_update(api_enums.PEApiNotificationStatus.SHOULD_RETRY, at)
 
-    def pe_save_success(self, at=None):
+    def pe_save_success(self, at):
         return self._pe_notification_update(api_enums.PEApiNotificationStatus.SUCCESS, at)
 
     def _pe_log(self, prefix, fmt, *args, **kwargs):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1848,7 +1848,7 @@ class TestPENotificationMixin:
     def test_save_error(self):
         now = timezone.now()
         approval = ApprovalFactory()
-        approval.pe_save_error("foo", "bar", at=now)
+        approval.pe_save_error(now, endpoint="foo", exit_code="bar")
         approval.refresh_from_db()
         assert approval.pe_notification_status == "notification_error"
         assert approval.pe_notification_time == now


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement, on ne met à jour que les attributs ayant une valeur (`{key: value for key, value in update_dict.items() if value}`).

Ce qui signifie que:
- `pe_save_success` n'efface pas les champs `pe_notification_endpoint` ou `pe_notification_exit_code`
- `pe_save_pending`  met à jour `pe_notification_exit_code` sans mettre à jour `pe_notification_endpoint`
- etc

avec des incohérences à la clef.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
