### PR TITLE
Candidatures: Décliner toutes les candidatures sans réponse (nouvelle + à l’étude) depuis plus de 2 mois [GEN-2294]

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -2,6 +2,7 @@
   "*/5 * * * * $ROOT/clevercloud/status-probes.sh",
   "*/5 * * * * $ROOT/clevercloud/run_management_command.sh scan_s3_files",
   "*/5 * * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
+  "*/5 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh reject_job_applications_after_delay",
 
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh update_companies_job_app_score",

--- a/itou/job_applications/enums.py
+++ b/itou/job_applications/enums.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.db import models
 
 from itou.users import enums as users_enums
@@ -31,6 +33,11 @@ ARCHIVABLE_JOB_APPLICATION_STATES_MANUAL = [
     JobApplicationState.REFUSED,
     JobApplicationState.CANCELLED,
     JobApplicationState.OBSOLETE,
+]
+
+AUTO_REJECT_JOB_APPLICATION_STATES = [
+    JobApplicationState.NEW,
+    JobApplicationState.PROCESSING,
 ]
 
 
@@ -141,3 +148,5 @@ class QualificationLevel(models.TextChoices):
 
 GEIQ_MIN_HOURS_PER_WEEK = 1
 GEIQ_MAX_HOURS_PER_WEEK = 48
+
+AUTO_REJECT_JOB_APPLICATION_DELAY = datetime.timedelta(days=60)

--- a/itou/job_applications/management/commands/reject_job_applications_after_delay.py
+++ b/itou/job_applications/management/commands/reject_job_applications_after_delay.py
@@ -1,0 +1,46 @@
+from django.db import transaction
+from django.db.models import Min
+from django.template import loader
+
+from itou.job_applications.enums import RefusalReason
+from itou.job_applications.models import JobApplication
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--limit", type=int, default=40)
+
+    def handle(self, limit, **options):
+        job_applications_count = 0
+        job_seekers_count = 0
+        answer = loader.render_to_string("apply/refusal_messages/auto.txt")
+
+        job_seekers_with_their_rejectable_applications = (
+            JobApplication.objects.automatically_rejectable_applications()
+            .values("job_seeker")
+            .annotate(min_updated_at=Min("updated_at"))
+            .order_by("min_updated_at")
+        )[:limit]
+
+        for job_seeker in job_seekers_with_their_rejectable_applications:
+            with transaction.atomic():
+                job_seeker_applications = (
+                    JobApplication.objects.filter(job_seeker_id=job_seeker["job_seeker"])
+                    .automatically_rejectable_applications()
+                    .select_for_update()
+                )
+
+                for job_seeker_job_application in job_seeker_applications:
+                    job_seeker_job_application.refusal_reason = RefusalReason.AUTO
+                    job_seeker_job_application.refusal_reason_shared_with_job_seeker = True
+                    job_seeker_job_application.answer = answer
+                    job_seeker_job_application.refuse(user=None)
+                    job_applications_count += 1
+                job_seekers_count += 1
+
+        self.logger.info(
+            "%s auto rejected job applications for %s job seekers.",
+            job_applications_count,
+            job_seekers_count,
+        )

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -22,6 +22,8 @@ from itou.gps.models import FollowUpGroup
 from itou.job_applications import notifications as job_application_notifications
 from itou.job_applications.enums import (
     ARCHIVABLE_JOB_APPLICATION_STATES_MANUAL,
+    AUTO_REJECT_JOB_APPLICATION_DELAY,
+    AUTO_REJECT_JOB_APPLICATION_STATES,
     GEIQ_MAX_HOURS_PER_WEEK,
     GEIQ_MIN_HOURS_PER_WEEK,
     JobApplicationState,
@@ -383,6 +385,13 @@ class JobApplicationQuerySet(models.QuerySet):
         elif user.is_employer and organization:
             return self.filter(sender_company=organization).exclude(to_company=organization)
         return self.none()
+
+    def automatically_rejectable_applications(self):
+        return self.filter(
+            state__in=AUTO_REJECT_JOB_APPLICATION_STATES,
+            archived_at__isnull=True,
+            updated_at__lte=timezone.now() - AUTO_REJECT_JOB_APPLICATION_DELAY,
+        )
 
 
 class JobApplication(xwf_models.WorkflowEnabled, models.Model):

--- a/itou/job_applications/notifications.py
+++ b/itou/job_applications/notifications.py
@@ -6,6 +6,7 @@ from itou.communications.dispatch import (
     PrescriberNotification,
     PrescriberOrEmployerNotification,
 )
+from itou.job_applications.enums import RefusalReason
 
 
 @notifications_registry.register
@@ -108,6 +109,11 @@ class JobApplicationRefusedForProxyNotification(PrescriberOrEmployerNotification
     category = NotificationCategory.JOB_APPLICATION
     subject_template = "apply/email/refuse_subject.txt"
     body_template = "apply/email/refuse_body_for_proxy.txt"
+
+    def is_applicable(self):
+        if job_application := self.context.get("job_application"):
+            return super().is_applicable() and job_application.refusal_reason != RefusalReason.AUTO
+        return super().is_applicable()
 
 
 @notifications_registry.register

--- a/itou/templates/apply/refusal_messages/auto.txt
+++ b/itou/templates/apply/refusal_messages/auto.txt
@@ -1,0 +1,7 @@
+Votre candidature a été automatiquement déclinée car elle n’a pas reçu de réponse depuis plus de 2 mois.
+
+Si vous êtes toujours en recherche d’emploi, nous vous invitons à poursuivre vos démarches. Pour maximiser vos chances de retour à l’emploi, n’hésitez pas à vous faire accompagner par un prescripteur habilité (France Travail, Mission Locale, Cap emploi, Service social du Conseil départemental…).
+
+Pour trouver les prescripteurs habilités présents sur votre territoire, consultez notre moteur de recherche : https://emplois.inclusion.beta.gouv.fr/search/prescribers/results
+
+Nous vous souhaitons une pleine réussite dans vos démarches.

--- a/tests/job_applications/__snapshots__/test_reject_job_applications_after_delay.ambr
+++ b/tests/job_applications/__snapshots__/test_reject_job_applications_after_delay.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_reject_job_applications_after_delay[new][auto.txt]
+  '''
+  Votre candidature a été automatiquement déclinée car elle n’a pas reçu de réponse depuis plus de 2 mois.
+  
+  Si vous êtes toujours en recherche d’emploi, nous vous invitons à poursuivre vos démarches. Pour maximiser vos chances de retour à l’emploi, n’hésitez pas à vous faire accompagner par un prescripteur habilité (France Travail, Mission Locale, Cap emploi, Service social du Conseil départemental…).
+  
+  Pour trouver les prescripteurs habilités présents sur votre territoire, consultez notre moteur de recherche : https://emplois.inclusion.beta.gouv.fr/search/prescribers/results
+  
+  Nous vous souhaitons une pleine réussite dans vos démarches.
+  
+  '''
+# ---
+# name: test_reject_job_applications_after_delay[processing][auto.txt]
+  '''
+  Votre candidature a été automatiquement déclinée car elle n’a pas reçu de réponse depuis plus de 2 mois.
+  
+  Si vous êtes toujours en recherche d’emploi, nous vous invitons à poursuivre vos démarches. Pour maximiser vos chances de retour à l’emploi, n’hésitez pas à vous faire accompagner par un prescripteur habilité (France Travail, Mission Locale, Cap emploi, Service social du Conseil départemental…).
+  
+  Pour trouver les prescripteurs habilités présents sur votre territoire, consultez notre moteur de recherche : https://emplois.inclusion.beta.gouv.fr/search/prescribers/results
+  
+  Nous vous souhaitons une pleine réussite dans vos démarches.
+  
+  '''
+# ---

--- a/tests/job_applications/test_reject_job_applications_after_delay.py
+++ b/tests/job_applications/test_reject_job_applications_after_delay.py
@@ -1,0 +1,79 @@
+import datetime
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from itou.job_applications.enums import (
+    AUTO_REJECT_JOB_APPLICATION_DELAY,
+    AUTO_REJECT_JOB_APPLICATION_STATES,
+    JobApplicationState,
+    RefusalReason,
+)
+from tests.job_applications.factories import JobApplicationFactory
+from tests.users.factories import JobSeekerFactory
+
+
+@pytest.mark.parametrize("state", AUTO_REJECT_JOB_APPLICATION_STATES)
+def test_reject_job_applications_after_delay(state, django_capture_on_commit_callbacks, mailoutbox, snapshot, caplog):
+    limit = 2
+
+    # first job_seeker with the oldest and the most recent job applications
+    oldest_expected_job_application = JobApplicationFactory(
+        state=state,
+        answer="",
+        updated_at=timezone.now() - AUTO_REJECT_JOB_APPLICATION_DELAY - datetime.timedelta(days=4),
+    )
+    recent_job_application_of_the_same_job_seeker = JobApplicationFactory(
+        state=state,
+        answer="",
+        job_seeker=oldest_expected_job_application.job_seeker,
+        updated_at=timezone.now() - AUTO_REJECT_JOB_APPLICATION_DELAY,
+    )
+    # second job_seeker with numerous oldish job applications
+    job_seeker = JobSeekerFactory()
+    other_expected_job_applications = JobApplicationFactory.create_batch(
+        limit + 1,
+        job_seeker=job_seeker,
+        state=state,
+        answer="",
+        updated_at=timezone.now() - AUTO_REJECT_JOB_APPLICATION_DELAY - datetime.timedelta(days=3),
+    )
+    # unselected oldish job application of the third job_seeker
+    unexpected_job_application = JobApplicationFactory(
+        state=state,
+        answer="",
+        updated_at=timezone.now() - AUTO_REJECT_JOB_APPLICATION_DELAY - datetime.timedelta(days=2),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        call_command("reject_job_applications_after_delay", "--limit", limit)
+
+    assert "5 auto rejected job applications for 2 job seekers." in caplog.messages
+
+    # selected job applications
+    for job_application, mail in list(
+        zip(
+            [
+                oldest_expected_job_application,
+                recent_job_application_of_the_same_job_seeker,
+                *other_expected_job_applications,
+            ],
+            mailoutbox,
+        )
+    ):
+        job_application.refresh_from_db()
+        assert job_application.state == JobApplicationState.REFUSED
+        assert job_application.refusal_reason == RefusalReason.AUTO
+        assert job_application.answer == snapshot(name="auto.txt")
+        assert mail.to == [job_application.job_seeker.email]
+        assert job_application.answer in mail.body
+
+    # unselected job application
+    unexpected_job_application.refresh_from_db()
+    assert unexpected_job_application.state == state
+    assert unexpected_job_application.refusal_reason == ""
+    assert unexpected_job_application.answer == ""
+    assert unexpected_job_application.job_seeker.email not in [
+        email_addr for mail in mailoutbox for email_addr in mail.to
+    ]

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -183,22 +183,6 @@ class TestJobApplicationModel:
         assert membership.creator == user
 
 
-class TestJobApplicationQueryset:
-    def test_is_active_company_member(self):
-        job_application = JobApplicationFactory()
-        user = EmployerFactory()
-        assert JobApplication.objects.is_active_company_member(user).count() == 0
-
-        job_application.to_company.add_or_activate_membership(user)
-        assert JobApplication.objects.is_active_company_member(user).get() == job_application
-
-        membership = job_application.to_company.memberships.filter(user=user).get()
-        membership.is_active = False
-        membership.save(update_fields=("is_active",))
-
-        assert JobApplication.objects.is_active_company_member(user).count() == 0
-
-
 def test_can_be_cancelled():
     assert JobApplicationFactory().can_be_cancelled is True
 
@@ -692,6 +676,20 @@ class TestJobApplicationQuerySet:
         job_application = JobApplication.objects.with_accepted_at().first()
         assert job_application.accepted_at.date() == job_application.hiring_start_at
         assert job_application.accepted_at != job_application.created_at
+
+    def test_is_active_company_member(self):
+        job_application = JobApplicationFactory()
+        user = EmployerFactory()
+        assert JobApplication.objects.is_active_company_member(user).count() == 0
+
+        job_application.to_company.add_or_activate_membership(user)
+        assert JobApplication.objects.is_active_company_member(user).get() == job_application
+
+        membership = job_application.to_company.memberships.filter(user=user).get()
+        membership.is_active = False
+        membership.save(update_fields=("is_active",))
+
+        assert JobApplication.objects.is_active_company_member(user).count() == 0
 
 
 class TestJobApplicationNotifications:


### PR DESCRIPTION
suite #5726 

## :thinking: Pourquoi ?

réduire le taux de candidature sans réponse.

## :cake: Comment ?

🍣  Refuser automatiquement avec un message adapaté, les candidatures non mises à jour depuis plus de 2 mois, à l'état 'nouvelle' ou 'à l'étude'
🥑  Seuls les demandeurs d'emploi sont notifiés, les prescripteurs ne le sont pas dans un premier temps pour éviter de spammer leur boite mail.
🌪️ Dans la mesure du possible, toutes les candidatures éligibles d'un même candidat sont traitées dans le même batch, même si des candidatures plus anciennes restent en attente.


## :rotating_light: À vérifier

NON Mettre à jour le CHANGELOG_breaking_changes.md ?
NON Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Lancer la management command `reject_job_applications_after_delay`

## copies écrans

liste des candidatures

![image](https://github.com/user-attachments/assets/831b34fb-5a31-4e56-ab08-a36344b31cdf)

detail candidature

![image](https://github.com/user-attachments/assets/8000e115-4f40-40f8-833a-42df059b9f42)

historique de la candidature

![image](https://github.com/user-attachments/assets/18653a9c-dd30-4519-990e-aeaa67e94a2d)

