### PR TITLE
Fiches salarié : Autoriser les employeur à séléctionner une annexe financière non valide [GEN-2245]

### DIFF
--- a/itou/templates/employee_record/includes/create_step_4.html
+++ b/itou/templates/employee_record/includes/create_step_4.html
@@ -11,7 +11,12 @@
                 <fieldset>
                     <legend>Annexe financière</legend>
                     <p>
-                        Si vous utilisez un logiciel de gestion des salariés, veuillez sélectionner une annexe financière. Sinon, vous pouvez passer à l'étape suivante.
+                        Si vous utilisez un logiciel de gestion des salariés,
+                        vous pouvez sélectionner une annexe financière (si la
+                        dernière en date n’est pas encore visible, vous pouvez
+                        sélectionner celle qui la précède).
+                        <br>
+                        Sinon, vous pouvez passer à l’étape suivante.
                     </p>
                     {% bootstrap_form form alert_error_type="all" %}
                 </fieldset>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Nous n’avons toujours pas reçu les AF de 2025 pour toutes les SIAE (prévu pour Avril), chaque année on les reçoit avec beaucoup de retard.

Cela est gênant pour les SIAE qui utilisent un logiciel de gestion car à l’étape 4 du parcours des fiches salarié la sélection d’une AF est un prérequis à la transmission de la donnée Fiche salarié vers le logiciel de gestion RH, par conséquent cela génère une double saisie pour nos utilisateurs.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/97e170e3-c330-4598-9fd9-eaadfd4724c5)
