### PR TITLE
Candidature: extension de l'affichage du bouton de promotion [GEN-2235]

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -737,7 +737,7 @@ RDV_SOLIDARITES_TOKEN_EXPIRY = os.getenv("RDV_SOLIDARITES_TOKEN_EXPIRY", 86000) 
 RDV_INSERTION_API_BASE_URL = os.getenv("RDV_INSERTION_API_BASE_URL")
 RDV_INSERTION_INVITE_HOLD_DURATION = datetime.timedelta(days=int(os.getenv("RDV_INSERTION_INVITE_HOLD_DAYS", 10)))
 RDV_INSERTION_WEBHOOK_SECRET = os.getenv("RDV_INSERTION_WEBHOOK_SECRET")
-RDV_INSERTION_PROMOTE_DEPARTMENTS = ["69"]
+RDV_INSERTION_PROMOTE_DEPARTMENTS = ["01", "03", "07", "15", "26", "38", "42", "43", "63", "69", "73", "74"]
 
 # API Particuliers
 # ------------------------------------------------------------------------------

--- a/itou/templates/apply/includes/buttons/rdv_insertion_promote.html
+++ b/itou/templates/apply/includes/buttons/rdv_insertion_promote.html
@@ -1,0 +1,4 @@
+<a href="{% url 'rdv_insertion:discover' %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-link-white btn-block btn-ico">
+    <i class="ri-mail-send-line fw-medium" aria-hidden="true"></i>
+    <span>Proposer un rendez-vous</span>
+</a>

--- a/itou/templates/apply/includes/siae_hiring_actions.html
+++ b/itou/templates/apply/includes/siae_hiring_actions.html
@@ -60,6 +60,10 @@
             </div>
         {% endif %}
 
+        {% if show_rdvi_promote_page|default:False %}
+            <div class="form-group col-12 col-lg-auto">{% include "apply/includes/buttons/rdv_insertion_promote.html" %}</div>
+        {% endif %}
+
         {# Transfer ------------------------------------------------------ #}
         {% if job_application.transfer.is_available %}
             <div class="form-group col-12 col-lg d-lg-flex justify-content-lg-end">

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -270,6 +270,10 @@ def details_for_company(request, job_application_id, template_name="apply/proces
         ),
         "matomo_custom_title": "Candidature",
         "job_application_sender_left_org": job_application_sender_left_org(job_application),
+        "show_rdvi_promote_page": (
+            request.current_organization.department in settings.RDV_INSERTION_PROMOTE_DEPARTMENTS
+            and not request.current_organization.rdv_solidarites_id
+        ),
     }
 
     return render(request, template_name, context)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car on n'a pas eu de soumission aux Tally depuis hier !

## :cake: Comment ? <!-- optionnel -->

On étend à d'autres départements (tout Auvergne Rhône-Alpes) et à la page de détail des candidatures.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
