### PR TITLE
Tableau de bord: Supprimer les sondages présentés aux employeurs et aux prescripteurs [GEN-2336]

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -258,24 +258,4 @@
 {% block script %}
     {{ block.super }}
     <script src="{% static 'js/sliding_tabs.js'%}"></script>
-
-    {% if user.is_employer or user.is_prescriber_with_authorized_org %}
-        <script async src="https://tally.so/widgets/embed.js"></script>
-        <script nonce="{{ CSP_NONCE }}">
-            window.TallyConfig = {
-                "formId": "{{ user.is_employer|yesno:'mKvOeK,mZvQpy' }}",
-                "popup": {
-                    "emoji": {
-                        "text": "👋",
-                        "animation": "wave"
-                    },
-                    "autoClose": 0,
-                    "showOnce": true,
-                    "hiddenFields": {
-                        "user_id": "{{ user.pk }}",
-                    },
-                }
-            };
-        </script>
-    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les sondages ne sont plus actifs.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

* Se connecter avec un employeur ou prescripteur
* Visiter la page d'acceuil
