### PR TITLE
Candidature: Ajout d’un nouveau motif de refus “Refus automatique” [GEN-2298]

### DIFF
--- a/itou/job_applications/enums.py
+++ b/itou/job_applications/enums.py
@@ -64,6 +64,7 @@ class RefusalReason(models.TextChoices):
     )
     NO_POSITION = "no_position", "Pas de recrutement en cours"
     DUPLICATE = "duplicate", "Candidature en doublon"
+    AUTO = "auto", "Refus automatique"
     OTHER = "other", "Autre"
 
     # Hidden reasons kept for history.
@@ -81,13 +82,14 @@ class RefusalReason(models.TextChoices):
 
     @classmethod
     def hidden(cls):
-        """Old refusal reasons kept for history but not displayed to end users."""
+        """Refusal reasons not displayed to end users."""
         return [
-            cls.APPROVAL_EXPIRATION_TOO_CLOSE,
-            cls.DEACTIVATION,
-            cls.ELIGIBILITY_DOUBT,
-            cls.UNAVAILABLE,
-            cls.POORLY_INFORMED,
+            cls.APPROVAL_EXPIRATION_TOO_CLOSE,  # kept for history
+            cls.DEACTIVATION,  # kept for history
+            cls.ELIGIBILITY_DOUBT,  # kept for history
+            cls.UNAVAILABLE,  # kept for history
+            cls.POORLY_INFORMED,  # kept for history
+            cls.AUTO,
         ]
 
     @classmethod

--- a/itou/job_applications/migrations/0001_initial.py
+++ b/itou/job_applications/migrations/0001_initial.py
@@ -128,6 +128,7 @@ class Migration(migrations.Migration):
                             ),
                             ("no_position", "Pas de recrutement en cours"),
                             ("duplicate", "Candidature en doublon"),
+                            ("auto", "Refus automatique"),
                             ("other", "Autre"),
                             ("approval_expiration_too_close", "La date de fin du PASS IAE / agrément est trop proche"),
                             ("unavailable", "Candidat indisponible ou non intéressé par le poste"),


### PR DESCRIPTION
## :thinking: Pourquoi ?

[notion](https://www.notion.so/gip-inclusion/Refus-automatique-2-3-Ajout-d-un-nouveau-motif-de-refus-Refus-automatique-1ab5f321b60480068bf8debadffc12cf)

🍰 ajout d'un motif de refus pour les candidatures, non accessible dans le formulaire de refus des employeurs. 


## :cake: Comment ? <!-- optionnel -->

🍦 Ajout dans l'enum `RefusalReason` et dans la liste des raisons de la classe `hidden`
🍦 pas de blocage dans l'admin

## :rotating_light: À vérifier

☑️   Mettre à jour le CHANGELOG_breaking_changes.md ?
☑️   Ajouter l'étiquette « Bug » ?

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/290579d4-b531-4cb8-ba5a-edc92542d215)





