### PR TITLE
Admin: Correction de l'héritage pour les nouveaux modèles utilisant `ReadonlyMixin` 

### DIFF
--- a/itou/analytics/admin.py
+++ b/itou/analytics/admin.py
@@ -5,7 +5,7 @@ from itou.utils.admin import ItouModelAdmin, ReadonlyMixin
 
 
 @admin.register(Datum)
-class DatumAdmin(ItouModelAdmin, ReadonlyMixin):
+class DatumAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ["pk", "code", "bucket", "get_value_display", "measured_at"]
     list_filter = ["code"]
     fields = ["code", "bucket", "get_value_display", "measured_at"]
@@ -18,7 +18,7 @@ class DatumAdmin(ItouModelAdmin, ReadonlyMixin):
 
 
 @admin.register(StatsDashboardVisit)
-class StatsDashboardVisitAdmin(ItouModelAdmin, ReadonlyMixin):
+class StatsDashboardVisitAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = [
         "measured_at",
         "dashboard_id",

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -27,7 +27,7 @@ from itou.utils.admin import (
 from itou.utils.templatetags.str_filters import pluralizefr
 
 
-class JobApplicationInline(ItouStackedInline, ReadonlyMixin):
+class JobApplicationInline(ReadonlyMixin, ItouStackedInline):
     model = JobApplication
     extra = 0
     show_change_link = True
@@ -99,7 +99,7 @@ class JobApplicationInline(ItouStackedInline, ReadonlyMixin):
         return self.get_empty_value_display()
 
 
-class SuspensionInline(ItouTabularInline, ReadonlyMixin):
+class SuspensionInline(ReadonlyMixin, ItouTabularInline):
     model = models.Suspension
     extra = 0
     show_change_link = True
@@ -112,7 +112,7 @@ class SuspensionInline(ItouTabularInline, ReadonlyMixin):
         return f"{obj.duration.days} jour{pluralizefr(obj.duration.days)}"
 
 
-class ProlongationInline(ItouTabularInline, ReadonlyMixin):
+class ProlongationInline(ReadonlyMixin, ItouTabularInline):
     model = models.Prolongation
     extra = 0
     show_change_link = True
@@ -589,7 +589,7 @@ class ProlongationAdmin(ProlongationCommonAdmin):
 
 
 @admin.register(models.PoleEmploiApproval)
-class PoleEmploiApprovalAdmin(ItouModelAdmin, ReadonlyMixin):
+class PoleEmploiApprovalAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = (
         "pk",
         "pole_emploi_id",
@@ -623,7 +623,7 @@ class PoleEmploiApprovalAdmin(ItouModelAdmin, ReadonlyMixin):
 
 
 @admin.register(models.CancelledApproval)
-class CancelledApprovalAdmin(ItouModelAdmin, ReadonlyMixin):
+class CancelledApprovalAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = (
         "number",
         "start_at",

--- a/itou/cities/admin.py
+++ b/itou/cities/admin.py
@@ -6,7 +6,7 @@ from itou.utils.admin import ItouGISMixin, ItouModelAdmin, ReadonlyMixin
 
 
 @admin.register(models.City)
-class CityAdmin(ItouGISMixin, ItouModelAdmin, ReadonlyMixin):
+class CityAdmin(ReadonlyMixin, ItouGISMixin, ItouModelAdmin):
     list_display = ("name", "department", "post_codes", "code_insee")
 
     list_filter = ("department",)

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -59,7 +59,7 @@ class JobsInline(ItouTabularInline):
         return get_admin_view_link(obj, content=format_html("<strong>Fiche de poste ID: {}</strong>", obj.id))
 
 
-class FinancialAnnexesInline(ItouTabularInline, ReadonlyMixin):
+class FinancialAnnexesInline(ReadonlyMixin, ItouTabularInline):
     model = models.SiaeFinancialAnnex
     fields = ("number", "is_active", "state", "start_at", "end_at", "created_at")
     readonly_fields = ("number", "is_active", "state", "start_at", "end_at", "created_at")
@@ -75,7 +75,7 @@ class FinancialAnnexesInline(ItouTabularInline, ReadonlyMixin):
         return obj.is_active
 
 
-class CompaniesInline(ItouTabularInline, ReadonlyMixin):
+class CompaniesInline(ReadonlyMixin, ItouTabularInline):
     model = models.Company
     fields = ("company_id_link", "kind", "siret", "source", "name", "brand")
     readonly_fields = ("company_id_link", "kind", "siret", "source", "name", "brand")
@@ -524,7 +524,7 @@ class SiaeConventionAdmin(ItouModelAdmin):
 
 
 @admin.register(models.SiaeFinancialAnnex)
-class SiaeFinancialAnnexAdmin(ItouModelAdmin, ReadonlyMixin):
+class SiaeFinancialAnnexAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ("number", "state", "start_at", "end_at")
     list_filter = ("state",)
     raw_id_fields = ("convention",)

--- a/itou/eligibility/admin.py
+++ b/itou/eligibility/admin.py
@@ -64,7 +64,7 @@ class SelectedGEIQAdministrativeCriteriaInline(AbstractSelectedAdministrativeCri
     model = models.GEIQEligibilityDiagnosis.administrative_criteria.through
 
 
-class ApprovalInline(ItouTabularInline, ReadonlyMixin):
+class ApprovalInline(ReadonlyMixin, ItouTabularInline):
     model = approvals_models.Approval
     extra = 0
     show_change_link = True
@@ -80,7 +80,7 @@ class ApprovalInline(ItouTabularInline, ReadonlyMixin):
         return obj.is_valid()
 
 
-class JobApplicationInline(ItouTabularInline, ReadonlyMixin):
+class JobApplicationInline(ReadonlyMixin, ItouTabularInline):
     model = job_applications_models.JobApplication
     extra = 0
     show_change_link = True
@@ -233,7 +233,7 @@ class GEIQEligibilityDiagnosisAdmin(AbstractEligibilityDiagnosisAdmin):
         return f"{obj.allowance_amount} EUR"
 
 
-class AbstractAdministrativeCriteriaAdmin(ItouModelAdmin, ReadonlyMixin):
+class AbstractAdministrativeCriteriaAdmin(ReadonlyMixin, ItouModelAdmin):
     # Administrative criteria are updated via fixtures
     list_display_links = ("pk", "name")
     list_filter = ("level",)

--- a/itou/emails/admin.py
+++ b/itou/emails/admin.py
@@ -35,7 +35,7 @@ class EmailStatusFilter(admin.SimpleListFilter):
 
 
 @admin.register(Email)
-class EmailAdmin(admin.ModelAdmin, ReadonlyMixin):
+class EmailAdmin(ReadonlyMixin, admin.ModelAdmin):
     class Media:
         css = {"all": ("css/itou-admin.css",)}
 

--- a/itou/gps/admin.py
+++ b/itou/gps/admin.py
@@ -4,7 +4,7 @@ import itou.gps.models as models
 from itou.utils.admin import ItouModelAdmin, ReadonlyMixin
 
 
-class MemberInline(admin.TabularInline, ReadonlyMixin):
+class MemberInline(ReadonlyMixin, admin.TabularInline):
     model = models.FollowUpGroup.members.through
     extra = 0
     readonly_fields = [

--- a/itou/job_applications/admin.py
+++ b/itou/job_applications/admin.py
@@ -25,14 +25,14 @@ from itou.utils.admin import (
 from itou.utils.templatetags.str_filters import pluralizefr
 
 
-class TransitionLogInline(ItouTabularInline, ReadonlyMixin):
+class TransitionLogInline(ReadonlyMixin, ItouTabularInline):
     model = models.JobApplicationTransitionLog
     extra = 0
     raw_id_fields = ("user",)
     readonly_fields = ("transition", "from_state", "to_state", "user", "timestamp", "target_company")
 
 
-class PriorActionInline(ItouTabularInline, ReadonlyMixin):
+class PriorActionInline(ReadonlyMixin, ItouTabularInline):
     model = models.PriorAction
     extra = 0
     readonly_fields = ("action", "dates")
@@ -60,7 +60,7 @@ class ManualApprovalDeliveryRequiredFilter(admin.SimpleListFilter):
         return queryset
 
 
-class EmployeeRecordInline(ItouStackedInline, ReadonlyMixin):
+class EmployeeRecordInline(ReadonlyMixin, ItouStackedInline):
     model = employee_record_models.EmployeeRecord
     extra = 0
     fields = ("link",)
@@ -336,7 +336,7 @@ class JobApplicationAdmin(InconsistencyCheckMixin, ItouModelAdmin):
 
 
 @admin.register(models.JobApplicationTransitionLog)
-class JobApplicationTransitionLogAdmin(ItouModelAdmin, ReadonlyMixin):
+class JobApplicationTransitionLogAdmin(ReadonlyMixin, ItouModelAdmin):
     actions = None
     date_hierarchy = "timestamp"
     list_display = ("job_application", "transition", "from_state", "to_state", "user", "timestamp")

--- a/itou/jobs/admin.py
+++ b/itou/jobs/admin.py
@@ -4,20 +4,20 @@ from itou.jobs import models
 from itou.utils.admin import ItouModelAdmin, ItouTabularInline, ReadonlyMixin
 
 
-class AppellationsInline(ItouTabularInline, ReadonlyMixin):
+class AppellationsInline(ReadonlyMixin, ItouTabularInline):
     model = models.Appellation
     readonly_fields = ("code", "name")
 
 
 @admin.register(models.Rome)
-class RomeAdmin(ItouModelAdmin, ReadonlyMixin):
+class RomeAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ("code", "name")
     search_fields = ("code", "name")
     inlines = (AppellationsInline,)
 
 
 @admin.register(models.Appellation)
-class AppellationAdmin(ItouModelAdmin, ReadonlyMixin):
+class AppellationAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ("code", "name")
     search_fields = ("code", "name", "rome__code")
     raw_id_fields = ("rome",)

--- a/itou/otp/admin.py
+++ b/itou/otp/admin.py
@@ -5,7 +5,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from itou.utils.admin import ReadonlyMixin
 
 
-class TOTPDeviceAdmin(django_otp_admin.TOTPDeviceAdmin, ReadonlyMixin):
+class TOTPDeviceAdmin(ReadonlyMixin, django_otp_admin.TOTPDeviceAdmin):
     pass
 
 

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -113,7 +113,7 @@ def _evaluated_siae_serializer(queryset):
 
 
 @admin.register(models.EvaluationCampaign)
-class EvaluationCampaignAdmin(ItouModelAdmin, ReadonlyMixin):
+class EvaluationCampaignAdmin(ReadonlyMixin, ItouModelAdmin):
     @admin.action(description="Exporter les SIAE des campagnes sélectionnées")
     def export_siaes(self, request, queryset):
         export_qs = (
@@ -218,7 +218,7 @@ class EvaluationCampaignAdmin(ItouModelAdmin, ReadonlyMixin):
 
 
 @admin.register(models.EvaluatedSiae)
-class EvaluatedSiaeAdmin(ItouModelAdmin, ReadonlyMixin):
+class EvaluatedSiaeAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ["evaluation_campaign", "siae", "state", "reviewed_at"]
     list_display_links = ("siae",)
     readonly_fields = (
@@ -257,7 +257,7 @@ class EvaluatedSiaeAdmin(ItouModelAdmin, ReadonlyMixin):
 
 
 @admin.register(models.EvaluatedJobApplication)
-class EvaluatedJobApplicationAdmin(ItouModelAdmin, ReadonlyMixin):
+class EvaluatedJobApplicationAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ("evaluated_siae", "job_application", "approval", "job_seeker")
     list_display_links = ("job_application",)
     list_select_related = ("evaluated_siae__siae", "job_application__approval", "job_application__job_seeker")
@@ -284,7 +284,7 @@ class EvaluatedJobApplicationAdmin(ItouModelAdmin, ReadonlyMixin):
 
 
 @admin.register(models.EvaluatedAdministrativeCriteria)
-class EvaluatedAdministrativeCriteriaAdmin(ItouModelAdmin, ReadonlyMixin):
+class EvaluatedAdministrativeCriteriaAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = ("evaluated_job_application", "administrative_criteria", "submitted_at", "review_state")
     list_display_links = ("administrative_criteria",)
     readonly_fields = (
@@ -309,7 +309,7 @@ class EvaluatedAdministrativeCriteriaAdmin(ItouModelAdmin, ReadonlyMixin):
 
 
 @admin.register(models.Sanctions)
-class SanctionsAdmin(ItouModelAdmin, ReadonlyMixin):
+class SanctionsAdmin(ReadonlyMixin, ItouModelAdmin):
     list_display = [
         "evaluated_siae",
         "evaluation_campaign",

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -46,7 +46,7 @@ from itou.utils.admin import (
 from itou.utils.urls import add_url_params
 
 
-class EmailAddressInline(ItouTabularInline, ReadonlyMixin):
+class EmailAddressInline(ReadonlyMixin, ItouTabularInline):
     model = EmailAddress
     extra = 0
     fields = ("pk_link", "verified", "primary")
@@ -77,7 +77,7 @@ class DisabledNotificationsMixin:
         return "Aucune"
 
 
-class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline, ReadonlyMixin):
+class CompanyMembershipInline(ReadonlyMixin, DisabledNotificationsMixin, ItouTabularInline):
     model = CompanyMembership
     extra = 0
     readonly_fields = (
@@ -99,7 +99,7 @@ class CompanyMembershipInline(DisabledNotificationsMixin, ItouTabularInline, Rea
         return get_structure_view_link(obj.company)
 
 
-class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline, ReadonlyMixin):
+class PrescriberMembershipInline(ReadonlyMixin, DisabledNotificationsMixin, ItouTabularInline):
     model = PrescriberMembership
     extra = 0
     readonly_fields = (
@@ -119,7 +119,7 @@ class PrescriberMembershipInline(DisabledNotificationsMixin, ItouTabularInline, 
         return get_structure_view_link(obj.organization)
 
 
-class InstitutionMembershipInline(ItouTabularInline, ReadonlyMixin):
+class InstitutionMembershipInline(ReadonlyMixin, ItouTabularInline):
     model = InstitutionMembership
     extra = 0
     readonly_fields = (
@@ -138,7 +138,7 @@ class InstitutionMembershipInline(ItouTabularInline, ReadonlyMixin):
         return get_structure_view_link(obj.institution)
 
 
-class JobApplicationInline(ItouTabularInline, ReadonlyMixin):
+class JobApplicationInline(ReadonlyMixin, ItouTabularInline):
     model = JobApplication
     fk_name = "job_seeker"
     extra = 0
@@ -171,7 +171,7 @@ class SentJobApplicationInline(JobApplicationInline):
         return get_admin_view_link(obj.job_seeker, content=obj.job_seeker.get_full_name())
 
 
-class EligibilityDiagnosisInline(ItouTabularInline, ReadonlyMixin):
+class EligibilityDiagnosisInline(ReadonlyMixin, ItouTabularInline):
     model = EligibilityDiagnosis
     fk_name = "job_seeker"
     extra = 0
@@ -198,7 +198,7 @@ class GEIQEligibilityDiagnosisInline(EligibilityDiagnosisInline):
     model = GEIQEligibilityDiagnosis
 
 
-class ApprovalInline(ItouTabularInline, ReadonlyMixin):
+class ApprovalInline(ReadonlyMixin, ItouTabularInline):
     model = Approval
     fk_name = "user"
     extra = 0


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car là le _mixin_ n'est pas pris en compte donc c'est _open-bar_.