### PR TITLE
Alimenter les listes de contacts Brevo avec certains profils candidats [GEN-1400]

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -19,7 +19,7 @@
   "1 0 * * * $ROOT/clevercloud/run_management_command.sh update_prescriber_organization_with_api_entreprise",
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "45 0 * * * $ROOT/clevercloud/run_management_command.sh import_advisor_information shared_bucket/imports-gps/export_gps.xlsx --wet-run",
-  "30 1 * * * $ROOT/clevercloud/run_management_command.sh new_users_to_brevo --wet-run",
+  "30 1 * * * $ROOT/clevercloud/run_management_command.sh send_users_to_brevo --wet-run",
   "0 3 * * * $ROOT/clevercloud/run_management_command.sh clearsessions",
   "15 5 * * * $ROOT/clevercloud/run_management_command.sh prolongation_requests_chores email_reminder --wet-run",
   "0 7 * * * $ROOT/clevercloud/run_management_command.sh sync_s3_files --check-existing",

--- a/itou/users/management/commands/new_users_to_brevo.py
+++ b/itou/users/management/commands/new_users_to_brevo.py
@@ -19,7 +19,7 @@ from itou.utils.command import BaseCommand
 logger = logging.getLogger(__name__)
 
 # https://app.brevo.com/contact/list-listing
-BREVO_LIST_ID = 31
+BREVO_LES_EMPLOIS_LIST_ID = 31
 BREVO_API_URL = "https://api.brevo.com/v3"
 
 
@@ -63,7 +63,7 @@ class BrevoClient:
             f"{BREVO_API_URL}/contacts/import",
             headers={"Content-Type": "application/json"},
             json={
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,  # Don't update because we don't want to update emailBlacklist

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -19,7 +19,7 @@ from itou.job_applications.models import JobApplication
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.enums import IdentityProvider
 from itou.users.management.commands import send_check_authorized_members_email
-from itou.users.management.commands.new_users_to_brevo import BREVO_API_URL, BREVO_LIST_ID
+from itou.users.management.commands.new_users_to_brevo import BREVO_API_URL, BREVO_LES_EMPLOIS_LIST_ID
 from itou.users.models import User
 from itou.utils.apis.pole_emploi import PoleEmploiAPIBadResponse
 from itou.utils.mocks.pole_emploi import API_RECHERCHE_ERROR, API_RECHERCHE_RESULT_KNOWN
@@ -294,7 +294,7 @@ class TestCommandNewUsersToBrevo:
 
         assert [json.loads(call.request.content) for call in import_mock.calls] == [
             {
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,
@@ -408,7 +408,7 @@ class TestCommandNewUsersToBrevo:
 
         assert [json.loads(call.request.content) for call in import_mock.calls] == [
             {
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,
@@ -494,7 +494,7 @@ class TestCommandNewUsersToBrevo:
 
         assert [json.loads(call.request.content) for call in import_mock.calls] == [
             {
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,
@@ -570,7 +570,7 @@ class TestCommandNewUsersToBrevo:
 
         assert [json.loads(call.request.content) for call in import_mock.calls] == [
             {
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,
@@ -588,7 +588,7 @@ class TestCommandNewUsersToBrevo:
                 ],
             },
             {
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,
@@ -643,7 +643,7 @@ class TestCommandNewUsersToBrevo:
 
         assert [json.loads(call.request.content) for call in import_mock.calls] == [
             {
-                "listIds": [BREVO_LIST_ID],
+                "listIds": [BREVO_LES_EMPLOIS_LIST_ID],
                 "emailBlacklist": False,
                 "smsBlacklist": False,
                 "updateExistingContacts": False,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mieux accompagner les candidats :

- à leur inscription
- autonomes bloqués
