### PR TITLE
Profil salarié : correction de la mention du PASS si celui-ci n'a pas démarré dans l'encart Immersion Facilitée

### DIFF
--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -49,11 +49,11 @@
                             <div class="p-3 p-lg-4">
                                 <p>
                                     {% if approval_expired %}
-                                        Le pass de ce candidat est expiré.
+                                        Le PASS IAE de ce candidat est expiré.
                                         <br />
                                         <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                     {% elif approval_expires_soon %}
-                                        Le pass IAE de ce candidat arrive bientôt à expiration.
+                                        Le PASS IAE de ce candidat arrive bientôt à expiration.
                                         <br />
                                         <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                     {% else %}

--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -48,7 +48,7 @@
                             </div>
                             <div class="p-3 p-lg-4">
                                 <p>
-                                    {% if approval_expired %}
+                                    {% if not approval_valid %}
                                         Le PASS IAE de ce candidat est expiré.
                                         <br />
                                         <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -120,7 +120,7 @@ class EmployeeDetailView(DetailView):
         context["link_immersion_facile"] = None
 
         context["link_immersion_facile"] = immersion_search_url(self.object)
-        context["approval_expired"] = approval and not approval.is_in_progress
+        context["approval_valid"] = approval and approval.is_valid()
         context["approval_expires_soon"] = approval and approval.remainder.days < 90
 
         context["all_job_applications"] = (

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1494,7 +1494,7 @@
                               <div class="p-3 p-lg-4">
                                   <p>
                                       
-                                          Le pass IAE de ce candidat arrive bientôt à expiration.
+                                          Le PASS IAE de ce candidat arrive bientôt à expiration.
                                           <br/>
                                           <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                       
@@ -1534,7 +1534,7 @@
                               <div class="p-3 p-lg-4">
                                   <p>
                                       
-                                          Le pass de ce candidat est expiré.
+                                          Le PASS IAE de ce candidat est expiré.
                                           <br/>
                                           <strong>Immersion Facilitée</strong> vous aide à lui trouver une immersion professionnelle sur son territoire.
                                       

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1546,3 +1546,22 @@
                           </div>
   '''
 # ---
+# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS non démarré]
+  '''
+  <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
+                              <div class="c-box__header--immersion-facile p-3 p-lg-4">
+                                  <span class="h4 m-0">Trouver une immersion</span>
+                              </div>
+                              <div class="p-3 p-lg-4">
+                                  <p>
+                                      
+                                          <strong>Immersion Facilitée</strong> vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
+                                      
+                                  </p>
+                                  <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&amp;mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                                      Rechercher une immersion
+                                  </a>
+                              </div>
+                          </div>
+  '''
+# ---

--- a/tests/www/employees_views/test_detail.py
+++ b/tests/www/employees_views/test_detail.py
@@ -211,3 +211,11 @@ class TestEmployeeDetailView:
         assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert str(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expirant dans longtemps")
+
+        approval.start_at = today + datetime.timedelta(days=2)
+        approval.end_at = today + datetime.timedelta(days=365)
+        approval.save()
+        response = client.get(url)
+        assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
+        alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
+        assert str(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS non démarré")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un PASS IAE peut être valide mais ne pas avoir démarré.
On corrige pour que l'encart Immersion Facilitée ne dise pas l'inverse du contenu de la page.
(voir captures)


## :computer: Captures d'écran <!-- optionnel -->
Avant :
![image](https://github.com/user-attachments/assets/148ad366-9ea6-4d95-ad1f-7d239564c79f)

Après :

![image](https://github.com/user-attachments/assets/d4e8fdd2-f9cd-40f7-aa23-e5b67fe07017)




<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
