### PR TITLE
Pilotage: Suivre le type de prescripteur dans les réponses au formulaire NPS TB 488

### DIFF
--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -82,7 +82,7 @@
     {% if tally_embed_form_id %}
         <section class="s-section mt-0 pt-0">
             <div class="s-section__container container">
-                <iframe data-tally-src="https://tally.so/embed/{{ tally_embed_form_id }}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1"
+                <iframe data-tally-src="{{ TALLY_URL }}/embed/{{ tally_embed_form_id }}?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1{% for key, value in tally_hidden_fields.items %}&{{ key|urlencode }}={{ value|urlencode }}{% endfor %}"
                         loading="lazy"
                         width="100%"
                         height="189"
@@ -112,6 +112,8 @@
     {% endif %}
 
     {% if tally_popup_form_id %}
+        {{ tally_hidden_fields|json_script:'tally-hidden-fields' }}
+
         {# `defer` ensures the script runs *after* embed.js above has been loaded. #}
         <script defer nonce="{{ CSP_NONCE }}">
             // Any given Tally popup will not be shown more than once every `minDaysBetweenDisplays` days.
@@ -120,6 +122,7 @@
             const formId = '{{ tally_popup_form_id }}';
             const key = 'statsTallyPopupLastShown-' + formId;
             const todaysDate = new Date();
+            const hiddenFields = JSON.parse(document.getElementById('tally-hidden-fields').textContent);
 
             function supportsLocalStorage() {
                 try {
@@ -139,6 +142,7 @@
                         text: "👋",
                         animation: "wave"
                     },
+                    hiddenFields: hiddenFields,
                     onClose: () => {
                         stopShowingPopupForAWhile();
                     },

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -132,8 +132,8 @@ METABASE_DASHBOARDS = {
     #
     "stats_ph_state_main": {
         "dashboard_id": 488,
-        "tally_popup_form_id": "mRG61J",
-        "tally_embed_form_id": "3qLKad",
+        "tally_popup_form_id": "3XQ5D4",
+        "tally_embed_form_id": "mVNGgv",
     },
     #
     # Institution stats - DDETS IAE - department level.

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -31,4 +31,5 @@ def expose_settings(request):
         "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
         "SHOW_DEMO_ACCOUNTS_BANNER": settings.SHOW_DEMO_ACCOUNTS_BANNER,
+        "TALLY_URL": settings.TALLY_URL,
     }

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -130,6 +130,7 @@ def render_stats(request, context, params=None, template_name="stats/stats.html"
         "tally_embed_form_id": tally_embed_form_id,
         "PILOTAGE_HELP_CENTER_URL": global_constants.PILOTAGE_HELP_CENTER_URL,
         "tally_suspension_form": tally_suspension_form,
+        "tally_hidden_fields": {},
     }
 
     # Key value pairs in context override preexisting pairs in base_context.
@@ -521,6 +522,7 @@ def stats_ph_state_main(request):
             mb.PRESCRIBER_FILTER_KEY: PrescriberOrganizationKind(request.current_organization.kind).label,
             mb.C1_PRESCRIBER_ORG_FILTER_KEY: allowed_org_pks,
         },
+        extra_context={"tally_hidden_fields": {"type_prescripteur": request.current_organization.kind}},
     )
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Carte Notion: https://www.notion.so/gip-inclusion/TB-488-Formulaire-Tally-par-type-de-prescripteur-1bb5f321b60480149bf4f04f0582eff1

## :cake: Comment ?

Dans [un nouveau formulaire Tally](https://tally.so/forms/3XQ5D4/submissions), on paramètre le type de prescripteur dans un [champ encaché](https://tally.so/help/hidden-fields).

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

* Créer un utilisateur test depuis le shell :

```python
from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
from itou.prescribers.enums import PrescriberOrganizationKind
PrescriberOrganizationWithMembershipFactory(kind=PrescriberOrganizationKind.CHRS, department="75", authorized=True)
```

* Détourner l'utilisateur membre de l'organisation.
* Visiter http://localhost:8000/stats/ph/state/main
* Attendre l'apparation du formulaire, ou lancer du JS depuis la console navigateur :

```javascript
displayTallyPopup();
```

* Vérifier la réponse avec le type de prescripteur sur le formulaire Tally

## :computer: Captures d'écran

<img width="353" alt="Screenshot 2025-03-24 at 12 37 44" src="https://github.com/user-attachments/assets/de8f213a-befa-4821-bb62-39c5b8cd17fd" />

<img width="988" alt="Screenshot 2025-03-24 at 12 36 46" src="https://github.com/user-attachments/assets/12865644-ce83-4d45-a553-f6080c9f98a8" />