### PR TITLE
Stabilité: Correction du script de suppression des buckets

### DIFF
--- a/scripts/delete-bucket
+++ b/scripts/delete-bucket
@@ -38,15 +38,20 @@ def main():
         endpoint_url=f"https://{creds['CELLAR_ADDON_HOST']}",
     )
     bucket_name = creds["S3_STORAGE_BUCKET_NAME"]
-    paginator = s3_client.get_paginator("list_objects_v2")
+    paginator = s3_client.get_paginator("list_object_versions")
     try:
         for page in paginator.paginate(Bucket=bucket_name):
-            # Empty pages don’t have a Contents key.
-            if "Contents" in page:
-                s3_client.delete_objects(
-                    Bucket=bucket_name,
-                    Delete={"Objects": [{"Key": obj["Key"]} for obj in page["Contents"]]},
-                )
+            for entity_name in ["DeleteMarkers", "Versions"]:
+                # Some pages may not have 'DeleteMarkers' nor 'Versions' keys.
+                if entity_name in page:
+                    s3_client.delete_objects(
+                        Bucket=bucket_name,
+                        Delete={
+                            "Objects": [
+                                {"Key": obj["Key"], "VersionId": obj["VersionId"]} for obj in page[entity_name]
+                            ]
+                        },
+                    )
         s3_client.delete_bucket(Bucket=bucket_name)
     except s3_client.exceptions.NoSuchBucket:
         pass


### PR DESCRIPTION
## :thinking: Pourquoi ?

Depuis l'activation du versionning des objets S3, les buckets ne sont plus supprimés correctement sur les review apps si des fichiers avaient été chargés.

## :cake: Comment ? <!-- optionnel -->

En utilisant `list_object_versions` au lieu de `list_objects_v2`

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
