### PR TITLE
GEIQ: ajout de la méthode `get_compte_pdf` utilisant le nouvel endpoint `/rest/DownloadCompte`

### DIFF
--- a/tests/utils/apis/test_geiq_label.py
+++ b/tests/utils/apis/test_geiq_label.py
@@ -163,6 +163,38 @@ def test_get_taux_geiq_batch(respx_mock, label_settings):
     assert client.get_taux_geiq() == expected_data
 
 
+def test_get_compte_pdf(respx_mock, label_settings):
+    expected_data = b"some pdf file"
+    respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/DownloadCompte?id=123").respond(
+        200,
+        content=expected_data,
+        headers={
+            "content-length": f"{len(expected_data)}",
+            "content-transfer-encoding": "binary",
+            "content-type": "application/pdf",
+        },
+    )
+
+    client = geiq_label.get_client()
+    assert client.get_compte_pdf(geiq_id=123) == expected_data
+
+
+def test_get_compte_pdf_invalid_content_type(respx_mock, label_settings):
+    client = geiq_label.get_client()
+
+    respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/DownloadCompte?id=123").respond(
+        200,
+        content=b"",
+        headers={
+            "content-length": "0",
+            "content-transfer-encoding": "binary",
+            "content-type": "text/html",
+        },
+    )
+    with pytest.raises(geiq_label.LabelAPIError):
+        assert client.get_compte_pdf(geiq_id=123)
+
+
 def test_get_synthese_pdf(respx_mock, label_settings):
     expected_data = b"some pdf file"
     respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/SynthesePDF?id=123").respond(


### PR DESCRIPTION
## :thinking: Pourquoi ?

On va en avoir besoin pour le nouveau bilan d'exécution.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
