### PR TITLE
Ajout du composant c-title aux templates geiq et job_seekers

### DIFF
--- a/itou/templates/geiq/assessment_info_for_employer.html
+++ b/itou/templates/geiq/assessment_info_for_employer.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Mes salariés - {{ assessment.company.display_name }} {{ block.super }}{% endblock %}
@@ -8,28 +9,30 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - {{ assessment.campaign.year }}</h1>
-            {% if not assessment.submitted_at %}
-                <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
-            {% elif not assessment.reviewed_at %}
-                <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
-            {% else %}
-                {% if assessment.review_state == ReviewState.ACCEPTED %}
-                    <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : totalité de l’aide accordée</span>
-                {% elif assessment.review_state == ReviewState.PARTIAL_ACCEPTED %}
-                    <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : solde partiellement accordé</span>
-                {% elif assessment.review_state == ReviewState.REMAINDER_REFUSED %}
-                    <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : solde refusé</span>
-                {% elif assessment.review_state == ReviewState.PARTIAL_REFUND %}
-                    <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement partiel</span>
-                {% elif assessment.review_state == ReviewState.FULL_REFUND %}
-                    <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement total</span>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Bilan d’exécution - {{ assessment.campaign.year }}
+                {% if not assessment.submitted_at %}
+                    <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
+                {% elif not assessment.reviewed_at %}
+                    <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
+                {% else %}
+                    {% if assessment.review_state == ReviewState.ACCEPTED %}
+                        <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : totalité de l’aide accordée</span>
+                    {% elif assessment.review_state == ReviewState.PARTIAL_ACCEPTED %}
+                        <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : solde partiellement accordé</span>
+                    {% elif assessment.review_state == ReviewState.REMAINDER_REFUSED %}
+                        <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : solde refusé</span>
+                    {% elif assessment.review_state == ReviewState.PARTIAL_REFUND %}
+                        <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement partiel</span>
+                    {% elif assessment.review_state == ReviewState.FULL_REFUND %}
+                        <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement total</span>
+                    {% endif %}
                 {% endif %}
-            {% endif %}
-        </div>
-    </div>
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/geiq/assessment_info_for_labor_inspector.html
+++ b/itou/templates/geiq/assessment_info_for_labor_inspector.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Bilan d’exécution - {{ assessment.company.display_name }} {{ block.super }}{% endblock %}
@@ -8,12 +9,14 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - {{ assessment.campaign.year }}</h1>
-            {% include "geiq/includes/labor_inspector_assessment_state_badge.html" with assessment=assessment extra_class="" ReviewState=ReviewState only %}
-        </div>
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Bilan d’exécution - {{ assessment.campaign.year }}
+                {% include "geiq/includes/labor_inspector_assessment_state_badge.html" with assessment=assessment ReviewState=ReviewState only %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/geiq/assessment_review.html
+++ b/itou/templates/geiq/assessment_review.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Bilan d’exécution - {{ assessment.company.display_name }} {{ block.super }}{% endblock %}
@@ -9,12 +10,14 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <div class="d-xl-flex align-items-xl-center">
-            <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Valider le bilan d’exécution - {{ assessment.campaign.year }}</h1>
-            {% include "geiq/includes/labor_inspector_assessment_state_badge.html" with assessment=assessment extra_class="" ReviewState=ReviewState only %}
-        </div>
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Valider le bilan d’exécution - {{ assessment.campaign.year }}
+                {% include "geiq/includes/labor_inspector_assessment_state_badge.html" with assessment=assessment ReviewState=ReviewState only %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/geiq/employee_details.html
+++ b/itou/templates/geiq/employee_details.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 
 {% block title %}Mes salariés - {{ request.current_organization.display_name }} {{ block.super }}{% endblock %}
@@ -8,9 +9,15 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>Mes salariés - {{ request.current_organization.display_name }} - {{ employee.assessment.campaign.year }}</h1>
-    <p>Dernière mise à jour: {{ employee.assessment.last_synced_at|default:"-" }}</p>
-    <h2>{{ employee.get_full_name }}</h2>
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>Mes salariés - {{ request.current_organization.display_name }} - {{ employee.assessment.campaign.year }}</h1>
+            <p>Dernière mise à jour: {{ employee.assessment.last_synced_at|default:"-" }}</p>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            <h2>{{ employee.get_full_name }}</h2>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/geiq/geiq_list.html
+++ b/itou/templates/geiq/geiq_list.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Rechercher un GEIQ - {{ request.current_organization.display_name }} {{ block.super }}{% endblock %}
 
@@ -6,7 +7,13 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Rechercher un GEIQ</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Rechercher un GEIQ</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/geiq/list_base.html
+++ b/itou/templates/geiq/list_base.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 {% load static %}
 
@@ -9,16 +10,20 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>{{ request.user.is_employer|yesno:"Mes salariés,Données salariés" }} - {{ assessment.campaign.year }}</h1>
-    <div class="d-flex align-items-center">
-        <p class="mb-0">Dernière mise à jour: {{ assessment.last_synced_at|default:"-" }}</p>
-        {% if not assessment.submitted_at and request.user.is_employer %}
-            <form method="post">
-                {% csrf_token %}
-                <button class="btn">Mise à jour</button>
-            </form>
-        {% endif %}
-    </div>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>{{ request.user.is_employer|yesno:"Mes salariés,Données salariés" }} - {{ assessment.campaign.year }}</h1>
+            <div>
+                <span>Dernière mise à jour: {{ assessment.last_synced_at|default:"-" }}</span>
+                {% if not assessment.submitted_at and request.user.is_employer %}
+                    <form method="post" class="d-inline-block ms-2">
+                        {% csrf_token %}
+                        <button class="btn-link">Mise à jour</button>
+                    </form>
+                {% endif %}
+            </div>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -1,13 +1,18 @@
 {% extends "apply/submit_base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title_content %}
-    <div class="d-xl-flex align-items-xl-center">
-        <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Informations personnelles de {{ job_seeker.get_full_name }}</h1>
-        {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
-    </div>
-    <p>Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                Informations personnelles de {{ job_seeker.get_full_name }}
+                {% include 'apply/includes/eligibility_badge.html' with force_valid=True %}
+            </h1>
+            <p>Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content_extend %}

--- a/itou/templates/job_seekers_views/create_or_update_job_seeker/step_base.html
+++ b/itou/templates/job_seekers_views/create_or_update_job_seeker/step_base.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
@@ -15,15 +16,19 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1>
-        {% if update_job_seeker %}
-            Modification
-        {% else %}
-            Création
-        {% endif %}
-        du compte
-        {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}
-    </h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                {% if update_job_seeker %}
+                    Modification
+                {% else %}
+                    Création
+                {% endif %}
+                du compte
+                {{ is_gps|default:False|yesno:"bénéficiaire,candidat" }}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/job_seekers_views/create_or_update_job_seeker/step_end.html
+++ b/itou/templates/job_seekers_views/create_or_update_job_seeker/step_end.html
@@ -1,10 +1,10 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 
 {% block title %}
-
     {% if is_gps|default:False %}
         Création du bénéficiaire
     {% else %}
@@ -19,18 +19,22 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1 class="my-5">
-        {% if is_gps|default:False %}
-            Création du bénéficiaire
-        {% else %}
-            {% if update_job_seeker %}
-                Modification
-            {% else %}
-                Création
-            {% endif %}
-            du compte candidat
-        {% endif %}
-    </h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>
+                {% if is_gps|default:False %}
+                    Création du bénéficiaire
+                {% else %}
+                    {% if update_job_seeker %}
+                        Modification
+                    {% else %}
+                        Création
+                    {% endif %}
+                    du compte candidat
+                {% endif %}
+            </h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 {% load matomo %}
 {% load static %}
@@ -14,16 +15,18 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <h1 class="mb-0">Candidat : {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</h1>
-        {% url 'search:employers_results' as search_url %}
-        {% if can_view_personal_information %}
-            {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
-        {% else %}
-            {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
-        {% endif %}
-        {% if can_edit_iae_eligibility %}
-            <div class="d-flex flex-column flex-md-row gap-3" role="group" aria-label="Actions sur le candidat">
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria-label="Actions sur le candidat" %}
+        {% fragment as c_title__main %}
+            <h1>Candidat : {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</h1>
+        {% endfragment %}
+        {% fragment as c_title__cta %}
+            {% url 'search:employers_results' as search_url %}
+            {% if can_view_personal_information %}
+                {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
+            {% else %}
+                {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
+            {% endif %}
+            {% if can_edit_iae_eligibility %}
                 <a href="{% url 'eligibility_views:update' public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-secondary">
                     <i class="ri-checkbox-circle-line fw-medium" aria-hidden="true"></i>
                     {% if iae_eligibility_diagnosis %}
@@ -36,14 +39,14 @@
                     <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                     <span>Postuler pour ce candidat</span>
                 </a>
-            </div>
-        {% else %}
-            <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
-                <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                <span>Postuler pour ce candidat</span>
-            </a>
-        {% endif %}
-    </div>
+            {% else %}
+                <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
+                    <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
+                    <span>Postuler pour ce candidat</span>
+                </a>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_extra %}

--- a/itou/templates/job_seekers_views/job_applications.html
+++ b/itou/templates/job_seekers_views/job_applications.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load format_filters %}
 {% load matomo %}
 {% load static %}
@@ -14,19 +15,23 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-        <h1 class="mb-0">Candidat : {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</h1>
-        {% url 'search:employers_results' as search_url %}
-        {% if can_view_personal_information %}
-            {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
-        {% else %}
-            {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
-        {% endif %}
-        <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
-            <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-            <span>Postuler pour ce candidat</span>
-        </a>
-    </div>
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta %}
+        {% fragment as c_title__main %}
+            <h1>Candidat : {{ job_seeker.get_full_name|mask_unless:can_view_personal_information }}</h1>
+        {% endfragment %}
+        {% fragment as c_title__cta %}
+            {% url 'search:employers_results' as search_url %}
+            {% if can_view_personal_information %}
+                {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
+            {% else %}
+                {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
+            {% endif %}
+            <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
+                <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
+                <span>Postuler pour ce candidat</span>
+            </a>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_extra %}

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load matomo %}
@@ -13,9 +14,11 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 justify-content-md-between">
-        <h1 class="m-0">Candidats</h1>
-        <div class="d-flex flex-column flex-md-row gap-3" role="group" aria-label="Actions sur les candidats">
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria-label="Actions sur les candidatures" %}
+        {% fragment as c_title__main %}
+            <h1>Candidats</h1>
+        {% endfragment %}
+        {% fragment as c_title__cta %}
             {% url "job_seekers_views:get_or_create_start" as get_or_create_url %}
             <a href="{% url_add_query get_or_create_url tunnel='standalone' from_url=request.path|urlencode %}"
                {% matomo_event "compte-candidat" "clic" "creer-un-compte-candidat" %}
@@ -27,8 +30,8 @@
                 <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                 <span>Postuler pour un candidat</span>
             </a>
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
+++ b/itou/templates/job_seekers_views/step_check_job_seeker_nir.html
@@ -1,5 +1,6 @@
 {% extends "job_seekers_views/submit_base_two_columns.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load matomo %}
@@ -7,30 +8,36 @@
 {% load str_filters %}
 
 {% block title_content %}
-    {{ block.super }}
-    {% if auto_prescription_process or hire_process %}
-        {% if siae.is_subject_to_eligibility_rules or siae.kind == CompanyKind.GEIQ %}
-            <p>
-                {% if hire_process %}
-                    Cet espace vous permet de déclarer directement une embauche sans avoir à créer une candidature au préalable.
-                    {% if siae.kind == CompanyKind.GEIQ %}
-                        Si vous souhaitez créer une candidature à traiter plus tard (avec la possibilité d’enregistrer une action préalable au recrutement), veuillez vous rendre
-                        sur <a href="{% url 'apply:start' company_pk=siae.pk %}" {% matomo_event "candidature" "clic" "start_application" %}>Enregistrer une candidature</a> depuis le tableau de bord.
-                    {% else %}
-                        Pour la création d’une candidature, veuillez vous rendre sur <a href="{% url 'apply:start' company_pk=siae.pk %}" {% matomo_event "candidature" "clic" "start_application" %}>Enregistrer une candidature</a> depuis le tableau de bord.
-                    {% endif %}
-                {% else %}
-                    {% if siae.kind == CompanyKind.GEIQ %}
-                        Cet espace vous permet d’enregistrer une candidature à traiter plus tard (avec la possibilité d’enregistrer une action préalable au recrutement).
-                    {% else %}
-                        Cet espace vous permet d’enregistrer une nouvelle candidature.
-                    {% endif %}
-                    Si vous souhaitez déclarer directement une embauche, veuillez vous rendre sur <a href="{% url 'apply:start_hire' company_pk=siae.pk %}">Déclarer une embauche</a> depuis le tableau de bord.
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            {% if auto_prescription_process or hire_process %}
+                {% if siae.is_subject_to_eligibility_rules or siae.kind == CompanyKind.GEIQ %}
+                    <p>
+                        {% if hire_process %}
+                            Cet espace vous permet de déclarer directement une embauche sans avoir à créer une candidature au préalable.
+                            {% if siae.kind == CompanyKind.GEIQ %}
+                                Si vous souhaitez créer une candidature à traiter plus tard (avec la possibilité d’enregistrer une action préalable au recrutement), veuillez vous rendre
+                                sur <a href="{% url 'apply:start' company_pk=siae.pk %}" {% matomo_event "candidature" "clic" "start_application" %}>Enregistrer une candidature</a> depuis le tableau de bord.
+                            {% else %}
+                                Pour la création d’une candidature, veuillez vous rendre sur <a href="{% url 'apply:start' company_pk=siae.pk %}" {% matomo_event "candidature" "clic" "start_application" %}>Enregistrer une candidature</a> depuis le tableau de bord.
+                            {% endif %}
+                        {% else %}
+                            {% if siae.kind == CompanyKind.GEIQ %}
+                                Cet espace vous permet d’enregistrer une candidature à traiter plus tard (avec la possibilité d’enregistrer une action préalable au recrutement).
+                            {% else %}
+                                Cet espace vous permet d’enregistrer une nouvelle candidature.
+                            {% endif %}
+                            Si vous souhaitez déclarer directement une embauche, veuillez vous rendre sur <a href="{% url 'apply:start_hire' company_pk=siae.pk %}">Déclarer une embauche</a> depuis le tableau de bord.
+                        {% endif %}
+                    </p>
                 {% endif %}
-            </p>
-        {% endif %}
-    {% endif %}
-{% endblock title_content %}
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block left_column %}
     <form method="post" class="js-prevent-multiple-submit js-format-nir">

--- a/itou/templates/job_seekers_views/submit_base_two_columns.html
+++ b/itou/templates/job_seekers_views/submit_base_two_columns.html
@@ -1,10 +1,15 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load static %}
 
 {% block title %}Postuler {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>{% include 'apply/includes/_submit_title.html' %}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -5299,12 +5299,7 @@ class TestCheckJobSeekerInformationsForHire:
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         response = client.get(url_check_infos)
-        assertContains(
-            response,
-            """<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
-            Informations personnelles de Son Prénom SON NOM DE FAMILLE</h1>""",
-            html=True,
-        )
+        assertContains(response, "Informations personnelles de Son Prénom SON NOM DE FAMILLE")
         assertTemplateNotUsed(response, "approvals/includes/box.html")
         assertContains(response, "Éligibilité IAE à valider")
         params = {
@@ -5344,12 +5339,7 @@ class TestCheckJobSeekerInformationsForHire:
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         response = client.get(url_check_infos)
-        assertContains(
-            response,
-            """<h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">
-            Informations personnelles de Son Prénom SON NOM DE FAMILLE</h1>""",
-            html=True,
-        )
+        assertContains(response, "Informations personnelles de Son Prénom SON NOM DE FAMILLE")
         assertTemplateNotUsed(response, "approvals/includes/box.html")
         params = {
             "job_seeker": job_seeker.public_id,

--- a/tests/www/geiq_views/__snapshots__/tests.ambr
+++ b/tests/www/geiq_views/__snapshots__/tests.ambr
@@ -108,16 +108,24 @@
   
   
                               
-      <h1>Mes salariés - 2023</h1>
-      <div class="d-flex align-items-center">
-          <p class="mb-0">Dernière mise à jour: -</p>
-          
-              <form method="post">
-                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                  <button class="btn">Mise à jour</button>
-              </form>
-          
-      </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Mes salariés - 2023</h1>
+              <div>
+                  <span>Dernière mise à jour: -</span>
+                  
+                      <form class="d-inline-block ms-2" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <button class="btn-link">Mise à jour</button>
+                      </form>
+                  
+              </div>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -155,11 +163,19 @@
   
   
                               
-      <h1>Données salariés - 2023</h1>
-      <div class="d-flex align-items-center">
-          <p class="mb-0">Dernière mise à jour: -</p>
-          
-      </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Données salariés - 2023</h1>
+              <div>
+                  <span>Dernière mise à jour: -</span>
+                  
+              </div>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -788,17 +804,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       
           <span class="badge badge-base rounded-pill text-nowrap bg-warning">Bilan validé : demande de remboursement total</span>
       
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -943,16 +965,22 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
                   
-                      <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement total</span>
+                      
+                          <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement total</span>
+                      
                   
-              
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -1146,17 +1174,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       
           <span class="badge badge-base rounded-pill text-nowrap bg-success">Bilan validé</span>
       
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -1299,16 +1333,22 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
                   
-                      <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : totalité de l’aide accordée</span>
+                      
+                          <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : totalité de l’aide accordée</span>
+                      
                   
-              
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -1502,17 +1542,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       
           <span class="badge badge-base rounded-pill text-nowrap bg-success">Bilan validé : solde partiellement accordé</span>
       
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -1657,16 +1703,22 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
                   
-                      <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : solde partiellement accordé</span>
+                      
+                          <span class="badge badge-base rounded-pill text-nowrap bg-success">Financement : solde partiellement accordé</span>
+                      
                   
-              
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -1860,17 +1912,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       
           <span class="badge badge-base rounded-pill text-nowrap bg-warning">Bilan validé : demande de remboursement partiel</span>
       
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -2015,16 +2073,22 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
                   
-                      <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement partiel</span>
+                      
+                          <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : demande de remboursement partiel</span>
+                      
                   
-              
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -2218,17 +2282,23 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       
           <span class="badge badge-base rounded-pill text-nowrap bg-warning">Bilan validé : solde refusé</span>
       
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -2371,16 +2441,22 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
                   
-                      <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : solde refusé</span>
+                      
+                          <span class="badge badge-base rounded-pill text-nowrap bg-warning">Financement : solde refusé</span>
+                      
                   
-              
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -2570,15 +2646,21 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -2719,14 +2801,20 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
-                  <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
+                      <span class="badge badge-base rounded-pill text-nowrap bg-info">Bilan à l’étude</span>
+                  
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -2901,15 +2989,21 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
       <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
   
   
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -3095,14 +3189,20 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <div class="d-xl-flex align-items-xl-center">
-              <h1 class="mb-1 mb-xl-0 me-xl-3 text-xl-nowrap">Bilan d’exécution - 2023</h1>
-              
-                  <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
-              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Bilan d’exécution - 2023
+                  
+                      <span class="badge badge-base rounded-pill text-nowrap bg-warning">En attente du bilan d’exécution</span>
+                  
+              </h1>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -17,19 +17,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -253,19 +262,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -467,14 +485,18 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <div aria-label="Actions sur le candidat" class="d-flex flex-column flex-md-row gap-3" role="group">
+              
+                  
+              
+              
                   <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                       <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium"></i>
                       
@@ -485,9 +507,12 @@
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
-              </div>
-          
-      </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -647,14 +672,18 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <div aria-label="Actions sur le candidat" class="d-flex flex-column flex-md-row gap-3" role="group">
+              
+                  
+              
+              
                   <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                       <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium"></i>
                       
@@ -665,9 +694,12 @@
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
-              </div>
-          
-      </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -917,17 +949,26 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div class="c-title__cta">
               
-          
-          <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-              <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-              <span>Postuler pour ce candidat</span>
-          </a>
-      </div>
+              
+                  
+              
+              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                  <span>Postuler pour ce candidat</span>
+              </a>
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -1872,19 +1913,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -2110,14 +2160,18 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <div aria-label="Actions sur le candidat" class="d-flex flex-column flex-md-row gap-3" role="group">
+              
+                  
+              
+              
                   <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                       <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium"></i>
                       
@@ -2128,9 +2182,12 @@
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
-              </div>
-          
-      </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -2336,19 +2393,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -2508,19 +2574,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -2724,14 +2799,18 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <div aria-label="Actions sur le candidat" class="d-flex flex-column flex-md-row gap-3" role="group">
+              
+                  
+              
+              
                   <a class="btn btn-lg btn-ico btn-secondary" href="/eligibility/update/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a">
                       <i aria-hidden="true" class="ri-checkbox-circle-line fw-medium"></i>
                       
@@ -2742,9 +2821,12 @@
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
-              </div>
-          
-      </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -2948,19 +3030,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -3120,19 +3211,28 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
-          <h1 class="mb-0">Candidat : Jane DOE</h1>
-          
-          
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidat : Jane DOE</h1>
+          </div>
+      
+          <div aria-label="Actions sur le candidat" class="c-title__cta" role="group">
               
-          
-          
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
-                  <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
-                  <span>Postuler pour ce candidat</span>
-              </a>
-          
-      </div>
+              
+                  
+              
+              
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                      <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
+                      <span>Postuler pour ce candidat</span>
+                  </a>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -17,9 +17,13 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 justify-content-md-between">
-          <h1 class="m-0">Candidats</h1>
-          <div aria-label="Actions sur les candidats" class="d-flex flex-column flex-md-row gap-3" role="group">
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidats</h1>
+          </div>
+      
+          <div aria-label="Actions sur les candidatures" class="c-title__cta" role="group">
               
               <a class="btn btn-lg btn-secondary btn-ico" data-matomo-action="clic" data-matomo-category="compte-candidat" data-matomo-event="true" data-matomo-option="creer-un-compte-candidat" href="/job-seekers/start?tunnel=standalone&amp;from_url=/job-seekers/list-organization">
                   <i aria-hidden="true" class="ri-user-add-line fw-medium"></i>
@@ -30,7 +34,10 @@
                   <span>Postuler pour un candidat</span>
               </a>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       
@@ -317,9 +324,13 @@
   
   
                               
-      <div class="d-flex flex-column flex-md-row gap-3 justify-content-md-between">
-          <h1 class="m-0">Candidats</h1>
-          <div aria-label="Actions sur les candidats" class="d-flex flex-column flex-md-row gap-3" role="group">
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Candidats</h1>
+          </div>
+      
+          <div aria-label="Actions sur les candidatures" class="c-title__cta" role="group">
               
               <a class="btn btn-lg btn-secondary btn-ico" data-matomo-action="clic" data-matomo-category="compte-candidat" data-matomo-event="true" data-matomo-option="creer-un-compte-candidat" href="/job-seekers/start?tunnel=standalone&amp;from_url=/job-seekers/list">
                   <i aria-hidden="true" class="ri-user-add-line fw-medium"></i>
@@ -330,7 +341,10 @@
                   <span>Postuler pour un candidat</span>
               </a>
           </div>
-      </div>
+      
+      
+  </div>
+  
   
                               
       


### PR DESCRIPTION
## :thinking: Pourquoi ?
Après redécoupage de la [fat PR slippers c-title](https://github.com/gip-inclusion/les-emplois/pull/5806/commits) composant. Voici la "petite" **part05**

## :cake: Comment ? <!-- optionnel -->
Refactorisation de la zone de titre des templates geiq et job_seekers afin d'utiliser le composant c-title.
Quelques corrections UI sur certains éléments de cette même zone.
