### PR TITLE
Ajout du composant c-title aux templates account et announcements

### DIFF
--- a/itou/templates/account/account_inactive.html
+++ b/itou/templates/account/account_inactive.html
@@ -1,9 +1,16 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Compte inactif {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Compte inactif</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Compte inactif</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_messages %}
     {{ block.super }}

--- a/itou/templates/account/account_type_selection.html
+++ b/itou/templates/account/account_type_selection.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load redirection_fields %}
 {% load static %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Connexion</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Connexion</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/email_confirm.html
+++ b/itou/templates/account/email_confirm.html
@@ -1,13 +1,19 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
-
 {% load account %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Confirmer l'adresse e-mail {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Confirmer l'adresse e-mail</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Confirmer l'adresse e-mail</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_messages %}
     {{ block.super }}

--- a/itou/templates/account/login_existing_user.html
+++ b/itou/templates/account/login_existing_user.html
@@ -1,5 +1,6 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
@@ -7,7 +8,13 @@
     {% include "layout/previous_step.html" with back_url=back_url|default:None only %}
 {% endblock %}
 
-{% block title_content %}<h1>Se connecter</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Se connecter</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/login_generic.html
+++ b/itou/templates/account/login_generic.html
@@ -1,9 +1,16 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Se connecter</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Se connecter</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/login_job_seeker.html
+++ b/itou/templates/account/login_job_seeker.html
@@ -1,13 +1,20 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load redirection_fields %}
 {% load static %}
 
 {% block title %}Connexion candidat {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Se connecter</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Se connecter</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/logout.html
+++ b/itou/templates/account/logout.html
@@ -1,12 +1,19 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load redirection_fields %}
 
 {% block title %}Déconnexion {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Déconnexion</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Déconnexion</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/password_change.html
+++ b/itou/templates/account/password_change.html
@@ -1,12 +1,18 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
-
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Modifier votre mot de passe {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Modifier votre mot de passe</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Modifier votre mot de passe</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/password_reset.html
+++ b/itou/templates/account/password_reset.html
@@ -2,18 +2,25 @@
 {% extends "layout/base.html" %}
 {% load account %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Réinitialisation du mot de passe {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Réinitialisation du mot de passe</h1>
-    {% if user.is_authenticated %}
-        {% include "account/snippets/already_logged_in.html" %}
-    {% endif %}
-    <p>
-        Mot de passe oublié ? Indiquez votre adresse e-mail ci-dessous et nous vous enverrons un e-mail pour le réinitialiser.
-    </p>
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>Réinitialisation du mot de passe</h1>
+            {% if user.is_authenticated %}
+                {% include "account/snippets/already_logged_in.html" %}
+            {% endif %}
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            <p>
+                Mot de passe oublié ? Indiquez votre adresse e-mail ci-dessous et nous vous enverrons un e-mail pour le réinitialiser.
+            </p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/account/password_reset_done.html
+++ b/itou/templates/account/password_reset_done.html
@@ -1,16 +1,22 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
-
 {% load account %}
+{% load components %}
 
 {% block title %}Réinitialisation du mot de passe {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Si un compte existe, vous recevrez un e-mail de réinitialisation</h1>
-    {% if request.GET.email %}
-        {# Give the user a chance to check that there is no typing error in email before contacting support. #}
-        <h2>{{ request.GET.email }}</h2>
-    {% endif %}
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>Si un compte existe, vous recevrez un e-mail de réinitialisation</h1>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            {% if request.GET.email %}
+                {# Give the user a chance to check that there is no typing error in email before contacting support. #}
+                <h2>{{ request.GET.email }}</h2>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/account/password_reset_from_key.html
+++ b/itou/templates/account/password_reset_from_key.html
@@ -1,20 +1,25 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Modification de votre mot de passe {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>
-        {% if token_fail|default:False %}
-            Le lien de réinitialisation n'est pas valide
-        {% elif user_is_new %}
-            Création de votre mot de passe
-        {% else %}
-            Modification de votre mot de passe
-        {% endif %}
-    </h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                {% if token_fail|default:False %}
+                    Le lien de réinitialisation n'est pas valide
+                {% elif user_is_new %}
+                    Création de votre mot de passe
+                {% else %}
+                    Modification de votre mot de passe
+                {% endif %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/account/password_reset_from_key_done.html
+++ b/itou/templates/account/password_reset_from_key_done.html
@@ -1,9 +1,16 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Modification de votre mot de passe {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Modification de votre mot de passe</h1>
-    <p>Votre mot de passe a été modifié !</p>
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>Modification de votre mot de passe</h1>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            <p>Votre mot de passe a été modifié !</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}

--- a/itou/templates/account/peamu_no_email.html
+++ b/itou/templates/account/peamu_no_email.html
@@ -1,6 +1,7 @@
 {# django-allauth template override. #}
 
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% comment %}
     Hijacking this template is the simplest, most elegant and less intrusive way
@@ -13,7 +14,13 @@
 
 {% block title %}Votre compte France Travail doit être validé {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Votre compte France Travail doit être validé</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Votre compte France Travail doit être validé</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/account/verification_sent.html
+++ b/itou/templates/account/verification_sent.html
@@ -1,11 +1,18 @@
 {# django-allauth template override. #}
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Vérifiez votre adresse e-mail {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Vérifiez votre adresse e-mail</h1>
-    <p>
-        Nous vous avons envoyé un e-mail avec un lien pour validation. Cliquez sur le lien fourni pour terminer votre inscription.
-    </p>
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>Vérifiez votre adresse e-mail</h1>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            <p>
+                Nous vous avons envoyé un e-mail avec un lien pour validation. Cliquez sur le lien fourni pour terminer votre inscription.
+            </p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}

--- a/itou/templates/account/verify_otp.html
+++ b/itou/templates/account/verify_otp.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Connexion {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Se connecter</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Se connecter</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/announcements/news.html
+++ b/itou/templates/announcements/news.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load theme_inclusion %}
 
 {% block title %}Nouveautés {{ block.super }}{% endblock %}
@@ -7,7 +8,13 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Nouveautés</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Nouveautés</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/tests/www/signup/__snapshots__/test_password.ambr
+++ b/tests/www/signup/__snapshots__/test_password.ambr
@@ -12,11 +12,19 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>
-          
-              Le lien de réinitialisation n'est pas valide
-          
-      </h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  
+                      Le lien de réinitialisation n'est pas valide
+                  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -64,11 +72,19 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>
-          
-              Création de votre mot de passe
-          
-      </h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  
+                      Création de votre mot de passe
+                  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Après redécoupage de la [fat PR slippers c-title](https://github.com/gip-inclusion/les-emplois/pull/5806/commits) composant.
Voici la part02


