### PR TITLE
Demandeur d’emploi : Certification du critère Parent Isolé (Allocation de Soutien Familial)

### DIFF
--- a/itou/eligibility/enums.py
+++ b/itou/eligibility/enums.py
@@ -63,4 +63,6 @@ class AdministrativeCriteriaKind(models.TextChoices):
     SANS_TRAVAIL_12 = "SANS_TRAVAIL_12", "Personne éloignée du marché du travail (> 1 an)"
 
 
-CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS = frozenset([AdministrativeCriteriaKind.RSA, AdministrativeCriteriaKind.AAH])
+CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS = frozenset(
+    [AdministrativeCriteriaKind.RSA, AdministrativeCriteriaKind.AAH, AdministrativeCriteriaKind.PI]
+)

--- a/itou/utils/apis/api_particulier.py
+++ b/itou/utils/apis/api_particulier.py
@@ -53,8 +53,16 @@ def has_required_info(job_seeker):
 
 
 def certify_criteria(criteria, client, job_seeker):
+    """
+    Two criteria are the same between the API and Les emplois: AAH and RSA.
+    The "Parent Isolé" criterion is not a subsidy in itself but an administrative terminology.
+    See https://www.service-public.fr/particuliers/vosdroits/F15553/
+    Regarding the Diagnosis Socio-Professionnel, the beneficiary should already receive
+    the Allocation Soutien Familial (ASF) to be considered a Parent Isolé.
+    """
     endpoint_mapping = {
         AdministrativeCriteriaKind.AAH: "/v2/allocation-adulte-handicape",
+        AdministrativeCriteriaKind.PI: "/v2/allocation-soutien-familial",
         AdministrativeCriteriaKind.RSA: "/v2/revenu-solidarite-active",
     }
     response = _request(client, endpoint_mapping[criteria], job_seeker)

--- a/itou/utils/mocks/api_particulier.py
+++ b/itou/utils/mocks/api_particulier.py
@@ -41,3 +41,15 @@ def aah_certified_mocker():
 
 def aah_not_certified_mocker():
     return {"status": "non_beneficiaire", "dateDebut": None, "dateFin": None}
+
+
+#################################################
+###################### PI #######################
+#################################################
+def asf_certified_mocker():
+    # https://particulier.api.gouv.fr/developpeurs/openapi#tag/Prestations-sociales/paths/~1api~1v2~1allocation-soutien-familial/get
+    return {"status": "beneficiaire", "dateDebut": "2024-08-01", "dateFin": None}
+
+
+def asf_not_certified_mocker():
+    return {"status": "non_beneficiaire", "dateDebut": None, "dateFin": None}

--- a/tests/eligibility/test_geiq.py
+++ b/tests/eligibility/test_geiq.py
@@ -483,6 +483,11 @@ def test_administrativecriteria_level_annex_consistency():
             True,
             id="employer_certified_criteria__aah",
         ),
+        pytest.param(
+            {"from_geiq": True, "criteria_kinds": [AdministrativeCriteriaKind.PI]},
+            True,
+            id="employer_certified_criteria__pi",
+        ),
     ],
 )
 def test_criteria_can_be_certified(factory_params, expected):

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -22,6 +22,7 @@ from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
 from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
 from itou.utils.mocks.api_particulier import (
     aah_certified_mocker,
+    asf_certified_mocker,
     rsa_certified_mocker,
     rsa_not_certified_mocker,
     rsa_not_found_mocker,
@@ -468,6 +469,11 @@ class TestEligibilityDiagnosisModel:
                 True,
                 id="employer_certified_criteria__aah",
             ),
+            pytest.param(
+                {"from_employer": True, "criteria_kinds": [AdministrativeCriteriaKind.PI]},
+                True,
+                id="employer_certified_criteria__pi",
+            ),
         ],
     )
     def test_criteria_can_be_certified(self, factory_params, expected):
@@ -567,6 +573,7 @@ def test_certifiable(AdministrativeCriteriaClass):
     [
         pytest.param(AdministrativeCriteriaKind.RSA, rsa_certified_mocker(), id="rsa"),
         pytest.param(AdministrativeCriteriaKind.AAH, aah_certified_mocker(), id="aah"),
+        pytest.param(AdministrativeCriteriaKind.PI, asf_certified_mocker(), id="pi"),
     ],
 )
 @freeze_time("2024-09-12")

--- a/tests/eligibility/test_tasks.py
+++ b/tests/eligibility/test_tasks.py
@@ -9,7 +9,7 @@ from huey.exceptions import RetryTask
 
 from itou.eligibility.enums import AdministrativeCriteriaKind
 from itou.eligibility.tasks import async_certify_criteria
-from itou.utils.mocks.api_particulier import aah_certified_mocker, rsa_certified_mocker
+from itou.utils.mocks.api_particulier import aah_certified_mocker, asf_certified_mocker, rsa_certified_mocker
 from itou.utils.types import InclusiveDateRange
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 
@@ -36,6 +36,12 @@ class TestCertifyCriteria:
                 AdministrativeCriteriaKind.AAH,
                 aah_certified_mocker(),
                 id="aah",
+            ),
+            pytest.param(
+                f"{settings.API_PARTICULIER_BASE_URL}v2/allocation-soutien-familial",
+                AdministrativeCriteriaKind.PI,
+                asf_certified_mocker(),
+                id="pi",
             ),
         ],
     )

--- a/tests/utils/apis/test_api_particulier.py
+++ b/tests/utils/apis/test_api_particulier.py
@@ -9,6 +9,7 @@ from itou.eligibility.tasks import certify_criteria
 from itou.utils.apis import api_particulier
 from itou.utils.mocks.api_particulier import (
     aah_not_certified_mocker,
+    asf_not_certified_mocker,
     rsa_data_provider_error,
     rsa_not_certified_mocker,
     rsa_not_found_mocker,
@@ -56,6 +57,12 @@ def test_build_params_from(snapshot):
             f"{settings.API_PARTICULIER_BASE_URL}v2/allocation-adulte-handicape",
             AdministrativeCriteriaKind.AAH,
             aah_not_certified_mocker(),
+            id="aah",
+        ),
+        pytest.param(
+            f"{settings.API_PARTICULIER_BASE_URL}v2/allocation-soutien-familial",
+            AdministrativeCriteriaKind.PI,
+            asf_not_certified_mocker(),
             id="aah",
         ),
     ],


### PR DESCRIPTION
## :thinking: Pourquoi ?

Utilisation de l'API Particulier pour certifier le critère Parent Isolé.

## :cake: Comment ?

Interrogation du endpoint [Allocation Soutien Familial](https://particulier.api.gouv.fr/developpeurs/openapi#tag/Prestations-sociales/paths/~1api~1v2~1allocation-soutien-familial/get). En effet, un justificatif de l'ASF doit être fourni pour justifier du critère Parent Isolé.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
