### PR TITLE
JS : utiliser le préfixe data-emplois- pour la synchronisation des checkboxes

### DIFF
--- a/itou/static/js/htmx_dropdown_filter.js
+++ b/itou/static/js/htmx_dropdown_filter.js
@@ -57,7 +57,7 @@
   }
 
   function syncInputs(target) {
-    target.querySelectorAll("input[data-sync-with]").forEach((syncedInputOrigin) => {
+    target.querySelectorAll("input[data-emplois-sync-with]").forEach((syncedInputOrigin) => {
       const syncedInputTarget = document.getElementById(syncedInputOrigin.dataset.syncWith);
       syncedInputOrigin.addEventListener("change", function(event) {
         syncedInputTarget.checked = event.target.checked;

--- a/itou/templates/includes/btn_dropdown_filter/checkboxes.html
+++ b/itou/templates/includes/btn_dropdown_filter/checkboxes.html
@@ -18,7 +18,7 @@ Arguments:
                            name="{{ choice.data.name }}"
                            type="checkbox"
                            value="{{ choice.data.value }}"
-                           {% if id_suffix|default:"" %}data-sync-with="{{ choice.id_for_label }}"{% endif %}
+                           {% if id_suffix|default:"" %}data-emplois-sync-with="{{ choice.id_for_label }}"{% endif %}
                            {% if choice.data.selected %}checked{% endif %}>
                     <label for="{{ choice.id_for_label }}{{ id_suffix|default:'' }}" class="form-check-label">
                         {{ choice.choice_label }}

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/single_checkbox.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/single_checkbox.html
@@ -11,7 +11,7 @@ Arguments:
                type="checkbox"
                name="{{ field.name }}"
                {% if field.value %}checked{% endif %}
-               {% if id_suffix|default:"" %}data-sync-with="{{ field.id_for_label }}"{% endif %}>
+               {% if id_suffix|default:"" %}data-emplois-sync-with="{{ field.id_for_label }}"{% endif %}>
         <label class="form-check-label" for="{{ field.id_for_label }}{{ id_suffix|default:'' }}">{{ field.label }}</label>
     </div>
 </div>

--- a/tests/www/apply/test_list_for_job_seeker.py
+++ b/tests/www/apply/test_list_for_job_seeker.py
@@ -131,7 +131,7 @@ def test_list_for_job_seeker_htmx_filters(client):
     url = reverse("apply:list_for_job_seeker")
     response = client.get(url)
     page = parse_response_to_soup(response, selector="#main")
-    # Simulate the data-sync-with and check both checkboxes.
+    # Simulate the data-emplois-sync-with and check both checkboxes.
     refused_checkboxes = page.find_all(
         "input",
         attrs={"name": "states", "value": "refused"},

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -96,7 +96,7 @@ class TestProcessListSiae:
             <div class="form-check">
             <input id="id_selected_jobs_0-top"
                    class="form-check-input"
-                   data-sync-with="id_selected_jobs_0"
+                   data-emplois-sync-with="id_selected_jobs_0"
                    name="{self.SELECTED_JOBS}"
                    type="checkbox"
                    value="{job1.appellation.code}">
@@ -107,7 +107,7 @@ class TestProcessListSiae:
             <div class="form-check">
                 <input id="id_selected_jobs_1-top"
                        class="form-check-input"
-                       data-sync-with="id_selected_jobs_1"
+                       data-emplois-sync-with="id_selected_jobs_1"
                        name="{self.SELECTED_JOBS}"
                        type="checkbox"
                        value="{job2.appellation.code}">
@@ -749,7 +749,7 @@ def test_list_for_siae_htmx_filters(client):
     url = reverse("apply:list_for_siae")
     response = client.get(url)
     page = parse_response_to_soup(response, selector="#main")
-    # Simulate the data-sync-with and check both checkboxes.
+    # Simulate the data-emplois-sync-with and check both checkboxes.
     refused_checkboxes = page.find_all(
         "input",
         attrs={"name": "states", "value": "refused"},

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -322,7 +322,7 @@ def test_htmx_filters(client):
     url = reverse("apply:list_prescriptions")
     response = client.get(url)
     page = parse_response_to_soup(response, selector="#main")
-    # Simulate the data-sync-with and check both checkboxes.
+    # Simulate the data-emplois-sync-with and check both checkboxes.
     refused_checkboxes = page.find_all(
         "input",
         attrs={"name": "states", "value": "refused"},

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -99,7 +99,7 @@
                       
   <div class="dropdown-item">
       <div class="form-check">
-          <input class="form-check-input" data-sync-with="id_eligibility_validated" id="id_eligibility_validated-offcanvas" name="eligibility_validated" type="checkbox"/>
+          <input class="form-check-input" data-emplois-sync-with="id_eligibility_validated" id="id_eligibility_validated-offcanvas" name="eligibility_validated" type="checkbox"/>
           <label class="form-check-label" for="id_eligibility_validated-offcanvas">Valide</label>
       </div>
   </div>
@@ -109,7 +109,7 @@
                       
   <div class="dropdown-item">
       <div class="form-check">
-          <input class="form-check-input" data-sync-with="id_eligibility_pending" id="id_eligibility_pending-offcanvas" name="eligibility_pending" type="checkbox"/>
+          <input class="form-check-input" data-emplois-sync-with="id_eligibility_pending" id="id_eligibility_pending-offcanvas" name="eligibility_pending" type="checkbox"/>
           <label class="form-check-label" for="id_eligibility_pending-offcanvas">À valider</label>
       </div>
   </div>
@@ -131,7 +131,7 @@
                       
   <div class="dropdown-item">
       <div class="form-check">
-          <input class="form-check-input" data-sync-with="id_pass_iae_active" id="id_pass_iae_active-offcanvas" name="pass_iae_active" type="checkbox"/>
+          <input class="form-check-input" data-emplois-sync-with="id_pass_iae_active" id="id_pass_iae_active-offcanvas" name="pass_iae_active" type="checkbox"/>
           <label class="form-check-label" for="id_pass_iae_active-offcanvas">Valide</label>
       </div>
   </div>
@@ -141,7 +141,7 @@
                       
   <div class="dropdown-item">
       <div class="form-check">
-          <input class="form-check-input" data-sync-with="id_pass_iae_expired" id="id_pass_iae_expired-offcanvas" name="pass_iae_expired" type="checkbox"/>
+          <input class="form-check-input" data-emplois-sync-with="id_pass_iae_expired" id="id_pass_iae_expired-offcanvas" name="pass_iae_expired" type="checkbox"/>
           <label class="form-check-label" for="id_pass_iae_expired-offcanvas">Expiré</label>
       </div>
   </div>
@@ -151,7 +151,7 @@
                       
   <div class="dropdown-item">
       <div class="form-check">
-          <input class="form-check-input" data-sync-with="id_no_pass_iae" id="id_no_pass_iae-offcanvas" name="no_pass_iae" type="checkbox"/>
+          <input class="form-check-input" data-emplois-sync-with="id_no_pass_iae" id="id_no_pass_iae-offcanvas" name="no_pass_iae" type="checkbox"/>
           <label class="form-check-label" for="id_no_pass_iae-offcanvas">Aucun</label>
       </div>
   </div>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -783,7 +783,7 @@ def test_htmx_filters(client, url):
     )
     response = client.get(url)
     page = parse_response_to_soup(response, selector="#main")
-    # Simulate the data-sync-with and check both checkboxes.
+    # Simulate the data-emplois-sync-with and check both checkboxes.
     eligibility_validated_checkboxes = page.find_all("input", attrs={"name": "eligibility_validated"})
     assert len(eligibility_validated_checkboxes) == 2
     for checkbox in eligibility_validated_checkboxes:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une contribution au grand renommage/préfixage de notre JS : https://github.com/gip-inclusion/les-emplois/commit/fbe4e43828a82380f41fb4175691fb70806a428e

