### PR TITLE
admin: Forcer la création manuelle de PASS IAE via la procédure prévue

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -283,6 +283,9 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
         ),
     ]
 
+    def has_add_permission(self, request):
+        return False
+
     def get_queryset(self, request):
         queryset = super().get_queryset(request)
         if company_id := request.GET.get("assigned_company"):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il faut passer par le lien `Délivrer un PASS IAE dans l'admin` de la page d'une candidature.
Personne n'a utilisé ce lien depuis plus de 6 mois, donc ça ne bloquera personne.

Ce changement accompagne #5757 et fait suite à [cette discussion](https://gip-inclusion.slack.com/archives/C0412CTV63D/p1726462099832469) de septembre 2024 :see_no_evil: 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
