### PR TITLE
Fiches salarié : Correction de l'URL du bouton "Créer une fiche salarié"

### DIFF
--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -57,7 +57,7 @@
                                     {% endif %}
                                 </span>
                                 <p class="c-info__detail mb-0">
-                                    <a href="{% url 'employee_record_views:missing_employee' %}">Cliquez-ici</a> pour faire une recherche avancée parmi l’ensemble des candidats ou salariés de votre structure.
+                                    <a href="{% url 'employee_record_views:missing_employee' %}?back_url={{ request.get_full_path|urlencode }}">Cliquez-ici</a> pour faire une recherche avancée parmi l’ensemble des candidats ou salariés de votre structure.
                                 </p>
                             </div>
                             <hr>

--- a/itou/templates/employee_record/includes/list_header.html
+++ b/itou/templates/employee_record/includes/list_header.html
@@ -1,0 +1,37 @@
+<div id="employee-records-list-header"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
+    {% if num_recently_missing_employee_records %}
+        <h2>Fiches salarié ASP</h2>
+        <div class="alert alert-info" role="status" id="id_missing_employee_records_alert">
+            <div class="row align-items-center">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
+                </div>
+                <div class="col">
+                    {% if num_recently_missing_employee_records == 1 %}
+                        <p class="mb-0">1 nouveau salarié, embauché il y a moins de 4 mois, n’a pas encore de fiche salarié.</p>
+                    {% else %}
+                        <p class="mb-0">
+                            {{ num_recently_missing_employee_records }} nouveaux salariés, embauchés il y a moins de 4 mois, n’ont pas encore de fiches salarié.
+                        </p>
+                    {% endif %}
+                </div>
+                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                    <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}?reset_url={{ request.get_full_path|urlencode }}">
+                        <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
+                        <span>Créer une fiche salarié</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+    {% else %}
+        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
+            <h2 class="mb-0">Fiches salarié ASP</h2>
+            <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les collaborateurs">
+                <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}?reset_url={{ request.get_full_path|urlencode }}">
+                    <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
+                    <span>Créer une fiche salarié</span>
+                </a>
+            </div>
+        </div>
+    {% endif %}
+</div>

--- a/itou/templates/employee_record/includes/list_results.html
+++ b/itou/templates/employee_record/includes/list_results.html
@@ -17,6 +17,7 @@
 </div>
 
 {% if request.htmx %}
+    {% include 'employee_record/includes/list_header.html' %}
     {% include "employee_record/includes/list_order.html" %}
     {% include "employee_record/includes/list_counter.html" %}
     {% include "employee_record/includes/employee_record_filters/status.html" %}

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -33,41 +33,7 @@
             <div class="row my-3 my-md-5">
                 <div class="col-12">
                     <div class="tab-content">
-                        {% if num_recently_missing_employee_records %}
-                            <h2>Fiches salarié ASP</h2>
-                            <div class="alert alert-info" role="status" id="id_missing_employee_records_alert">
-                                <div class="row align-items-center">
-                                    <div class="col-auto pe-0">
-                                        <i class="ri-information-line ri-xl text-info" aria-hidden="true"></i>
-                                    </div>
-                                    <div class="col">
-                                        {% if num_recently_missing_employee_records == 1 %}
-                                            <p class="mb-0">1 nouveau salarié, embauché il y a moins de 4 mois, n’a pas encore de fiche salarié.</p>
-                                        {% else %}
-                                            <p class="mb-0">
-                                                {{ num_recently_missing_employee_records }} nouveaux salariés, embauchés il y a moins de 4 mois, n’ont pas encore de fiches salarié.
-                                            </p>
-                                        {% endif %}
-                                    </div>
-                                    <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                                        <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}?reset_url={{ request.get_full_path|urlencode }}">
-                                            <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
-                                            <span>Créer une fiche salarié</span>
-                                        </a>
-                                    </div>
-                                </div>
-                            </div>
-                        {% else %}
-                            <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
-                                <h2 class="mb-0">Fiches salarié ASP</h2>
-                                <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les collaborateurs">
-                                    <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}">
-                                        <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
-                                        <span>Créer une fiche salarié</span>
-                                    </a>
-                                </div>
-                            </div>
-                        {% endif %}
+                        {% include 'employee_record/includes/list_header.html' %}
                         <p>
                             Cette interface vous permet de créer et transmettre vos fiches salariés à l'Extranet IAE 2.0 de l'ASP.
                             <a href="{{ ITOU_HELP_CENTER_URL }}/articles/29251628906257--Fonctionnement-des-fiches-salarié"

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -24,7 +24,7 @@ from itou.utils.auth import check_user
 from itou.utils.pagination import pager
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.perms.employee_record import can_create_employee_record, siae_is_allowed
-from itou.utils.urls import get_safe_url
+from itou.utils.urls import add_url_params, get_safe_url
 from itou.www.employee_record_views.enums import EmployeeRecordOrder, MissingEmployeeCase
 from itou.www.employee_record_views.forms import (
     AddEmployeeRecordChooseApprovalForm,
@@ -134,7 +134,10 @@ class AddView(UserPassesTestMixin, WizardView):
 @check_user(lambda user: user.is_employer)
 def missing_employee(request, template_name="employee_record/missing_employee.html"):
     siae = get_current_company_or_404(request)
-    back_url = reverse("employee_record_views:add")
+    back_url = add_url_params(
+        reverse("employee_record_views:add"),
+        {"reset_url": get_safe_url(request, "back_url", fallback_url=reverse("employee_record_views:list"))},
+    )
 
     if not siae.can_use_employee_record:
         raise PermissionDenied

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -517,7 +517,7 @@
                                       
                                   </span>
                                   <p class="c-info__detail mb-0">
-                                      <a href="/employee_record/missing">Cliquez-ici</a> pour faire une recherche avancée parmi l’ensemble des candidats ou salariés de votre structure.
+                                      <a href="/employee_record/missing?back_url=/employee_record/add/[UUID of session]/choose-approval">Cliquez-ici</a> pour faire une recherche avancée parmi l’ensemble des candidats ou salariés de votre structure.
                                   </p>
                               </div>
                               <hr/>
@@ -950,7 +950,7 @@
                                       
                                   </span>
                                   <p class="c-info__detail mb-0">
-                                      <a href="/employee_record/missing">Cliquez-ici</a> pour faire une recherche avancée parmi l’ensemble des candidats ou salariés de votre structure.
+                                      <a href="/employee_record/missing?back_url=/employee_record/add/[UUID of session]/choose-employee">Cliquez-ici</a> pour faire une recherche avancée parmi l’ensemble des candidats ou salariés de votre structure.
                                   </p>
                               </div>
                               <hr/>

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -33,47 +33,47 @@
 # name: TestListEmployeeRecords.test_missing_employee_records_alert[plural]
   '''
   <div class="alert alert-info" id="id_missing_employee_records_alert" role="status">
-                                  <div class="row align-items-center">
-                                      <div class="col-auto pe-0">
-                                          <i aria-hidden="true" class="ri-information-line ri-xl text-info"></i>
-                                      </div>
-                                      <div class="col">
-                                          
-                                              <p class="mb-0">
-                                                  2 nouveaux salariés, embauchés il y a moins de 4 mois, n’ont pas encore de fiches salarié.
-                                              </p>
-                                          
-                                      </div>
-                                      <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                                          <a class="btn btn-primary btn-ico" href="/employee_record/add/?reset_url=/employee_record/list%3Fstatus%3DNEW%26status%3DREJECTED%26order%3D">
-                                              <i aria-hidden="true" class="ri-user-add-line ri-lg"></i>
-                                              <span>Créer une fiche salarié</span>
-                                          </a>
-                                      </div>
-                                  </div>
-                              </div>
+              <div class="row align-items-center">
+                  <div class="col-auto pe-0">
+                      <i aria-hidden="true" class="ri-information-line ri-xl text-info"></i>
+                  </div>
+                  <div class="col">
+                      
+                          <p class="mb-0">
+                              2 nouveaux salariés, embauchés il y a moins de 4 mois, n’ont pas encore de fiches salarié.
+                          </p>
+                      
+                  </div>
+                  <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                      <a class="btn btn-primary btn-ico" href="/employee_record/add/?reset_url=/employee_record/list%3Fstatus%3DNEW%26status%3DREJECTED%26order%3D">
+                          <i aria-hidden="true" class="ri-user-add-line ri-lg"></i>
+                          <span>Créer une fiche salarié</span>
+                      </a>
+                  </div>
+              </div>
+          </div>
   '''
 # ---
 # name: TestListEmployeeRecords.test_missing_employee_records_alert[singular]
   '''
   <div class="alert alert-info" id="id_missing_employee_records_alert" role="status">
-                                  <div class="row align-items-center">
-                                      <div class="col-auto pe-0">
-                                          <i aria-hidden="true" class="ri-information-line ri-xl text-info"></i>
-                                      </div>
-                                      <div class="col">
-                                          
-                                              <p class="mb-0">1 nouveau salarié, embauché il y a moins de 4 mois, n’a pas encore de fiche salarié.</p>
-                                          
-                                      </div>
-                                      <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                                          <a class="btn btn-primary btn-ico" href="/employee_record/add/?reset_url=/employee_record/list%3Fstatus%3DNEW%26status%3DREJECTED%26order%3D">
-                                              <i aria-hidden="true" class="ri-user-add-line ri-lg"></i>
-                                              <span>Créer une fiche salarié</span>
-                                          </a>
-                                      </div>
-                                  </div>
-                              </div>
+              <div class="row align-items-center">
+                  <div class="col-auto pe-0">
+                      <i aria-hidden="true" class="ri-information-line ri-xl text-info"></i>
+                  </div>
+                  <div class="col">
+                      
+                          <p class="mb-0">1 nouveau salarié, embauché il y a moins de 4 mois, n’a pas encore de fiche salarié.</p>
+                      
+                  </div>
+                  <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                      <a class="btn btn-primary btn-ico" href="/employee_record/add/?reset_url=/employee_record/list%3Fstatus%3DNEW%26status%3DREJECTED%26order%3D">
+                          <i aria-hidden="true" class="ri-user-add-line ri-lg"></i>
+                          <span>Créer une fiche salarié</span>
+                      </a>
+                  </div>
+              </div>
+          </div>
   '''
 # ---
 # name: TestListEmployeeRecords.test_new_employee_records_sorted[employee records]

--- a/tests/www/employee_record_views/test_add.py
+++ b/tests/www/employee_record_views/test_add.py
@@ -61,6 +61,7 @@ def test_wizard(snapshot, client):
                     "company_[PK of Company]_add_employee_record-current_step",
                 ),
                 ("value", str(job_application.job_seeker.pk), "[PK of job seeker]"),
+                ("href", wizard_session_name, "[UUID of session]"),
             ],
         )
     ) == snapshot(name="choose-employee")
@@ -85,6 +86,7 @@ def test_wizard(snapshot, client):
         replace_in_attr=[
             ("value", wizard_session_name, "[UUID of session]"),
             ("value", str(approval.pk), "[PK of Approval]"),
+            ("href", wizard_session_name, "[UUID of session]"),
         ],
     )
     assert str(soup) == snapshot(name="choose-approval")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement l'URL n'a pas de `reset_url` et se termine donc pas une 404.
Ajouter dans 54451cdf7 suite à #5736.