### PR TITLE
Pilotage: Ajout d'un fonction utilitaire pour l'accès au champ d'un modèle donnée

### DIFF
--- a/itou/metabase/tables/approvals.py
+++ b/itou/metabase/tables/approvals.py
@@ -10,16 +10,13 @@ from itou.metabase.tables.utils import (
     get_column_from_field,
     get_department_and_region_columns,
     get_hiring_company,
+    get_model_field,
     hash_content,
 )
 from itou.prescribers.models import PrescriberOrganization
 
 
 POLE_EMPLOI_APPROVAL_MINIMUM_START_DATE = datetime(2018, 1, 1)
-
-
-def get_field(name):
-    return Approval._meta.get_field(name)
 
 
 @functools.cache
@@ -77,7 +74,7 @@ def get_approval_type(approval):
 TABLE = MetabaseTable(name="pass_agréments")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
+        get_column_from_field(get_model_field(Approval, "id"), name="id"),
         {"name": "type", "type": "varchar", "comment": "Type", "fn": get_approval_type},
         {"name": "date_début", "type": "date", "comment": "Date de début", "fn": lambda o: o.start_at},
         {"name": "date_fin", "type": "date", "comment": "Date de fin", "fn": lambda o: o.end_at},

--- a/itou/metabase/tables/companies.py
+++ b/itou/metabase/tables/companies.py
@@ -10,11 +10,8 @@ from itou.metabase.tables.utils import (
     get_establishment_is_active_column,
     get_establishment_last_login_date_column,
     get_first_membership_join_date,
+    get_model_field,
 )
-
-
-def get_field(name):
-    return Company._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="structures_v0")
@@ -53,9 +50,9 @@ TABLE.add_columns(
             "comment": "Source des données de la structure",
             "fn": lambda o: get_choice(choices=Company.SOURCE_CHOICES, key=o.source),
         },
-        get_column_from_field(get_field("naf"), name="code_naf"),
-        get_column_from_field(get_field("email"), name="email_public"),
-        get_column_from_field(get_field("auth_email"), name="email_authentification"),
+        get_column_from_field(get_model_field(Company, "naf"), name="code_naf"),
+        get_column_from_field(get_model_field(Company, "email"), name="email_public"),
+        get_column_from_field(get_model_field(Company, "auth_email"), name="email_authentification"),
         {
             "name": "convergence_france",
             "type": "boolean",

--- a/itou/metabase/tables/criteria.py
+++ b/itou/metabase/tables/criteria.py
@@ -1,17 +1,13 @@
 from itou.eligibility.models import AdministrativeCriteria
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
-
-
-def get_field(name):
-    return AdministrativeCriteria._meta.get_field(name)
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 
 
 TABLE = MetabaseTable(name="critères_iae")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("name"), name="nom"),
-        get_column_from_field(get_field("level"), name="niveau"),
-        get_column_from_field(get_field("desc"), name="description"),
+        get_column_from_field(get_model_field(AdministrativeCriteria, "id"), name="id"),
+        get_column_from_field(get_model_field(AdministrativeCriteria, "name"), name="nom"),
+        get_column_from_field(get_model_field(AdministrativeCriteria, "level"), name="niveau"),
+        get_column_from_field(get_model_field(AdministrativeCriteria, "desc"), name="description"),
     ]
 )

--- a/itou/metabase/tables/evaluated_criteria.py
+++ b/itou/metabase/tables/evaluated_criteria.py
@@ -1,19 +1,21 @@
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria
-
-
-def get_field(name):
-    return EvaluatedAdministrativeCriteria._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="cap_critères_iae")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("administrative_criteria"), name="id_critère_iae"),
-        get_column_from_field(get_field("evaluated_job_application"), name="id_cap_candidature"),
-        get_column_from_field(get_field("uploaded_at"), name="date_dépôt"),
-        get_column_from_field(get_field("submitted_at"), name="date_transmission"),
-        get_column_from_field(get_field("review_state"), name="état"),
+        get_column_from_field(get_model_field(EvaluatedAdministrativeCriteria, "id"), name="id"),
+        get_column_from_field(
+            get_model_field(EvaluatedAdministrativeCriteria, "administrative_criteria"), name="id_critère_iae"
+        ),
+        get_column_from_field(
+            get_model_field(EvaluatedAdministrativeCriteria, "evaluated_job_application"), name="id_cap_candidature"
+        ),
+        get_column_from_field(get_model_field(EvaluatedAdministrativeCriteria, "uploaded_at"), name="date_dépôt"),
+        get_column_from_field(
+            get_model_field(EvaluatedAdministrativeCriteria, "submitted_at"), name="date_transmission"
+        ),
+        get_column_from_field(get_model_field(EvaluatedAdministrativeCriteria, "review_state"), name="état"),
     ]
 )

--- a/itou/metabase/tables/evaluated_job_applications.py
+++ b/itou/metabase/tables/evaluated_job_applications.py
@@ -1,17 +1,13 @@
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 from itou.siae_evaluations.models import EvaluatedJobApplication
-
-
-def get_field(name):
-    return EvaluatedJobApplication._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="cap_candidatures")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("job_application"), name="id_candidature"),
-        get_column_from_field(get_field("evaluated_siae"), name="id_cap_structure"),
+        get_column_from_field(get_model_field(EvaluatedJobApplication, "id"), name="id"),
+        get_column_from_field(get_model_field(EvaluatedJobApplication, "job_application"), name="id_candidature"),
+        get_column_from_field(get_model_field(EvaluatedJobApplication, "evaluated_siae"), name="id_cap_structure"),
         {
             "name": "état",
             "type": "varchar",

--- a/itou/metabase/tables/evaluated_siaes.py
+++ b/itou/metabase/tables/evaluated_siaes.py
@@ -1,24 +1,20 @@
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 from itou.siae_evaluations.models import EvaluatedSiae
-
-
-def get_field(name):
-    return EvaluatedSiae._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="cap_structures")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("evaluation_campaign"), name="id_cap_campagne"),
-        get_column_from_field(get_field("siae"), name="id_structure"),
+        get_column_from_field(get_model_field(EvaluatedSiae, "id"), name="id"),
+        get_column_from_field(get_model_field(EvaluatedSiae, "evaluation_campaign"), name="id_cap_campagne"),
+        get_column_from_field(get_model_field(EvaluatedSiae, "siae"), name="id_structure"),
         {
             "name": "état",
             "type": "varchar",
             "comment": "Etat du contrôle de la structure",
             "fn": lambda o: o.state,
         },
-        get_column_from_field(get_field("reviewed_at"), name="date_contrôle"),
-        get_column_from_field(get_field("final_reviewed_at"), name="date_définitive_contrôle"),
+        get_column_from_field(get_model_field(EvaluatedSiae, "reviewed_at"), name="date_contrôle"),
+        get_column_from_field(get_model_field(EvaluatedSiae, "final_reviewed_at"), name="date_définitive_contrôle"),
     ]
 )

--- a/itou/metabase/tables/evaluation_campaigns.py
+++ b/itou/metabase/tables/evaluation_campaigns.py
@@ -1,19 +1,15 @@
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 from itou.siae_evaluations.models import EvaluationCampaign
-
-
-def get_field(name):
-    return EvaluationCampaign._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="cap_campagnes")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("name"), name="nom"),
-        get_column_from_field(get_field("institution"), name="id_institution"),
-        get_column_from_field(get_field("evaluated_period_start_at"), name="date_début"),
-        get_column_from_field(get_field("evaluated_period_end_at"), name="date_fin"),
-        get_column_from_field(get_field("chosen_percent"), name="pourcentage_sélection"),
+        get_column_from_field(get_model_field(EvaluationCampaign, "id"), name="id"),
+        get_column_from_field(get_model_field(EvaluationCampaign, "name"), name="nom"),
+        get_column_from_field(get_model_field(EvaluationCampaign, "institution"), name="id_institution"),
+        get_column_from_field(get_model_field(EvaluationCampaign, "evaluated_period_start_at"), name="date_début"),
+        get_column_from_field(get_model_field(EvaluationCampaign, "evaluated_period_end_at"), name="date_fin"),
+        get_column_from_field(get_model_field(EvaluationCampaign, "chosen_percent"), name="pourcentage_sélection"),
     ]
 )

--- a/itou/metabase/tables/gps.py
+++ b/itou/metabase/tables/gps.py
@@ -1,18 +1,14 @@
 from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
-
-
-def get_group_field(name):
-    return FollowUpGroup._meta.get_field(name)
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 
 
 GroupsTable = MetabaseTable(name="gps_groups_v1")
 GroupsTable.add_columns(
     [
-        get_column_from_field(get_group_field("id"), "id"),
-        get_column_from_field(get_group_field("created_at"), "created_at"),
-        get_column_from_field(get_group_field("updated_at"), "updated_at"),
-        get_column_from_field(get_group_field("created_in_bulk"), "created_in_bulk"),
+        get_column_from_field(get_model_field(FollowUpGroup, "id"), "id"),
+        get_column_from_field(get_model_field(FollowUpGroup, "created_at"), "created_at"),
+        get_column_from_field(get_model_field(FollowUpGroup, "updated_at"), "updated_at"),
+        get_column_from_field(get_model_field(FollowUpGroup, "created_in_bulk"), "created_in_bulk"),
         {
             "name": "department",
             "type": "text",
@@ -23,26 +19,22 @@ GroupsTable.add_columns(
 )
 
 
-def get_membership_field(name):
-    return FollowUpGroupMembership._meta.get_field(name)
-
-
 MembershipsTable = MetabaseTable(name="gps_membres_v1")
 MembershipsTable.add_columns(
     [
-        get_column_from_field(get_membership_field("id"), "id"),
-        get_column_from_field(get_membership_field("follow_up_group_id"), "group_id"),
-        get_column_from_field(get_membership_field("created_at"), "created_at"),
-        get_column_from_field(get_membership_field("updated_at"), "updated_at"),
-        get_column_from_field(get_membership_field("ended_at"), "ended_at"),
-        get_column_from_field(get_membership_field("is_referent"), "is_referent"),
-        get_column_from_field(get_membership_field("member_id"), "member_id"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "id"), "id"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "follow_up_group_id"), "group_id"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "created_at"), "created_at"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "updated_at"), "updated_at"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "ended_at"), "ended_at"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "is_referent"), "is_referent"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "member_id"), "member_id"),
         {
             "name": "org_departments",
             "type": "text[]",
             "comment": "Départements de l'organisation",
             "fn": lambda o: o.companies_departments or o.prescriber_departments,
         },
-        get_column_from_field(get_membership_field("created_in_bulk"), "created_in_bulk"),
+        get_column_from_field(get_model_field(FollowUpGroupMembership, "created_in_bulk"), "created_in_bulk"),
     ]
 )

--- a/itou/metabase/tables/institutions.py
+++ b/itou/metabase/tables/institutions.py
@@ -1,19 +1,20 @@
 from itou.institutions.models import Institution
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_department_and_region_columns
-
-
-def get_field(name):
-    return Institution._meta.get_field(name)
+from itou.metabase.tables.utils import (
+    MetabaseTable,
+    get_column_from_field,
+    get_department_and_region_columns,
+    get_model_field,
+)
 
 
 TABLE = MetabaseTable(name="institutions")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("kind"), name="type"),
+        get_column_from_field(get_model_field(Institution, "id"), name="id"),
+        get_column_from_field(get_model_field(Institution, "kind"), name="type"),
     ]
     + get_department_and_region_columns()
     + [
-        get_column_from_field(get_field("name"), name="nom"),
+        get_column_from_field(get_model_field(Institution, "name"), name="nom"),
     ]
 )

--- a/itou/metabase/tables/job_descriptions.py
+++ b/itou/metabase/tables/job_descriptions.py
@@ -1,9 +1,4 @@
-from itou.companies.models import JobDescription
 from itou.metabase.tables.utils import MetabaseTable, get_department_and_region_columns
-
-
-def get_field(name):
-    return JobDescription._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="fiches_de_poste")

--- a/itou/metabase/tables/memberships.py
+++ b/itou/metabase/tables/memberships.py
@@ -1,19 +1,15 @@
 from itou.companies.models import CompanyMembership
 from itou.institutions.models import InstitutionMembership
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 from itou.prescribers.models import PrescriberMembership
-
-
-def get_field(name):
-    return InstitutionMembership._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="collaborations")
 TABLE.add_columns(
     [
         # Do not add an `id` field as it would *not* be unique among various kinds of memberships.
-        get_column_from_field(get_field("user"), name="id_utilisateur"),
-        get_column_from_field(get_field("is_admin"), name="administrateur"),
+        get_column_from_field(get_model_field(InstitutionMembership, "user"), name="id_utilisateur"),
+        get_column_from_field(get_model_field(InstitutionMembership, "is_admin"), name="administrateur"),
         {
             "name": "id_structure",
             "type": "integer",

--- a/itou/metabase/tables/prolongation_requests.py
+++ b/itou/metabase/tables/prolongation_requests.py
@@ -9,13 +9,9 @@ from itou.metabase.tables.utils import (
 )
 
 
-def get_field(name):
-    return ProlongationRequest._meta.get_field(name)
-
-
 TABLE = MetabaseTable(name="demandes_de_prolongation")
 TABLE.add_columns(
-    get_common_prolongation_columns(get_field_fn=get_field)
+    get_common_prolongation_columns(model=ProlongationRequest)
     + [
         {
             "name": "id_prolongation",

--- a/itou/metabase/tables/prolongation_requests.py
+++ b/itou/metabase/tables/prolongation_requests.py
@@ -5,6 +5,7 @@ from itou.metabase.tables.utils import (
     get_choice,
     get_column_from_field,
     get_common_prolongation_columns,
+    get_model_field,
 )
 
 
@@ -44,8 +45,8 @@ TABLE.add_columns(
             "comment": "Date de la demande",
             "fn": lambda o: o.created_at.date(),
         },
-        get_column_from_field(get_field("processed_at"), name="date_traitement"),
-        get_column_from_field(get_field("processed_by"), name="id_utilisateur_traitant"),
-        get_column_from_field(get_field("reminder_sent_at"), name="date_envoi_rappel"),
+        get_column_from_field(get_model_field(ProlongationRequest, "processed_at"), name="date_traitement"),
+        get_column_from_field(get_model_field(ProlongationRequest, "processed_by"), name="id_utilisateur_traitant"),
+        get_column_from_field(get_model_field(ProlongationRequest, "reminder_sent_at"), name="date_envoi_rappel"),
     ]
 )

--- a/itou/metabase/tables/prolongations.py
+++ b/itou/metabase/tables/prolongations.py
@@ -1,5 +1,10 @@
 from itou.approvals.models import Prolongation
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_common_prolongation_columns
+from itou.metabase.tables.utils import (
+    MetabaseTable,
+    get_column_from_field,
+    get_common_prolongation_columns,
+    get_model_field,
+)
 
 
 def get_field(name):
@@ -16,6 +21,6 @@ TABLE.add_columns(
             "comment": "Date de création",
             "fn": lambda o: o.created_at.date(),
         },
-        get_column_from_field(get_field("request"), name="id_demande_de_prolongation"),
+        get_column_from_field(get_model_field(Prolongation, "request"), name="id_demande_de_prolongation"),
     ]
 )

--- a/itou/metabase/tables/prolongations.py
+++ b/itou/metabase/tables/prolongations.py
@@ -7,13 +7,9 @@ from itou.metabase.tables.utils import (
 )
 
 
-def get_field(name):
-    return Prolongation._meta.get_field(name)
-
-
 TABLE = MetabaseTable(name="prolongations")
 TABLE.add_columns(
-    get_common_prolongation_columns(get_field_fn=get_field)
+    get_common_prolongation_columns(model=Prolongation)
     + [
         {
             "name": "date_de_création",

--- a/itou/metabase/tables/users.py
+++ b/itou/metabase/tables/users.py
@@ -1,18 +1,14 @@
-from itou.metabase.tables.utils import MetabaseTable, get_column_from_field
+from itou.metabase.tables.utils import MetabaseTable, get_column_from_field, get_model_field
 from itou.users.models import User
-
-
-def get_field(name):
-    return User._meta.get_field(name)
 
 
 TABLE = MetabaseTable(name="utilisateurs_v0")
 TABLE.add_columns(
     [
-        get_column_from_field(get_field("id"), name="id"),
-        get_column_from_field(get_field("email"), name="email"),
-        get_column_from_field(get_field("kind"), name="type"),
-        get_column_from_field(get_field("first_name"), name="prenom"),
-        get_column_from_field(get_field("last_name"), name="nom"),
+        get_column_from_field(get_model_field(User, "id"), name="id"),
+        get_column_from_field(get_model_field(User, "email"), name="email"),
+        get_column_from_field(get_model_field(User, "kind"), name="type"),
+        get_column_from_field(get_model_field(User, "first_name"), name="prenom"),
+        get_column_from_field(get_model_field(User, "last_name"), name="nom"),
     ]
 )

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -44,6 +44,10 @@ class MetabaseTable:
         return fn(input)
 
 
+def get_model_field(model, name):
+    return model._meta.get_field(name)
+
+
 def get_field_type_from_field(field):
     if isinstance(field, CharField):
         return "varchar"

--- a/itou/metabase/tables/utils.py
+++ b/itou/metabase/tables/utils.py
@@ -322,12 +322,12 @@ def hash_content(content):
     return hashlib.sha256(f"{content}{settings.METABASE_HASH_SALT}".encode()).hexdigest()
 
 
-def get_common_prolongation_columns(get_field_fn):
+def get_common_prolongation_columns(model):
     return [
-        get_column_from_field(get_field_fn("id"), name="id"),
-        get_column_from_field(get_field_fn("approval"), name="id_pass_agrément"),
-        get_column_from_field(get_field_fn("start_at"), name="date_début"),
-        get_column_from_field(get_field_fn("end_at"), name="date_fin"),
+        get_column_from_field(get_model_field(model, "id"), name="id"),
+        get_column_from_field(get_model_field(model, "approval"), name="id_pass_agrément"),
+        get_column_from_field(get_model_field(model, "start_at"), name="date_début"),
+        get_column_from_field(get_model_field(model, "end_at"), name="date_fin"),
         {
             "name": "motif",
             "type": "varchar",
@@ -335,8 +335,8 @@ def get_common_prolongation_columns(get_field_fn):
             "fn": lambda o: get_choice(choices=ProlongationReason.choices, key=o.reason),
         },
         # Do not inject `reason_explanation` as it contains highly sensitive personal information in practice.
-        get_column_from_field(get_field_fn("declared_by"), name="id_utilisateur_déclarant"),
-        get_column_from_field(get_field_fn("declared_by_siae"), name="id_structure_déclarante"),
-        get_column_from_field(get_field_fn("validated_by"), name="id_utilisateur_prescripteur"),
-        get_column_from_field(get_field_fn("prescriber_organization"), name="id_organisation_prescripteur"),
+        get_column_from_field(get_model_field(model, "declared_by"), name="id_utilisateur_déclarant"),
+        get_column_from_field(get_model_field(model, "declared_by_siae"), name="id_structure_déclarante"),
+        get_column_from_field(get_model_field(model, "validated_by"), name="id_utilisateur_prescripteur"),
+        get_column_from_field(get_model_field(model, "prescriber_organization"), name="id_organisation_prescripteur"),
     ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avec ce changement on peut supprimer la patterne d'implementer un `get_field` clone pour chaque table de l'import Metabase.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?