### PR TITLE
A11Y: Mise à jour de la mise en forme et du comportement des liens d'évitements

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -50,7 +50,7 @@
             </div>
         </noscript>
 
-        <nav role="navigation" aria-label="Accès rapide" tabindex="0" class="visually-hidden">
+        <nav role="navigation" aria-label="Accès rapide" class="c-skiplinks">
             <ul>
                 <li>
                     <a href="#nav-primary">Aller au menu principal</a>

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -219,11 +219,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.7.3.zip",
-            "sha256": "00cf92a2c325a529e22bdc3c51451512c9fac6c901bad790b58f9b43ba7ca142",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.8.2.zip",
+            "sha256": "3869ee78be9f1c984863666f7bd269dbdb5496e2ac4d3f287df516791a9e4f04",
         },
         "extract": {
-            "origin": "itou-theme-2.7.3/dist",
+            "origin": "itou-theme-2.8.2/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcque faire apparaitre le menu à la tabulation semble une meilleure pratique A11Y (et iso DSFR).
Du coup, quelques petites adaptations  UI
![capture 2025-04-07 à 10 57 39](https://github.com/user-attachments/assets/fedd1ef2-ffce-4c1d-a1ad-ab3f73416f3c)

