### PR TITLE
Ajout d’un champ JobSeekerProfile.identity_certifications [GEN-1380]

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -27,6 +27,8 @@ from itou.employee_record.enums import Status
 from itou.files.models import File
 from itou.job_applications import enums as job_application_enums
 from itou.prescribers import enums as prescribers_enums
+from itou.users.enums import IdentityCertificationAuthorities
+from itou.users.models import IdentityCertification
 from itou.utils.apis import enums as api_enums, pole_emploi_api_client
 from itou.utils.apis.pole_emploi import DATE_FORMAT, PoleEmploiAPIBadResponse, PoleEmploiAPIException
 from itou.utils.db import or_queries
@@ -1003,6 +1005,15 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
                 )
             self.user.jobseeker_profile.pe_obfuscated_nir = id_national
             self.user.jobseeker_profile.pe_last_certification_attempt_at = timezone.now()
+            IdentityCertification.objects.upsert_certifications(
+                [
+                    IdentityCertification(
+                        certifier=IdentityCertificationAuthorities.API_FT_RECHERCHE_INDIVIDU_CERTIFIE,
+                        jobseeker_profile=self.user.jobseeker_profile,
+                        certified_at=now,
+                    ),
+                ]
+            )
             self.user.jobseeker_profile.save(update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at"])
 
         return self.pe_maj_pass(

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -60,6 +60,14 @@ IDENTITY_PROVIDER_SUPPORTED_USER_KIND = {
 }
 
 
+class IdentityCertificationAuthorities(models.TextChoices):
+    API_FT_RECHERCHE_INDIVIDU_CERTIFIE = (
+        "api_recherche_individu_certifie",
+        "API France Travail recherche individu certifié",
+    )
+    API_PARTICULIER = "api_particulier", "API Particulier"
+
+
 class LackOfNIRReason(models.TextChoices):
     TEMPORARY_NUMBER = "TEMPORARY_NUMBER", "Numéro temporaire (NIA/NTT)"
     NO_NIR = "NO_NIR", "Pas de numéro de sécurité sociale"

--- a/itou/users/migrations/0026_identitycertification.py
+++ b/itou/users/migrations/0026_identitycertification.py
@@ -1,0 +1,44 @@
+import django.db.models.deletion
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0025_jobseekerprofile_fields_history"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IdentityCertification",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                (
+                    "certifier",
+                    models.CharField(
+                        choices=[
+                            ("api_recherche_individu_certifie", "API France Travail recherche individu certifié"),
+                            ("api_particulier", "API Particulier"),
+                        ],
+                        max_length=32,
+                    ),
+                ),
+                ("certified_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "jobseeker_profile",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="identity_certifications",
+                        to="users.jobseekerprofile",
+                    ),
+                ),
+            ],
+            options={
+                "constraints": [
+                    models.UniqueConstraint(
+                        models.F("jobseeker_profile"), models.F("certifier"), name="uniq_jobseeker_profile_certifier"
+                    )
+                ],
+            },
+        ),
+    ]

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -23,7 +23,6 @@ from django.utils.crypto import salted_hmac
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 
-from itou.approvals.models import PoleEmploiApproval
 from itou.asp.models import (
     AllocationDuration,
     Commune,
@@ -516,6 +515,8 @@ class User(AbstractUser, AddressMixin):
 
     @cached_property
     def latest_pe_approval(self):
+        from itou.approvals.models import PoleEmploiApproval
+
         if not self.is_job_seeker:
             return None
 

--- a/tests/users/__snapshots__/test_management_commands.ambr
+++ b/tests/users/__snapshots__/test_management_commands.ambr
@@ -118,6 +118,7 @@
     'no match found either for pk=424242 when swapping last and first names exc=PoleEmploiAPIBadResponse(code=R010)',
     'count=1 users have been examined.',
     'count=0 users have been certified',
+    'count=0 identity certifications recorded.',
     'count=1 users could not be certified.',
     'count=0 users have been swapped',
   ])
@@ -130,6 +131,7 @@
     'certified user pk=424242',
     'count=1 users have been examined.',
     'count=1 users have been certified',
+    'count=1 identity certifications recorded.',
     'count=0 users could not be certified.',
     'count=0 users have been swapped',
   ])
@@ -146,6 +148,7 @@
     'certified user pk=424243',
     'count=1 users have been examined.',
     'count=1 users have been certified',
+    'count=1 identity certifications recorded.',
     'count=0 users could not be certified.',
     'count=1 users have been swapped',
   ])

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -19,7 +19,7 @@ from itou.eligibility.models import EligibilityDiagnosis
 from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication
 from itou.prescribers.enums import PrescriberOrganizationKind
-from itou.users.enums import IdentityProvider
+from itou.users.enums import IdentityCertificationAuthorities, IdentityProvider
 from itou.users.management.commands import send_check_authorized_members_email
 from itou.users.management.commands.send_users_to_brevo import (
     BREVO_API_URL,
@@ -1051,6 +1051,11 @@ def test_pe_certify_users(settings, respx_mock, caplog, snapshot):
         2022, 9, 13, 0, 0, tzinfo=datetime.UTC
     )
     assert user.jobseeker_profile.pe_obfuscated_nir == "ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ"
+    assertQuerySetEqual(
+        user.jobseeker_profile.identity_certifications.all(),
+        [IdentityCertificationAuthorities.API_FT_RECHERCHE_INDIVIDU_CERTIFIE],
+        transform=lambda certification: certification.certifier,
+    )
 
 
 @freeze_time("2022-09-13")
@@ -1099,6 +1104,11 @@ def test_pe_certify_users_with_swap(settings, respx_mock, caplog, snapshot):
         2022, 9, 13, 0, 0, tzinfo=datetime.UTC
     )
     assert user.jobseeker_profile.pe_obfuscated_nir == "ruLuawDxNzERAFwxw6Na4V8A8UCXg6vXM_WKkx5j8UQ"
+    assertQuerySetEqual(
+        user.jobseeker_profile.identity_certifications.all(),
+        [IdentityCertificationAuthorities.API_FT_RECHERCHE_INDIVIDU_CERTIFIE],
+        transform=lambda certification: certification.certifier,
+    )
 
     user.refresh_from_db()
     assert user.first_name == "Durand"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Enregistrer facilement la certification de l’identité d’un individu.

Plusieurs objectifs :
1. Centraliser les informations de certification afin d’afficher les champs correspondants en lecture seule, en expliquant pourquoi aux utilisateurs. #5749 
2. Empêcher les utilisateurs de changer d’identité une fois que le système les a retrouvé dans un référentiel d’identité et a confirmé certains critères d’éligibilité (ex. BRSA sur l’API Particulier)
3. Horodater les mises à jour de l’identité, pour pouvoir rafraîchir les informations
4. Lorsque la CNAV fournira l’identité, les champs certifiés dépendront de chaque utilisateur. L’utilisation d’un modèle intermédiaire permettra d’indiquer quels champs ont été certifiés.