### PR TITLE
Candidature : ajouter `back_url` sur les boutons Postuler

### DIFF
--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -41,7 +41,7 @@
                 {% else %}
                     <div class="form-group col-12 col-lg-auto">
                         {% url 'apply:start' company_pk=siae.pk as apply_url %}
-                        <a href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" %}"
+                        <a href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
                            class="btn btn-lg btn-white btn-block btn-ico"
                            {% matomo_event "candidature" "clic" "start_application" %}
                            aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
@@ -206,7 +206,7 @@
                                 <div class="d-flex justify-content-end mt-3">
                                     {% url 'apply:start' company_pk=siae.pk as apply_url %}
                                     <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
-                                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" %}"
+                                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
                                        {% matomo_event "candidature" "clic" "start_application" %}
                                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                                         <i class="ri-draft-line" aria-hidden="true"></i>

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -80,7 +80,7 @@
                     <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
                     {% url 'apply:start' company_pk=siae.pk as apply_url %}
                     <a class="btn btn-ico btn-primary"
-                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:'' %}"
+                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                         <i class="ri ri-draft-line" aria-hidden="true"></i>
@@ -163,7 +163,7 @@
                     <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
                     {% url 'apply:start' company_pk=siae.pk as apply_url %}
                     <a class="btn btn-ico btn-primary"
-                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:'' %}"
+                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                         <i class="ri ri-draft-line" aria-hidden="true"></i>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -66,7 +66,7 @@
                     {% else %}
                         <div class="form-group col-12 col-lg-auto">
                             {% url "apply:start" company_pk=siae.pk as apply_url %}
-                            <a href="{% url_add_query apply_url job_description_id=job.pk job_seeker=job_seeker.public_id|default:'' %}"
+                            <a href="{% url_add_query apply_url job_description_id=job.pk job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                                class="btn btn-lg btn-white btn-block btn-ico"
                                {% matomo_event "candidature" "clic" "start_application" %}
                                aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -1,5 +1,6 @@
 {% load format_filters %}
 {% load matomo %}
+{% load url_add_query %}
 
 <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
     <div>
@@ -51,7 +52,8 @@
                         <span>Déclarer une embauche</span>
                     </button>
                 {% else %}
-                    <a href="{% url 'apply:start_hire' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
+                    {% url "apply:start_hire" company_pk=request.current_organization.pk as hire_url %}
+                    <a href="{% url_add_query hire_url back_url=request.get_full_path %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "declarer-embauche" %}>
                         <i class="ri-user-follow-line fw-medium" aria-hidden="true"></i>
                         <span>Déclarer une embauche</span>
                     </a>

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -254,6 +254,8 @@ class StartView(ApplyStepBaseView):
         if self.company.block_job_applications and not self.company.has_member(request.user):
             raise Http404("Cette organisation n'accepte plus de candidatures pour le moment.")
 
+        self.apply_session.init({})
+
         # Store away the selected job in the session to avoid passing it
         # along the many views before ApplicationJobsView.
         if job_description_id := request.GET.get("job_description_id"):
@@ -262,7 +264,7 @@ class StartView(ApplyStepBaseView):
             except (JobDescription.DoesNotExist, ValueError):
                 pass
             else:
-                self.apply_session.init({"selected_jobs": [job_description.pk]})
+                self.apply_session.set("selected_jobs", [job_description.pk])
 
         # Go directly to step ApplicationJobsView if we're carrying the job seeker public id with us.
         if tunnel == "sender" and (job_seeker := _get_job_seeker_to_apply_for(self.request)):

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -168,7 +168,7 @@
                               
                                   <div class="d-flex justify-content-end mt-3">
                                       
-                                      <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start">
+                                      <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
                                           <i aria-hidden="true" class="ri-draft-line"></i>
                                           <span>Postuler</span>
                                       </a>
@@ -246,7 +246,7 @@
                               
                                   <div class="d-flex justify-content-end mt-3">
                                       
-                                      <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start">
+                                      <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
                                           <i aria-hidden="true" class="ri-draft-line"></i>
                                           <span>Postuler</span>
                                       </a>
@@ -481,7 +481,7 @@
                               
                                   <div class="d-flex justify-content-end mt-3">
                                       
-                                      <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start">
+                                      <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
                                           <i aria-hidden="true" class="ri-draft-line"></i>
                                           <span>Postuler</span>
                                       </a>
@@ -564,7 +564,7 @@
                       
                           <div class="form-group col-12 col-lg-auto">
                               
-                              <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
+                              <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42&amp;back_url=/company/job_description/42/card">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                                   <span>Postuler</span>
                               </a>
@@ -606,7 +606,7 @@
                       
                           <div class="form-group col-12 col-lg-auto">
                               
-                              <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
+                              <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42&amp;back_url=/company/job_description/42/card">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                                   <span>Postuler</span>
                               </a>
@@ -655,7 +655,7 @@
                       
                           <div class="form-group col-12 col-lg-auto">
                               
-                              <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42">
+                              <a aria-label="Postuler auprès de l'employeur inclusif Acme inc." class="btn btn-lg btn-white btn-block btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/100/start?job_description_id=42&amp;back_url=/company/job_description/42/card">
                                   <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                                   <span>Postuler</span>
                               </a>

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -135,7 +135,9 @@ class TestGetOrCreateForJobSeeker:
         # Init session
         start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
         client.get(start_url)
-        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        [job_seeker_session_name] = [
+            k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
+        ]
 
         response = client.get(
             reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"session_uuid": job_seeker_session_name})
@@ -163,7 +165,9 @@ class TestGetOrCreateForJobSeeker:
         # Init session
         start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
         client.get(start_url)
-        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        [job_seeker_session_name] = [
+            k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
+        ]
 
         response = client.get(
             reverse("job_seekers_views:check_nir_for_job_seeker", kwargs={"session_uuid": job_seeker_session_name})
@@ -303,7 +307,9 @@ class TestGetOrCreateForSender:
         # Init session
         start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
         client.get(start_url, follow=True)
-        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        [job_seeker_session_name] = [
+            k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
+        ]
 
         response = client.get(
             reverse("job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name})
@@ -320,7 +326,9 @@ class TestGetOrCreateForSender:
 
         # Init session
         client.get(reverse("apply:start", kwargs={"company_pk": company.pk}), follow=True)
-        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        [job_seeker_session_name] = [
+            k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
+        ]
 
         birthdate = datetime.date(1911, 11, 1)
         response = client.post(
@@ -358,7 +366,9 @@ class TestGetOrCreateForSender:
 
         # Init session
         client.get(reverse("apply:start", kwargs={"company_pk": company.pk}), follow=True)
-        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        [job_seeker_session_name] = [
+            k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
+        ]
 
         birthdate = datetime.date(1911, 11, 1)
         response = client.post(
@@ -392,7 +402,9 @@ class TestGetOrCreateForSender:
 
         # Init session
         client.get(reverse("apply:start", kwargs={"company_pk": company.pk}), follow=True)
-        [job_seeker_session_name] = [k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS]
+        [job_seeker_session_name] = [
+            k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
+        ]
 
         response = client.post(
             reverse(

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -134,7 +134,7 @@ class TestGetOrCreateForJobSeeker:
 
         # Init session
         start_url = reverse("apply:start", kwargs={"company_pk": company.pk})
-        client.get(start_url)
+        client.get(start_url, {"back_url": reset_url})
         [job_seeker_session_name] = [
             k for k in client.session.keys() if k not in KNOWN_SESSION_KEYS and not k.startswith("job_application")
         ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

> _Indiquez le problème que nous sommes en train de résoudre et les objectifs métiers ou techniques qui sont visés par ces changements._

Je vois deux petits problèmes au fonctionnement actuel :
1. quand on clique sur un bouton **Postuler** directement dans les résultats de la recherche, puis qu'on annule le parcours, on revient à une fiche de poste ou une fiche d'entreprise. On s'attendrait davantage à revenir aux résultats de recherche.
2. lors du parcours "Postuler pour ce candidat", lorsqu'on annule, on retourne également à la fiche de poste ou d'entreprise, **sans le bandeau "Vous postulez actuellement pour…"**.

## :cake: Comment ? <!-- optionnel -->

Une solution est d'ajouter le traditionnel (mais controversé ?) `?back_url=` aux boutons Postuler.
La vue `StartView` insère dans `apply_session` cette info dans `reset_url`.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
