### PR TITLE
Ajout du composant c-title aux templates gps, search et signup

### DIFF
--- a/itou/templates/gps/group_details_base.html
+++ b/itou/templates/gps/group_details_base.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load static %}
 {% load str_filters %}
 
@@ -11,26 +12,26 @@
 {% endblock %}
 
 {% block title_content %}
-    <div class="c-title">
-        <div class="c-title__main">
-            <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                <h1 class="m-0">{{ group.beneficiary.get_full_name|mask_unless:can_view_personal_information }}</h1>
-                {% if can_print_page %}
-                    <button class="btn btn-lg btn-ico-only btn-link" type="button" data-it-action="print" aria-label="Imprimer la page">
-                        <i class="ri-printer-line font-weight-normal" aria-hidden="true"></i>
-                    </button>
-                {% endif %}
-            </div>
-        </div>
-        {% if not can_view_personal_information %}
-            <div class="c-title__cta" role="group" aria-label="Actions sur les groupes de suivi">
-                <button class="btn btn-lg btn-secondary btn-ico" data-bs-toggle="modal" data-bs-target="#ask_access_modal">
-                    <i class="ri-user-unfollow-line fw-medium" aria-hidden="true"></i>
-                    <span>Demander l’accès complet à la fiche</span>
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta %}
+        {% fragment as c_title__main %}
+            <h1>{{ group.beneficiary.get_full_name|mask_unless:can_view_personal_information }}</h1>
+        {% endfragment %}
+        {% fragment as c_title__cta %}
+            {% if can_print_page %}
+                <button class="btn btn-lg btn-ico-only btn-link" type="button" data-it-action="print" aria-label="Imprimer la page">
+                    <i class="ri-printer-line font-weight-normal" aria-hidden="true"></i>
                 </button>
-            </div>
-        {% endif %}
-    </div>
+            {% endif %}
+            {% if not can_view_personal_information %}
+                <div class="c-title__cta" role="group" aria-label="Actions sur les groupes de suivi">
+                    <button class="btn btn-lg btn-secondary btn-ico" data-bs-toggle="modal" data-bs-target="#ask_access_modal">
+                        <i class="ri-user-unfollow-line fw-medium" aria-hidden="true"></i>
+                        <span>Demander l’accès complet à la fiche</span>
+                    </button>
+                </div>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_extra %}

--- a/itou/templates/gps/group_edition.html
+++ b/itou/templates/gps/group_edition.html
@@ -39,7 +39,7 @@
                         </div>
                         <div class="c-box mb-4">
                             <h3>Motif de l’intervention</h3>
-                            <div class="c-info mb-1">
+                            <div class="c-info mb-3">
                                 <span class="c-info__summary">Cette information sera visible aux autres intervenants. N’inscrivez aucune information confidentielle dans ce champ.</span>
                             </div>
                             {% bootstrap_field form.reason show_label=False %}

--- a/itou/templates/gps/group_list.html
+++ b/itou/templates/gps/group_list.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load matomo %}
 {% load static %}
@@ -7,20 +8,22 @@
 
 {% block title %}GPS - Mes bénéficiaires {{ block.super }}{% endblock %}
 
-
 {% block title_content %}
-    <div class="d-flex flex-column flex-md-row gap-3 mb-3 mb-md-3 justify-content-md-between align-items-md-center">
-        <div>
-            <h1 class="m-0">GPS</h1>
+    {% component_title c_title__main=c_title__main c_title__cta=c_title__cta role="group" aria-label="Actions sur les groupes de suivi" %}
+        {% fragment as c_title__main %}
+            <h1>GPS</h1>
             <p>Guide de partage et de suivi</p>
-        </div>
-        <div class="d-flex flex-column flex-md-row gap-md-3" role="group" aria-label="Actions sur les groupes de suivi">
-            <a href="{% url 'gps:join_group' %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-primary mt-3 mt-md-0">
+        {% endfragment %}
+        {% fragment as c_title__cta %}
+            <a href="{% url 'gps:join_group' %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-primary">
                 <i class="ri-user-add-line" aria-hidden="true"></i>
                 <span>Ajouter un bénéficiaire</span>
             </a>
-        </div>
-    </div>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block title_extra %}
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
         <li class="nav-item">
             <a class="nav-link{% if active_memberships %} active{% endif %}" href="{% url 'gps:group_list' %}">En cours d’accompagnement</a>
@@ -30,7 +33,6 @@
         </li>
     </ul>
 {% endblock %}
-
 
 {% block content %}
     <section class="s-section" id="gps-my-groups">

--- a/itou/templates/gps/join_group.html
+++ b/itou/templates/gps/join_group.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load static %}
 
 {% block title %}GPS - Ajouter un bénéficiaire {{ block.super }}{% endblock %}
@@ -8,7 +9,13 @@
     {% include "layout/previous_step.html" with back_url=back_url only %}
 {% endblock %}
 
-{% block title_content %}<h1>Ajouter un bénéficiaire</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Ajouter un bénéficiaire</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/gps/join_group_from_coworker.html
+++ b/itou/templates/gps/join_group_from_coworker.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 {% load str_filters %}
 
-{% block title_content %}<h1>Ajouter un bénéficiaire</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Ajouter un bénéficiaire</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section" id="join_group">

--- a/itou/templates/gps/join_group_from_name_and_email.html
+++ b/itou/templates/gps/join_group_from_name_and_email.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
 
-{% block title_content %}<h1>Ajouter un bénéficiaire</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Ajouter un bénéficiaire</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section" id="join_group">

--- a/itou/templates/gps/join_group_from_nir.html
+++ b/itou/templates/gps/join_group_from_nir.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
 
-{% block title_content %}<h1>Ajouter un bénéficiaire</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Ajouter un bénéficiaire</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section" id="join_group">

--- a/itou/templates/institutions/members.html
+++ b/itou/templates/institutions/members.html
@@ -1,8 +1,15 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Collaborateurs {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Organisation</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Organisation</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/logout/warning.html
+++ b/itou/templates/logout/warning.html
@@ -1,10 +1,16 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load static %}
-
 
 {% block title %}Déconnexion {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Déconnexion</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Déconnexion</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section pt-lg-3">

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load static %}
 {% load str_filters %}
 
@@ -7,7 +8,13 @@
     {{ block.super }}
 {% endblock %}
 
-{% block title_content %}<h1>Rechercher des prescripteurs habilités</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Rechercher des prescripteurs habilités</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_extra %}
     <form class="mt-md-4">

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
@@ -14,8 +15,13 @@
     {% endif %}
 {% endblock %}
 
-
-{% block title_content %}<h1>Rechercher un emploi inclusif</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Rechercher un emploi inclusif</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block title_extra %}
     <form class="mt-md-4">

--- a/itou/templates/signup/choose_user_kind.html
+++ b/itou/templates/signup/choose_user_kind.html
@@ -1,10 +1,17 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Inscription</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -1,5 +1,6 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load str_filters %}
 {% load tally %}
@@ -7,8 +8,12 @@
 {% block title %}Employeur inclusif - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Employeur inclusif</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Employeur inclusif</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/employer.html
+++ b/itou/templates/signup/employer.html
@@ -1,12 +1,17 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 
 {% block title %}Employeur solidaire - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Employeur solidaire</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Employeur solidaire</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/signup/facilitator_search.html
+++ b/itou/templates/signup/facilitator_search.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
@@ -6,22 +7,28 @@
 {% block title %}Facilitateur de clauses sociales - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Facilitateur de clauses sociales</p>
-    <h2>Inscrire mon organisation porteuse de la clause sociale d’insertion</h2>
-    <p>
-        Cette inscription est soumise à des conditions qui ont été définies en lien avec nos partenaires publics et privés nationaux.
-    </p>
-    <p>
-        <span class="d-block">Les conditions suivantes sont nécessaires :</span>
-        <b>
-            La structure qui s’inscrit, pour un territoire donné, doit être porteuse d’un poste occupé par une personne ayant des compétences de facilitateur (reconnues et validées par le réseau national des facilitateurs) et s’engager à respecter les fondamentaux de la clause sociale.
-        </b>
-    </p>
-    <p>
-        Dans le cas contraire votre inscription sera déclarée non pertinente et votre compte sera désactivé.
-        Si vous souhaitez avoir davantage d’informations, vous pouvez contacter le réseau national des facilitateurs de la clause sociale, Alliance Villes Emploi : <a href="mailto:ave@ville-emploi.asso.fr" aria-label="Rédiger un e-mail à Alliance Villes Emploi">ave@ville-emploi.asso.fr</a>.
-    </p>
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Facilitateur de clauses sociales</p>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            <h2>Inscrire mon organisation porteuse de la clause sociale d’insertion</h2>
+            <p>
+                Cette inscription est soumise à des conditions qui ont été définies en lien avec nos partenaires publics et privés nationaux.
+            </p>
+            <p>
+                <span class="d-block">Les conditions suivantes sont nécessaires :</span>
+                <b>
+                    La structure qui s’inscrit, pour un territoire donné, doit être porteuse d’un poste occupé par une personne ayant des compétences de facilitateur (reconnues et validées par le réseau national des facilitateurs) et s’engager à respecter les fondamentaux de la clause sociale.
+                </b>
+            </p>
+            <p>
+                Dans le cas contraire votre inscription sera déclarée non pertinente et votre compte sera désactivé.
+                Si vous souhaitez avoir davantage d’informations, vous pouvez contacter le réseau national des facilitateurs de la clause sociale, Alliance Villes Emploi : <a href="mailto:ave@ville-emploi.asso.fr" aria-label="Rédiger un e-mail à Alliance Villes Emploi">ave@ville-emploi.asso.fr</a>.
+            </p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/job_seeker_signup_base.html
+++ b/itou/templates/signup/job_seeker_signup_base.html
@@ -1,12 +1,18 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load static %}
 
 {% block title %}Demandeur d'emploi - Inscription {{ block.super }}{% endblock %}
 
-{% block title_content %}<h1>Inscription candidat</h1>{% endblock %}
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription candidat</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
-
     <section class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">
@@ -24,5 +30,4 @@
             </div>
         </div>
     </section>
-
 {% endblock content %}

--- a/itou/templates/signup/prescriber_check_already_exists.html
+++ b/itou/templates/signup/prescriber_check_already_exists.html
@@ -1,13 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur/Orienteur</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur/Orienteur</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/signup/prescriber_check_pe_email.html
+++ b/itou/templates/signup/prescriber_check_pe_email.html
@@ -1,13 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Prescripteur France Travail - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur France Travail</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur France Travail</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/signup/prescriber_choose_kind.html
+++ b/itou/templates/signup/prescriber_choose_kind.html
@@ -1,13 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur/Orienteur</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur/Orienteur</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_choose_org.html
+++ b/itou/templates/signup/prescriber_choose_org.html
@@ -1,13 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur/Orienteur</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur/Orienteur</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/signup/prescriber_confirm_authorization.html
+++ b/itou/templates/signup/prescriber_confirm_authorization.html
@@ -1,13 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur habilité</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur habilité</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_pole_emploi_safir_code.html
+++ b/itou/templates/signup/prescriber_pole_emploi_safir_code.html
@@ -1,13 +1,18 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load static %}
 
 {% block title %}Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur France Travail</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur France Travail</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_pole_emploi_user.html
+++ b/itou/templates/signup/prescriber_pole_emploi_user.html
@@ -1,11 +1,16 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 
 {% block title %}Prescripteur France Travail - Inscription {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur France Travail</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur France Travail</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/itou/templates/signup/prescriber_request_invitation.html
+++ b/itou/templates/signup/prescriber_request_invitation.html
@@ -1,15 +1,19 @@
 {% extends "layout/base.html" %}
 {% load buttons_form %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 {% load static %}
 
 {% block title %}Prescripteur/Orienteur - Inscription {{ block.super }}{% endblock %}
 
-
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur/Orienteur</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur/Orienteur</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/signup/prescriber_user.html
+++ b/itou/templates/signup/prescriber_user.html
@@ -1,4 +1,5 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
 
@@ -9,8 +10,12 @@
 {% endblock %}
 
 {% block title_content %}
-    <h1 class="mb-0">Inscription</h1>
-    <p>Prescripteur/Orienteur</p>
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Inscription</h1>
+            <p>Prescripteur/Orienteur</p>
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block content %}

--- a/itou/templates/stats/stats.html
+++ b/itou/templates/stats/stats.html
@@ -1,23 +1,30 @@
 {% extends "layout/base.html" %}
+{% load components %}
 {% load static %}
 
 {% block title %}Statistiques et pilotage {{ block.super }}{% endblock %}
 
 {% block title_content %}
-    <h1>{{ page_title }}</h1>
-    {% if show_siae_evaluation_message %}
-        <p>
-            Le tableau ci-dessous comprend 100 % des auto-prescriptions réalisées en année N-1. Vous pouvez affiner les données en utilisant les filtres disponibles.
-        </p>
-    {% endif %}
-    {% if is_stats_public %}
-        <p>
-            Cette page a pour objectif de présenter l'impact des emplois de l'inclusion. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
-            <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" class="has-external-link" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
-                pilotage de l'inclusion
-            </a>
-        </p>
-    {% endif %}
+    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+        {% fragment as c_title__main %}
+            <h1>{{ page_title }}</h1>
+        {% endfragment %}
+        {% fragment as c_title__secondary %}
+            {% if show_siae_evaluation_message %}
+                <p>
+                    Le tableau ci-dessous comprend 100 % des auto-prescriptions réalisées en année N-1. Vous pouvez affiner les données en utilisant les filtres disponibles.
+                </p>
+            {% endif %}
+            {% if is_stats_public %}
+                <p>
+                    Cette page a pour objectif de présenter l'impact des emplois de l'inclusion. Pour retrouver les indicateurs qui étaient présentés ici, merci de vous rendre sur le
+                    <a href="{{ ITOU_PILOTAGE_URL }}/tableaux-de-bord" rel="noopener" target="_blank" class="has-external-link" aria-label="Vous rendre sur le pilotage de l'inclusion (ouverture dans un nouvel onglet)">
+                        pilotage de l'inclusion
+                    </a>
+                </p>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
 {% endblock %}
 
 {% block title_messages %}

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -27,26 +27,31 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">J… D…</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>J… D…</h1>
           </div>
-          
-              <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
-                  <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
-                      <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
-                      <span>Demander l’accès complet à la fiche</span>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
                   </button>
-              </div>
-          
-      </div>
+              
+              
+                  <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
+                      <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
+                          <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
+                          <span>Demander l’accès complet à la fiche</span>
+                      </button>
+                  </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -136,19 +141,24 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">Jane DOE</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Jane DOE</h1>
           </div>
-          
-      </div>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
+                  </button>
+              
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -286,19 +296,24 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">Jane DOE</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Jane DOE</h1>
           </div>
-          
-      </div>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
+                  </button>
+              
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -443,19 +458,24 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">Jane DOE</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Jane DOE</h1>
           </div>
-          
-      </div>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
+                  </button>
+              
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -620,19 +640,24 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">Jane DOE</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Jane DOE</h1>
           </div>
-          
-      </div>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
+                  </button>
+              
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -804,26 +829,31 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">J… D…</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>J… D…</h1>
           </div>
-          
-              <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
-                  <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
-                      <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
-                      <span>Demander l’accès complet à la fiche</span>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
                   </button>
-              </div>
-          
-      </div>
+              
+              
+                  <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
+                      <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
+                          <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
+                          <span>Demander l’accès complet à la fiche</span>
+                      </button>
+                  </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -933,26 +963,31 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">J… D…</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>J… D…</h1>
           </div>
-          
-              <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
-                  <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
-                      <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
-                      <span>Demander l’accès complet à la fiche</span>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
                   </button>
-              </div>
-          
-      </div>
+              
+              
+                  <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
+                      <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
+                          <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
+                          <span>Demander l’accès complet à la fiche</span>
+                      </button>
+                  </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -1062,22 +1097,27 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">J… D…</h1>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>J… D…</h1>
           </div>
-          
-              <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
-                  <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
-                      <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
-                      <span>Demander l’accès complet à la fiche</span>
-                  </button>
-              </div>
-          
-      </div>
+      
+          <div class="c-title__cta">
+              
+              
+                  <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
+                      <button class="btn btn-lg btn-secondary btn-ico" data-bs-target="#ask_access_modal" data-bs-toggle="modal">
+                          <i aria-hidden="true" class="ri-user-unfollow-line fw-medium"></i>
+                          <span>Demander l’accès complet à la fiche</span>
+                      </button>
+                  </div>
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -1144,7 +1184,7 @@
                           </div>
                           <div class="c-box mb-4">
                               <h3>Motif de l’intervention</h3>
-                              <div class="c-info mb-1">
+                              <div class="c-info mb-3">
                                   <span class="c-info__summary">Cette information sera visible aux autres intervenants. N’inscrivez aucune information confidentielle dans ce champ.</span>
                               </div>
                               <div class="form-group"><label class="visually-hidden" for="id_reason">Motif de suivi</label><textarea class="form-control" cols="40" id="id_reason" name="reason" placeholder="Raison de l’accompagnement et/ou actions menées avec la personne." rows="3"></textarea></div>
@@ -1322,19 +1362,24 @@
   
   
                               
-      <div class="c-title">
-          <div class="c-title__main">
-              <div class="d-flex flex-row gap-3 align-items-center mb-3">
-                  <h1 class="m-0">Jane DOE</h1>
-                  
-                      <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
-                          <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
-                      </button>
-                  
-              </div>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Jane DOE</h1>
           </div>
-          
-      </div>
+      
+          <div class="c-title__cta">
+              
+                  <button aria-label="Imprimer la page" class="btn btn-lg btn-ico-only btn-link" data-it-action="print" type="button">
+                      <i aria-hidden="true" class="ri-printer-line font-weight-normal"></i>
+                  </button>
+              
+              
+          </div>
+      
+      
+  </div>
+  
   
                               
                                   
@@ -2078,18 +2123,31 @@
                           <div class="s-title-02__col col-12">
                               
                               
-      <div class="d-flex flex-column flex-md-row gap-3 mb-3 mb-md-3 justify-content-md-between align-items-md-center">
-          <div>
-              <h1 class="m-0">GPS</h1>
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>GPS</h1>
               <p>Guide de partage et de suivi</p>
           </div>
-          <div aria-label="Actions sur les groupes de suivi" class="d-flex flex-column flex-md-row gap-md-3" role="group">
-              <a class="btn btn-lg btn-ico btn-primary mt-3 mt-md-0" href="/gps/groups/join?back_url=/gps/groups/list">
+      
+          <div aria-label="Actions sur les groupes de suivi" class="c-title__cta" role="group">
+              <a class="btn btn-lg btn-ico btn-primary" href="/gps/groups/join?back_url=/gps/groups/list">
                   <i aria-hidden="true" class="ri-user-add-line"></i>
                   <span>Ajouter un bénéficiaire</span>
               </a>
           </div>
-      </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
       <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
           <li class="nav-item">
               <a class="nav-link active" href="/gps/groups/list">En cours d’accompagnement</a>
@@ -2099,13 +2157,6 @@
           </li>
       </ul>
   
-                              
-                                  
-  
-  
-  
-                              
-                              
                           </div>
                       </div>
                   </div>
@@ -2821,7 +2872,17 @@
   
   
   
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -2927,7 +2988,17 @@
   
   
   
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3033,7 +3104,17 @@
   
   
   
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3119,7 +3200,17 @@
                       <div class="s-title-02__row row">
                           <div class="s-title-02__col col-12">
                               
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3194,7 +3285,17 @@
                       <div class="s-title-02__row row">
                           <div class="s-title-02__col col-12">
                               
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3302,7 +3403,17 @@
                       <div class="s-title-02__row row">
                           <div class="s-title-02__col col-12">
                               
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3414,7 +3525,17 @@
                       <div class="s-title-02__row row">
                           <div class="s-title-02__col col-12">
                               
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3521,7 +3642,17 @@
                       <div class="s-title-02__row row">
                           <div class="s-title-02__col col-12">
                               
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   
@@ -3683,7 +3814,17 @@
                       <div class="s-title-02__row row">
                           <div class="s-title-02__col col-12">
                               
-                              <h1>Ajouter un bénéficiaire</h1>
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>Ajouter un bénéficiaire</h1>
+          </div>
+      
+      
+  </div>
+  
+  
                               
                                   
   


### PR DESCRIPTION
## :thinking: Pourquoi ?
Après redécoupage de la [fat PR slippers c-title](https://github.com/gip-inclusion/les-emplois/pull/5806/commits) composant. Voici la "petite" **part06**

## :cake: Comment ? <!-- optionnel -->
Refactorisation de la zone de titre des templates gps, search et signup afin d'utiliser le composant c-title.
Quelques corrections UI sur certains éléments de cette même zone.
