### PR TITLE
Candidature : Autoriser l'annulation quand la fiche salarié n'a pas été transmise

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -101,6 +101,16 @@ class EmployeeRecordTransition(enum.StrEnum):
     UNARCHIVE_PROCESSED = "unarchive_processed"
     UNARCHIVE_REJECTED = "unarchive_rejected"
 
+    @classmethod
+    def without_asp_exchange(cls):
+        return {
+            cls.READY,
+            cls.DISABLE,
+            cls.ENABLE,
+            cls.ARCHIVE,
+            cls.UNARCHIVE_NEW,
+        }
+
 
 class EmployeeRecordWorkflow(xwf_models.Workflow):
     states = Status.choices

--- a/tests/employee_record/factories.py
+++ b/tests/employee_record/factories.py
@@ -4,7 +4,10 @@ import factory
 
 from itou.asp import models as asp_models
 from itou.employee_record.enums import NotificationStatus, Status
-from itou.employee_record.models import EmployeeRecord, EmployeeRecordUpdateNotification
+from itou.employee_record.models import (
+    EmployeeRecord,
+    EmployeeRecordUpdateNotification,
+)
 from tests.job_applications.factories import (
     JobApplicationFactory,
     JobApplicationWithApprovalNotCancellableFactory,

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1832,10 +1832,26 @@
           '_check_user_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT %s AS "a"
+          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecord"."asp_processing_code",
+                 "employee_record_employeerecord"."asp_processing_label",
+                 "employee_record_employeerecord"."asp_batch_file",
+                 "employee_record_employeerecord"."asp_batch_line_number",
+                 "employee_record_employeerecord"."archived_json",
+                 "employee_record_employeerecord"."created_at",
+                 "employee_record_employeerecord"."updated_at",
+                 "employee_record_employeerecord"."processed_at",
+                 "employee_record_employeerecord"."status",
+                 "employee_record_employeerecord"."job_application_id",
+                 "employee_record_employeerecord"."financial_annex_id",
+                 "employee_record_employeerecord"."approval_number",
+                 "employee_record_employeerecord"."asp_id",
+                 "employee_record_employeerecord"."asp_measure",
+                 "employee_record_employeerecord"."siret",
+                 "employee_record_employeerecord"."processed_as_duplicate"
           FROM "employee_record_employeerecord"
           WHERE "employee_record_employeerecord"."job_application_id" = %s
-          LIMIT 1
+          ORDER BY "employee_record_employeerecord"."created_at" DESC
         ''',
       }),
       dict({
@@ -2988,10 +3004,26 @@
           '_check_user_view_wrapper[utils/auth.py]',
         ]),
         'sql': '''
-          SELECT %s AS "a"
+          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecord"."asp_processing_code",
+                 "employee_record_employeerecord"."asp_processing_label",
+                 "employee_record_employeerecord"."asp_batch_file",
+                 "employee_record_employeerecord"."asp_batch_line_number",
+                 "employee_record_employeerecord"."archived_json",
+                 "employee_record_employeerecord"."created_at",
+                 "employee_record_employeerecord"."updated_at",
+                 "employee_record_employeerecord"."processed_at",
+                 "employee_record_employeerecord"."status",
+                 "employee_record_employeerecord"."job_application_id",
+                 "employee_record_employeerecord"."financial_annex_id",
+                 "employee_record_employeerecord"."approval_number",
+                 "employee_record_employeerecord"."asp_id",
+                 "employee_record_employeerecord"."asp_measure",
+                 "employee_record_employeerecord"."siret",
+                 "employee_record_employeerecord"."processed_as_duplicate"
           FROM "employee_record_employeerecord"
           WHERE "employee_record_employeerecord"."job_application_id" = %s
-          LIMIT 1
+          ORDER BY "employee_record_employeerecord"."created_at" DESC
         ''',
       }),
       dict({

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -33,6 +33,7 @@ from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, Ad
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQSelectedAdministrativeCriteria
 from itou.employee_record.enums import Status
+from itou.employee_record.models import EmployeeRecordTransition, EmployeeRecordTransitionLog
 from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.enums import JobApplicationState, QualificationLevel, QualificationType, SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
@@ -1568,7 +1569,12 @@ class TestProcessViews:
         )
         employer = job_application.to_company.members.first()
         # Add a blocking employee record
-        EmployeeRecordFactory(job_application=job_application, status=Status.PROCESSED)
+        EmployeeRecordTransitionLog.log_transition(
+            transition=factory.fuzzy.FuzzyChoice(EmployeeRecordTransition.without_asp_exchange()),
+            from_state=factory.fuzzy.FuzzyChoice(Status),
+            to_state=factory.fuzzy.FuzzyChoice(Status),
+            modified_object=EmployeeRecordFactory(job_application=job_application, status=Status.PROCESSED),
+        )
 
         client.force_login(employer)
         detail_url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car maintenant nous avons les logs de transitions donc on sais si une FS a déjà été transmise ou pas, cela permettra au support (mais aussi aux employeurs !) de ne pas être bloqué dans les cas où l'employeur n'a fait que créer la FS sans l'envoyer, par exemple quand une embauche est annulée.