### PR TITLE
❄️ Fiche de poste : améliorer l'affichage du nom de la fiche de poste et les filtres associés dans les candidatures

### DIFF
--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -28,7 +28,13 @@
 
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{{ job.display_name }}</h1>
+            <div>
+                <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{{ job.display_name }}</h1>
+                {% if job.custom_name %}
+                    {# display_name returns the custom_name and we show the appellation bellow #}
+                    <p class="mb-0">{{ job.appellation.name }}</p>
+                {% endif %}
+            </div>
             {% if job.is_active %}
                 <span class="badge rounded-pill bg-success">
                     {{ job.open_positions }} {{ job.open_positions|pluralizefr:"poste ouvert,postes ouverts" }} au recrutement

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -30,10 +30,15 @@
         <div class="d-xl-flex align-items-xl-center">
             <div>
                 <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{{ job.display_name }}</h1>
-                {% if job.custom_name %}
-                    {# display_name returns the custom_name and we show the appellation bellow #}
-                    <p class="mb-0">{{ job.appellation.name }}</p>
-                {% endif %}
+                <p class="mb-0">
+                    {% if job.custom_name %}
+                        {# display_name above returns the custom_name and we show the appellation name and code bellow #}
+                        {{ job.appellation.name }} ({{ job.appellation.code }})
+                    {% else %}
+                        {# display_name above returns the appellation and we only add the appellation code #}
+                        {{ job.appellation.code }}
+                    {% endif %}
+                </p>
             </div>
             {% if job.is_active %}
                 <span class="badge rounded-pill bg-success">

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -29,7 +29,7 @@
     <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
         <div class="d-xl-flex align-items-xl-center">
             <div>
-                <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{{ job.display_name }}</h1>
+                <h1 class="mb-1 mb-xl-0 me-xl-3">{{ job.display_name }}</h1>
                 <p class="mb-0">
                     {% if job.custom_name %}
                         {# display_name above returns the custom_name and we show the appellation name and code bellow #}

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -907,7 +907,7 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
         jobs = set()
         for job_application in self.job_applications_qs.prefetch_related("selected_jobs__appellation"):
             for job in job_application.selected_jobs.all():
-                jobs.add((job.pk, job.display_name))
+                jobs.add((job.pk, f"{job.display_name} ({job.appellation.code})"))
         return sorted(jobs, key=lambda job: job[1])
 
     def _get_choices_for_job_seeker(self, users):
@@ -962,7 +962,7 @@ class PrescriberFilterJobApplicationsForm(CompanyPrescriberFilterJobApplications
         jobs = set()
         for job_application in self.job_applications_qs.prefetch_related("selected_jobs__appellation"):
             for job in job_application.selected_jobs.all():
-                jobs.add((job.appellation.code, job.appellation.name))
+                jobs.add((job.appellation.code, f"{job.appellation.name} ({job.appellation.code})"))
         return sorted(jobs, key=lambda job: job[1])
 
     def get_to_companies_choices(self):

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -734,8 +734,6 @@ class FilterJobApplicationsForm(forms.Form):
             filters.append(Q(created_at__lte=end_date))
         if departments := data.get("departments"):
             filters.append(Q(job_seeker__department__in=departments))
-        if selected_jobs := data.get("selected_jobs"):
-            filters.append(Q(selected_jobs__appellation__code__in=selected_jobs))
         if criteria := data.get("criteria"):
             # Filter on the `eligibility_diagnosis_criterion_{criterion}` annotation,
             # which is set in `with_list_related_data()`.
@@ -821,13 +819,6 @@ class CompanyPrescriberFilterJobApplicationsForm(FilterJobApplicationsForm):
         }
         return sorted(departments, key=lambda dpts: dpts[1])
 
-    def _get_choices_for_jobs(self):
-        jobs = set()
-        for job_application in self.job_applications_qs.prefetch_related("selected_jobs__appellation"):
-            for job in job_application.selected_jobs.all():
-                jobs.add((job.appellation.code, job.appellation.name))
-        return sorted(jobs, key=lambda job: job[1])
-
     def filter(self, queryset):
         queryset = super().filter(queryset)
 
@@ -908,7 +899,16 @@ class CompanyFilterJobApplicationsForm(CompanyPrescriberFilterJobApplicationsFor
             queryset = queryset.filter(sender_prescriber_organization__id__in=sender_prescriber_organizations)
         if sender_companies := self.cleaned_data.get("sender_companies"):
             queryset = queryset.filter(sender_company__id__in=sender_companies)
+        if selected_jobs := self.cleaned_data.get("selected_jobs"):
+            queryset = queryset.filter(selected_jobs__in=selected_jobs)
         return queryset
+
+    def _get_choices_for_jobs(self):
+        jobs = set()
+        for job_application in self.job_applications_qs.prefetch_related("selected_jobs__appellation"):
+            for job in job_application.selected_jobs.all():
+                jobs.add((job.pk, job.display_name))
+        return sorted(jobs, key=lambda job: job[1])
 
     def _get_choices_for_job_seeker(self, users):
         users = [(user.id, user_full_name) for user in users if (user_full_name := user.get_full_name())]
@@ -954,7 +954,16 @@ class PrescriberFilterJobApplicationsForm(CompanyPrescriberFilterJobApplications
         queryset = super().filter(queryset)
         if to_companies := self.cleaned_data.get("to_companies"):
             queryset = queryset.filter(to_company__id__in=to_companies)
+        if selected_jobs := self.cleaned_data.get("selected_jobs"):
+            queryset = queryset.filter(selected_jobs__appellation__code__in=selected_jobs)
         return queryset
+
+    def _get_choices_for_jobs(self):
+        jobs = set()
+        for job_application in self.job_applications_qs.prefetch_related("selected_jobs__appellation"):
+            for job in job_application.selected_jobs.all():
+                jobs.add((job.appellation.code, job.appellation.name))
+        return sorted(jobs, key=lambda job: job[1])
 
     def get_to_companies_choices(self):
         to_companies = self.job_applications_qs.get_unique_fk_objects("to_company")

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -100,7 +100,9 @@ class TestProcessListSiae:
                    name="{self.SELECTED_JOBS}"
                    type="checkbox"
                    value="{job1.pk}">
-            <label for="id_selected_jobs_0-top" class="form-check-label">{job1.display_name}</label>
+            <label for="id_selected_jobs_0-top" class="form-check-label">
+                {job1.display_name} ({job1.appellation.code})
+            </label>
             </div>
             </li>
             <li class="dropdown-item">
@@ -111,7 +113,9 @@ class TestProcessListSiae:
                        name="{self.SELECTED_JOBS}"
                        type="checkbox"
                        value="{job2.pk}">
-                <label for="id_selected_jobs_1-top" class="form-check-label">{job2.display_name}</label>
+                <label for="id_selected_jobs_1-top" class="form-check-label">
+                    {job2.display_name} ({job2.appellation.code})
+                </label>
             </div>
             </li>
             </ul>

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -99,8 +99,8 @@ class TestProcessListSiae:
                    data-emplois-sync-with="id_selected_jobs_0"
                    name="{self.SELECTED_JOBS}"
                    type="checkbox"
-                   value="{job1.appellation.code}">
-            <label for="id_selected_jobs_0-top" class="form-check-label">{job1.appellation.name}</label>
+                   value="{job1.pk}">
+            <label for="id_selected_jobs_0-top" class="form-check-label">{job1.display_name}</label>
             </div>
             </li>
             <li class="dropdown-item">
@@ -110,8 +110,8 @@ class TestProcessListSiae:
                        data-emplois-sync-with="id_selected_jobs_1"
                        name="{self.SELECTED_JOBS}"
                        type="checkbox"
-                       value="{job2.appellation.code}">
-                <label for="id_selected_jobs_1-top" class="form-check-label">{job2.appellation.name}</label>
+                       value="{job2.pk}">
+                <label for="id_selected_jobs_1-top" class="form-check-label">{job2.display_name}</label>
             </div>
             </li>
             </ul>
@@ -559,11 +559,14 @@ class TestProcessListSiae:
 
         create_test_romes_and_appellations(["M1805", "N1101"], appellations_per_rome=2)
         (appellation1, appellation2) = Appellation.objects.all().order_by("?")[:2]
-        job_app = JobApplicationSentByJobSeekerFactory(to_company=company, selected_jobs=[appellation1])
-        _another_job_app = JobApplicationSentByJobSeekerFactory(to_company=company, selected_jobs=[appellation2])
+        job1 = JobDescriptionFactory(company=company, appellation=appellation1)
+        job2 = JobDescriptionFactory(company=company, appellation=appellation2)
+
+        job_app = JobApplicationSentByJobSeekerFactory(to_company=company, selected_jobs=[job1])
+        _another_job_app = JobApplicationSentByJobSeekerFactory(to_company=company, selected_jobs=[job2])
 
         client.force_login(employer)
-        response = client.get(reverse("apply:list_for_siae"), {"selected_jobs": [appellation1.pk]})
+        response = client.get(reverse("apply:list_for_siae"), {"selected_jobs": [job1.pk]})
         assert response.context["job_applications_page"].object_list == [job_app]
 
     @freeze_time("2025-03-13")

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -715,3 +715,19 @@ class TestJobDescriptionCard(JobDescriptionAbstract):
         assertContains(response, "a job description")
         assertContains(response, "a profile description")
         assertNotContains(response, PLACE_HOLDER)
+
+    def test_display_custom_or_appellation_name(self, client):
+        TITLE_MARKUP = '<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">%s</h1>'
+        SUBTITLE_MARKUP = '<p class="mb-0">%s</p>'
+
+        # custom_name is missing, show only appellation.name
+        response = self._login(client, self.user)
+        assertContains(response, TITLE_MARKUP % self.job_description.appellation.name, html=True)
+
+        # custom_name is provided, show both
+        self.job_description.custom_name = "Custom name"
+        self.job_description.save()
+        response = client.get(self.url)
+        assertContains(response, TITLE_MARKUP % self.job_description.custom_name, html=True)
+        assertNotContains(response, TITLE_MARKUP % self.job_description.appellation.name, html=True)
+        assertContains(response, SUBTITLE_MARKUP % self.job_description.appellation.name, html=True)

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -717,7 +717,7 @@ class TestJobDescriptionCard(JobDescriptionAbstract):
         assertNotContains(response, PLACE_HOLDER)
 
     def test_display_custom_or_appellation_name(self, client):
-        TITLE_MARKUP = '<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">%s</h1>'
+        TITLE_MARKUP = '<h1 class="mb-1 mb-xl-0 me-xl-3">%s</h1>'
         SUBTITLE_MARKUP = '<p class="mb-0">%s</p>'
 
         # custom_name is missing, show only appellation.name, and bellow appellation.code

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -720,14 +720,18 @@ class TestJobDescriptionCard(JobDescriptionAbstract):
         TITLE_MARKUP = '<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">%s</h1>'
         SUBTITLE_MARKUP = '<p class="mb-0">%s</p>'
 
-        # custom_name is missing, show only appellation.name
+        # custom_name is missing, show only appellation.name, and bellow appellation.code
         response = self._login(client, self.user)
         assertContains(response, TITLE_MARKUP % self.job_description.appellation.name, html=True)
+        assertContains(response, SUBTITLE_MARKUP % self.job_description.appellation.code, html=True)
 
-        # custom_name is provided, show both
+        # custom_name is provided: custom_name in title and appellation name + code in subtitle
         self.job_description.custom_name = "Custom name"
         self.job_description.save()
         response = client.get(self.url)
         assertContains(response, TITLE_MARKUP % self.job_description.custom_name, html=True)
-        assertNotContains(response, TITLE_MARKUP % self.job_description.appellation.name, html=True)
-        assertContains(response, SUBTITLE_MARKUP % self.job_description.appellation.name, html=True)
+        assertContains(
+            response,
+            SUBTITLE_MARKUP % f"{self.job_description.appellation.name} ({self.job_description.appellation.code})",
+            html=True,
+        )


### PR DESCRIPTION
Statut : en attente. On met au frigo, il faut retravailler l'édition; Antoine P retravaillera certains éléments.

## :thinking: Pourquoi ?
Afficher plus d'info quand on en a.

## :cake: Comment ? <!-- optionnel -->
**Dans la page de détail de fiche de poste :**
- si le nom personnalisé est rempli, afficher
    - en titre : ce nom personnalisé
    - en sous-titre : l'intitulé du code ROME
- si le nom personnalisé n'est pas rempli, afficher
    - en titre : l'intitulé du code ROME
    - (pas de sous-titre)


**Dans l'espace candidatire :**
- **employeurs** : afficher le libellé personnalisé (ou ROME si pas de libellé personnalisé)
- **les autres** : afficher le code ROME systématiquement



## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
