### PR TITLE
Admin : conserver le statut d'administrateur lors du transfert d'une SIAE à une autre, et supprimer les membres lors de la désactivation [GEN-2374] 

### DIFF
--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -33,7 +33,7 @@ class TransferField(TextChoices):
 
 class ReportSection(TextChoices):
     JOB_UNLINK = "job_unlink", "Désassociation de fiche de poste"
-    COMPANY_DEACTIVATION = "company_deactivation", "Désactivation entreprise"
+    COMPANY_DEACTIVATION = "company_deactivation", "Désactivation entreprise avec désactivation des membres"
 
 
 TRANSFER_SPECS = {
@@ -227,5 +227,6 @@ def transfer_company_data(
             job_applications_blocked_at=timezone.now(),
             is_searchable=False,
         )
+        models.CompanyMembership.objects.filter(company=from_company).update(is_active=False)
         reporter.add(ReportSection.COMPANY_DEACTIVATION, _format_model(from_company))
     return reporter

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertNumQueries, assertRedirects
 
 from itou.companies.enums import CompanyKind
-from itou.companies.models import Company
+from itou.companies.models import Company, CompanyMembership
 from itou.utils.models import PkSupportRemark
 from tests.common_apps.organizations.tests import (
     assert_set_admin_role_creation,
@@ -358,6 +358,69 @@ class TestTransferCompanyData:
         assert "Candidatures reçues" in remark
         assert f"Désactivation entreprise:\n  * companies.Company[{from_company.pk}]" in remark
         assert "Peut apparaître dans la recherche:\n  * is_searchable: False remplacé par True" in remark
+
+    @pytest.mark.parametrize("field", {"is_admin", "is_active"})
+    @pytest.mark.parametrize(
+        "value_in_from_company,value_in_to_company,expected",
+        [
+            (None, False, False),
+            (False, None, False),
+            (None, True, True),
+            (True, None, True),
+            (False, False, False),
+            (True, False, True),
+            (False, True, True),
+            (True, True, True),
+        ],
+    )
+    def test_transfer_data_memberships(
+        self, admin_client, field, value_in_from_company, value_in_to_company, expected
+    ):
+        user = EmployerFactory()
+        default_args = {"user": user, "is_active": False, "is_admin": False}
+        from_company = CompanyFactory(with_membership=False)
+        if value_in_from_company is not None:
+            CompanyMembership(company=from_company, **{**default_args, field: value_in_from_company}).save()
+
+        to_company = CompanyFactory(with_membership=False)
+        if value_in_to_company is not None:
+            CompanyMembership(company=to_company, **{**default_args, field: value_in_to_company}).save()
+
+        transfer_url = reverse(
+            "admin:transfer_company_data", kwargs={"from_company_pk": from_company.pk, "to_company_pk": to_company.pk}
+        )
+
+        response = admin_client.get(transfer_url)
+        assertContains(response, "Choisissez les objets à transférer")
+
+        if value_in_from_company is not None:
+            assertContains(response, str(from_company.memberships.get(user=user)))
+
+            response = admin_client.post(
+                transfer_url,
+                data={"fields_to_transfer": ["memberships"], "disable_from_company": False},
+            )
+            assertRedirects(response, reverse("admin:companies_company_change", kwargs={"object_id": from_company.pk}))
+            assertMessages(
+                response,
+                [
+                    messages.Message(
+                        messages.INFO,
+                        f"Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}.",
+                    ),
+                ],
+            )
+
+        from_company.refresh_from_db()
+        to_company.refresh_from_db()
+
+        if value_in_to_company is None or value_in_from_company is None:
+            # Real transfer, membership in from_company is moved
+            assert from_company.memberships.count() == 0
+        else:
+            assert from_company.memberships.count() == 1
+        assert to_company.memberships.count() == 1
+        assert getattr(to_company.memberships.first(), field) is expected
 
 
 class TestJobDescriptionAdmin:

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -302,6 +302,7 @@ class TestTransferCompanyData:
         assert from_company.is_searchable
         assert not from_company.block_job_applications
         assert not from_company.job_applications_blocked_at
+        assert from_company.memberships.filter(is_active=True).count() == 1
         EmployerInvitationFactory(company=from_company)
 
         to_company = CompanyFactory(is_searchable=False)
@@ -334,11 +335,12 @@ class TestTransferCompanyData:
             ],
         )
 
-        # Check that from_company has been properly disable
+        # Check that from_company has been properly disabled and that the memberships have been disabled
         from_company.refresh_from_db()
         assert not from_company.is_searchable
         assert from_company.block_job_applications
         assert from_company.job_applications_blocked_at
+        assert from_company.memberships.filter(is_active=True).count() == 0
 
         # and to_company should now be searchable
         to_company.refresh_from_db()
@@ -356,7 +358,10 @@ class TestTransferCompanyData:
         remark = to_user_remark.remark
         assert "Transfert du 2023-08-31 12:34:56 effectué par" in remark
         assert "Candidatures reçues" in remark
-        assert f"Désactivation entreprise:\n  * companies.Company[{from_company.pk}]" in remark
+        assert (
+            f"Désactivation entreprise avec désactivation des membres:\n  * companies.Company[{from_company.pk}]"
+            in remark
+        )
         assert "Peut apparaître dans la recherche:\n  * is_searchable: False remplacé par True" in remark
 
     @pytest.mark.parametrize("field", {"is_admin", "is_active"})


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le bouton de transfert d'une entreprise est souvent utilisé pour transférer les données vers une entreprise **qui a déjà des membres**.

Actuellement, si un membre existe dans les 2 entreprises, quels que soient les attributs du *membership* (`is_admin` ou `is_active`), on ne fait rien.

On voudrait dans un premier temps que si le statut `is_admin` diffère, celui-ci soit transféré également.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
