### PR TITLE
Performances: Ajout de docker-compose.override.yml au .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ envs/prod.env
 envs/secrets.env
 
 # Config
+docker-compose.override.yml
 docker-compose-prod.yml
 docker/dev/postgres/
 docker/prod/


### PR DESCRIPTION
## :thinking: Pourquoi ?

Postgis ne distribue qu'une image `amd64` de postgres sur DockerHub. Il y a 2-3 semaines j'ai build une image `aarch64` et l'utilise depuis pour éviter d'émuler l'archi x86 en local.
Grâce à ce fichier, je ne surcharge que l'image du service postgres.

Le gain en perfs est négligeable lorsqu'on lance un test spécifique, mais lorsqu'il s'agit de toute la batterie de tests, ça représente bien 15-20% de gain avec 14 workers.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
