### PR TITLE
Pilotage : Corriger le bug associé aux TBs DGEFP

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -301,15 +301,6 @@
                                 <span>Suivi des demandes de prolongation</span>
                             </a>
                         </li>
-                        <!-- Stats temporarily suspended until we stabilize them
-                            Which should happen once the dgefp starts working with us properly
-                        <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_dgefp_iae_iae' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
-                                <span>Données IAE France entière</span>
-                            </a>
-                        </li>
-                        -->
                         <li class="d-flex justify-content-between align-items-center mb-3">
                             <a href="{% url 'stats:stats_dgefp_iae_siae_evaluation' %}" class="btn-link btn-ico">
                                 <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -251,45 +251,45 @@ METABASE_DASHBOARDS = {
     # Institution stats - DGEFP - nation level.
     #
     "stats_dgefp_iae_auto_prescription": {
-        "dashboard_id": 267,
+        "dashboard_id": 515,
         "tally_popup_form_id": "3qLpE2",
         "tally_embed_form_id": "nG6gBj",
     },
     "stats_dgefp_iae_follow_siae_evaluation": {
-        "dashboard_id": 265,
+        "dashboard_id": 516,
         "tally_popup_form_id": "w2XZxV",
         "tally_embed_form_id": "n9Ba6G",
     },
     "stats_dgefp_iae_follow_prolongation": {
-        "dashboard_id": 357,
+        "dashboard_id": 517,
         "tally_popup_form_id": "nG0lDp",
         "tally_embed_form_id": "mO0GY7",
     },
     "stats_dgefp_iae_tension": {
-        "dashboard_id": 389,
+        "dashboard_id": 519,
         "tally_popup_form_id": "nrEPLl",
         "tally_embed_form_id": "3jxPWx",
     },
     "stats_dgefp_iae_hiring": {
-        "dashboard_id": 160,
+        "dashboard_id": 520,
         "tally_popup_form_id": "mVLBXv",
         "tally_embed_form_id": "nPpXpQ",
     },
     "stats_dgefp_iae_state": {
-        "dashboard_id": 310,
+        "dashboard_id": 521,
         "tally_popup_form_id": "w2az2j",
         "tally_embed_form_id": "3Nlvzl",
     },
     "stats_dgefp_iae_ph_prescription": {
-        "dashboard_id": 289,
+        "dashboard_id": 522,
         "tally_popup_form_id": "wbWKEo",
         "tally_embed_form_id": "wvPEvQ",
     },
     "stats_dgefp_iae_siae_evaluation": {
-        "dashboard_id": 144,
+        "dashboard_id": 518,
     },
     "stats_dgefp_iae_orga_etp": {
-        "dashboard_id": 485,
+        "dashboard_id": 523,
         "tally_popup_form_id": "3N0oLB",
         "tally_embed_form_id": "mOoDva",
     },

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -280,9 +280,6 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "w2az2j",
         "tally_embed_form_id": "3Nlvzl",
     },
-    "stats_dgefp_iae_iae": {
-        "dashboard_id": 117,
-    },
     "stats_dgefp_iae_ph_prescription": {
         "dashboard_id": 289,
         "tally_popup_form_id": "wbWKEo",
@@ -290,9 +287,6 @@ METABASE_DASHBOARDS = {
     },
     "stats_dgefp_iae_siae_evaluation": {
         "dashboard_id": 144,
-    },
-    "stats_dgefp_iae_af": {
-        "dashboard_id": 142,
     },
     "stats_dgefp_iae_orga_etp": {
         "dashboard_id": 485,

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -121,7 +121,6 @@ urlpatterns = [
         views.stats_dgefp_iae_tension,
         name="stats_dgefp_iae_tension",
     ),
-    path("dgefp/iae", views.stats_dgefp_iae_iae, name="stats_dgefp_iae_iae"),
     path(
         "dgefp/ph_prescription",
         views.stats_dgefp_iae_ph_prescription,
@@ -130,7 +129,6 @@ urlpatterns = [
     path("dgefp/hiring", views.stats_dgefp_iae_hiring, name="stats_dgefp_iae_hiring"),
     path("dgefp/state", views.stats_dgefp_iae_state, name="stats_dgefp_iae_state"),
     path("dgefp/siae_evaluation", views.stats_dgefp_iae_siae_evaluation, name="stats_dgefp_iae_siae_evaluation"),
-    path("dgefp/af", views.stats_dgefp_iae_af, name="stats_dgefp_iae_af"),
     path("dgefp/orga_etp", views.stats_dgefp_iae_orga_etp, name="stats_dgefp_iae_orga_etp"),
     # Institution stats - DIHAL - nation level.
     path("dihal/state", views.stats_dihal_state, name="stats_dihal_state"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -729,42 +729,32 @@ def render_stats_dgefp_iae(request, page_title, extra_params=None, extra_context
 
 
 def stats_dgefp_iae_auto_prescription(request):
-    return render_stats_dgefp_iae(
-        request=request, page_title="Focus auto-prescription", extra_params=get_params_for_whole_country()
-    )
+    return render_stats_dgefp_iae(request=request, page_title="Focus auto-prescription")
 
 
 def stats_dgefp_iae_follow_siae_evaluation(request):
-    return render_stats_dgefp_iae(
-        request=request, page_title="Suivi du contrôle à posteriori", extra_params=get_params_for_whole_country()
-    )
+    return render_stats_dgefp_iae(request=request, page_title="Suivi du contrôle à posteriori")
 
 
 def stats_dgefp_iae_follow_prolongation(request):
-    return render_stats_dgefp_iae(
-        request=request, page_title="Suivi des demandes de prolongation", extra_params=get_params_for_whole_country()
-    )
+    return render_stats_dgefp_iae(request=request, page_title="Suivi des demandes de prolongation")
 
 
 def stats_dgefp_iae_tension(request):
     return render_stats_dgefp_iae(
         request=request,
         page_title="SIAE qui peinent à recruter sur le territoire",
-        extra_params=get_params_for_whole_country(),
     )
 
 
 def stats_dgefp_iae_hiring(request):
-    return render_stats_dgefp_iae(
-        request=request, page_title="Données facilitation de l'embauche", extra_params=get_params_for_whole_country()
-    )
+    return render_stats_dgefp_iae(request=request, page_title="Données facilitation de l'embauche")
 
 
 def stats_dgefp_iae_state(request):
     return render_stats_dgefp_iae(
         request=request,
         page_title="Suivi des prescriptions des AHI de ma région",
-        extra_params=get_params_for_whole_country(),
     )
 
 
@@ -772,7 +762,6 @@ def stats_dgefp_iae_ph_prescription(request):
     return render_stats_dgefp_iae(
         request=request,
         page_title="Suivi des prescriptions des prescripteurs habilités",
-        extra_params=get_params_for_whole_country(),
     )
 
 
@@ -781,7 +770,6 @@ def stats_dgefp_iae_siae_evaluation(request):
         request=request,
         page_title="Données (version bêta) du contrôle a posteriori",
         extra_context={"show_siae_evaluation_message": True},
-        extra_params=get_params_for_whole_country(),
     )
 
 
@@ -789,7 +777,6 @@ def stats_dgefp_iae_orga_etp(request):
     return render_stats_dgefp_iae(
         request=request,
         page_title="Suivi des effectifs annuels et mensuels en ETP",
-        extra_params=get_params_for_whole_country(),
     )
 
 

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -768,12 +768,6 @@ def stats_dgefp_iae_state(request):
     )
 
 
-def stats_dgefp_iae_iae(request):
-    return render_stats_dgefp_iae(
-        request=request, page_title="Données des régions", extra_params=get_params_for_whole_country()
-    )
-
-
 def stats_dgefp_iae_ph_prescription(request):
     return render_stats_dgefp_iae(
         request=request,
@@ -789,10 +783,6 @@ def stats_dgefp_iae_siae_evaluation(request):
         extra_context={"show_siae_evaluation_message": True},
         extra_params=get_params_for_whole_country(),
     )
-
-
-def stats_dgefp_iae_af(request):
-    return render_stats_dgefp_iae(request=request, page_title="Annexes financières actives")
 
 
 def stats_dgefp_iae_orga_etp(request):

--- a/tests/www/dashboard/__snapshots__/test_dashboard_stats.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard_stats.ambr
@@ -3791,15 +3791,6 @@
                                   <span>Suivi des demandes de prolongation</span>
                               </a>
                           </li>
-                          <!-- Stats temporarily suspended until we stabilize them
-                              Which should happen once the dgefp starts working with us properly
-                          <li class="d-flex justify-content-between align-items-center mb-3">
-                              <a href="/stats/dgefp/iae" class="btn-link btn-ico">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
-                                  <span>Données IAE France entière</span>
-                              </a>
-                          </li>
-                          -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
                                   <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
@@ -3914,15 +3905,6 @@
                                   <span>Suivi des demandes de prolongation</span>
                               </a>
                           </li>
-                          <!-- Stats temporarily suspended until we stabilize them
-                              Which should happen once the dgefp starts working with us properly
-                          <li class="d-flex justify-content-between align-items-center mb-3">
-                              <a href="/stats/dgefp/iae" class="btn-link btn-ico">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
-                                  <span>Données IAE France entière</span>
-                              </a>
-                          </li>
-                          -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
                                   <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>
@@ -4037,15 +4019,6 @@
                                   <span>Suivi des demandes de prolongation</span>
                               </a>
                           </li>
-                          <!-- Stats temporarily suspended until we stabilize them
-                              Which should happen once the dgefp starts working with us properly
-                          <li class="d-flex justify-content-between align-items-center mb-3">
-                              <a href="/stats/dgefp/iae" class="btn-link btn-ico">
-                                  <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
-                                  <span>Données IAE France entière</span>
-                              </a>
-                          </li>
-                          -->
                           <li class="d-flex justify-content-between align-items-center mb-3">
                               <a class="btn-link btn-ico" href="/stats/dgefp/siae_evaluation">
                                   <i aria-hidden="true" class="ri-bar-chart-line ri-lg fw-normal align-self-start"></i>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La DGEFP ne peut pas accéder à ses TBs privés car on touche la limite pour la longueur d'une URL à cause des filtres géographiques, les nouveaux TB ont été dupliqué afin de supprimer ces filtres.
https://www.notion.so/gip-inclusion/Corriger-le-bug-associ-aux-TBs-DGEFP-1985f321b6048049b235df2cfaec9533
