### PR TITLE
UX/UI : Réduire la taille des badges dans le tableau des demandeurs d’emplois des prescripteurs

### DIFF
--- a/itou/templates/apply/includes/eligibility_badge.html
+++ b/itou/templates/apply/includes/eligibility_badge.html
@@ -1,14 +1,16 @@
 {% load badges %}
-{% if is_subject_to_eligibility_rules %}
-    {% if job_seeker.has_valid_approval %}
-        {% approval_state_badge job_seeker.latest_approval force_valid=force_valid span_extra_class="badge-base" %}
-    {% else %}
-        {% iae_eligibility_badge is_eligible=eligibility_diagnosis extra_class="badge-base" %}
+{% with badge_size|default:"badge-base" as badge_class %}
+    {% if is_subject_to_eligibility_rules %}
+        {% if job_seeker.has_valid_approval %}
+            {% approval_state_badge job_seeker.latest_approval force_valid=force_valid span_extra_class=badge_class %}
+        {% else %}
+            {% iae_eligibility_badge is_eligible=eligibility_diagnosis extra_class=badge_class %}
+        {% endif %}
+    {% elif is_subject_to_geiq_eligibility_rules %}
+        {% if geiq_eligibility_diagnosis.is_valid and geiq_eligibility_diagnosis.allowance_amount %}
+            {% geiq_eligibility_badge is_eligible=True extra_class=badge_class %}
+        {% else %}
+            {% geiq_eligibility_badge is_eligible=False extra_class=badge_class %}
+        {% endif %}
     {% endif %}
-{% elif is_subject_to_geiq_eligibility_rules %}
-    {% if geiq_eligibility_diagnosis.is_valid and geiq_eligibility_diagnosis.allowance_amount %}
-        {% geiq_eligibility_badge is_eligible=True extra_class="badge-base" %}
-    {% else %}
-        {% geiq_eligibility_badge is_eligible=False extra_class="badge-base" %}
-    {% endif %}
-{% endif %}
+{% endwith %}

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -33,7 +33,7 @@
                                 <a href="{% url "job_seekers_views:details" public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_seeker.get_full_name|mask_unless:job_seeker.user_can_view_personal_information }}</a>
                             </td>
                             <td>
-                                {% include "apply/includes/eligibility_badge.html" with job_seeker=job_seeker is_subject_to_eligibility_rules=True eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid=False only %}
+                                {% include "apply/includes/eligibility_badge.html" with job_seeker=job_seeker is_subject_to_eligibility_rules=True eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid=False badge_size="badge-xs" only %}
                             </td>
                             <td>{{ job_seeker.job_applications_nb }}</td>
                             <td>{{ job_seeker.last_updated_at|date:"d/m/Y" }}</td>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -919,6 +919,7 @@
           'SimpleNode[apply/includes/eligibility_badge.html]',
           'IfNode[apply/includes/eligibility_badge.html]',
           'IfNode[apply/includes/eligibility_badge.html]',
+          'WithNode[apply/includes/eligibility_badge.html]',
           'IncludeNode[job_seekers_views/includes/list_results.html]',
           'ForNode[job_seekers_views/includes/list_results.html]',
           'IfNode[job_seekers_views/includes/list_results.html]',
@@ -1012,10 +1013,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-success-lighter text-success">
+          
+                      <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
               <i aria-hidden="true" class="ri-check-line"></i>
               Éligible à l’IAE
           </span>
+          
       
   
   
@@ -1041,10 +1044,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-warning-lighter text-warning">
+          
+                      <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
               <i aria-hidden="true" class="ri-error-warning-line"></i>
               Éligibilité IAE à valider
           </span>
+          
       
   
   
@@ -1070,10 +1075,12 @@
                                   
   
       
-                      <span class="badge badge-base rounded-pill bg-success-lighter text-success">
+          
+                          <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
                   <i aria-hidden="true" class="ri-pass-valid-line"></i>
                   PASS IAE valide
               </span>
+          
       
   
   
@@ -1099,10 +1106,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-success-lighter text-success">
+          
+                      <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
               <i aria-hidden="true" class="ri-check-line"></i>
               Éligible à l’IAE
           </span>
+          
       
   
   
@@ -1822,10 +1831,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-success-lighter text-success">
+          
+                      <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
               <i aria-hidden="true" class="ri-check-line"></i>
               Éligible à l’IAE
           </span>
+          
       
   
   
@@ -1851,10 +1862,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-warning-lighter text-warning">
+          
+                      <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
               <i aria-hidden="true" class="ri-error-warning-line"></i>
               Éligibilité IAE à valider
           </span>
+          
       
   
   
@@ -1880,10 +1893,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-warning-lighter text-warning">
+          
+                      <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
               <i aria-hidden="true" class="ri-error-warning-line"></i>
               Éligibilité IAE à valider
           </span>
+          
       
   
   
@@ -1909,10 +1924,12 @@
                                   
   
       
-                  <span class="badge badge-base rounded-pill bg-warning-lighter text-warning">
+          
+                      <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
               <i aria-hidden="true" class="ri-error-warning-line"></i>
               Éligibilité IAE à valider
           </span>
+          
       
   
   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les badges dans les tableaux devraient avoir la taille XS.
https://github.com/gip-inclusion/les-emplois/pull/5790#discussion_r2000457981

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/ebdfb7ac-ad46-40d4-909a-691b392781ee)
