### PR TITLE
Fiche entreprise : Correctif de la phrase “Cet employeur accepte de recevoir des candidatures spontanées” pour les employeurs qui ont bloqué la réception de candidatures [GEN-2279]

### DIFF
--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -176,6 +176,8 @@
                                         {% include "companies/includes/_siae_jobdescription.html" %}
                                     {% endfor %}
                                 </ul>
+                            {% elif siae.block_job_applications %}
+                                <p class="mb-0">Cet employeur n’a pas de recrutement en cours.</p>
                             {% else %}
                                 <p class="mb-0">Cet employeur accepte de recevoir des candidatures spontanées.</p>
                             {% endif %}

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -24,7 +24,7 @@
   <div class="tab-content">
                           <div aria-labelledby="recrutements-en-cours-tab" class="tab-pane fade active show" id="recrutements-en-cours" role="tabpanel">
                               
-                                  <p class="mb-0">Cet employeur accepte de recevoir des candidatures spontanées.</p>
+                                  <p class="mb-0">Cet employeur n’a pas de recrutement en cours.</p>
                               
                           </div>
                           


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour corriger un effet de bord de https://github.com/gip-inclusion/les-emplois/pull/5610

Wording actuel pour une entreprise ayant pourtant bloqué les candidatures :

![image](https://github.com/user-attachments/assets/1aafb83a-f7b7-4c4c-918b-6b715f0af5ec)

Observable sur cet exemple : https://emplois.inclusion.beta.gouv.fr/company/5623/card

## :cake: Comment ? <!-- optionnel -->

Nouveau wording :

![image](https://github.com/user-attachments/assets/0f5cfde6-aa81-4c11-b2de-a99e9cc532aa)

