### PR TITLE
PASS IAE: Correction de l'affichage de la durée destante du PASS

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -137,7 +137,7 @@ class CommonApprovalMixin(models.Model):
         ) - max(obj.start_at - timezone.localdate(), datetime.timedelta(0))
 
     def _get_human_readable_estimate(self, delta: datetime.timedelta) -> str:
-        res = timeuntil(timezone.localdate() + delta)
+        res = timeuntil(timezone.localdate() + delta, now=timezone.localdate())
         res = res.replace("année", "an")
         res = res.split(", ")
         if any(v in res[0] for v in ["an", "mois"]):

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -568,7 +568,7 @@ class TestApprovalModel:
         assert approval.remainder == datetime.timedelta(days=(prolonged_remainder + 5 + 30 - 10))
         assert approval.get_remainder_display() == "187 jours (Environ 6 mois)"
 
-    @freeze_time("2024-07-18")
+    @freeze_time("2024-07-18 03:00")
     def test_human_readable_estimate(self):
         approval = Approval()
         for delta, expected_display in [


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le code actuel se tromps d'un jour quand il n'est pas minuit pile (c'est à dire tout le temps)
 
## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

Avant:
![image](https://github.com/user-attachments/assets/0ea070e4-26c4-4ec7-9c8f-97b8de872668)

Après:
![image](https://github.com/user-attachments/assets/c622db61-9c2d-4926-93ce-b60e647feb10)


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
