### PR TITLE
Ajout du composant c-title aux templates dashboard et employees

### DIFF
--- a/itou/templates/dashboard/api_token.html
+++ b/itou/templates/dashboard/api_token.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Accès aux APIs {{ block.super }}{% endblock %}
@@ -7,7 +8,13 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Accès aux APIs</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Accès aux APIs</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Informations personnelles de {{ job_seeker.get_full_name }} {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Informations personnelles de {{ job_seeker.get_full_name }}</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Informations personnelles de {{ job_seeker.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_messages %}
     {{ block.super }}

--- a/itou/templates/dashboard/edit_user_email.html
+++ b/itou/templates/dashboard/edit_user_email.html
@@ -1,9 +1,16 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Modifier mon profil {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Modifier votre adresse e-mail</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Modifier votre adresse e-mail</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_messages %}
     {{ block.super }}

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -1,11 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Modifier mon profil {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Modifier mon profil</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Modifier mon profil</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_messages %}
     {{ block.super }}

--- a/itou/templates/dashboard/edit_user_notifications.html
+++ b/itou/templates/dashboard/edit_user_notifications.html
@@ -1,12 +1,19 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 {% load theme_inclusion %}
 
 {% block title %}Mes notifications {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Mes notifications</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Mes notifications</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -1,19 +1,20 @@
+{% load components %}
 {% load format_filters %}
 {% load matomo %}
 {% load url_add_query %}
 
-<div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-    <div>
+{% component_title c_title__main=c_title__main c_title__cta=c_title__cta %}
+    {% fragment as c_title__main %}
         {% if not request.organizations %}
-            {% if user.get_full_name %}<h1 class="mb-0">{{ user.get_full_name }}</h1>{% endif %}
+            {% if user.get_full_name %}<h1>{{ user.get_full_name }}</h1>{% endif %}
             {% if user.is_prescriber %}
-                <p class="mb-0">Orienteur seul</p>
+                <p>Orienteur seul</p>
             {% elif user.is_job_seeker %}
-                <p class="mb-0">Candidat</p>
+                <p>Candidat</p>
             {% endif %}
         {% else %}
-            <h1 class="mb-0">{{ request.current_organization.display_name }}</h1>
-            <p class="mb-0">
+            <h1>{{ request.current_organization.display_name }}</h1>
+            <p>
                 {% if user.is_prescriber %}
                     {% if request.current_organization.code_safir_pole_emploi %}
                         {% if request.current_organization.is_authorized %}Prescripteur habilité -{% endif %}
@@ -31,16 +32,16 @@
                 {% endif %}
             </p>
         {% endif %}
-    </div>
-    {% if user.is_employer %}
-        {% if request.current_organization.is_subject_to_eligibility_rules or request.current_organization.kind == CompanyKind.GEIQ %}
-            {% comment %}
-            NOTE(vperron):
-            We currently do not allow OPCS users to apply for an offer.
-            We will have to discuss this matter further with AVE, but it has been
-            decided that it probably did not make much sense initially.
-            {% endcomment %}
-            <div>
+    {% endfragment %}
+    {% fragment as c_title__cta %}
+        {% if user.is_employer %}
+            {% if request.current_organization.is_subject_to_eligibility_rules or request.current_organization.kind == CompanyKind.GEIQ %}
+                {% comment %}
+                NOTE(vperron):
+                We currently do not allow OPCS users to apply for an offer.
+                We will have to discuss this matter further with AVE, but it has been
+                decided that it probably did not make much sense initially.
+                {% endcomment %}
                 {% if siae_suspension_text_with_dates %}
                     <button type="button"
                             class="btn btn-lg btn-primary btn-ico disabled"
@@ -58,7 +59,7 @@
                         <span>Déclarer une embauche</span>
                     </a>
                 {% endif %}
-            </div>
+            {% endif %}
         {% endif %}
-    {% endif %}
-</div>
+    {% endfragment %}
+{% endcomponent_title %}

--- a/itou/templates/eligibility/update.html
+++ b/itou/templates/eligibility/update.html
@@ -1,18 +1,24 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load url_add_query %}
 
 {% block title %}Éligibilité IAE - {{ job_seeker.get_full_name }}{{ block.super }}{% endblock %}
+
 {% block title_content %}
-    <h1>
-        {% if eligibility_diagnosis %}
-            Mettre à jour
-        {% else %}
-            Valider
-        {% endif %}
-        l'éligibilité de {{ job_seeker.get_full_name }}
-    </h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                {% if eligibility_diagnosis %}
+                    Mettre à jour
+                {% else %}
+                    Valider
+                {% endif %}
+                l'éligibilité de {{ job_seeker.get_full_name }}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load matomo %}
@@ -9,7 +10,11 @@
 {% block title %}Créer une fiche salarié {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>Créer une fiche salarié - {{ request.current_organization.display_name }}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Créer une fiche salarié - {{ request.current_organization.display_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/create.html
+++ b/itou/templates/employee_record/create.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load list_filters %}
@@ -8,7 +9,13 @@
     Nouvelle fiche salarié ASP - étape {{ step }} - {{ request.current_organization.display_name }} {{ block.super }}
 {% endblock %}
 
-{% block title_content %}<h1>Fiches salarié ASP : {{ job_application.job_seeker.get_full_name }}</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Fiches salarié ASP : {{ job_application.job_seeker.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/employee_record/disable.html
+++ b/itou/templates/employee_record/disable.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
@@ -9,8 +10,12 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Désactiver la fiche salarié ASP</h1>
-    <h2>{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Désactiver la fiche salarié ASP</h1>
+            <p>{{ employee_record.job_application.job_seeker.get_full_name }}</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/includes/_status.html
+++ b/itou/templates/employee_record/includes/_status.html
@@ -1,27 +1,27 @@
 {% if employee_record.status == "NEW" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-emploi">Nouvelle à compléter</span>
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-emploi">Nouvelle à compléter</span>
 {% elif employee_record.status == "SENT" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-warning">
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-warning">
         Envoyée à l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
 {% elif employee_record.status == "REJECTED" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-danger">
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-danger">
         Retour en erreur le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
 {% elif employee_record.status == "PROCESSED" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-success">
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-success">
         Intégrée par l'ASP le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
 {% elif employee_record.status == "READY" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-secondary">
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-secondary">
         Complétée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
 {% elif employee_record.status == "DISABLED" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-emploi-lightest text-primary">
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-emploi-lightest text-primary">
         Désactivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
 {% elif employee_record.status == "ARCHIVED" %}
-    <span class="badge rounded-pill badge-sm text-nowrap bg-emploi-lightest text-primary">
+    <span class="badge rounded-pill {{ extra_class|default:"badge-base" }} text-nowrap bg-emploi-lightest text-primary">
         Archivée le {{ employee_record.updated_at|date:"SHORT_DATETIME_FORMAT" }}
     </span>
 {% endif %}

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -14,7 +14,9 @@
                     </div>
                 </div>
             </div>
-            <div>{% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}</div>
+            <div>
+                {% include 'employee_record/includes/_status.html' with employee_record=employee_record extra_class="badge-sm" only %}
+            </div>
         </div>
     </div>
     <hr class="m-0">

--- a/itou/templates/employee_record/list.html
+++ b/itou/templates/employee_record/list.html
@@ -1,11 +1,18 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load matomo %}
 {% load static %}
 
 {% block title %}Fiches salarié ASP - {{ request.current_organization.display_name }} {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Salariés</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Salariés</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_extra %}
     {% if request.current_organization.can_use_employee_record %}

--- a/itou/templates/employee_record/missing_employee.html
+++ b/itou/templates/employee_record/missing_employee.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load matomo %}
@@ -12,7 +13,13 @@
     {% include "layout/previous_step.html" with back_url=back_url|default:None only %}
 {% endblock %}
 
-{% block title_content %}<h1>Rechercher un salarié - {{ request.current_organization.display_name }}</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Rechercher un salarié - {{ request.current_organization.display_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/employee_record/reactivate.html
+++ b/itou/templates/employee_record/reactivate.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
@@ -9,8 +10,12 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Réactiver la fiche salarié ASP</h1>
-    <h2>{{ employee_record.job_application.job_seeker.get_full_name }}</h2>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Réactiver la fiche salarié ASP</h1>
+            <p>{{ employee_record.job_application.job_seeker.get_full_name }}</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
@@ -10,12 +11,14 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-xl-flex align-items-xl-center">
-        <h1 class="mb-1 mb-xl-0 me-xl-3">
-            Fiche salarié ASP : {{ employee_record.job_application.job_seeker.get_full_name }}
-        </h1>
-        {% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Fiche salarié ASP : {{ employee_record.job_application.job_seeker.get_full_name }}
+                {% include 'employee_record/includes/_status.html' with employee_record=employee_record only %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load matomo %}
 
 {% block title %}Profil salarié - {{ job_seeker.get_full_name }} {{ block.super }}{% endblock %}
@@ -7,7 +8,13 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Salarié : {{ job_seeker.get_full_name }}</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Salarié : {{ job_seeker.get_full_name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/tests/www/eligibility_views/__snapshots__/test_views.ambr
+++ b/tests/www/eligibility_views/__snapshots__/test_views.ambr
@@ -12,12 +12,20 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>
-          
-              Valider
-          
-          l'éligibilité de Jane DOE
-      </h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  
+                      Valider
+                  
+                  l'éligibilité de Jane DOE
+              </h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -243,12 +251,20 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <h1>
-          
-              Mettre à jour
-          
-          l'éligibilité de Jane DOE
-      </h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  
+                      Mettre à jour
+                  
+                  l'éligibilité de Jane DOE
+              </h1>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   


### PR DESCRIPTION
## :thinking: Pourquoi ?
Après redécoupage de la [fat PR slippers c-title](https://github.com/gip-inclusion/les-emplois/pull/5806/commits) composant. Voici la "petite" **part04**

## :cake: Comment ? <!-- optionnel -->
Refactorisation de la zone de titre des templates dashboard, employee_record et employees afin d'utiliser le composant c-title.
Quelques corrections UI sur certains éléments de cette même zone.
