### PR TITLE
apis: Change data⋅inclusion themes

### DIFF
--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -10,11 +10,10 @@ logger = logging.getLogger(__name__)
 API_TIMEOUT_SECONDS = 1.0
 API_THEMATIQUES = [
     "acces-aux-droits-et-citoyennete",
-    "accompagnement-social-et-professionnel-personnalise",
-    "apprendre-francais",
-    "choisir-un-metier",
-    "mobilite",
-    "trouver-un-emploi",
+    "equipement-et-alimentation",
+    "logement-hebergementmobilite",
+    "numerique",
+    "remobilisation",
 ]
 
 

--- a/tests/utils/apis/test_data_inclusion_api.py
+++ b/tests/utils/apis/test_data_inclusion_api.py
@@ -33,11 +33,10 @@ def test_data_inclusion_client(settings, respx_mock):
         "score_qualite_minimum": ["0.6"],
         "thematiques": [
             "acces-aux-droits-et-citoyennete",
-            "accompagnement-social-et-professionnel-personnalise",
-            "apprendre-francais",
-            "choisir-un-metier",
-            "mobilite",
-            "trouver-un-emploi",
+            "equipement-et-alimentation",
+            "logement-hebergementmobilite",
+            "numerique",
+            "remobilisation",
         ],
     }
     assert api_mock.calls[0].request.headers["authorization"] == "Bearer fake-token"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Soliguide est rentré dans une phase d'expérimentation qui nous permet d'afficher leurs données hors DORA. Nous modifions les thématiques de recherche pour  que ces offres de service soient affichées.

## :cake: Comment ? <!-- optionnel -->

En modifiant les thématiques de recherche. Malin.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md => pas nécessaire je pense
- [x] Ajouter l'étiquette « Bug » ? => Non plus

## :desert_island: Comment tester ?

Le test était déjà là.
