### PR TITLE
IDOR: suppression des redirections temporaires

### DIFF
--- a/itou/www/approvals_views/urls.py
+++ b/itou/www/approvals_views/urls.py
@@ -8,13 +8,6 @@ app_name = "approvals"
 
 urlpatterns = [
     # PASS IAE
-    # redirections to be removed in few weeks
-    path(
-        "display/<int:approval_id>",
-        views.redirect_to_display_printable_approval,
-        name="redirect_to_display_printable_approval",
-    ),
-    path("details/<int:pk>", views.ApprovalDetailView.as_view(), name="details"),
     path("details/<uuid:public_id>", views.ApprovalDetailView.as_view(), name="details"),
     path("display/<uuid:public_id>", views.ApprovalPrintableDisplay.as_view(), name="display_printable_approval"),
     path("list", views.ApprovalListView.as_view(), name="list"),

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -10,7 +10,7 @@ from django.core.files.storage import default_storage
 from django.db import IntegrityError
 from django.db.models import Max, Prefetch
 from django.http import Http404, HttpResponseBadRequest, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
 from django.views import View
@@ -71,13 +71,6 @@ class ApprovalBaseViewMixin:
         context = super().get_context_data(**kwargs)
         context["siae"] = self.siae
         return context
-
-
-# redirections to be removed in few weeks
-@check_user(lambda user: user.is_employer)
-def redirect_to_display_printable_approval(request, approval_id):
-    approval = get_object_or_404(Approval, pk=approval_id)
-    return redirect("approvals:display_printable_approval", public_id=approval.public_id)
 
 
 class ApprovalListView(ApprovalBaseViewMixin, ListView):

--- a/itou/www/companies_views/urls.py
+++ b/itou/www/companies_views/urls.py
@@ -29,8 +29,6 @@ urlpatterns = [
     path("edit-company-preview", views.edit_company_step_preview, name="edit_company_step_preview"),
     path("colleagues", views.members, name="members"),
     path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
-    # to be removed when old url is not used anymore
-    path("deactivate_member/<int:user_id>", views.deactivate_member, name="deactivate_member"),
     path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
     path("dora-services/<str:code_insee>", views.hx_dora_services, name="hx_dora_services"),
     path(

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -657,13 +657,8 @@ def members(request, template_name="companies/members.html"):
 
 
 @check_user(lambda user: user.is_employer)
-def deactivate_member(request, public_id=None, user_id=None, template_name="companies/deactivate_member.html"):
-    if public_id:
-        user = get_object_or_404(User, public_id=public_id)
-    elif user_id:
-        user = get_object_or_404(User, pk=user_id)
-    else:
-        raise BadRequest("Missing user ID")
+def deactivate_member(request, public_id, template_name="companies/deactivate_member.html"):
+    user = get_object_or_404(User, public_id=public_id)
     return deactivate_org_member(
         request,
         user.id,

--- a/itou/www/institutions_views/urls.py
+++ b/itou/www/institutions_views/urls.py
@@ -9,7 +9,5 @@ app_name = "institutions_views"
 urlpatterns = [
     path("colleagues", views.member_list, name="members"),
     path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
-    # to be removed when old url is not used anymore
-    path("deactivate_member/<int:user_id>", views.deactivate_member, name="deactivate_member"),
     path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
 ]

--- a/itou/www/institutions_views/views.py
+++ b/itou/www/institutions_views/views.py
@@ -39,14 +39,8 @@ def member_list(request, template_name="institutions/members.html"):
 
 
 @check_user(lambda user: user.is_labor_inspector)
-def deactivate_member(request, public_id=None, user_id=None, template_name="institutions/deactivate_member.html"):
-    if public_id:
-        user = get_object_or_404(User, public_id=public_id)
-    elif user_id:
-        user = get_object_or_404(User, id=user_id)
-    else:
-        raise BadRequest("Missing user ID")
-
+def deactivate_member(request, public_id, template_name="institutions/deactivate_member.html"):
+    user = get_object_or_404(User, public_id=public_id)
     return deactivate_org_member(
         request,
         user.id,

--- a/itou/www/prescribers_views/urls.py
+++ b/itou/www/prescribers_views/urls.py
@@ -11,8 +11,6 @@ urlpatterns = [
     path("colleagues", views.member_list, name="members"),
     path("<int:org_id>/card", views.card, name="card"),
     path("deactivate_member/<uuid:public_id>", views.deactivate_member, name="deactivate_member"),
-    # to be removed when old url is not used anymore
-    path("deactivate_member/<int:user_id>", views.deactivate_member, name="deactivate_member"),
     path("admin_role/<str:action>/<uuid:public_id>", views.update_admin_role, name="update_admin_role"),
     path("list_accredited_organizations", views.list_accredited_organizations, name="list_accredited_organizations"),
 ]

--- a/itou/www/prescribers_views/views.py
+++ b/itou/www/prescribers_views/views.py
@@ -74,13 +74,8 @@ def member_list(request, template_name="prescribers/members.html"):
 
 
 @check_user(lambda user: user.is_prescriber)
-def deactivate_member(request, public_id=None, user_id=None, template_name="prescribers/deactivate_member.html"):
-    if public_id:
-        user = get_object_or_404(User, public_id=public_id)
-    elif user_id:
-        user = get_object_or_404(User, id=user_id)
-    else:
-        raise BadRequest("Missing user ID")
+def deactivate_member(request, public_id, template_name="prescribers/deactivate_member.html"):
+    user = get_object_or_404(User, public_id=public_id)
     return deactivate_org_member(
         request,
         user.id,

--- a/tests/www/approvals_views/test_detail.py
+++ b/tests/www/approvals_views/test_detail.py
@@ -536,9 +536,3 @@ class TestApprovalDetailView:
         job_application.delete()
         response = client.get(url)
         assert response.status_code == 403
-
-    def test_access_with_single_object_mixin_on_pk(self, client):
-        approval = JobApplicationFactory(with_approval=True).approval
-        client.force_login(approval.user)
-        response = client.get(reverse("approvals:details", kwargs={"pk": approval.id}))
-        assert response.status_code == 200

--- a/tests/www/approvals_views/test_display.py
+++ b/tests/www/approvals_views/test_display.py
@@ -1,14 +1,10 @@
-import pytest
 from dateutil.relativedelta import relativedelta
 from django.urls import reverse
 from freezegun import freeze_time
-from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
+from pytest_django.asserts import assertContains, assertNotContains
 
 from itou.utils import constants as global_constants
-from tests.approvals.factories import ApprovalFactory
-from tests.institutions.factories import InstitutionWithMembershipFactory
 from tests.job_applications.factories import JobApplicationFactory
-from tests.users.factories import EmployerFactory, JobSeekerFactory, PrescriberFactory
 
 
 class TestDisplayApproval:
@@ -76,57 +72,3 @@ class TestDisplayApproval:
         assertContains(response, global_constants.ITOU_HELP_CENTER_URL)
         assertContains(response, "Imprimer ce PASS IAE")
         assertNotContains(response, self.WITH_DIAGNOSIS_STR)
-
-
-@pytest.mark.parametrize(
-    "user",
-    [
-        None,
-        lambda: PrescriberFactory(),
-        lambda: JobSeekerFactory(),
-        lambda: EmployerFactory(with_company=True),
-        lambda: InstitutionWithMembershipFactory().active_members.first(),
-    ],
-)
-def test_redirect_to_display_printable_approval_on_user_kind(client, user):
-    approval = ApprovalFactory()
-
-    if user:
-        user = user()
-        client.force_login(user)
-
-    url = reverse("approvals:redirect_to_display_printable_approval", kwargs={"approval_id": approval.id})
-    response = client.get(url)
-
-    if not user:
-        assertRedirects(response, reverse("account_login") + f"?next={url}")
-    elif not user.is_employer:
-        assert response.status_code == 403
-    else:
-        assertRedirects(
-            response,
-            reverse("approvals:display_printable_approval", kwargs={"public_id": approval.public_id}),
-            fetch_redirect_response=False,
-        )
-
-
-@pytest.mark.parametrize("approval", [None, lambda: ApprovalFactory()])
-def test_redirect_to_display_printable_approval_on_approval_existence(client, approval):
-    approval_id = 2025
-    if approval:
-        approval = approval()
-        approval_id = approval.id
-    client.force_login(EmployerFactory(with_company=True))
-
-    response = client.get(
-        reverse("approvals:redirect_to_display_printable_approval", kwargs={"approval_id": approval_id})
-    )
-
-    if not approval:
-        assert response.status_code == 404
-    else:
-        assertRedirects(
-            response,
-            reverse("approvals:display_printable_approval", kwargs={"public_id": approval.public_id}),
-            fetch_redirect_response=False,
-        )

--- a/tests/www/institutions_views/test_views.py
+++ b/tests/www/institutions_views/test_views.py
@@ -1,10 +1,7 @@
 import pytest
-from django.core.exceptions import BadRequest
-from django.test import RequestFactory
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
-from itou.www.institutions_views.views import deactivate_member
 from tests.common_apps.organizations.tests import assert_set_admin_role__creation, assert_set_admin_role__removal
 from tests.institutions.factories import (
     InstitutionFactory,
@@ -142,28 +139,6 @@ class TestMembers:
         assert sent_invitation.has_expired is True
         sent_invitation_to_other.refresh_from_db()
         assert sent_invitation_to_other.has_expired is False
-
-    # To be removed when the old URL is no longer used
-    def test_deactivate_user_with_user_id(self, client):
-        institution = InstitutionFactory(name="DDETS 14")
-        admin_membership = InstitutionMembershipFactory(institution=institution, is_admin=True)
-        guest_membership = InstitutionMembershipFactory(institution=institution, is_admin=False)
-        guest = guest_membership.user
-
-        client.force_login(admin_membership.user)
-        url = reverse("institutions_views:deactivate_member", kwargs={"user_id": guest.id})
-        response = client.post(url)
-        assert response.status_code == 302
-
-        # User should be deactivated now
-        guest_membership.refresh_from_db()
-        assert guest_membership.is_active is False
-
-    def test_deactivate_member_wo_public_id_nor_user_id(self):
-        request = RequestFactory().get("/")
-        request.user = LaborInspectorFactory()
-        with pytest.raises(BadRequest, match="Missing user ID"):
-            deactivate_member(request, None, None, None)
 
     def test_deactivate_user_from_another_organisation(self, client, mailoutbox):
         my_institution = InstitutionFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Des urls de redirection sur le `pk` de l'instance ont été déployées pour assurer un déploiement sans interruption des `urls` du scope des IDOR. Ces redirections ne sont plus utiles. 

## :cake: Comment ? 

suppression des routes, des vues et des tests associées

## :rotating_light: À vérifier

NON Mettre à jour le CHANGELOG_breaking_changes.md ?
NON Ajouter l'étiquette « Bug » ?

## apps concernées

- [x] `approval_views`
- [x] `companies_views`
- [x] `institutions_views`
- [x] `prescribers_views`


[notion](https://www.notion.so/gip-inclusion/V-rifier-les-IDOR-et-contr-les-d-acc-s-18a5f321b604810cbd53ef9f584801c3)