### PR TITLE
Statistiques : Migrer le NPS de Hotjar vers Tally [GEN-2357]

### DIFF
--- a/itou/static/js/nps_popup.js
+++ b/itou/static/js/nps_popup.js
@@ -1,0 +1,39 @@
+/********************************************************************
+  Show tally form as a popup to prompt user for NPS.
+
+  Example use:
+  {% load static %}
+  <script async src="https://tally.so/widgets/embed.js"></script>
+  <script src='{% static "js/nps_popup.js" %}' data-delaypopup="true" data-userkind="employeur" data-page="liste-candidatures"></script>
+
+********************************************************************/
+
+const data = document.currentScript.dataset;
+
+tallyConfig = {
+  "formId": "3qzqeO",
+  "popup": {
+    "width": 300,
+    "emoji": {
+        "text": "👋",
+        "animation": "wave"
+    },
+    "hiddenFields": {
+        "Userkind": data.userkind,
+        "Page": data.page
+    },
+    "hideTitle": true,
+    "autoClose": 4000,
+    "showOnce": true,
+    "doNotShowAfterSubmit": true
+  }
+};
+
+if (data.delaypopup == "true") {
+  tallyConfig.popup.open = {
+    "trigger": "time",
+    "ms": 10000
+  };
+};
+
+window.TallyConfig = tallyConfig;

--- a/itou/static/js/nps_popup.js
+++ b/itou/static/js/nps_popup.js
@@ -10,7 +10,7 @@
 
 const data = document.currentScript.dataset;
 
-tallyConfig = {
+const tallyConfig = {
   "formId": "3qzqeO",
   "popup": {
     "width": 300,

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -91,4 +91,6 @@
     {{ filters_form.media.js }}
     <script src='{% static "js/htmx_compat.js" %}'></script>
     <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
+    <script async src="https://tally.so/widgets/embed.js"></script>
+    <script src='{% static "js/nps_popup.js" %}' data-delaypopup="true" data-userkind="employeur" data-page="liste-candidatures"></script>
 {% endblock %}

--- a/itou/templates/apply/list_prescriptions.html
+++ b/itou/templates/apply/list_prescriptions.html
@@ -52,4 +52,6 @@
     {{ filters_form.media.js }}
     <script src='{% static "js/htmx_compat.js" %}'></script>
     <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
+    <script async src="https://tally.so/widgets/embed.js"></script>
+    <script src='{% static "js/nps_popup.js" %}' data-delaypopup="true" data-userkind="prescripteur" data-page="liste-candidatures"></script>
 {% endblock %}

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -3,6 +3,7 @@
 {% load components %}
 {% load django_bootstrap5 %}
 {% load format_filters %}
+{% load static %}
 {% load str_filters %}
 
 {% block title %}{{ page_title }} {{ block.super }}{% endblock %}
@@ -128,4 +129,9 @@
     {{ block.super }}
     {% comment %} Needed for the AddressAutocompleteWidget {% endcomment %}
     {{ form.media.js }}
+    {% if request.user.is_employer or request.user.is_prescriber %}
+        <script async src="https://tally.so/widgets/embed.js"></script>
+        <script src='{% static "js/nps_popup.js" %}' data-delaypopup="false" data-userkind="{% if request.user.is_employer %}employeur{% else %}prescripteur{% endif %}" data-page="depot-candidature">
+        </script>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

On est en train de quitter Hotjar. 🔪

## :cake: Comment ? 

J'ai ajouté un script `nps_popup.js` statique qui prend quelques paramètres.

Je ne suis pas très à l'aise en js donc ne pas hésiter à me dire si j'aurai du faire autrement.

## :computer: Captures d'écran

### page liste candidatures, employeur

<img width="744" alt="image" src="https://github.com/user-attachments/assets/8045491b-5488-4a7e-b2c0-a36c48ba8ec4" />

<img width="742" alt="image" src="https://github.com/user-attachments/assets/8ab936b8-3992-47de-8fc2-69b47494c9c4" />

### page dépôt de candidature, prescripteur

<img width="742" alt="image" src="https://github.com/user-attachments/assets/a866d7a1-8189-472a-a3ae-9e241b965d93" />

### les `hiddenFields` arrivent bien à destination

![image](https://github.com/user-attachments/assets/76b8917b-2218-493f-a66c-307a80dd4fec)

<img width="672" alt="image" src="https://github.com/user-attachments/assets/0f386f1b-5908-4ff0-98f2-0538b6d8851a" />




