### PR TITLE
Identifier les candidats dans la file active depuis plus de 30j [GEN-556]

### DIFF
--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -1,3 +1,5 @@
+{% load str_filters %}
+
 <div class="col mb-3 mb-md-5">
     <div class="c-box p-0 h-100">
         <div class="p-3 p-lg-4 d-flex">
@@ -27,6 +29,17 @@
                     </li>
                 {% endif %}
             </ul>
+            {% if stalled_job_seekers_count %}
+                <div class="c-box bg-warning-lightest border-warning mt-lg-n3 mb-3 mb-lg-5">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <a href="{% url "job_seekers_views:list" %}?is_stalled=on" class="text-warning fw-bold text-decoration-none btn-ico">
+                            <i class="ri-user-forbid-line fw-normal" aria-hidden="true"></i>
+                            <span>Candidat{{ stalled_job_seekers_count|pluralizefr }} sans solution</span>
+                        </a>
+                        <span class="badge rounded-pill badge-xs bg-warning-light text-warning">{{ stalled_job_seekers_count }}</span>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
+++ b/itou/templates/job_seekers_views/includes/job_seekers_filters/top_filters.html
@@ -5,6 +5,20 @@
         <div>{% bootstrap_form_errors filters_form %}</div>
         <div class="btn-dropdown-filter-group mb-3 mb-md-4">
             {% include "job_seekers_views/includes/job_seekers_filters/approval_state.html" with filters_form=filters_form btn_dropdown_filter=True only %}
+            <div class="dropdown">
+                <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+                    Candidat sans solution
+                </button>
+                <ul class="dropdown-menu">
+                    <li>{% bootstrap_field filters_form.is_stalled wrapper_class="dropdown-item" %}</li>
+                    <li>
+                        <hr class="dropdown-divider">
+                    </li>
+                    <li>
+                        <a href="{{ ITOU_HELP_CENTER_URL }}/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" class="btn btn-link has-external-link" target="_blank" rel="noopener">Qu’est-ce qu’un candidat sans solution ?</a>
+                    </li>
+                </ul>
+            </div>
             {% if list_organization %}
                 <button type="button" class="btn btn-ico btn-dropdown-filter" data-bs-toggle="offcanvas" data-bs-target="#offcanvasApplyFilters" aria-controls="offcanvasApplyFilters">
                     <i class="ri-sound-module-fill fw-medium" aria-hidden="true"></i>

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -32,6 +32,9 @@
                         <tr>
                             <td>
                                 <a href="{% url "job_seekers_views:details" public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_seeker.get_full_name|mask_unless:job_seeker.user_can_view_personal_information }}</a>
+                                {% if job_seeker.jobseeker_profile.is_stalled %}
+                                    <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning" aria-label="Candidat sans solution"><i class="ri-user-forbid-line" aria-hidden="true" data-bs-title="Candidat sans solution" data-bs-toggle="tooltip"></i></span>
+                                {% endif %}
                             </td>
                             <td>
                                 {% include "apply/includes/eligibility_badge.html" with job_seeker=job_seeker is_subject_to_eligibility_rules=True eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid=False badge_size="badge-xs" only %}

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -68,7 +68,7 @@
                   hx-swap="outerHTML"
                   hx-push-url="true"
                   hx-include="#id_job_seeker{% if list_organization %},#id_organization_members{% endif %}">
-                {% include "job_seekers_views/includes/job_seekers_filters/top_filters.html" with request=request filters_counter=filters_counter filters_form=filters_form list_organization=list_organization order=order only %}
+                {% include "job_seekers_views/includes/job_seekers_filters/top_filters.html" with request=request filters_counter=filters_counter filters_form=filters_form list_organization=list_organization order=order ITOU_HELP_CENTER_URL=ITOU_HELP_CENTER_URL only %}
                 <input id="id_order" type="hidden" name="order" value="{{ order }}">
             </form>
             <div class="s-section__row row">

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -122,12 +122,18 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "evaluated_siae_notifications": EvaluatedSiae.objects.none(),
         "siae_suspension_text_with_dates": None,
         "siae_search_form": SiaeSearchForm(),
+        "stalled_job_seekers_count": None,
     }
 
     if request.user.is_employer:
         context.update(_employer_dashboard_context(request))
     elif request.user.is_prescriber:
         if current_org := request.current_organization:
+            context["stalled_job_seekers_count"] = User.objects.linked_job_seeker_ids(
+                request.user,
+                request.current_organization,
+                stalled=True,
+            ).count()
             if current_org.is_authorized:
                 context["pending_prolongation_requests"] = ProlongationRequest.objects.filter(
                     prescriber_organization=current_org,

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -37,6 +37,8 @@ class FilterForm(forms.Form):
     pass_iae_expired = forms.BooleanField(label="Expiré", required=False)
     no_pass_iae = forms.BooleanField(label="Aucun", required=False)
 
+    is_stalled = forms.BooleanField(label="N’afficher que les candidats sans solution", required=False)
+
     organization_members = forms.MultipleChoiceField(
         label="Nom de la personne", required=False, widget=Select2MultipleWidget
     )
@@ -113,6 +115,9 @@ class FilterForm(forms.Form):
             if self.cleaned_data.get("no_pass_iae"):
                 pass_status_filter |= Q(last_approval_end_at__isnull=True)
             filters.append(pass_status_filter)
+
+        if self.cleaned_data.get("is_stalled"):
+            queryset = queryset.filter(jobseeker_profile__is_stalled=True)
 
         # Organization members
         if organization_members := self.cleaned_data.get("organization_members"):

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -150,6 +150,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     )
     queryset = (
         User.objects.filter(kind=UserKind.JOB_SEEKER, pk__in=job_seekers_ids)
+        .select_related("jobseeker_profile")
         .prefetch_related("approvals")
         .annotate(
             full_name=Concat(Lower("first_name"), Value(" "), Lower("last_name")),

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -38,6 +38,7 @@ from tests.geiq.factories import ImplementationAssessmentCampaignFactory, Implem
 from tests.institutions.factories import InstitutionFactory, InstitutionMembershipFactory, LaborInspectorFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers import factories as prescribers_factories
+from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.siae_evaluations.factories import (
     EvaluatedAdministrativeCriteriaFactory,
     EvaluatedJobApplicationFactory,
@@ -973,3 +974,17 @@ def test_prolongation_requests_badge(client):
         f"""a[href^='{reverse("approvals:prolongation_requests_list")}'] + .badge""",
     )
     assert soup.text == "3"
+
+
+def test_stalled_job_seekers_box(client):
+    prescriber = PrescriberMembershipFactory(organization__authorized=True).user
+    client.force_login(prescriber)
+    JobApplicationFactory(
+        sender=prescriber,
+        job_seeker__jobseeker_profile__is_stalled=True,
+    )
+    JobApplicationFactory(sender=prescriber)
+
+    response = client.get(reverse("dashboard:index"))
+    assert response.context["stalled_job_seekers_count"] == 1
+    assertContains(response, "<span>Candidat sans solution</span>", count=1)

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -218,6 +218,20 @@
       </div>
   
   
+              <div class="dropdown">
+                  <button aria-expanded="false" class="btn btn-dropdown-filter dropdown-toggle" data-bs-auto-close="outside" data-bs-toggle="dropdown" type="button">
+                      Candidat sans solution
+                  </button>
+                  <ul class="dropdown-menu">
+                      <li><div class="dropdown-item"><div class="form-check"><input class="form-check-input" id="id_is_stalled" name="is_stalled" type="checkbox"/><label class="form-check-label" for="id_is_stalled">N’afficher que les candidats sans solution</label></div></div></li>
+                      <li>
+                          <hr class="dropdown-divider"/>
+                      </li>
+                      <li>
+                          <a class="btn btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/33573455767441--Qu-est-ce-qu-un-candidat-sans-solution-sur-les-Emplois-de-l-inclusion" rel="noopener" target="_blank">Qu’est-ce qu’un candidat sans solution ?</a>
+                      </li>
+                  </ul>
+              </div>
               
               
   
@@ -499,9 +513,48 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -509,7 +562,8 @@
                                            %s))
           GROUP BY "users_user"."id",
                    34,
-                   35
+                   35,
+                   "users_jobseekerprofile"."user_id"
           ORDER BY "users_user"."first_name" ASC,
                    "users_user"."last_name" ASC
         ''',
@@ -638,9 +692,48 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -648,7 +741,8 @@
                                            %s))
           GROUP BY "users_user"."id",
                    34,
-                   35
+                   35,
+                   "users_jobseekerprofile"."user_id"
           ORDER BY RANDOM() ASC
         ''',
       }),
@@ -847,9 +941,48 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -857,7 +990,8 @@
                                            %s))
           GROUP BY "users_user"."id",
                    34,
-                   35
+                   35,
+                   "users_jobseekerprofile"."user_id"
           ORDER BY 34 ASC,
                    "users_user"."id" ASC
           LIMIT 4
@@ -1024,6 +1158,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/11111111-1111-1111-1111-111111111111?back_url=/job-seekers/list">Alain ZORRO</a>
+                                  
                               </td>
                               <td>
                                   
@@ -1069,6 +1204,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list">Bernard YGREC</a>
+                                  
                               </td>
                               <td>
                                   
@@ -1114,6 +1250,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list">Charlotte XERUS</a>
+                                  
                               </td>
                               <td>
                                   
@@ -1151,6 +1288,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/44444444-4444-4444-4444-444444444444?back_url=/job-seekers/list">David WATERFORD</a>
+                                  
                               </td>
                               <td>
                                   
@@ -1424,16 +1562,56 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
                                            %s))
           GROUP BY "users_user"."id",
                    34,
-                   35
+                   35,
+                   "users_jobseekerprofile"."user_id"
           ORDER BY "users_user"."first_name" ASC,
                    "users_user"."last_name" ASC
         ''',
@@ -1561,16 +1739,56 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
                                            %s))
           GROUP BY "users_user"."id",
                    34,
-                   35
+                   35,
+                   "users_jobseekerprofile"."user_id"
           ORDER BY RANDOM() ASC
         ''',
       }),
@@ -1769,16 +1987,56 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
                                            %s))
           GROUP BY "users_user"."id",
                    34,
-                   35
+                   35,
+                   "users_jobseekerprofile"."user_id"
           ORDER BY 34 ASC,
                    "users_user"."id" ASC
           LIMIT 3
@@ -1888,6 +2146,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/11111111-1111-1111-1111-111111111111?back_url=/job-seekers/list-organization">Alain ZORRO</a>
+                                  
                               </td>
                               <td>
                                   
@@ -1933,6 +2192,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list-organization">Bernard YGREC</a>
+                                  
                               </td>
                               <td>
                                   
@@ -1978,6 +2238,7 @@
                           <tr>
                               <td>
                                   <a class="btn-link" href="/job-seekers/details/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list-organization">Charlotte XERUS</a>
+                                  
                               </td>
                               <td>
                                   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mieux accompagner ces candidats.

## :cake: Comment

L’info candidat bloqué devrait bientôt remonter de pilotage. Je n’ai donc pas trop mis l’accent sur les tests du filtre, sachant qu’il est déjà pas mal validé par `send_users_to_brevo`.

En termes de perfs, en utilisant des gros émetteurs de candidatures avec la requête suivante, je passe de 100 à 150 ms en locale. Pas de quoi fouetter des chats.

```sql
SELECT sender_id, COUNT(*)
FROM job_applications_jobapplication
WHERE sender_kind='prescriber'
GROUP BY sender_id
ORDER BY 2 DESC;
```

Romain a maintenant un double intérêt à nous remonter l’info candidat sans solution depuis le pilotage, pour éviter qu’on ne fouette des chats.
## :desert_island: Comment tester ?

Se connecter en tant que prescripteur habilité, un membre de la liste des candidats est dans ce cas.

## :computer: Captures d'écran <!-- optionnel -->
