### PR TITLE
new_users_to_brevo: Interpréter User.joined_at dans la timezone active

### DIFF
--- a/itou/users/management/commands/new_users_to_brevo.py
+++ b/itou/users/management/commands/new_users_to_brevo.py
@@ -6,6 +6,7 @@ import httpx
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
+from django.utils import timezone
 from sentry_sdk.crons import monitor
 
 from itou.companies.enums import SIAE_WITH_CONVENTION_KINDS
@@ -47,7 +48,7 @@ class BrevoClient:
                 "attributes": {
                     "prenom": user["first_name"].title(),
                     "nom": user["last_name"].upper(),
-                    "date_inscription": user["date_joined"].strftime("%Y-%m-%d"),
+                    "date_inscription": timezone.localdate(user["date_joined"]).isoformat(),
                     "type": category.value,
                 },
             }

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -226,7 +226,7 @@ class TestCommandNewUsersToBrevo:
     def setup(self, settings):
         settings.BREVO_API_KEY = "BREVO_API_KEY"
 
-    @freeze_time("2023-05-02")
+    @freeze_time("2023-05-01T23:30:00Z")
     def test_wet_run_siae(self, caplog, respx_mock):
         # Job seekers are ignored.
         JobSeekerFactory(with_verified_email=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Off-by-one sur les inscriptions autour de minuit.
