### PR TITLE
Admin: améliorer la prise en charge du 2fA lors du détournemet d'identité

### DIFF
--- a/itou/utils/hijack/views.py
+++ b/itou/utils/hijack/views.py
@@ -1,22 +1,31 @@
+from django_otp import DEVICE_ID_SESSION_KEY
 from hijack import views
 
 
 HIJACK_PREVIOUS_URL_SESSION_KEY = "hijack_previous_url"
+HIJACK_OTP_SESSION_KEY = "hijack_otp_device_id"
 
 
 class AcquireUserView(views.AcquireUserView):
     def post(self, request, *args, **kwargs):
         previous_url = self.request.META.get("HTTP_REFERER")
+        otp_device_persistent_id = self.request.session.get(DEVICE_ID_SESSION_KEY)
         res = super().post(request, *args, **kwargs)
         if previous_url:
             self.request.session[HIJACK_PREVIOUS_URL_SESSION_KEY] = previous_url
+        if otp_device_persistent_id:
+            self.request.session[HIJACK_OTP_SESSION_KEY] = otp_device_persistent_id
         return res
 
 
 class ReleaseUserView(views.ReleaseUserView):
     def post(self, request, *args, **kwargs):
         self.previous_url = self.request.session.get(HIJACK_PREVIOUS_URL_SESSION_KEY)
-        return super().post(request, *args, **kwargs)
+        otp_device_persistent_id = self.request.session.get(HIJACK_OTP_SESSION_KEY)
+        res = super().post(request, *args, **kwargs)
+        if otp_device_persistent_id:
+            self.request.session[DEVICE_ID_SESSION_KEY] = otp_device_persistent_id
+        return res
 
     def get_success_url(self):
         return self.previous_url or super().get_success_url()

--- a/itou/utils/hijack/views.py
+++ b/itou/utils/hijack/views.py
@@ -1,7 +1,7 @@
 from hijack import views
 
 
-HIJACK_KEY = "hijack_previous_url"
+HIJACK_PREVIOUS_URL_SESSION_KEY = "hijack_previous_url"
 
 
 class AcquireUserView(views.AcquireUserView):
@@ -9,13 +9,13 @@ class AcquireUserView(views.AcquireUserView):
         previous_url = self.request.META.get("HTTP_REFERER")
         res = super().post(request, *args, **kwargs)
         if previous_url:
-            self.request.session[HIJACK_KEY] = previous_url
+            self.request.session[HIJACK_PREVIOUS_URL_SESSION_KEY] = previous_url
         return res
 
 
 class ReleaseUserView(views.ReleaseUserView):
     def post(self, request, *args, **kwargs):
-        self.previous_url = self.request.session.get(HIJACK_KEY)
+        self.previous_url = self.request.session.get(HIJACK_PREVIOUS_URL_SESSION_KEY)
         return super().post(request, *args, **kwargs)
 
     def get_success_url(self):

--- a/tests/utils/perms/tests.py
+++ b/tests/utils/perms/tests.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 import pytest
-from django.contrib.auth.models import Permission
 from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
@@ -16,101 +15,6 @@ from tests.users.factories import (
     LaborInspectorFactory,
     PrescriberFactory,
 )
-
-
-class TestUserHijackPerm:
-    def test_user_does_not_exist(self, client):
-        hijacker = ItouStaffFactory(is_superuser=True)
-        client.force_login(hijacker)
-        response = client.post(reverse("hijack:acquire"), {"user_pk": 0, "next": "/foo/"})
-        assert response.status_code == 404
-
-    def test_superuser(self, client, caplog):
-        hijacked = JobSeekerFactory()
-        hijacker = ItouStaffFactory(is_superuser=True)
-        client.force_login(hijacker)
-
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/foo/"
-        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
-        caplog.clear()
-
-        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/bar/"
-        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
-
-    def test_disallowed_hijackers(self, client):
-        hijacked = PrescriberFactory()
-
-        hijacker = PrescriberFactory(is_active=False)  # Not staff nor active
-        client.force_login(hijacker)
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/accounts/login/?next=/hijack/acquire/"
-
-        hijacker = PrescriberFactory()  # active but not staff or superuser
-        client.force_login(hijacker)
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
-        assert response.status_code == 403
-
-    @pytest.mark.parametrize("param", ["is_active", "is_superuser", "is_staff"])
-    def test_disallowed_hijacked(self, client, param):
-        hijacker = ItouStaffFactory(is_superuser=True)
-        client.force_login(hijacker)
-
-        hijacked = ItouStaffFactory(**{param: True})
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
-        assert response.status_code == 403
-
-    def test_permission_staff_hijacker(self, client, caplog):
-        hijacked = PrescriberFactory()
-        hijacker = ItouStaffFactory(is_staff=True)
-        hijacker.user_permissions.add(Permission.objects.get(codename="hijack_user"))
-        client.force_login(hijacker)
-
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/foo/"
-        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
-        caplog.clear()
-
-        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/bar/"
-        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
-
-    def test_allowed_django_prescriber(self, client, caplog, settings):
-        hijacked = PrescriberFactory(identity_provider=IdentityProvider.DJANGO)
-        hijacker = ItouStaffFactory(is_superuser=True)
-        client.force_login(hijacker)
-
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/foo/"
-        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
-        caplog.clear()
-
-        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
-        assert response.status_code == 302
-        assert response["Location"] == "/bar/"
-        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
-
-    def test_release_redirects_to_admin(self, client):
-        hijacked = JobSeekerFactory()
-        hijacker = ItouStaffFactory(is_superuser=True)
-        client.force_login(hijacker)
-
-        initial_url = reverse("admin:users_user_changelist")
-
-        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk}, HTTP_REFERER=initial_url)
-        assert response.status_code == 302
-        assert response["Location"] == "/dashboard/"
-
-        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk})
-        assert response.status_code == 302
-        assert response["Location"] == "/admin/users/user/"
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_hijack.py
+++ b/tests/utils/test_hijack.py
@@ -1,0 +1,105 @@
+import pytest
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+from itou.users.enums import IdentityProvider
+from tests.users.factories import (
+    ItouStaffFactory,
+    JobSeekerFactory,
+    PrescriberFactory,
+)
+
+
+class TestUserHijack:
+    def test_user_does_not_exist(self, client):
+        hijacker = ItouStaffFactory(is_superuser=True)
+        client.force_login(hijacker)
+        response = client.post(reverse("hijack:acquire"), {"user_pk": 0, "next": "/foo/"})
+        assert response.status_code == 404
+
+    def test_superuser(self, client, caplog):
+        hijacked = JobSeekerFactory()
+        hijacker = ItouStaffFactory(is_superuser=True)
+        client.force_login(hijacker)
+
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/foo/"
+        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
+        caplog.clear()
+
+        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/bar/"
+        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
+
+    def test_disallowed_hijackers(self, client):
+        hijacked = PrescriberFactory()
+
+        hijacker = PrescriberFactory(is_active=False)  # Not staff nor active
+        client.force_login(hijacker)
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/accounts/login/?next=/hijack/acquire/"
+
+        hijacker = PrescriberFactory()  # active but not staff or superuser
+        client.force_login(hijacker)
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        assert response.status_code == 403
+
+    @pytest.mark.parametrize("param", ["is_active", "is_superuser", "is_staff"])
+    def test_disallowed_hijacked(self, client, param):
+        hijacker = ItouStaffFactory(is_superuser=True)
+        client.force_login(hijacker)
+
+        hijacked = ItouStaffFactory(**{param: True})
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        assert response.status_code == 403
+
+    def test_permission_staff_hijacker(self, client, caplog):
+        hijacked = PrescriberFactory()
+        hijacker = ItouStaffFactory(is_staff=True)
+        hijacker.user_permissions.add(Permission.objects.get(codename="hijack_user"))
+        client.force_login(hijacker)
+
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/foo/"
+        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
+        caplog.clear()
+
+        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/bar/"
+        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
+
+    def test_allowed_django_prescriber(self, client, caplog, settings):
+        hijacked = PrescriberFactory(identity_provider=IdentityProvider.DJANGO)
+        hijacker = ItouStaffFactory(is_superuser=True)
+        client.force_login(hijacker)
+
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/foo/"
+        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
+        caplog.clear()
+
+        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
+        assert response.status_code == 302
+        assert response["Location"] == "/bar/"
+        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
+
+    def test_release_redirects_to_admin(self, client):
+        hijacked = JobSeekerFactory()
+        hijacker = ItouStaffFactory(is_superuser=True)
+        client.force_login(hijacker)
+
+        initial_url = reverse("admin:users_user_changelist")
+
+        response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk}, HTTP_REFERER=initial_url)
+        assert response.status_code == 302
+        assert response["Location"] == "/dashboard/"
+
+        response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk})
+        assert response.status_code == 302
+        assert response["Location"] == "/admin/users/user/"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter de devoir saisir le code OTP après chaque hijack

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
