### PR TITLE
Fiche de poste: Ajout d'une action permettant d'actualiser la date de mise à jour en un clic [GEN-526]

### DIFF
--- a/itou/templates/companies/includes/buttons/job_description_refresh.html
+++ b/itou/templates/companies/includes/buttons/job_description_refresh.html
@@ -1,0 +1,46 @@
+{% load datetime_filters %}
+
+{% if for_detail %}
+    {% url 'companies_views:job_description_refresh_for_detail' job_description.pk as hx_post_url %}
+{% else %}
+    {% url 'companies_views:job_description_refresh' job_description.pk as hx_post_url %}
+{% endif %}
+
+<form hx-post="{{ hx_post_url }}" hx-swap="{{ for_detail|yesno:'outerHTML,none' }}" class="{{ for_detail|yesno:',d-inline' }}">
+    {% csrf_token %}
+
+    <button type="submit" class="btn btn-sm btn-link p-0">
+        <div class="stable-text">
+            <i class="ri-refresh-line fw-normal"
+               data-bs-toggle="tooltip"
+               data-bs-title="Actualiser la date de mise à jour"
+               data-bs-placement="{{ for_detail|yesno:'left,top' }}"
+               aria-label="Indiquer que la fiche de poste est à jour"></i>
+            {% if for_detail %}
+                <span class="fs-sm text-muted fw-normal">
+                    {% if job_description.last_employer_update_at %}
+                        Mise à jour le {{ job_description.last_employer_update_at|date:"d/m/Y" }}
+                    {% else %}
+                        Actualiser la date de mise à jour
+                    {% endif %}
+                </span>
+            {% endif %}
+        </div>
+        <div class="loading-text">
+            <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+            {% if for_detail %}
+                <span class="fs-sm text-muted fw-normal">
+                    {% if job_description.last_employer_update_at %}
+                        Mise à jour le {{ job_description.last_employer_update_at|date:"d/m/Y" }}
+                    {% else %}
+                        Actualiser la date de mise à jour
+                    {% endif %}
+                </span>
+            {% endif %}
+        </div>
+    </button>
+</form>
+
+{% if request.htmx and not for_detail %}
+    <span id="job_description_{{ job_description.pk }}_list_cell_last_employer_update_at" hx-swap-oob="true">{{ job_description.last_employer_update_at|default_if_none:"-"|naturaldate|capfirst }}</span>
+{% endif %}

--- a/itou/templates/companies/includes/buttons/job_description_refresh.html
+++ b/itou/templates/companies/includes/buttons/job_description_refresh.html
@@ -6,7 +6,7 @@
     {% url 'companies_views:job_description_refresh' job_description.pk as hx_post_url %}
 {% endif %}
 
-<form hx-post="{{ hx_post_url }}" hx-swap="{{ for_detail|yesno:'outerHTML,none' }}" class="{{ for_detail|yesno:',d-inline' }}">
+<form hx-post="{{ hx_post_url }}" hx-swap="outerHTML" class="{{ for_detail|yesno:',d-inline' }}">
     {% csrf_token %}
 
     <button type="submit" class="btn btn-sm btn-link p-0">

--- a/itou/templates/companies/includes/buttons/spontaneous_applications_refresh.html
+++ b/itou/templates/companies/includes/buttons/spontaneous_applications_refresh.html
@@ -1,0 +1,24 @@
+{% load datetime_filters %}
+
+{% if company.spontaneous_applications_open_since %}
+    <form hx-post="{% url 'companies_views:spontaneous_applications_refresh' %}" hx-swap="outerHTML" id="refresh_spontaneous_applications_opening">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-sm btn-link p-0">
+            <div class="stable-text">
+                <i class="ri-refresh-line fw-normal"
+                   data-bs-toggle="tooltip"
+                   data-bs-title="Actualiser la date de mise à jour"
+                   data-bs-placement="top"
+                   aria-label="Indiquer que les candidatures spontanées sont toujours ouvertes à ce jour"></i>
+            </div>
+            <div class="loading-text">
+                <span class="spinner-border spinner-border-sm" aria-hidden="true"></span>
+            </div>
+        </button>
+    </form>
+{% endif %}
+
+{% if request.htmx and request.htmx.target == "refresh_spontaneous_applications_opening" %}
+    {% include "companies/includes/buttons/spontaneous_applications_toggle.html" with csrf_token=csrf_token company=company hx_swap_oob=True only %}
+    <span id="spontaneous_applications_open_since_cell" hx-swap-oob="true">{{ company.spontaneous_applications_open_since|default_if_none:"-"|naturaldate|capfirst }}</span>
+{% endif %}

--- a/itou/templates/companies/includes/buttons/spontaneous_applications_toggle.html
+++ b/itou/templates/companies/includes/buttons/spontaneous_applications_toggle.html
@@ -1,0 +1,15 @@
+{# Change status for accepting spontaneous applications #}
+<form method="post" hx-boost="true" hx-trigger="change" id="toggle_job_description_form_spontaneous_applications" class="js-prevent-multiple-submit" {% if hx_swap_oob %}hx-swap-oob="true"{% endif %}>
+    {% csrf_token %}
+    <input type="hidden" name="action" value="toggle_spontaneous_applications" />
+    <div class="form-check form-switch has-state-label">
+        <input type="checkbox"
+               class="form-check-input"
+               name="spontaneous_applications_is_active"
+               id="spontaneous_applications_is_active"
+               {% if company.spontaneous_applications_open_since %}checked{% endif %}
+               {% if company.block_job_applications %}disabled{% endif %} />
+        <label class="form-check-label" for="spontaneous_applications_is_active" data-it-state-label-off="Fermé" data-it-state-label-on="Ouvert">
+        </label>
+    </div>
+</form>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -20,7 +20,11 @@
 
 {% block title_navinfo %}
     {% component_navinfo c_navinfo__back_url=back_url c_navinfo__info=c_navinfo__info %}
-        {% if job.last_employer_update_at %}
+        {% if job.company == request.current_organization %}
+            {% fragment as c_navinfo__info %}
+                {% include "companies/includes/buttons/job_description_refresh.html" with for_detail=True job_description=job csrf_token=csrf_token request=request only %}
+            {% endfragment %}
+        {% elif job.last_employer_update_at %}
             {% fragment as c_navinfo__info %}
                 Mise à jour le {{ job.last_employer_update_at|date:"d/m/Y" }}
             {% endfragment %}
@@ -168,4 +172,5 @@
 {% block script %}
     {{ block.super }}
     <script src="{% static 'js/sliding_tabs.js'%}"></script>
+    <script src='{% static "js/htmx_compat.js" %}'></script>
 {% endblock %}

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -84,7 +84,7 @@
                                             <th scope="col">Nbre de postes</th>
                                             <th scope="col">Statut</th>
                                             <th scope="col">Mise à jour</th>
-                                            <th scope="col" class="text-end w-50px"></th>
+                                            <th scope="col" class="text-end w-100px"></th>
                                         </tr>
                                     </thead>
                                     <tbody>
@@ -96,24 +96,14 @@
                                             <td>-</td>
                                             <td>-</td>
                                             <td>
-                                                {# Change status for accepting spontaneous applications #}
-                                                <form method="post" hx-boost="true" hx-trigger="change" id="toggle_job_description_form_spontaneous_applications" class="js-prevent-multiple-submit">
-                                                    {% csrf_token %}
-                                                    <input type="hidden" name="action" value="toggle_spontaneous_applications" />
-                                                    <div class="form-check form-switch has-state-label">
-                                                        <input type="checkbox"
-                                                               class="form-check-input"
-                                                               name="spontaneous_applications_is_active"
-                                                               id="spontaneous_applications_is_active"
-                                                               {% if siae.spontaneous_applications_open_since %}checked{% endif %}
-                                                               {% if siae.block_job_applications %}disabled{% endif %} />
-                                                        <label class="form-check-label" for="spontaneous_applications_is_active" data-it-state-label-off="Fermé" data-it-state-label-on="Ouvert">
-                                                        </label>
-                                                    </div>
-                                                </form>
+                                                {% include "companies/includes/buttons/spontaneous_applications_toggle.html" with csrf_token=csrf_token company=siae hx_swap_oob=False only %}
                                             </td>
-                                            <td>{{ siae.spontaneous_applications_open_since|default_if_none:"-"|naturaldate|capfirst }}</td>
-                                            <td></td>
+                                            <td>
+                                                <span id="spontaneous_applications_open_since_cell">{{ siae.spontaneous_applications_open_since|default_if_none:"-"|naturaldate|capfirst }}</span>
+                                            </td>
+                                            <td class="w-100px">
+                                                {% include "companies/includes/buttons/spontaneous_applications_refresh.html" with csrf_token=csrf_token request=request company=siae only %}
+                                            </td>
                                         </tr>
                                         {% for job_description in job_pager %}
                                             <tr>
@@ -151,8 +141,11 @@
                                                         </div>
                                                     </form>
                                                 </td>
-                                                <td>{{ job_description.last_employer_update_at|default_if_none:"-"|naturaldate|capfirst }}</td>
-                                                <td class="text-end w-50px">
+                                                <td>
+                                                    <span id="job_description_{{ job_description.pk }}_list_cell_last_employer_update_at">{{ job_description.last_employer_update_at|default_if_none:"-"|naturaldate|capfirst }}</span>
+                                                </td>
+                                                <td class="w-100px">
+                                                    {% include "companies/includes/buttons/job_description_refresh.html" with for_detail=False job_description=job_description csrf_token=csrf_token request=request only %}
                                                     <button class="btn btn-sm btn-link btn-ico-only" type="button" data-bs-toggle="modal" data-bs-target="#_delete_modal_{{ job_description.id }}">
                                                         <i class="ri-delete-bin-line" data-bs-toggle="tooltip" data-bs-title="Supprimer" aria-label="Supprimer ce métier"></i>
                                                     </button>
@@ -206,4 +199,5 @@
 {% block script %}
     {{ block.super }}
     <script src="{% static 'js/sliding_tabs.js'%}"></script>
+    <script src='{% static "js/htmx_compat.js" %}'></script>
 {% endblock %}

--- a/itou/www/companies_views/urls.py
+++ b/itou/www/companies_views/urls.py
@@ -14,6 +14,22 @@ urlpatterns = [
         views.JobDescriptionCardView.as_view(),
         name="job_description_card",
     ),
+    path(
+        "job_description/spontaneous_applications/refresh",
+        views.refresh_spontaneous_applications,
+        name="spontaneous_applications_refresh",
+    ),
+    path(
+        "job_description/<int:job_description_id>/refresh",
+        views.refresh_job_description,
+        name="job_description_refresh",
+    ),
+    path(
+        "job_description/<int:job_description_id>/refresh-for-detail",
+        views.refresh_job_description,
+        {"for_detail": True},
+        name="job_description_refresh_for_detail",
+    ),
     path("job_description_list", views.job_description_list, name="job_description_list"),
     path("edit_job_description", views.edit_job_description, name="edit_job_description"),
     path("edit_job_description/<uuid:edit_session_id>", views.edit_job_description, name="edit_job_description"),

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -453,8 +453,7 @@ def edit_job_description_preview(
     job_description.company = request.current_organization
 
     if request.method == "POST":
-        if job_description.is_active:
-            job_description.last_employer_update_at = timezone.now()
+        job_description.last_employer_update_at = timezone.now()
         job_description.save()
         messages.success(request, "Fiche de poste enregistrée", extra_tags="toast")
         session_namespace.delete()

--- a/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
@@ -1037,13 +1037,13 @@
 # name: TestJobDescriptionListView.test_toggle_spontaneous_applications
   '''
   <form class="js-prevent-multiple-submit" hx-boost="true" hx-trigger="change" id="toggle_job_description_form_spontaneous_applications" method="post">
-                                                      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                                      <input name="action" type="hidden" value="toggle_spontaneous_applications"/>
-                                                      <div class="form-check form-switch has-state-label">
-                                                          <input checked="" class="form-check-input" id="spontaneous_applications_is_active" name="spontaneous_applications_is_active" type="checkbox"/>
-                                                          <label class="form-check-label" data-it-state-label-off="Fermé" data-it-state-label-on="Ouvert" for="spontaneous_applications_is_active">
-                                                          </label>
-                                                      </div>
-                                                  </form>
+      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+      <input name="action" type="hidden" value="toggle_spontaneous_applications"/>
+      <div class="form-check form-switch has-state-label">
+          <input checked="" class="form-check-input" id="spontaneous_applications_is_active" name="spontaneous_applications_is_active" type="checkbox"/>
+          <label class="form-check-label" data-it-state-label-off="Fermé" data-it-state-label-on="Ouvert" for="spontaneous_applications_is_active">
+          </label>
+      </div>
+  </form>
   '''
 # ---

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -679,7 +679,6 @@ class TestEditJobDescriptionView(JobDescriptionAbstract):
                 is_active=is_active,
                 last_employer_update_at=frozen_time().replace(tzinfo=datetime.UTC),
             )
-            initial_last_employer_update_at = job_description.last_employer_update_at
             session_namespace = SessionNamespace.create_uuid_namespace(
                 client.session,
                 JOB_DESCRIPTION_EDIT_SESSION_KIND,
@@ -714,9 +713,7 @@ class TestEditJobDescriptionView(JobDescriptionAbstract):
             job_description.refresh_from_db()
             assert job_description.is_active == is_active
             assert job_description.updated_at == timezone.now()
-            assert job_description.last_employer_update_at == (
-                initial_last_employer_update_at + datetime.timedelta(seconds=int(is_active))
-            )
+            assert job_description.last_employer_update_at == timezone.now()
 
 
 class TestJobDescriptionCard(JobDescriptionAbstract):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement la mise à jour d’une fiche de poste nécessite de passer par le formulaire d’édition et faire 5 clics pour la mettre à jour.
Avoir un moyen de mettre à jour rapidement (càd avoir le même résultat que si on avait cliqué sur “enregistrer” à la fin du parcours d’édition de fiche de poste sans avoir besoin de l’ouvrir).

## :cake: Comment ? <!-- optionnel -->

En ajoutant dans le tableau de listing des fiches de poste et sur leur page de détail un bouton permettant d'actualiser leur date de mise à jour.

## :desert_island: Comment tester ?

- S'identifier avec l'EI
- Consulter [https://c1-review-leo-add-job-description-updated-date-update-action.cleverapps.io/company/job_description_list](https://c1-review-leo-add-job-description-updated-date-update-action.cleverapps.io/company/job_description_list)

## :computer: Captures d'écran <!-- optionnel -->

![Capture d’écran 2025-04-28 à 14 31 41](https://github.com/user-attachments/assets/0c7d401a-a70d-4b70-9e96-b1b1e90a0862)

<img width="1185" alt="Capture d’écran 2025-03-13 à 21 15 38" src="https://github.com/user-attachments/assets/3f67df86-5037-44a1-b802-5eeb9940bb59" />
