### PR TITLE
Stabilité: Ajout du composant c-title aux templates apply et approvals

### DIFF
--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Modification de la date de contrat {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Candidature de {{ job_application.job_seeker.get_full_name }}</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Candidature de {{ job_application.job_seeker.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/apply/includes/job_applications_export_button.html
+++ b/itou/templates/apply/includes/job_applications_export_button.html
@@ -1,6 +1,6 @@
 {% if list_exports_url %}
     <div id="job-applications-export-link"{% if request.htmx %} hx-swap-oob="true"{% endif %}>
-        <a href="{{ list_exports_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-secondary" aria-label="Exporter la liste de candidatures">
+        <a href="{{ list_exports_url }}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-secondary w-100" aria-label="Exporter la liste de candidatures">
             <i class="ri-download-line fw-medium" aria-hidden="true"></i>
             <span>Exporter</span>
         </a>

--- a/itou/templates/apply/list_for_job_seeker.html
+++ b/itou/templates/apply/list_for_job_seeker.html
@@ -1,11 +1,18 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 {% load str_filters %}
 
 {% block title %}Candidatures envoyées {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Candidatures envoyées</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Candidatures envoyées</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     {% include "apply/includes/job_applications_filters/offcanvas.html" %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -7,9 +7,9 @@
 {% block title %}Candidatures reçues {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        {% include "apply/includes/list_job_applications_title.html" %}
-        <div class="d-flex flex-column flex-md-row gap-3" data-emplois-elements-visibility-on-selection="hidden" role="group" aria-label="Actions sur les candidatures">
+    <div class="c-title">
+        <div class="c-title__main">{% include "apply/includes/list_job_applications_title.html" %}</div>
+        <div class="c-title__cta" data-emplois-elements-visibility-on-selection="hidden" role="group" aria-label="Actions sur les candidatures">
             {% include "apply/includes/job_applications_export_button.html" %}
             {% if can_apply %}
                 <a href="{% url 'apply:start' company_pk=request.current_organization.pk %}" class="btn btn-lg btn-primary btn-ico" {% matomo_event "employeurs" "clic" "enregistrer-candidature" %}>
@@ -18,13 +18,15 @@
                 </a>
             {% endif %}
         </div>
+        {% if siae.is_subject_to_eligibility_rules %}
+            <div class="c-title__secondary">
+                <p>
+                    Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.
+                </p>
+                <p>Les demandes rétroactives ne sont pas autorisées.</p>
+            </div>
+        {% endif %}
     </div>
-    {% if siae.is_subject_to_eligibility_rules %}
-        <p class="mb-0">
-            Toute demande de PASS IAE doit être effectuée <b>au plus tard le jour de l'embauche</b>.
-        </p>
-        <p>Les demandes rétroactives ne sont pas autorisées.</p>
-    {% endif %}
     {% include "apply/includes/siae_actions.html" with batch_mode=False %}
 {% endblock %}
 

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load i18n %}
 {% load matomo %}
 
@@ -9,8 +10,8 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div>
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta %}
+        {% fragment as c_title__main %}
             <h1>
                 Exporter les candidatures
                 {% if export_for == "siae" %}
@@ -19,18 +20,15 @@
                     envoyées
                 {% endif %}
             </h1>
-        </div>
-        <div>
+        {% endfragment %}
+        {% fragment as c_title__cta %}
             {% if export_for == "siae" %}
-                <a class="btn btn-lg btn-primary btn-ico w-100 w-md-auto"
-                   {% matomo_event "candidature" "exports" "export-siae" %}
-                   aria-label="Télécharger cet export SIAE"
-                   href="{% url 'apply:list_for_siae_exports_download' %}">
+                <a class="btn btn-lg btn-primary btn-ico" {% matomo_event "candidature" "exports" "export-siae" %} aria-label="Télécharger cet export SIAE" href="{% url 'apply:list_for_siae_exports_download' %}">
                     <i class="ri-download-line fw-medium" aria-hidden="true"></i>
                     <span>Télécharger toutes les candidatures</span>
                 </a>
             {% else %}
-                <a class="btn btn-lg btn-primary btn-ico w-100 w-md-auto"
+                <a class="btn btn-lg btn-primary btn-ico"
                    {% matomo_event "candidature" "exports" "export-prescripteur" %}
                    aria-label="Télécharger cet export prescripteur"
                    href="{% url 'apply:list_prescriptions_exports_download' %}">
@@ -38,8 +36,8 @@
                     <span>Télécharger toutes les candidatures</span>
                 </a>
             {% endif %}
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/list_prescriptions.html
+++ b/itou/templates/apply/list_prescriptions.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load matomo %}
 {% load static %}
@@ -8,16 +9,18 @@
 {% block title %}Candidatures envoyées {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 justify-content-md-between">
-        {% include "apply/includes/list_job_applications_title.html" %}
-        <div class="d-flex flex-column flex-md-row gap-3" role="group" aria-label="Actions sur les candidatures">
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria-label="Actions sur les candidatures" %}
+        {% fragment as c_title__main %}
+            {% include "apply/includes/list_job_applications_title.html" %}
+        {% endfragment %}
+        {% fragment as c_title__cta %}
             {% include "apply/includes/job_applications_export_button.html" %}
             <a href="{% url 'search:employers_results' %}" class="btn btn-lg btn-primary btn-ico">
                 <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                 <span>Postuler pour un candidat</span>
             </a>
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/process_accept.html
+++ b/itou/templates/apply/process_accept.html
@@ -1,5 +1,6 @@
 {% extends "apply/process_base.html" %}
 {% load badges %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 {% load str_filters %}
@@ -10,12 +11,14 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-md-flex align-items-center">
-        <h1 class="mb-1 mb-md-0 me-3">
-            Accepter la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
-        </h1>
-        {% job_application_state_badge job_application extra_class="badge-base" %}
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Accepter la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
+                {% job_application_state_badge job_application extra_class="badge-base" %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content_extend %}

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -1,20 +1,23 @@
 {% extends "layout/base.html" %}
 {% load badges %}
+{% load components %}
 {% load matomo %}
 {% load str_filters %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary c_title__cta=c_title__cta %}
+        {% fragment as c_title__main %}
+            <h1>
                 Candidature de
                 {% if with_job_seeker_detail_url|default:False %}
                     <a href="{% url "job_seekers_views:details" public_id=job_application.job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn-link">{{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}</a>
                 {% else %}
                     {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
                 {% endif %}
+                {% job_application_state_badge job_application extra_class="badge-base" %}
             </h1>
-            {% job_application_state_badge job_application extra_class="badge-base" %}
+        {% endfragment %}
+        {% fragment as c_title__cta %}
             <button class="btn btn-lg btn-ico-only btn-link"
                     type="button"
                     data-it-action="print"
@@ -22,11 +25,9 @@
                     aria-label="Imprimer la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}">
                 <i class="ri-printer-line fw-normal" aria-hidden="true"></i>
             </button>
-        </div>
-        <div>
             {% block title_inline_actions %}{% endblock %}
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
     {% block actions %}{% endblock %}
 {% endblock %}
 

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -53,7 +53,7 @@
 
 {% block title_inline_actions %}
     {% if can_be_cancelled %}
-        <button class="btn btn-danger btn-lg btn-ico w-100 w-md-auto" data-bs-toggle="modal" data-bs-target="#cancel_hire_modal">
+        <button class="btn btn-danger btn-lg btn-ico" data-bs-toggle="modal" data-bs-target="#cancel_hire_modal">
             <i class="ri-arrow-go-back-line fw-medium" aria-hidden="true"></i>
             <span>Annuler l’embauche</span>
         </button>

--- a/itou/templates/apply/process_eligibility.html
+++ b/itou/templates/apply/process_eligibility.html
@@ -1,5 +1,6 @@
 {% extends "apply/process_base.html" %}
 {% load badges %}
+{% load components %}
 {% load str_filters %}
 
 {% block title %}
@@ -8,12 +9,14 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-md-flex align-items-center">
-        <h1 class="mb-1 mb-md-0 me-3">
-            Accepter la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
-        </h1>
-        {% job_application_state_badge job_application extra_class="badge-base" %}
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Accepter la candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
+                {% job_application_state_badge job_application extra_class="badge-base" %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content_extend %}

--- a/itou/templates/apply/process_external_transfer_siaes_search_results.html
+++ b/itou/templates/apply/process_external_transfer_siaes_search_results.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
@@ -9,7 +10,11 @@
 
 {% block title_content %}
     {% include "apply/includes/job_application_external_transfer_progress.html" with job_app_to_transfer=job_app_to_transfer step=1 only %}
-    <h1>Rechercher un emploi inclusif</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Rechercher un emploi inclusif</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_extra %}

--- a/itou/templates/apply/process_geiq_eligibility.html
+++ b/itou/templates/apply/process_geiq_eligibility.html
@@ -1,11 +1,16 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
 
 {% block title %}Embauche - Eligibilité GEIQ {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Candidature de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Candidature de {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/process_internal_transfer.html
+++ b/itou/templates/apply/process_internal_transfer.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 
 {% block title %}
     Transférer une candidature vers une autre structure
@@ -8,11 +9,15 @@
 
 {% block title_content %}
     {% include "apply/includes/job_application_external_transfer_progress.html" with job_app_to_transfer=job_app_to_transfer step=3 only %}
-    {% if job_app_to_transfer.to_company == company %}
-        <h1>Transfert impossible</h1>
-    {% else %}
-        <h1>Confirmation du transfert</h1>
-    {% endif %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            {% if job_app_to_transfer.to_company == company %}
+                <h1>Transfert impossible</h1>
+            {% else %}
+                <h1>Confirmation du transfert</h1>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/process_postpone.html
+++ b/itou/templates/apply/process_postpone.html
@@ -1,5 +1,6 @@
 {% extends "apply/process_base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
 
@@ -9,9 +10,11 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-md-flex align-items-center mb-3">
-        <h1 class="mb-1 mb-md-0 me-3">Mettre en attente la candidature de {{ job_application.job_seeker.get_full_name }}</h1>
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Mettre en attente la candidature de {{ job_application.job_seeker.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content_extend %}

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
 {% load theme_inclusion %}
@@ -14,15 +15,17 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-md-flex align-items-center mb-3">
-        <h1 class="mb-1 mb-md-0 me-3">
-            {% if job_applications|length == 1 %}
-                Décliner la candidature de {{ job_applications.0.job_seeker.get_full_name }}
-            {% else %}
-                Décliner {{ job_applications|length }} candidature{{ job_applications|pluralizefr }}
-            {% endif %}
-        </h1>
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                {% if job_applications|length == 1 %}
+                    Décliner la candidature de {{ job_applications.0.job_seeker.get_full_name }}
+                {% else %}
+                    Décliner {{ job_applications|length }} candidature{{ job_applications|pluralizefr }}
+                {% endif %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -1,22 +1,29 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}{{ page_title }} {{ block.super }}{% endblock %}
 
 {% block title_content %}
     {% if not job_app_to_transfer|default:False %}
-        <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">{% include 'apply/includes/_submit_title.html' %}</h1>
-            {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
-        </div>
-        <p>
-            Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}
-            {% if can_view_personal_information and not request.user.is_job_seeker %}
-                <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
-            {% endif %}
-            {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>{% endif %}
-        </p>
+        {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+            {% fragment as c_title__main %}
+                <h1>
+                    {% include 'apply/includes/_submit_title.html' %}
+                    {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
+                </h1>
+            {% endfragment %}
+            {% fragment as c_title__secondary %}
+                <p>
+                    Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}
+                    {% if can_view_personal_information and not request.user.is_job_seeker %}
+                        <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
+                    {% endif %}
+                    {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>{% endif %}
+                </p>
+            {% endfragment %}
+        {% endcomponent_title %}
     {% endif %}
 {% endblock %}
 

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load str_filters %}
@@ -7,15 +8,21 @@
 {% block title %}{{ page_title }} {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>{{ page_title }} !</h1>
-    <p>
-        {% if request.user.is_job_seeker %}
-            Votre candidature
-        {% else %}
-            La candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
-        {% endif %}
-        <b>a bien été envoyée chez {{ job_application.to_company.display_name }}</b>.
-    </p>
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>{{ page_title }} !</h1>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            <p>
+                {% if request.user.is_job_seeker %}
+                    Votre candidature
+                {% else %}
+                    La candidature de {{ job_application.job_seeker.get_full_name|mask_unless:can_view_personal_information }}
+                {% endif %}
+                <b>a bien été envoyée chez {{ job_application.to_company.display_name }}</b>.
+            </p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -1,12 +1,17 @@
 {% extends "apply/submit_base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title_content %}
-    <div class="d-md-flex align-items-center mb-3">
-        <h1 class="mb-1 mb-md-0 me-3">{% include 'apply/includes/_submit_title.html' %}</h1>
-        {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                {% include 'apply/includes/_submit_title.html' %}
+                {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content_extend %}

--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -1,9 +1,14 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Postuler {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/declare_prolongation.html
+++ b/itou/templates/approvals/declare_prolongation.html
@@ -1,11 +1,16 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Déclarer une prolongation de PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Déclarer une prolongation de PASS IAE pour {{ approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Déclarer une prolongation de PASS IAE pour {{ approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/details.html
+++ b/itou/templates/approvals/details.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 {% load matomo %}
 {% load static %}
@@ -13,9 +14,11 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 justify-content-md-between">
-        <h1 class="m-0">PASS IAE de {{ approval.user.get_full_name|mask_unless:can_view_personal_information }}</h1>
-        <div class="d-flex flex-column flex-md-row gap-3" role="group" aria-label="Actions sur le PASS IAE">
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria-label="sur le PASS IAE" %}
+        {% fragment as c_title__main %}
+            <h1>PASS IAE de {{ approval.user.get_full_name|mask_unless:can_view_personal_information }}</h1>
+        {% endfragment %}
+        {% fragment as c_title__cta %}
             {% if approval_deletion_form_url %}
                 <a href="{{ approval_deletion_form_url }}"
                    id="approval-deletion-link"
@@ -33,8 +36,8 @@
                     <span>Afficher l’attestation</span>
                 </a>
             {% endif %}
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load matomo %}
 {% load static %}
@@ -6,7 +7,13 @@
 
 {% block title %}Salariés et PASS IAE {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Salariés</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Salariés</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_extra %}
     {% if request.current_organization.can_use_employee_record %}

--- a/itou/templates/approvals/prolongation_requests/deny.html
+++ b/itou/templates/approvals/prolongation_requests/deny.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load theme_inclusion %}
 
@@ -8,7 +9,11 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Refuser la demande de prolongation pour {{ prolongation_request.approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Refuser la demande de prolongation pour {{ prolongation_request.approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 {% load static %}
 {% load str_filters %}
@@ -9,7 +10,13 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Gérer les prolongations de PASS IAE</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Gérer les prolongations de PASS IAE</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section" hx-select=".s-section" hx-target=".s-section" hx-swap="outerHTML show:window:top">

--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 {% load str_filters %}
 
@@ -11,14 +12,17 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
                 Demande de prolongation pour {{ prolongation_request.approval.user.get_full_name }}
+                {% include "approvals/prolongation_requests/_status_badge.html" with badge_size="badge-base" %}
             </h1>
-            {% include "approvals/prolongation_requests/_status_badge.html" with badge_size="badge-base" %}
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block title_extra %}
     {% if prolongation_request.status == ProlongationRequestStatus.PENDING %}
         <div class="c-box c-box--action">
             <h2 class="visually-hidden">Actions rapides</h2>

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -1,12 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load theme_inclusion %}
 
 {% block title %}Déclarer une suspension de PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Déclarer une suspension de PASS IAE pour {{ approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Déclarer une suspension de PASS IAE pour {{ approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_action_choice.html
+++ b/itou/templates/approvals/suspension_action_choice.html
@@ -1,11 +1,16 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_delete.html
+++ b/itou/templates/approvals/suspension_delete.html
@@ -1,12 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
 
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -1,11 +1,16 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Modifier la suspension de PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Modifier la suspension de PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Modifier la suspension de PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/approvals/suspension_update_enddate.html
+++ b/itou/templates/approvals/suspension_update_enddate.html
@@ -1,11 +1,16 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Supprimer la suspension du PASS IAE {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Supprimer la suspension du PASS IAE de {{ suspension.approval.user.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -219,11 +219,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.8.2.zip",
-            "sha256": "3869ee78be9f1c984863666f7bd269dbdb5496e2ac4d3f287df516791a9e4f04",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.8.3.zip",
+            "sha256": "a44e997942af8c59f3b353c5e13c719b5178370e91553c5b8da49a26fa864939",
         },
         "extract": {
-            "origin": "itou-theme-2.8.2/dist",
+            "origin": "itou-theme-2.8.3/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -143,7 +143,15 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -372,7 +380,15 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -531,7 +547,15 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -690,7 +714,15 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Refuser la demande de prolongation pour Jane DOE</h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -1510,20 +1542,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
                   Demande de prolongation pour Jane DOE
-              </h1>
-              
+                  
       
           <span class="badge rounded-pill badge-base bg-danger">Refusée</span>
       
   
   
+              </h1>
           </div>
-      </div>
       
+      
+  </div>
+  
   
                               
                                   
@@ -1532,6 +1567,8 @@
   
                               
                               
+      
+  
                           </div>
                       </div>
                   </div>
@@ -1765,20 +1802,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
                   Demande de prolongation pour Jane DOE
-              </h1>
-              
+                  
       
           <span class="badge rounded-pill badge-base bg-success">Acceptée</span>
       
   
   
+              </h1>
           </div>
-      </div>
       
+      
+  </div>
+  
   
                               
                                   
@@ -1787,6 +1827,8 @@
   
                               
                               
+      
+  
                           </div>
                       </div>
                   </div>
@@ -2020,19 +2062,31 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
                   Demande de prolongation pour Jane DOE
-              </h1>
-              
+                  
       
           <span class="badge rounded-pill badge-base bg-accent-03 text-primary">À traiter</span>
       
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
       
           <div class="c-box c-box--action">
               <h2 class="visually-hidden">Actions rapides</h2>
@@ -2056,13 +2110,6 @@
           </div>
       
   
-                              
-                                  
-  
-  
-  
-                              
-                              
                           </div>
                       </div>
                   </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?
Après redécoupage de la [fat PR slippers c-title](https://github.com/gip-inclusion/les-emplois/pull/5806/commits) composant. Voici la "petite" **part03**

## :cake: Comment ? <!-- optionnel -->
Refactorisation de la zone de titre des templates apply et approvals afin d'utiliser le composant c-title.
Quelques corrections UI sur certains éléments de cette même zone.
