### PR TITLE
Ajout d'une commande make pour que les tests échouent à la première erreur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,13 @@ populate_db: populate_db_with_reference_data
 # Tests.
 # =============================================================================
 
-.PHONY: test
+.PHONY: test test-failfast
 
 test: $(VIRTUAL_ENV)
 	pytest --numprocesses=logical --create-db $(TARGET)
+
+test-failfast: $(VIRTUAL_ENV)
+	pytest --numprocesses=logical --create-db --exitfirst $(TARGET)
 
 # Docker shell.
 # =============================================================================


### PR DESCRIPTION
Pytest has the option `--exitfirst `to stop running tests as soon as an error is detected. It comes in handy when multiple tests fail for different reasons.
This would replace the not-very-pratical `make test TARGET=--exitfirst` I use quite often.