### PR TITLE
Tableau de bord : Ajout d'un évènement matomo pour le lien des candidats sans solution

### DIFF
--- a/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
+++ b/itou/templates/dashboard/includes/prescriber_job_seekers_card.html
@@ -1,3 +1,4 @@
+{% load matomo %}
 {% load str_filters %}
 
 <div class="col mb-3 mb-md-5">
@@ -32,7 +33,7 @@
             {% if stalled_job_seekers_count %}
                 <div class="c-box bg-warning-lightest border-warning mt-lg-n3 mb-3 mb-lg-5">
                     <div class="d-flex justify-content-between align-items-center">
-                        <a href="{% url "job_seekers_views:list" %}?is_stalled=on" class="text-warning fw-bold text-decoration-none btn-ico">
+                        <a href="{% url "job_seekers_views:list" %}?is_stalled=on" class="text-warning fw-bold text-decoration-none btn-ico" {% matomo_event "dashboard" "clic" "candidats-sans-solution" %}>
                             <i class="ri-user-forbid-line fw-normal" aria-hidden="true"></i>
                             <span>Candidat{{ stalled_job_seekers_count|pluralizefr }} sans solution</span>
                         </a>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin de suivre l'utilisation de celui-ci.

@vincentporte @francoisfreitag Je n'ai plus les règles qui avait été données pour le nommage et pas trouvé de logique claire dans les existants donc n'hésitez pas à corriger si ce que j'ai fait n'est pas bon :).

