### PR TITLE
[ GEN-2321 ] Stabilité: automatisation de l'import IAE

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -32,6 +32,7 @@
   "20 23 * * * $ROOT/clevercloud/run_management_command.sh archive_job_applications",
   "40 23 * * * $ROOT/clevercloud/run_management_command.sh archive_old_gps_memberships",
 
+  "0 12 * * 1-4 $ROOT/clevercloud/import-iae.sh",
   "0 9-12 * * 1 $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
   "0 0 * * 1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
   "0 2 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",

--- a/clevercloud/import-iae.sh
+++ b/clevercloud/import-iae.sh
@@ -35,5 +35,8 @@ time ./manage.py import_siae --wet-run --verbosity=2 |& tee -a "$OUTPUT_PATH/imp
 # Destroy the data
 rm -rf "$FLUX_IAE_DIR"
 
+# Rename the flux IAE file
+mv "$FLUX_IAE_FILE" "${FLUX_IAE_FILE}.imported"
+
 # Remove files older than 3 weeks
-find asp_riae_shared_bucket/ -name "$FLUX_IAE_FILE_GLOB" -type f -mtime +20 -delete
+find asp_riae_shared_bucket/ -name "${FLUX_IAE_FILE_GLOB}.imported" -type f -mtime +20 -delete

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -328,6 +328,7 @@ LOGGING = {
 }
 
 DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE = r"django_datadog_logger\.middleware\.request_log"
+DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE = r"itou\.[a-z\_]+\.management\.commands"
 
 AUTH_USER_MODEL = "users.User"
 

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -4,7 +4,12 @@ SiaeFinancialAnnex object logic used by the import_siae.py script is gathered he
 
 """
 
+import logging
+
 from itou.companies.models import SiaeConvention, SiaeFinancialAnnex
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_creatable_and_deletable_afs(af_number_to_row):
@@ -84,10 +89,10 @@ def build_financial_annex_from_number(row):
 def manage_financial_annexes(af_number_to_row):
     creatable_afs, deletable_afs = get_creatable_and_deletable_afs(af_number_to_row)
 
-    print(f"will create {len(creatable_afs)} financial annexes")
+    logger.info("will create financial annexes", extra={"count": len(creatable_afs)})
     for af in creatable_afs:
         af.save()
 
-    print(f"will delete {len(deletable_afs)} financial annexes")
+    logger.info("will delete financial annexes", extra={"count": len(deletable_afs)})
     for af in deletable_afs:
         af.delete()

--- a/itou/companies/management/commands/import_geiq.py
+++ b/itou/companies/management/commands/import_geiq.py
@@ -131,24 +131,25 @@ class Command(BaseCommand):
         )
 
         # Display some "stats" about the dataset
-        self.stdout.write("-" * 80)
-        self.stdout.write(f"Rows in file: {info_stats['rows_in_file']}")
-        self.stdout.write(f"Rows with a SIRET: {info_stats['rows_with_a_siret']}")
-        self.stdout.write(f"Rows with an empty email: {info_stats['rows_with_empty_email']}")
-        self.stdout.write(f"Rows used: {len(geiq_df)}")
-        self.stdout.write(f" > Creatable: {info_stats['creatable_sirets']}")
-        self.stdout.write(f" >> Created: {info_stats['structures_created']}")
-        self.stdout.write(
-            f" >> Not created because of missing email: {info_stats['not_created_because_of_missing_email']}"
+        self.logger.info("-" * 80)
+        self.logger.info("Rows in file", extra={"count": info_stats["rows_in_file"]})
+        self.logger.info("Rows with a SIRET", extra={"count": info_stats["rows_with_a_siret"]})
+        self.logger.info("Rows with an empty email", extra={"count": info_stats["rows_with_empty_email"]})
+        self.logger.info("Rows used", extra={"count": len(geiq_df)})
+        self.logger.info(" > Creatable", extra={"count": info_stats["creatable_sirets"]})
+        self.logger.info(" >> Created", extra={"count": info_stats["structures_created"]})
+        self.logger.info(
+            " >> Not created because of missing email",
+            extra={"count": info_stats["not_created_because_of_missing_email"]},
         )
-        self.stdout.write(f" > Updatable: {info_stats['updatable_sirets']}")
-        self.stdout.write(f" >> Updated: {info_stats['structures_updated']}")
-        self.stdout.write(f" > Deletable: {info_stats['deletable_sirets']}")
-        self.stdout.write(f" >> Deleted: {info_stats['structures_deleted']}")
-        self.stdout.write(f" >> Undeletable: {info_stats['structures_undeletable']}")
-        self.stdout.write(f" >> Skipped: {info_stats['structures_deletable_skipped']}")
-        self.stdout.write("-" * 80)
-        self.stdout.write("Done.")
+        self.logger.info(" > Updatable", extra={"count": info_stats["updatable_sirets"]})
+        self.logger.info(" >> Updated", extra={"count": info_stats["structures_updated"]})
+        self.logger.info(" > Deletable", extra={"count": info_stats["deletable_sirets"]})
+        self.logger.info(" >> Deleted", extra={"count": info_stats["structures_deleted"]})
+        self.logger.info(" >> Undeletable", extra={"count": info_stats["structures_undeletable"]})
+        self.logger.info(" >> Skipped", extra={"count": info_stats["structures_deletable_skipped"]})
+        self.logger.info("-" * 80)
+        self.logger.info("Done.")
 
         warning_messages = []
         if info_stats["rows_with_empty_email"] > 20:

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -44,7 +44,6 @@ from itou.companies.management.commands._import_siae.vue_structure import (
     get_vue_structure_df,
 )
 from itou.utils.command import BaseCommand
-from itou.utils.templatetags.str_filters import pluralizefr
 
 
 class Command(BaseCommand):
@@ -97,10 +96,10 @@ class Command(BaseCommand):
             raise CommandError("DRY RUN mode, use --wet-run to apply changes")
 
         if errors >= 1:
-            s = pluralizefr(errors)
-            self.stdout.write(
-                f"*** ERROR{s.upper()} *** The command completed all its actions successfully "
-                f"but {errors} error{s} needs manual resolution, see the command's output"
+            self.logger.warning(
+                "The command completed all its actions successfully, but error(s) needs manual resolution, see "
+                "the command's logs",
+                extra={"count": errors},
             )
         else:
-            self.stdout.write("All done!")
+            self.logger.info("All done!")

--- a/itou/companies/management/commands/update_companies_coords.py
+++ b/itou/companies/management/commands/update_companies_coords.py
@@ -46,4 +46,4 @@ class Command(BaseCommand):
                 companies_to_save,
                 ["coords", "geocoding_score", "ban_api_resolved_address", "geocoding_updated_at"],
             )
-            self.stdout.write(f"> count={len(companies_to_save)} companies geolocated with a high score.")
+            logger.info("companies geolocated with a high score", extra={"count": len(companies_to_save)})

--- a/tests/companies/__snapshots__/test_import_ea_eatt.ambr
+++ b/tests/companies/__snapshots__/test_import_ea_eatt.ambr
@@ -34,34 +34,5 @@
   ])
 # ---
 # name: test_process_file_from_archive[output]
-  '''
-  Loaded 2 EA_EATT from export.
-  1 EA_EATT will be created.
-  0 EA_EATT will be updated when needed.
-  0 EA_EATT will be deleted when possible.
-  EA_EATT siret=00000000000001 will be created.
-  EA_EATT siret=00000000000001 has been created with siae.id=[ID].
-  EA_EATT siret=00000000000001 will be created.
-  EA_EATT siret=00000000000001 has been created with siae.id=[ID].
-  0 EA_EATT can and will be deleted.
-  0 EA_EATT cannot be deleted as they have data.
-  --------------------------------------------------------------------------------
-  Rows in file: 4
-  Rows after kind filter: 3
-  Rows after deduplication: 2
-  Rows used: 2
-   > With a SIRET: 2
-   > With an empty email: 0
-   > Creatable: 1
-   >> Created: 2
-   > Updatable: 0
-   >> Updated: 0
-   > Deletable: 0
-   >> Deleted: 0
-   >> Undeletable: 0
-   >> Skipped: 0
-  --------------------------------------------------------------------------------
-  Done.
-  
-  '''
+  ''
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Libérer `supportix` de l'execution manuelle sur une fast-machine du script `./scripts/import-iae.sh`, puisqu'il s'execute rapidement depuis `c1-worker`

## :cake: Comment ? <!-- optionnel -->

🐢 remplacement des `self.stdout` et des `print` par des appels au `logger`
🐢 déplacement du script `sh` dans le repertoire des scripts planifiés
🐢 renommage du fichier traité en fin de script pour éviter un double traitement

## :rotating_light: À vérifier

NON Mettre à jour le CHANGELOG_breaking_changes.md ?
NON Ajouter l'étiquette « Bug » ?

