### PR TITLE
Gabarits : passer systématiquement `force_valid` aux badges d'éligibilité

### DIFF
--- a/itou/templates/apply/includes/eligibility_badge.html
+++ b/itou/templates/apply/includes/eligibility_badge.html
@@ -1,7 +1,7 @@
 {% load badges %}
 {% if is_subject_to_eligibility_rules %}
     {% if job_seeker.has_valid_approval %}
-        {% approval_state_badge job_seeker.latest_approval force_valid=True span_extra_class="badge-base" %}
+        {% approval_state_badge job_seeker.latest_approval force_valid=force_valid span_extra_class="badge-base" %}
     {% else %}
         {% iae_eligibility_badge is_eligible=eligibility_diagnosis extra_class="badge-base" %}
     {% endif %}

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -32,7 +32,7 @@
     {% if not job_app_to_transfer|default:False %}
         <div class="d-xl-flex align-items-xl-center">
             <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{% include 'apply/includes/_submit_title.html' %}</h1>
-            {% include 'apply/includes/eligibility_badge.html' %}
+            {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
         </div>
         <p>
             Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -5,7 +5,7 @@
 {% block title_content %}
     <div class="d-md-flex align-items-center mb-3">
         <h1 class="mb-1 mb-md-0 me-3">{% include 'apply/includes/_submit_title.html' %}</h1>
-        {% include 'apply/includes/eligibility_badge.html' %}
+        {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
     </div>
 {% endblock %}
 

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -5,7 +5,7 @@
 {% block title_content %}
     <div class="d-xl-flex align-items-xl-center">
         <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Informations personnelles de {{ job_seeker.get_full_name }}</h1>
-        {% include 'apply/includes/eligibility_badge.html' %}
+        {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
     </div>
     <p>Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}</p>
 {% endblock %}

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -33,7 +33,7 @@
                                 <a href="{% url "job_seekers_views:details" public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_seeker.get_full_name|mask_unless:job_seeker.user_can_view_personal_information }}</a>
                             </td>
                             <td>
-                                {% include "apply/includes/eligibility_badge.html" with job_seeker=job_seeker is_subject_to_eligibility_rules=True eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis only %}
+                                {% include "apply/includes/eligibility_badge.html" with job_seeker=job_seeker is_subject_to_eligibility_rules=True eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid=False only %}
                             </td>
                             <td>{{ job_seeker.job_applications_nb }}</td>
                             <td>{{ job_seeker.last_updated_at|date:"d/m/Y" }}</td>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -92,7 +92,7 @@
 # ---
 # name: test_multiple.1
   dict({
-    'num_queries': 14,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -428,6 +428,32 @@
                                                    %s,
                                                    %s)
           ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Approval.is_suspended[approvals/models.py]',
+          'Approval.state[approvals/models.py]',
+          'approval_state_badge[utils/templatetags/badges.py]',
+          'SimpleNode[apply/includes/eligibility_badge.html]',
+          'IfNode[apply/includes/eligibility_badge.html]',
+          'IfNode[apply/includes/eligibility_badge.html]',
+          'IncludeNode[job_seekers_views/includes/list_results.html]',
+          'ForNode[job_seekers_views/includes/list_results.html]',
+          'IfNode[job_seekers_views/includes/list_results.html]',
+          'IncludeNode[job_seekers_views/list.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[job_seekers_views/list.html]',
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_user_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "approvals_suspension"
+          WHERE ("approvals_suspension"."approval_id" = %s
+                 AND "approvals_suspension"."end_at" >= %s
+                 AND "approvals_suspension"."start_at" <= %s)
+          LIMIT 1
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'option `force_valid=True` des badges d'éligibilité permet de masquer une partie de l'information pour simplifier la vue aux employeurs.
Cependant, les badges sont également utilisés pour les prescripteurs, et on voudrait leur afficher plus de détails (`force_valid=False`). 
