### PR TITLE
Candidatures : Supprimer les fiches salariés non transmises lors de l'annulation

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -12,6 +12,7 @@ from itou.employee_record.exceptions import SerializationError
 from itou.employee_record.mocks.fake_serializers import TestEmployeeRecordBatchSerializer
 from itou.employee_record.models import EmployeeRecord, EmployeeRecordBatch, EmployeeRecordUpdateNotification
 from itou.employee_record.serializers import EmployeeRecordBatchSerializer
+from itou.job_applications.enums import JobApplicationState
 from itou.utils import asp as asp_utils
 from itou.utils.iterators import chunks
 
@@ -166,9 +167,11 @@ class Command(EmployeeRecordTransferCommand):
         Upload a file composed of all ready employee records
         """
         self.logger.info("Starting UPLOAD of employee records")
-        ready_employee_records = EmployeeRecord.objects.filter(status=Status.READY)
+        employee_records_to_send = EmployeeRecord.objects.filter(
+            status=Status.READY, job_application__state=JobApplicationState.ACCEPTED
+        )
         for batch in chunks(
-            ready_employee_records, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS, max_chunk=self.MAX_UPLOADED_FILES
+            employee_records_to_send, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS, max_chunk=self.MAX_UPLOADED_FILES
         ):
             self._upload_batch_file(sftp, batch, dry_run)
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -409,6 +409,9 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
         if self.status != Status.ARCHIVED:
             raise xwf_models.InvalidTransitionError()
 
+    def was_sent(self):
+        return self.logs.exclude(transition__in=EmployeeRecordTransition.without_asp_exchange()).exists()
+
     @property
     def status_based_on_asp_processing_code(self):
         if not self.asp_processing_code:

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -51,6 +51,12 @@
     ''',
   ])
 # ---
+# name: test_preflight_without_an_accepted_job_application
+  list([
+    'Preflight activated, checking for possible serialization errors...',
+    'No object to check. Exiting preflight.',
+  ])
+# ---
 # name: test_preflight_without_object
   list([
     'Preflight activated, checking for possible serialization errors...',
@@ -101,6 +107,16 @@
     'Starting UPLOAD of employee records',
     'Successfully uploaded: RIAE_FS_20210927000000.json',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.wait_for_asp_response (READY -> SENT)',
+    '[chan 0] sftp session closed.',
+    'Employee records processing done!',
+  ])
+# ---
+# name: test_upload_without_an_accepted_job_application
+  list([
+    '[chan 0] Opened sftp connection (server version 3)',
+    'Connected to "0.0.0.0" as "django_tests"',
+    'Current remote dir is "/"',
+    'Starting UPLOAD of employee records',
     '[chan 0] sftp session closed.',
     'Employee records processing done!',
   ])


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Erreur sentry 1](https://inclusion.sentry.io/issues/35896481/?notification_uuid=ae6927d3-dfaa-4acc-8a1a-f14c01d9dfa3&project=4508410589020240)
- La candidature est acceptée
- La fiche salarié est complétée par l'employeur (statut `READY`)
- L'employeur annule la candidature

=> Le PASS IAE est supprimé, ce qui casse l'envoi de la FS en attente. (Cas résolu par la version actuelle de la PR)

[Erreur sentry 2](https://inclusion.sentry.io/issues/37050035/?alert_rule_id=106033&alert_type=issue&notification_uuid=369b9dc5-e2d5-4d41-acf8-9feadbea7477)
- La candidature est acceptée
- La fiche est pré-remplis (statut `NEW`)
- La candidature est annulée

=> La fiche salarié reste et ne peux pas être finalisée. (Cas résolu par la version actuelle de la PR)


Idéalement il faudrait gérer ce genre de cas proprement et faire transitionner la FS dans un autre état (probablement `DISABLED`), mais ça veux aussi dire gérer le cas des candidatures non-acceptées partout où on peux accéder à une FS ainsi que rajouter le cas dans la recherche d'une FS manquante.