### PR TITLE
GPS: Mise à jour des règles de suivi automatique

### DIFF
--- a/itou/gps/models.py
+++ b/itou/gps/models.py
@@ -16,6 +16,7 @@ class BulkCreatedAtQuerysetProxy:
 
 class FollowUpGroupManager(models.Manager):
     def follow_beneficiary(self, beneficiary, user, is_referent=None, is_active=True):
+        assert beneficiary.is_job_seeker
         now = timezone.now()
         with transaction.atomic():
             group, _ = FollowUpGroup.objects.get_or_create(beneficiary=beneficiary)

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -657,7 +657,7 @@ class ApplicationResumeView(RequireApplySessionMixin, ApplicationBaseView):
         # The job application is now saved in DB, delete the session early to avoid any problems
         self.apply_session.delete()
 
-        if self.request.user.is_employer or self.request.user.is_prescriber_with_authorized_org:
+        if self.request.user.is_employer or self.request.user.is_prescriber:
             # New job application -> sync GPS groups if the sender is not a jobseeker
             FollowUpGroup.objects.follow_beneficiary(self.job_seeker, self.request.user)
 

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -21,6 +21,7 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
 from itou.eligibility.models.iae import EligibilityDiagnosis
+from itou.gps.models import FollowUpGroup
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
 from itou.users.models import JobSeekerProfile, User
@@ -847,6 +848,8 @@ class CreateJobSeekerStepEndForSenderView(CreateJobSeekerForSenderBaseView):
                     .exists()
                 )
                 gps_utils.add_beneficiary(request, user, notify_duplicate)
+            else:
+                FollowUpGroup.objects.follow_beneficiary(beneficiary=user, user=request.user)
 
         return HttpResponseRedirect(url)
 

--- a/tests/gps/test_models.py
+++ b/tests/gps/test_models.py
@@ -11,7 +11,9 @@ from tests.gps.factories import FollowUpGroupFactory, FollowUpGroupMembershipFac
 from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.users.factories import (
     EmployerFactory,
+    ItouStaffFactory,
     JobSeekerFactory,
+    LaborInspectorFactory,
     PrescriberFactory,
 )
 
@@ -122,6 +124,14 @@ class TestFollowBeneficiary:
         FollowUpGroup.objects.follow_beneficiary(beneficiary, prescriber, is_active=False)
         membership.refresh_from_db()
         assert membership.is_active is False
+
+    @pytest.mark.parametrize("factory", [PrescriberFactory, EmployerFactory, LaborInspectorFactory, ItouStaffFactory])
+    def test_is_job_seeker(self, factory):
+        not_a_beneficiary = factory()
+        prescriber = PrescriberFactory()
+
+        with pytest.raises(AssertionError):
+            FollowUpGroup.objects.follow_beneficiary(not_a_beneficiary, prescriber)
 
 
 @pytest.mark.parametrize(

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -1484,6 +1484,12 @@ class TestApplyAsAuthorizedPrescriber:
         )
         assertRedirects(response, next_url)
 
+        # Check GPS group
+        membership = FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).get()
+        membership.delete()  # delete it to check it is created again when applying
+
         # Step application's jobs.
         # ----------------------------------------------------------------------
 
@@ -1572,13 +1578,10 @@ class TestApplyAsAuthorizedPrescriber:
         response = client.get(next_url)
         assert response.status_code == 200
 
-        # Check GPS group
-        # ----------------------------------------------------------------------
-        group = FollowUpGroup.objects.get()
-        assert group.beneficiary == new_job_seeker
-        membership = FollowUpGroupMembership.objects.get(follow_up_group=group)
-        assert membership.member == user
-        assert membership.creator == user
+        # Check GPS group again
+        assert FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).exists()
 
     def test_cannot_create_job_seeker_with_pole_emploi_email(self, client):
         company = CompanyMembershipFactory().company
@@ -1986,6 +1989,12 @@ class TestApplyAsPrescriber:
         )
         assertRedirects(response, next_url)
 
+        # Check GPS group
+        membership = FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).get()
+        membership.delete()  # delete it to check it is created again when applying
+
         # Step application's jobs.
         # ----------------------------------------------------------------------
 
@@ -2060,9 +2069,10 @@ class TestApplyAsPrescriber:
         response = client.get(next_url)
         assert response.status_code == 200
 
-        # GPS : no following for not authorized prescribers
-        # ----------------------------------------------------------------------
-        assert not FollowUpGroup.objects.exists()
+        # Check GPS group again
+        assert FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).exists()
 
     def test_check_info_as_prescriber_for_job_seeker_with_incomplete_info(self, client):
         company = CompanyFactory(with_membership=True, with_jobs=True, romes=("N1101", "N1105"))
@@ -2569,6 +2579,12 @@ class TestApplyAsCompany:
         )
         assertRedirects(response, next_url)
 
+        # Check GPS group
+        membership = FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).get()
+        membership.delete()  # delete it to check it is created again when applying
+
         # Step application's jobs.
         # ----------------------------------------------------------------------
 
@@ -2643,13 +2659,10 @@ class TestApplyAsCompany:
         response = client.get(next_url)
         assert response.status_code == 200
 
-        # Check GPS group
-        # ----------------------------------------------------------------------
-        group = FollowUpGroup.objects.get()
-        assert group.beneficiary == new_job_seeker
-        membership = FollowUpGroupMembership.objects.get(follow_up_group=group)
-        assert membership.member == user
-        assert membership.creator == user
+        # Check GPS group again
+        assert FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).exists()
 
     @pytest.mark.ignore_unknown_variable_template_error("job_seeker")
     def test_apply_as_employer(self, client, pdf_file):

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertMessages, assertRedirects
 
 from itou.asp.models import Commune, Country, RSAAllocation
+from itou.gps.models import FollowUpGroupMembership
 from itou.users.enums import LackOfPoleEmploiId, Title
 from itou.users.models import JobSeekerProfile, User
 from itou.utils.mocks.address_format import mock_get_geocoding_data_by_ban_api_resolved
@@ -819,6 +820,10 @@ class TestStandaloneCreateAsPrescriber:
                 )
             ],
         )
+
+        assert FollowUpGroupMembership.objects.filter(
+            follow_up_group__beneficiary=new_job_seeker, member=user
+        ).exists()
 
 
 class TestUpdateAsOther:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Voir https://www.notion.so/gip-inclusion/Flux-d-ajout-la-cr-ation-d-un-compte-candidat-1ae5f321b604802d947dc5a98ab181d9?pvs=4

Maintenant qu'on utilise `can_view_personal_information` pour paramétrer l'affichage des informations personnelles
- les prescripteurs non habilités peuvent également suivre les candidats lorsqu'ils postulent pour eux
- les prescripteurs / employeurs peuvent suivre les candidats lorsqu'ils créent un compte même sans postuler ensuite (vu que c'est encore plus facile avec l'espace candidat)


Je lancerai la commande `sync_follow_up_groups_and_members` une fois la PR mergée pour rattraper les groupes manquants 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
