### PR TITLE
Outillage: ajout debugger pour les management command dans vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,14 @@
             ],
             "django": true,
             "justMyCode": false
+        },
+        {"name": "Django Management Command",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/manage.py",
+            "args": [
+                "${fileBasenameNoExtension}"
+            ]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
     "configurations": [
         {
             "name": "Python: Current File",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${file}",
             "purpose": ["debug-test"],
@@ -15,7 +15,7 @@
         },
         {
             "name": "Python Django",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/manage.py",
             "args": [


### PR DESCRIPTION
## :thinking: Pourquoi ?

permettre le debuggage des commandes de gestion dans `vscode`

