### PR TITLE
Mise à jour de Boto3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
+      CELLAR_ADDON_HOST_TEST: ${{ secrets.CLEVER_CELLAR_ADDON_HOST_FOR_TESTS }}
+      CELLAR_ADDON_KEY_ID_TEST: ${{ secrets.CLEVER_CELLAR_ADDON_KEY_ID_FOR_TESTS }}
+      CELLAR_ADDON_SECRET_KEY_TEST: ${{ secrets.CLEVER_CELLAR_ADDON_SECRET_KEY_FOR_TESTS }}
       DJANGO_SETTINGS_MODULE: config.settings.test
       REDIS_URL: redis://127.0.0.1:6379
       REQUIREMENTS_PATH: requirements/test.txt
@@ -18,14 +21,6 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
       cancel-in-progress: true
     services:
-      minio:
-        image: bitnami/minio
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-
       redis:
         image: redis
         ports:

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -8,6 +8,7 @@ import json
 import os
 import warnings
 
+from botocore.config import Config
 from dotenv import load_dotenv
 
 from config.sentry import sentry_init
@@ -617,6 +618,13 @@ ASP_EA2_UNZIP_PASSWORD = os.getenv("ASP_EA2_UNZIP_PASSWORD")
 AWS_S3_ACCESS_KEY_ID = os.getenv("CELLAR_ADDON_KEY_ID")
 AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_KEY_SECRET")
 AWS_STORAGE_BUCKET_NAME = os.getenv("S3_STORAGE_BUCKET_NAME")
+# CleverCloud S3 implementation does not support recent data integrity features from AWS.
+# https://github.com/boto/boto3/issues/4392
+# https://github.com/boto/boto3/issues/4398#issuecomment-2619946229
+AWS_S3_CLIENT_CONFIG = Config(
+    request_checksum_calculation="when_required",
+    response_checksum_validation="when_required",
+)
 
 # S3 store for communicating with the Pilotage.
 PILOTAGE_DATASTORE_S3_ENDPOINT_URL = os.getenv("PILOTAGE_DATASTORE_S3_ENDPOINT_URL")

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -34,10 +34,18 @@ DATABASES["default"]["PASSWORD"] = os.getenv("PGPASSWORD", "password")  # noqa: 
 
 HUEY["immediate"] = True  # noqa: F405
 
-AWS_S3_ENDPOINT_URL = f"http://{os.getenv('CELLAR_ADDON_HOST', 'localhost:9000')}/"
-AWS_S3_ACCESS_KEY_ID = "minioadmin"
-AWS_S3_SECRET_ACCESS_KEY = "minioadmin"
-AWS_STORAGE_BUCKET_NAME = "tests"
+cellar_addon_host = os.getenv("CELLAR_ADDON_HOST_TEST")
+AWS_S3_ENDPOINT_URL = (
+    f"https://{cellar_addon_host}/"
+    if cellar_addon_host
+    else f"http://{os.getenv('CELLAR_ADDON_HOST', 'localhost:9000')}/"
+)
+AWS_S3_ACCESS_KEY_ID = os.getenv("CELLAR_ADDON_KEY_ID_TEST", "minioadmin")
+AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_SECRET_KEY_TEST", "minioadmin")
+# S3 bucket names must be globally unique. CI uses Cellar, so the storage
+# bucket name must not exist on all of Cellar.
+# https://www.clever-cloud.com/developers/doc/addons/cellar/#name-your-bucket
+AWS_STORAGE_BUCKET_NAME = "c1-tests"
 
 PILOTAGE_DATASTORE_S3_ENDPOINT_URL = AWS_S3_ENDPOINT_URL
 PILOTAGE_DATASTORE_S3_ACCESS_KEY = AWS_S3_ACCESS_KEY_ID

--- a/itou/utils/storage/s3.py
+++ b/itou/utils/storage/s3.py
@@ -1,5 +1,4 @@
 import boto3
-from botocore.client import Config
 from django.conf import settings
 from storages.backends.s3 import S3Storage
 
@@ -14,7 +13,7 @@ def s3_client():
         aws_access_key_id=settings.AWS_S3_ACCESS_KEY_ID,
         aws_secret_access_key=settings.AWS_S3_SECRET_ACCESS_KEY,
         region_name=settings.AWS_S3_REGION_NAME,
-        config=Config(signature_version="s3v4"),
+        config=settings.AWS_S3_CLIENT_CONFIG,
     )
 
 
@@ -25,6 +24,7 @@ def pilotage_s3_client():
         endpoint_url=settings.PILOTAGE_DATASTORE_S3_ENDPOINT_URL,
         aws_access_key_id=settings.PILOTAGE_DATASTORE_S3_ACCESS_KEY,
         aws_secret_access_key=settings.PILOTAGE_DATASTORE_S3_SECRET_KEY,
+        config=settings.AWS_S3_CLIENT_CONFIG,
     )
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -75,13 +75,13 @@ bleach[css]==6.2.0 \
     --hash=sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e \
     --hash=sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f
     # via django-markdownify
-boto3==1.35.99 \
-    --hash=sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71 \
-    --hash=sha256:e0abd794a7a591d90558e92e29a9f8837d25ece8e3c120e530526fe27eba5fca
+boto3==1.37.14 \
+    --hash=sha256:56b4d1e084dbca43d5fdd070f633a84de61a6ce592655b4d239d263d1a0097fc \
+    --hash=sha256:cf2e5e6d56efd5850db8ce3d9094132e4759cf2d4b5fd8200d69456bf61a20f3
     # via -r requirements/base.in
-botocore==1.35.99 \
-    --hash=sha256:1eab44e969c39c5f3d9a3104a0836c24715579a455f12b3979a31d7cde51b3c3 \
-    --hash=sha256:b22d27b6b617fc2d7342090d6129000af2efd20174215948c0d7ae2da0fab445
+botocore==1.37.14 \
+    --hash=sha256:709a1796f436f8e378e52170e58501c1f3b5f2d1308238cf1d6a3bdba2e32851 \
+    --hash=sha256:b0adce3f0fb42b914eb05079f50cf368cb9cf9745fdd206bd91fe6ac67b29aca
     # via
     #   -r requirements/base.in
     #   boto3
@@ -1241,9 +1241,9 @@ rpds-py==0.23.1 \
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.4 \
-    --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
-    --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
+s3transfer==0.11.4 \
+    --hash=sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679 \
+    --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
     # via boto3
 segno==1.6.6 \
     --hash=sha256:28c7d081ed0cf935e0411293a465efd4d500704072cdb039778a2ab8736190c7 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -91,13 +91,13 @@ bleach[css]==6.2.0 \
     # via
     #   -r requirements/test.txt
     #   django-markdownify
-boto3==1.35.99 \
-    --hash=sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71 \
-    --hash=sha256:e0abd794a7a591d90558e92e29a9f8837d25ece8e3c120e530526fe27eba5fca
+boto3==1.37.14 \
+    --hash=sha256:56b4d1e084dbca43d5fdd070f633a84de61a6ce592655b4d239d263d1a0097fc \
+    --hash=sha256:cf2e5e6d56efd5850db8ce3d9094132e4759cf2d4b5fd8200d69456bf61a20f3
     # via -r requirements/test.txt
-botocore==1.35.99 \
-    --hash=sha256:1eab44e969c39c5f3d9a3104a0836c24715579a455f12b3979a31d7cde51b3c3 \
-    --hash=sha256:b22d27b6b617fc2d7342090d6129000af2efd20174215948c0d7ae2da0fab445
+botocore==1.37.14 \
+    --hash=sha256:709a1796f436f8e378e52170e58501c1f3b5f2d1308238cf1d6a3bdba2e32851 \
+    --hash=sha256:b0adce3f0fb42b914eb05079f50cf368cb9cf9745fdd206bd91fe6ac67b29aca
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -1667,9 +1667,9 @@ ruff==0.11.2 \
     --hash=sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94 \
     --hash=sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9
     # via -r requirements/test.txt
-s3transfer==0.10.4 \
-    --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
-    --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
+s3transfer==0.11.4 \
+    --hash=sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679 \
+    --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
     # via
     #   -r requirements/test.txt
     #   boto3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -87,13 +87,13 @@ bleach[css]==6.2.0 \
     # via
     #   -r requirements/base.txt
     #   django-markdownify
-boto3==1.35.99 \
-    --hash=sha256:83e560faaec38a956dfb3d62e05e1703ee50432b45b788c09e25107c5058bd71 \
-    --hash=sha256:e0abd794a7a591d90558e92e29a9f8837d25ece8e3c120e530526fe27eba5fca
+boto3==1.37.14 \
+    --hash=sha256:56b4d1e084dbca43d5fdd070f633a84de61a6ce592655b4d239d263d1a0097fc \
+    --hash=sha256:cf2e5e6d56efd5850db8ce3d9094132e4759cf2d4b5fd8200d69456bf61a20f3
     # via -r requirements/base.txt
-botocore==1.35.99 \
-    --hash=sha256:1eab44e969c39c5f3d9a3104a0836c24715579a455f12b3979a31d7cde51b3c3 \
-    --hash=sha256:b22d27b6b617fc2d7342090d6129000af2efd20174215948c0d7ae2da0fab445
+botocore==1.37.14 \
+    --hash=sha256:709a1796f436f8e378e52170e58501c1f3b5f2d1308238cf1d6a3bdba2e32851 \
+    --hash=sha256:b0adce3f0fb42b914eb05079f50cf368cb9cf9745fdd206bd91fe6ac67b29aca
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -1544,9 +1544,9 @@ ruff==0.11.2 \
     --hash=sha256:ec47591497d5a1050175bdf4e1a4e6272cddff7da88a2ad595e1e326041d8d94 \
     --hash=sha256:ecf20854cc73f42171eedb66f006a43d0a21bfb98a2523a809931cda569552d9
     # via -r requirements/test.in
-s3transfer==0.10.4 \
-    --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
-    --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
+s3transfer==0.11.4 \
+    --hash=sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679 \
+    --hash=sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d
     # via
     #   -r requirements/base.txt
     #   boto3

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -50,7 +50,7 @@ def test_bucket_policy_for_anonymous_user():
 
     # Anything under the resume prefix is public.
     filename = f"{uuid.uuid4()}.pdf"
-    root_url = f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/"
+    root_url = f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}"
     s3_client().put_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Body=b"", Key=f"resume/{filename}")
     response = httpx.head(f"{root_url}/resume/{filename}")
     assert response.status_code == 200

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -1,7 +1,10 @@
 import io
+import os
 import uuid
 
 import httpx
+import pytest
+from botocore.config import Config
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.core.management import call_command
@@ -109,3 +112,11 @@ def test_sync_files_check_existing(temporary_bucket, caplog):
     assert caplog.messages[-1].startswith(
         "Management command itou.files.management.commands.sync_s3_files succeeded in"
     )
+
+
+@pytest.mark.skipif(os.getenv("CI") != "true", reason="Not using to Cellar")
+@pytest.mark.xfail
+def test_cellar_does_not_support_checksum_validation():
+    client = s3_client()
+    client.config = Config()
+    client.put_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Body=b"", Key="file")

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -401,7 +401,7 @@ def test_step_3_no_previous_CV(client, mocker, pdf_file):
     assert new_job_application.job_seeker == job_application.job_seeker
     assert new_job_application.sender == employer
     assert new_job_application.resume_link == (
-        f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
+        f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}"
         f"/resume/11111111-1111-1111-1111-111111111111.pdf"
     )
     assert new_job_application.state == JobApplicationState.NEW
@@ -489,7 +489,7 @@ def test_step_3_replace_previous_CV(client, mocker, pdf_file):
     assert new_job_application.job_seeker == job_application.job_seeker
     assert new_job_application.sender == employer
     assert new_job_application.resume_link == (
-        f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
+        f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}"
         f"/resume/11111111-1111-1111-1111-111111111111.pdf"
     )
     assert new_job_application.state == JobApplicationState.NEW

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -592,7 +592,7 @@ class TestApplyAsJobSeeker:
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert job_application.selected_jobs.get() == selected_job
         assert job_application.resume_link == (
-            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -1241,7 +1241,7 @@ class TestApplyAsAuthorizedPrescriber:
         assert job_application.selected_jobs.get() == selected_job
         assert (
             job_application.resume_link == f"{settings.AWS_S3_ENDPOINT_URL}"
-            f"tests/{storages['public'].location}/resume/11111111-1111-1111-1111-111111111111.pdf"
+            f"{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
         assert f"job_application-{company.pk}" not in client.session
@@ -1556,7 +1556,7 @@ class TestApplyAsAuthorizedPrescriber:
         assert job_application.message == "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         assert job_application.selected_jobs.get() == selected_job
         assert job_application.resume_link == (
-            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -2044,7 +2044,7 @@ class TestApplyAsPrescriber:
         assert job_application.selected_jobs.get() == selected_job
 
         assert job_application.resume_link == (
-            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 
@@ -2627,7 +2627,7 @@ class TestApplyAsCompany:
         assert job_application.selected_jobs.get() == selected_job
 
         assert job_application.resume_link == (
-            f"{settings.AWS_S3_ENDPOINT_URL}tests/{storages['public'].location}"
+            f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{storages['public'].location}"
             "/resume/11111111-1111-1111-1111-111111111111.pdf"
         )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

La nouvelle version de Boto3 dans sa configuration par défaut ne peut plus recevoir ou envoyer d’objets vers Cellar. Elle nécessite une adaptation.

## :cake: Comment ?

1. Utiliser Cellar dans la CI au lieu de MinIO, pour révéler le problème avec la mise à jour. Autrement, on découvre le problème en production, [comme la commu’](https://github.com/gip-inclusion/itou-communaute-django/issues/897).
2. Mettre à jour avec le contournement documenté par Amazon.