### PR TITLE
Candidat: stabilisation du tri en cas d'égalité

### DIFF
--- a/itou/www/job_seekers_views/enums.py
+++ b/itou/www/job_seekers_views/enums.py
@@ -22,6 +22,10 @@ class JobSeekerOrder(enum.StrEnum):
         else:
             return self.__class__(f"-{self.value}")
 
+    @property
+    def order_by(self):
+        return (str(self), "-pk" if self.value.startswith("-") else "pk")
+
     # Make the Enum work in Django's templates
     # See:
     # - https://docs.djangoproject.com/en/dev/ref/templates/api/#variables-and-lookups

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -158,7 +158,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html"):
         order = JobSeekerOrder(request.GET.get("order"))
     except ValueError:
         order = JobSeekerOrder.FULL_NAME_ASC
-    queryset = queryset.order_by(str(order))
+    queryset = queryset.order_by(*order.order_by)
 
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=10)
     for job_seeker in page_obj:

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -392,7 +392,8 @@
                                            %s,
                                            %s,
                                            %s))
-          ORDER BY 34 ASC
+          ORDER BY 34 ASC,
+                   "users_user"."id" ASC
           LIMIT 4
         ''',
       }),
@@ -918,7 +919,8 @@
                                            %s,
                                            %s,
                                            %s))
-          ORDER BY 34 ASC
+          ORDER BY 34 ASC,
+                   "users_user"."id" ASC
           LIMIT 4
         ''',
       }),

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -493,6 +493,11 @@ def test_job_seekers_order(client, subtests):
         first_name="Zorro",
         last_name="Martin",
     )
+    second_created_job_seeker = JobSeekerFactory(
+        created_by=prescriber,
+        first_name="Zorro",
+        last_name="Martin",
+    )
     a_b_job_seeker = JobApplicationFactory(
         sender=prescriber, job_seeker__first_name="Alice", job_seeker__last_name="Berger"
     ).job_seeker
@@ -501,9 +506,9 @@ def test_job_seekers_order(client, subtests):
     url = reverse("job_seekers_views:list")
 
     expected_order = {
-        "full_name": [a_b_job_seeker, c_d_job_seeker, created_job_seeker],
-        "job_applications_nb": [created_job_seeker, a_b_job_seeker, c_d_job_seeker],
-        "last_updated_at": [c_d_job_seeker, a_b_job_seeker, created_job_seeker],
+        "full_name": [a_b_job_seeker, c_d_job_seeker, created_job_seeker, second_created_job_seeker],
+        "job_applications_nb": [created_job_seeker, second_created_job_seeker, a_b_job_seeker, c_d_job_seeker],
+        "last_updated_at": [c_d_job_seeker, a_b_job_seeker, created_job_seeker, second_created_job_seeker],
     }
 
     with subtests.test(order="<missing_value>"):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si 2 candidats ont les mêmes noms & prénoms, ou plus simplement, le même nombre de candidature le tri:
- doit être stable dans le temps
- doit bien s'inverser si l'ordre sélectionné est inversé

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
