### PR TITLE
Prescripteur: Améliorer la liste des candidats affichés dans l'onglet  "Tous les candidats de ma structure"

### DIFF
--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -118,9 +118,11 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
     if list_organization:
         if not request.current_organization or not request.current_organization.memberships.count() > 1:
             raise Http404
-        job_seekers_ids = list(User.objects.linked_job_seeker_ids(request.user, request.current_organization))
+        job_seekers_ids = list(
+            User.objects.linked_job_seeker_ids(request.user, request.current_organization, from_all_coworkers=True)
+        )
     else:
-        job_seekers_ids = list(User.objects.linked_job_seeker_ids(request.user, None))
+        job_seekers_ids = list(User.objects.linked_job_seeker_ids(request.user, request.current_organization))
 
     user_applications = JobApplication.objects.prescriptions_of(request.user, request.current_organization).filter(
         job_seeker=OuterRef("pk")
@@ -343,7 +345,7 @@ class JobSeekerBaseView(ExpectedJobSeekerSessionMixin, TemplateView):
             return False
 
         return job_seeker.pk in User.objects.linked_job_seeker_ids(
-            self.request.user, self.request.current_organization
+            self.request.user, self.request.current_organization, from_all_coworkers=True
         )
 
 

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -408,12 +408,19 @@
           
             (SELECT "users_user"."id" AS "col1"
              FROM "users_user"
-             WHERE "users_user"."created_by_id" = %s
+             LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+             WHERE (("users_user"."created_by_id" = %s
+                     AND "users_jobseekerprofile"."created_by_prescriber_organization_id" IS NULL)
+                    OR ("users_user"."created_by_id" = %s
+                        AND "users_jobseekerprofile"."created_by_prescriber_organization_id" = %s))
              ORDER BY RANDOM() ASC)
           UNION
             (SELECT "job_applications_jobapplication"."job_seeker_id" AS "col1"
              FROM "job_applications_jobapplication"
-             WHERE "job_applications_jobapplication"."sender_id" = %s
+             WHERE (("job_applications_jobapplication"."sender_id" = %s
+                     AND "job_applications_jobapplication"."sender_prescriber_organization_id" IS NULL)
+                    OR ("job_applications_jobapplication"."sender_id" = %s
+                        AND "job_applications_jobapplication"."sender_prescriber_organization_id" = %s))
              ORDER BY "job_applications_jobapplication"."created_at" DESC)
         ''',
       }),
@@ -1272,12 +1279,10 @@
           
             (SELECT "users_user"."id" AS "col1"
              FROM "users_user"
-             WHERE "users_user"."created_by_id" = %s
-             ORDER BY RANDOM() ASC)
-          UNION
-            (SELECT "users_jobseekerprofile"."user_id" AS "col1"
-             FROM "users_jobseekerprofile"
-             WHERE "users_jobseekerprofile"."created_by_prescriber_organization_id" = %s
+             LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+             WHERE (("users_user"."created_by_id" = %s
+                     AND "users_jobseekerprofile"."created_by_prescriber_organization_id" IS NULL)
+                    OR "users_jobseekerprofile"."created_by_prescriber_organization_id" = %s)
              ORDER BY RANDOM() ASC)
           UNION
             (SELECT "job_applications_jobapplication"."job_seeker_id" AS "col1"
@@ -1361,7 +1366,6 @@
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
-                                           %s,
                                            %s))
           GROUP BY "users_user"."id",
                    34,
@@ -1399,7 +1403,6 @@
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
           WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
                                                    %s,
                                                    %s)
           ORDER BY "approvals_approval"."created_at" DESC
@@ -1500,7 +1503,6 @@
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
-                                           %s,
                                            %s))
           GROUP BY "users_user"."id",
                    34,
@@ -1537,7 +1539,6 @@
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
           WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
                                                    %s,
                                                    %s)
           ORDER BY "approvals_approval"."created_at" DESC
@@ -1633,7 +1634,6 @@
              WHERE ("users_user"."kind" = %s
                     AND "users_user"."id" IN (%s,
                                               %s,
-                                              %s,
                                               %s))
              GROUP BY "users_user"."id",
                       1,
@@ -1711,14 +1711,13 @@
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
-                                           %s,
                                            %s))
           GROUP BY "users_user"."id",
                    34,
                    35
           ORDER BY 34 ASC,
                    "users_user"."id" ASC
-          LIMIT 4
+          LIMIT 3
         ''',
       }),
       dict({
@@ -1748,7 +1747,6 @@
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
           WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
                                                    %s,
                                                    %s)
           ORDER BY "approvals_approval"."created_at" DESC
@@ -1911,37 +1909,6 @@
                                       
                                   
                                   <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=33333333-3333-3333-3333-333333333333&amp;city=brest-29">
-                                      <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
-                                  </a>
-                              </td>
-                          </tr>
-                      
-                          <tr>
-                              <td>
-                                  <a class="btn-link" href="/job-seekers/details/44444444-4444-4444-4444-444444444444?back_url=/job-seekers/list-organization">David WATERFORD</a>
-                              </td>
-                              <td>
-                                  
-  
-      
-          
-                      <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-              <i aria-hidden="true" class="ri-error-warning-line"></i>
-              Éligibilité IAE à valider
-          </span>
-          
-      
-  
-  
-                              </td>
-                              <td>0</td>
-                              <td></td>
-                              <td class="text-end w-50px">
-                                  
-                                  
-                                      
-                                  
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=44444444-4444-4444-4444-444444444444&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                               </td>

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -445,9 +445,7 @@ class TestStandaloneCreateAsPrescriber:
 
         match case:
             case "in_list_user":
-                # Job seeker in user's list even if it was for another orga
                 existing_job_seeker.created_by = user
-                existing_job_seeker.jobseeker_profile.created_by_prescriber_organization = other_organization
                 next_url = add_url_params(
                     reverse(
                         "search:employers_results",
@@ -525,9 +523,7 @@ class TestStandaloneCreateAsPrescriber:
 
         match case:
             case "in_list_user":
-                # Job seeker in user's list even if it was for another orga
                 existing_job_seeker.created_by = user
-                existing_job_seeker.jobseeker_profile.created_by_prescriber_organization = other_organization
                 next_url = add_url_params(
                     reverse(
                         "search:employers_results",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faisant suite à la discussion du début de semaine sur la liste de candidats dans les 2 onglets.
Je propose de modifier les candidats affichés dans l'onglet `Tous les candidats de ma structure` pour n'avoir que ceux effectivement concernés pas des actions réalisés dans cette structure.

Actuellement :
- Dans l'onglet "Mes candidats" on a:
  - les candidats que j'ai créé (quelque soit l'orga sélectionnée)
  - les candidats pour lesquels j'ai postulé (quelque soit l'orga sélectionnée)
- Dans l'onglet "tous les candidats de la structure" on a :
  - les candidats que j'ai créé (quelque soit l'orga sélectionnée)
  - les candidats créés par un membre de mon orga (aka en ayant sélectionné cette orga)
  - les candidats avec une candidature envoyée par mon organisation
  - les candidats avec une candidature envoyés par moi sans organisation

**Solution 1** 
- Dans l'onglet "Mes candidats" on a:
  - les candidats que j'ai créé (quelque soit l'orga sélectionnée)
  - les candidats pour lesquels j'ai postulé (quelque soit l'orga sélectionnée)
- Dans l'onglet "tous les candidats de la structure" on a :
  - ~les candidats que j'ai créé (quelque soit l'orga sélectionnée)~
  - les candidats créés par un membre de mon orga (aka en ayant sélectionné cette orga)
  - les candidats avec une candidature envoyée par mon organisation
  - ~les candidats avec une candidature envoyés par moi sans organisation~

**Solution 2** 
On pourrait envisager d'aller plus loin en n'affichant dans Mes Candidats que les candidats liés à cet utilisateur et à l'organisation active.
Les candidats affichés dépendraient donc de l'organisation selectionnée.
Gros avantage : on peut décider d'afficher les candidats qu'on suit "hors orga" dans les 2 pages (comme actuellement).
Cela permet donc d'avoir : 
- Dans l'onglet "Mes candidats" on a:
  - les candidats que j'ai créé (avec cette orga, ou sans orga) ~(quelque soit l'orga sélectionnée)~ 
  - les candidats pour lesquels j'ai postulé (avec cette orga, ou sans orga) ~(quelque soit l'orga sélectionnée)~ 
- Dans l'onglet "tous les candidats de la structure" on a :
  - les même que dans mes candidats
  - les candidats créés par un membre de mon orga (aka en ayant sélectionné cette orga)
  - les candidats avec une candidature envoyée par mon organisation
On a donc strictement plus de candidats dans le second onglet.  

@marionholis a validé la solution 2

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
