### PR TITLE
UX/UI: Correction du formulaire critères administratifs GEIQ

### DIFF
--- a/itou/templates/apply/includes/geiq/geiq_administrative_criteria_form.html
+++ b/itou/templates/apply/includes/geiq/geiq_administrative_criteria_form.html
@@ -18,7 +18,7 @@
 {# A "parent" criterion, controls the visibility and filling of "children" criteria #}
 {% bootstrap_field form.beneficiaire_des_minimas_sociaux %}
 {% if form.beneficiaire_des_minimas_sociaux.value %}
-    <div class="ps-4 text-primary">
+    <div class="ps-4 mb-4">
         {% bootstrap_field form.beneficiaire_du_rsa %}
         {% bootstrap_field form.allocataire_ass %}
         {% bootstrap_field form.allocataire_aah %}
@@ -27,44 +27,46 @@
 {% endif %}
 
 <h3 class="h5">Critères liés à l'âge du candidat</h3>
-{% bootstrap_field form.jeune_26_ans field_class="text-primary" %}
+{% bootstrap_field form.jeune_26_ans %}
 {% if form.jeune_26_ans.value %}
-    <div class="ps-4 text-primary">{% bootstrap_field form.jeune_de_moins_de_26_ans_sans_qualification %}</div>
+    <div class="ps-4">{% bootstrap_field form.jeune_de_moins_de_26_ans_sans_qualification %}</div>
 {% endif %}
-{% bootstrap_field form.senior_50_ans field_class="text-primary" %}
+{% bootstrap_field form.senior_50_ans %}
 
 <h3 class="h5">Niveau de compétences</h3>
-{% bootstrap_field form.niveau_etude_3 field_class="text-primary" %}
-{% bootstrap_field form.maitrise_de_la_langue_francaise field_class="text-primary" %}
+{% bootstrap_field form.niveau_etude_3 %}
+{% bootstrap_field form.maitrise_de_la_langue_francaise %}
 
 <h3 class="h5">Situation professionnelle</h3>
-{% bootstrap_field form.personne_eloignee_du_marche_du_travail field_class="text-primary" %}
+{% bootstrap_field form.personne_eloignee_du_marche_du_travail %}
 {% if form.personne_eloignee_du_marche_du_travail.value %}
-    <div class="ps-4 text-primary">
+    <div class="ps-4 mb-4">
         {% bootstrap_field form.personne_inscrite_a_pole_emploi %}
-        {% if form.personne_inscrite_a_pole_emploi.value %}<div class="ps-4">{{ form.pole_emploi_related }}</div>{% endif %}
+        {% if form.personne_inscrite_a_pole_emploi.value %}
+            <div class="ps-4 mb-4">{{ form.pole_emploi_related }}</div>
+        {% endif %}
     </div>
 {% endif %}
-{% bootstrap_field form.de_45_ans_et_plus field_class="text-primary" %}
-{% bootstrap_field form.personne_en_reconversion_professionnelle_contrainte field_class="text-primary" %}
-{% bootstrap_field form.personne_en_dispositif_insertion field_class="text-primary" %}
+{% bootstrap_field form.de_45_ans_et_plus %}
+{% bootstrap_field form.personne_en_reconversion_professionnelle_contrainte %}
+{% bootstrap_field form.personne_en_dispositif_insertion %}
 
 <h3 class="h5">Situation de handicap</h3>
-{% bootstrap_field form.travailleur_handicape field_class="text-primary" %}
+{% bootstrap_field form.travailleur_handicape %}
 
 <h3 class="h5">Situation d'hébergement</h3>
-{% bootstrap_field form.personne_sans_hebergement field_class="text-primary" %}
-{% bootstrap_field form.resident_zrr field_class="text-primary" %}
-{% bootstrap_field form.resident_qpv field_class="text-primary" %}
+{% bootstrap_field form.personne_sans_hebergement %}
+{% bootstrap_field form.resident_zrr %}
+{% bootstrap_field form.resident_qpv %}
 
 <h3 class="h5">Situation familiale</h3>
-{% bootstrap_field form.parent_isole field_class="text-primary" %}
-{% bootstrap_field form.sortant_ase field_class="text-primary" %}
+{% bootstrap_field form.parent_isole %}
+{% bootstrap_field form.sortant_ase %}
 
 <h3 class="h5">Situation juridique</h3>
-{% bootstrap_field form.sortant_de_detention_ou_personne_placee_sous_main_de_justice field_class="text-primary" %}
-{% bootstrap_field form.refugie_statutaire field_class="text-primary" %}
-{% bootstrap_field form.demandeur_asile field_class="text-primary" %}
+{% bootstrap_field form.sortant_de_detention_ou_personne_placee_sous_main_de_justice %}
+{% bootstrap_field form.refugie_statutaire %}
+{% bootstrap_field form.demandeur_asile %}
 
 <h3 class="h5">Autre critère</h3>
-{% bootstrap_field form.mobilite field_class="text-primary" %}
+{% bootstrap_field form.mobilite %}

--- a/tests/www/geiq_eligibility_views/test_forms.py
+++ b/tests/www/geiq_eligibility_views/test_forms.py
@@ -98,10 +98,10 @@ def test_geiq_administrative_criteria_validation_for_geiq(new_geiq, administrati
     assert [["Vous devez saisir au moins un critère d'éligibilité GEIQ"]] == list(form.errors.values())
 
     for criterion in administrative_criteria_for_checkboxes:
-        # Check CSS classes
+        # Check <strong> element
         help_text = form.fields[criterion.key].help_text
 
-        assert "mt-2 form-text text-muted fs-xs" in help_text or help_text == ""
+        assert "<strong>" in help_text or help_text == ""
 
 
 def test_geiq_administrative_criteria_exclusions(new_geiq):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Plusieurs défauts de mise en forme à corriger

- les checkbox se déformaient a cause de l’application de la class `.has-spinner-loading` utilisée par htmx directement sur les inputs (au lieu du `<div>` parent comme pour le radio oui/non de la première question)
- certains espacements n'étaient pas bons
- le contenu du `help_text` n'était pas visuellement "disabled" quand le input + label était "disabled" (maj du thème)

