### PR TITLE
Fiches salarié: Correctif de bug pour les imports depuis un agrément PE

### DIFF
--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -190,7 +190,7 @@ def missing_employee(request, template_name="employee_record/missing_employee.ht
                 else:
                     approval_case = MissingEmployeeCase.EXISTING_EMPLOYEE_RECORD_OTHER_COMPANY
             else:
-                if job_application.hiring_start_at > timezone.localdate():
+                if job_application.hiring_start_at and job_application.hiring_start_at > timezone.localdate():
                     approval_case = MissingEmployeeCase.FUTURE_HIRING
                 else:
                     approval_case = MissingEmployeeCase.NO_EMPLOYEE_RECORD

--- a/tests/www/employee_record_views/__snapshots__/test_missing_employee.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_missing_employee.ambr
@@ -196,7 +196,38 @@
       </section>
   '''
 # ---
-# name: test_missing_employee[no_employee_record]
+# name: test_missing_employee[no_employee_record_a]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-md-9">
+                      <div class="c-form mb-3 mb-lg-5">
+                          
+                              <h2>Charles CONSTANTIN</h2>
+  
+                              
+                                  <p>Ce salarié a 1 PASS IAE disponible</p>
+  
+                                  
+                                      <hr/>
+                                      <p>
+                                          <strong>XXXXXXX00001</strong> du 14/02/2025 au 13/02/2027
+                                      </p>
+                                      
+                                          <a href="/employee_record/create/[PK of JobApplication]">Créer la fiche salarié</a>
+                                      
+                                  
+                              
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_missing_employee[no_employee_record_b]
   '''
   <section class="s-section">
           <div class="s-section__container container">
@@ -213,6 +244,37 @@
                                       <hr/>
                                       <p>
                                           <strong>XXXXXXX00004</strong> du 14/02/2025 au 13/02/2027
+                                      </p>
+                                      
+                                          <a href="/employee_record/create/[PK of JobApplication]">Créer la fiche salarié</a>
+                                      
+                                  
+                              
+                          
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+  '''
+# ---
+# name: test_missing_employee[no_employee_record_c]
+  '''
+  <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12 col-md-9">
+                      <div class="c-form mb-3 mb-lg-5">
+                          
+                              <h2>Fabienne FAVRISEAU</h2>
+  
+                              
+                                  <p>Ce salarié a 1 PASS IAE disponible</p>
+  
+                                  
+                                      <hr/>
+                                      <p>
+                                          <strong>XXXXXXX00005</strong> du 14/02/2025 au 13/02/2027
                                       </p>
                                       
                                           <a href="/employee_record/create/[PK of JobApplication]">Créer la fiche salarié</a>


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://inclusion.sentry.io/issues/30893648/?project=4508410589020240&referrer=github-pr-bot

> TypeError
> 
> '>' not supported between instances of 'NoneType' and 'datetime.date'

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
