### PR TITLE
Fiche de poste: Le passage en statut ouvert a un impact sur la date de modification [GEN-113]

### DIFF
--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -441,6 +441,22 @@ class JobDescriptionAdmin(ItouModelAdmin):
     def display_name(self, obj):
         return obj.custom_name if obj.custom_name else obj.appellation
 
+    def save_model(self, request, obj, form, change):
+        # Closing recruitment as an action isn't considered as modifying the job description,
+        # with respect to the timestamp.
+        if change:
+            old_obj = models.JobDescription.objects.get(id=obj.id)
+            changed_fields = [
+                field.name
+                for field in models.JobDescription._meta.fields
+                if getattr(old_obj, field.name) != getattr(obj, field.name)
+            ]
+            if changed_fields == ["is_active"] and not obj.is_active:
+                obj.save(update_fields=["is_active"])
+                return
+        # Otherwise save as normal.
+        return super().save_model(request, obj, form, change)
+
 
 @admin.register(models.SiaeConvention)
 class SiaeConventionAdmin(ItouModelAdmin):

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -203,7 +203,8 @@ def job_description_list(request, template_name="companies/job_description_list.
                     company_id=company.pk, pk=job_description_id
                 ).first():
                     job_description.is_active = is_active
-                    job_description.save(update_fields=["is_active"])
+                    # Opening recruitment updates the "last modified" date.
+                    job_description.save(update_fields=["is_active", "updated_at"] if is_active else ["is_active"])
                     if is_active:
                         messages.success(
                             request,

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -8,10 +8,12 @@ from pytest_django.asserts import assertContains, assertMessages, assertNotConta
 
 from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
+from itou.jobs.models import Appellation
 from itou.utils.models import PkSupportRemark
 from tests.common_apps.organizations.tests import assert_set_admin_role__creation, assert_set_admin_role__removal
 from tests.companies.factories import CompanyFactory
 from tests.job_applications.factories import JobApplicationFactory
+from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import EmployerFactory, ItouStaffFactory
 from tests.utils.test import (
     BASE_NUM_QUERIES,
@@ -346,3 +348,41 @@ class TestTransferCompanyData:
         assert "Candidatures reçues" in remark
         assert f"Désactivation entreprise:\n  * companies.Company[{from_company.pk}]" in remark
         assert "Peut apparaître dans la recherche:\n  * is_searchable: False remplacé par True" in remark
+
+
+@freeze_time("2023-08-31 12:34:56")
+def test_toggle_job_description_active_updating_last_modified(admin_client):
+    # Closing recruitment does not modify the last modified time, but opening it does.
+    company = CompanyFactory()
+    create_test_romes_and_appellations(["N1101"])
+    appellation = Appellation.objects.first()
+    company.jobs.add(appellation)
+    job_description = appellation.jobdescription_set.first()
+    original_job_updated_at = job_description.updated_at
+    assert job_description.is_active
+
+    url = reverse("admin:companies_jobdescription_change", kwargs={"object_id": job_description.pk})
+    # POST the required fields with only is_active changed.
+    post_data = {
+        "appellation": appellation.pk,
+        "company": company.pk,
+        "created_at_0": job_description.created_at.strftime("%d/%m/%Y"),
+        "created_at_1": job_description.created_at.strftime("%H:%M:%S"),
+        "creation_source": job_description.creation_source,
+        "ui_rank": job_description.ui_rank,
+        "is_active": False,
+    }
+    response = admin_client.post(url, data=post_data)
+    change_url = reverse("admin:companies_jobdescription_changelist")
+    assertRedirects(response, change_url, fetch_redirect_response=False)
+    response = admin_client.get(change_url)
+    job_description.refresh_from_db()
+    assert not job_description.is_active
+    assert job_description.updated_at == original_job_updated_at
+
+    with freeze_time("2023-09-01 12:34:56"):
+        post_data["is_active"] = True
+        admin_client.post(url, data=post_data)
+        job_description.refresh_from_db()
+        assert job_description.is_active
+        assert job_description.updated_at > original_job_updated_at

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -248,6 +248,26 @@ class TestJobDescriptionListView(JobDescriptionAbstract):
         other_company_job_description.refresh_from_db()
         assert not other_company_job_description.is_active
 
+    def test_toggle_job_description_active_updating_last_modified(self, client):
+        # Closing recruitment does not modify the last modified time, but opening it does.
+        self._login(client, self.user)
+
+        job_description = self.company.job_description_through.first()
+        job_creation_time = job_description.updated_at
+        assert job_description.is_active
+
+        post_data = {"job_description_id": job_description.pk, "action": "toggle_active"}
+        client.post(self.url, data=post_data)
+        job_description.refresh_from_db()
+        assert not job_description.is_active
+        assert job_description.updated_at == job_creation_time
+
+        post_data["job_description_is_active"] = "on"
+        client.post(self.url, data=post_data)
+        job_description.refresh_from_db()
+        assert job_description.is_active
+        assert job_description.updated_at > job_creation_time
+
     def test_delete_job_descriptions(self, client):
         response = self._login(client, self.user)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si une fiche de poste en statut “fermé au recrutement” passe en statut “ouvert au recrutement” (que ce soit par l’utilisateur ou dans l’admin), alors on met à jour la date de modification (updated_at). Le passage en statut fermé au recrutement ne doit pas impacter cette date de modification (comme c’est le cas actuellement).

## :cake: Comment ?

J'ai évité la solution la plus concrète (surcharger la méthode `save()` du modèle JobDescription) afin d'éviter une requête à la base de données supplementaire pour chaque sauvegarde

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?