### PR TITLE
Pinner les actions GitHub avec des hashes complets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           ALTER SYSTEM SET full_page_writes=off;
         SQL
         docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: 🌍 Install spatial libraries
       run: sudo apt-get update && sudo apt-get install binutils build-essential libproj-dev gdal-bin
     - name: 💾 Create a database to check migrations
@@ -62,12 +62,12 @@ jobs:
             CREATE DATABASE itou;
         SQL
     - name: ⏬ Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
       with:
         enable-cache: true
         cache-dependency-glob: "requirements/test.txt"
     - name: 💾 Restore static files cache
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         key: staticfiles-${{ hashFiles('itou/utils/staticfiles.py') }}
         path: |

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Block Fixup Commit Merge
-      uses: 13rac1/block-fixup-merge-action@v2.0.0
+      uses: 13rac1/block-fixup-merge-action@bd5504fb9ca0253e109d98eb86b7debc01970cdc # v2.0.0

--- a/.github/workflows/mkchangelog.yml
+++ b/.github/workflows/mkchangelog.yml
@@ -9,9 +9,9 @@ jobs:
   generate-changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.2.2
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: 💂 Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
       with:
         python-version: "3.13"
     - name: 📥 Generate changelog

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -16,7 +16,7 @@ jobs:
         # Can't use `!contains(...)` because it give us a "tag suffix cannot contain flow indicator characters" error.
         # Oddly enough, using `if: > !contains(...)` works...
         if: contains(github.event.pull_request.labels.*.name, 'no-changelog') == false
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_MEP_C1_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -25,7 +25,7 @@ jobs:
               ${{ format('<{0}|{1}>', github.event.pull_request.html_url, github.event.pull_request.title) }}
       - name: "📢 Notify the #mep-c2 channel"
         if: contains(github.event.pull_request.labels.*.name, 'pilotage')
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
           webhook: ${{ secrets.SLACK_MEP_C2_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/require-labels.yml
+++ b/.github/workflows/require-labels.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify changelog label
-        uses: mheap/github-action-required-labels@5.5.0
+        uses: mheap/github-action-required-labels@388fd6af37b34cdfe5a23b37060e763217e58b03 # v5.5
         with:
           mode: exactly
           count: 1

--- a/.github/workflows/review-app-creation.yml
+++ b/.github/workflows/review-app-creation.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout to the PR branch
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.head_ref }}
 
@@ -80,7 +80,7 @@ jobs:
         $CLEVER_CLI env rm CC_PYTHON_VERSION
 
     - name: 💂 Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
       with:
         python-version: "3.13"
 
@@ -96,7 +96,7 @@ jobs:
         scripts/clever-deploy --clever-cli "$CLEVER_CLI" --branch "$BRANCH" --app-alias "$REVIEW_APP_NAME"
 
     - name: 🍻 Add link to pull request
-      uses: thollander/actions-comment-pull-request@v3.0.1
+      uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
       with:
         message: |-
           🥁 La recette jetable est prête ! [👉 Je veux tester cette PR !](https://${{ env.DEPLOY_URL }})
@@ -109,7 +109,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout to the PR branch
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ github.head_ref }}
 
@@ -133,7 +133,7 @@ jobs:
         $CLEVER_CLI env set SKIP_FIXTURES true
 
     - name: 💂 Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
       with:
         python-version: "3.13"
 

--- a/.github/workflows/review-app-removal.yml
+++ b/.github/workflows/review-app-removal.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: 📥 Checkout to the PR branch
-      uses: actions/checkout@v4.2.2
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: 🏷 Set review app name
       run:
@@ -40,7 +40,7 @@ jobs:
         $CLEVER_CLI link $REVIEW_APP_NAME --org itou_review_apps
 
     - name: 💂 Install Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
       with:
         python-version: "3.13"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sécurité, suivre les bonnes pratiques du GIP.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

> Pin actions to a full length commit SHA

https://github.com/dependabot/dependabot-core/issues/7913#issuecomment-2748641653

> Note that if you pin the action version in a workflow and use a sha, dependabot will update with a sha already. Further, if you have a comment on the end of the uses line (like #v1.2.3) it will update the comment too.
