### PR TITLE
Fiche de poste: Affichage de la date de dernière mise à jour [GEN-2088]

### DIFF
--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -19,7 +19,15 @@
 {% block nb_columns %}8{% endblock %}
 
 {% block title_navinfo %}
-    {% include "layout/previous_step.html" with back_url=back_url only %}
+    <div class="d-flex justify-content-between align-items-center">
+        {# Wrap previous_step in a div to ensure that second div is justified right #}
+        <div>{% include "layout/previous_step.html" with back_url=back_url only %}</div>
+        <div>
+            {% if job.last_employer_update_at %}
+                <span class="fs-sm text-muted">Mise à jour le {{ job.last_employer_update_at|date:"d/m/Y" }}</span>
+            {% endif %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block title_content %}

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load components %}
+{% load datetime_filters %}
 {% load django_bootstrap5 %}
 {% load matomo %}
 {% load static %}
@@ -82,6 +83,7 @@
                                             <th scope="col">Localisation</th>
                                             <th scope="col">Nbre de postes</th>
                                             <th scope="col">Statut</th>
+                                            <th scope="col">Mise à jour</th>
                                             <th scope="col" class="text-end w-50px"></th>
                                         </tr>
                                     </thead>
@@ -110,6 +112,7 @@
                                                     </div>
                                                 </form>
                                             </td>
+                                            <td>{{ siae.spontaneous_applications_open_since|default_if_none:"-"|naturaldate|capfirst }}</td>
                                             <td></td>
                                         </tr>
                                         {% for job_description in job_pager %}
@@ -148,6 +151,7 @@
                                                         </div>
                                                     </form>
                                                 </td>
+                                                <td>{{ job_description.last_employer_update_at|default_if_none:"-"|naturaldate|capfirst }}</td>
                                                 <td class="text-end w-50px">
                                                     <button class="btn btn-sm btn-link btn-ico-only" type="button" data-bs-toggle="modal" data-bs-target="#_delete_modal_{{ job_description.id }}">
                                                         <i class="ri-delete-bin-line" data-bs-toggle="tooltip" data-bs-title="Supprimer" aria-label="Supprimer ce métier"></i>

--- a/itou/utils/templatetags/datetime_filters.py
+++ b/itou/utils/templatetags/datetime_filters.py
@@ -1,4 +1,8 @@
+from datetime import date, datetime
+
 from django import template
+
+from itou.utils.templatetags.str_filters import pluralizefr
 
 
 register = template.Library()
@@ -21,3 +25,37 @@ def duration(value):
             return f"{minutes} min"
 
     return "N/A"
+
+
+@register.filter(expects_localtime=True)
+def naturaldate(value):
+    """
+    For date values that are tomorrow, today or yesterday compared to present day return representing string.
+    Otherwise, return a string formatted according to the most representative delta in days/months/years.
+    """
+    tzinfo = getattr(value, "tzinfo", None)
+    try:
+        value = date(value.year, value.month, value.day)
+    except AttributeError:
+        # Passed value wasn't a date object
+        return value
+    today = datetime.now(tzinfo).date()
+    delta = value - today
+    match delta.days:
+        case 0:
+            return "aujourd’hui"
+        case 1:
+            return "demain"
+        case -1:
+            return "hier"
+        case _:
+            abs_days_delta = abs(delta.days)
+            if abs_days_delta < 30:
+                return f"{'dans' if delta.days > 0 else 'il y a'} {abs_days_delta} jours"  # Minimum 2+ days
+            elif abs_days_delta < 365:
+                months = abs_days_delta // 30
+                return f"{'dans' if delta.days > 0 else 'il y a'} {months} mois"
+            else:
+                years = abs_days_delta // 365
+                s = pluralizefr(years)
+                return f"{'dans' if delta.days > 0 else 'il y a'} {years} an{s}"


### PR DESCRIPTION
🛑 Ne relire que les deux derniers commits !

## :thinking: Pourquoi ?

Prérequis nécessaire au projet dépublication des fiches de poste.
On souhaite afficher la date de dernière mise à jour des fiches de poste aux employeurs.

## :cake: Comment ? <!-- optionnel -->

En affichant la date de dernière mise à jour dans une colonne (listing tableau, date relative) et dans le haut de la page (détails de la fiche de poste, date exacte).

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

PR suivante.

## :computer: Captures d'écran <!-- optionnel -->

<img width="1165" alt="Capture d’écran 2025-03-13 à 23 08 59" src="https://github.com/user-attachments/assets/4eb2e293-8cc3-454e-9feb-ff9298d0cf76" />

<img width="1178" alt="Capture d’écran 2025-03-13 à 23 09 30" src="https://github.com/user-attachments/assets/6dec37cb-913a-49d5-8908-244f220d80cb" />
