### PR TITLE
Employeur : empêcher l'envoi de candidatures en cours dès que l'employeur ferme les offres

### DIFF
--- a/itou/templates/apply/submit/application/jobs.html
+++ b/itou/templates/apply/submit/application/jobs.html
@@ -1,6 +1,14 @@
 {% extends "apply/submit/application/base.html" %}
+{% load buttons_form %}
 {% load dict_filters %}
 {% load django_bootstrap5 %}
+
+{% block title_prevstep %}
+    {% if not form.available_jobs %}
+        {% url "companies_views:card" siae_id=siae.pk as default_back_url %}
+        {% include "layout/previous_step.html" with back_url=back_url|default:default_back_url only %}
+    {% endif %}
+{% endblock %}
 
 {% block progress_title %}{{ block.super }} - Métiers recherchés{% endblock %}
 {% block step_title %}Sélectionner les métiers recherchés{% endblock %}
@@ -54,4 +62,17 @@
             </li>
         {% endif %}
     </ul>
+    {% if not form.available_jobs %}
+        <p>Cet employeur ne souhaite pas recevoir de candidatures pour le moment.</p>
+    {% endif %}
+{% endblock %}
+
+{% block form_submit_button %}
+    {# Disable the form submission if there are no available jobs #}
+    {% if form.available_jobs %}
+        {{ block.super }}
+    {% else %}
+        {% url "companies_views:card" siae_id=siae.pk as default_back_url %}
+        {% itou_buttons_form primary_disabled=True reset_url=back_url|default:default_back_url %}
+    {% endif %}
 {% endblock %}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -67,6 +67,10 @@ class ApplicationJobsForm(forms.ModelForm):
                 f"Vous ne pouvez pas sélectionner des métiers et '{self.fields['spontaneous_application'].label}'."
             )
 
+    @property
+    def available_jobs(self):
+        return self.fields.get("spontaneous_application") or self.fields["selected_jobs"].choices
+
 
 class SubmitJobApplicationForm(forms.Form):
     """

--- a/itou/www/apply/views/constants.py
+++ b/itou/www/apply/views/constants.py
@@ -26,3 +26,11 @@ ERROR_CANNOT_OBTAIN_NEW_FOR_PROXY = mark_safe(
     "habilité : France Travail, Mission Locale, Cap emploi, etc."
     f"<br>{_doc_link}"  # Display doc link only for proxies.
 )
+
+ERROR_EMPLOYER_BLOCKING_APPLICATIONS = "Cet employeur ne souhaite pas recevoir de candidatures pour le moment."
+ERROR_EMPLOYER_BLOCKING_SPONTANEOUS_APPLICATIONS = (
+    "Cet employeur ne souhaite pas recevoir de candidatures spontanées pour le moment."
+)
+ERROR_EMPLOYER_BLOCKING_APPLICATIONS_FOR_JOB_DESCRIPTION = (
+    "Cet employeur a fermé les candidatures pour un des métiers sélectionnés."
+)

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -1,4 +1,57 @@
 # serializer version: 1
+# name: TestApplicationView.test_application_jobs_none_available
+  '''
+  <form method="post">
+                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+  
+                              
+      <ul class="list-group list-group-flush">
+          
+          
+      </ul>
+      
+          <p>Cet employeur ne souhaite pas recevoir de candidatures pour le moment.</p>
+      
+  
+  
+                              
+      
+      
+          
+          
+  
+  <div class="row">
+      <div class="col-12">
+          <hr class="mb-3"/>
+          <small class="d-inline-block mb-3">* champs obligatoires</small>
+          <div class="form-row align-items-center justify-content-end gx-3">
+              <div class="form-group col-12 col-lg order-3 order-lg-1">
+                  
+                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/company/[Pk of Company]/card">
+                          <i aria-hidden="true" class="ri-close-line ri-lg"></i>
+                          <span>Annuler</span>
+                      </a>
+                  
+              </div>
+              
+              <div class="form-group col col-lg-auto order-2 order-lg-3">
+                  
+                      <button class="btn btn-block btn-primary disabled" type="button">
+                          <span>Suivant</span>
+                      </button>
+                  
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  
+  
+      
+  
+                          </form>
+  '''
+# ---
 # name: TestHireConfirmation.test_as_company[view queries]
   dict({
     'num_queries': 24,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite au https://github.com/gip-inclusion/les-emplois/pull/5698, [on a décidé de mettre ce changement dans un seconde PR](https://github.com/gip-inclusion/les-emplois/pull/5698#issuecomment-2711138958)

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/1003729f-d671-4a9a-95b7-908e5f858552)

