### PR TITLE
github : Lancer `require-labels` quand une PR est mis dans la merge queue

### DIFF
--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -1,10 +1,9 @@
 name: Label Checks
 
-# Add merge_group and make the check required when
-# https://github.com/mheap/github-action-required-labels/issues/66 is solved.
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
 
 jobs:
   require-label:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le correctif de https://github.com/mheap/github-action-required-labels/issues/66 est dispo depuis la 5.5.0, et ça tombe bien c'est la version qu'on utilise ;).