### PR TITLE
apis: Remove "numerique" from data⋅inclusion themes

### DIFF
--- a/itou/utils/apis/data_inclusion.py
+++ b/itou/utils/apis/data_inclusion.py
@@ -13,7 +13,6 @@ API_THEMATIQUES = [
     "equipement-et-alimentation",
     "logement-hebergement",
     "mobilite",
-    "numerique",
     "remobilisation",
 ]
 

--- a/tests/utils/apis/test_data_inclusion_api.py
+++ b/tests/utils/apis/test_data_inclusion_api.py
@@ -36,7 +36,6 @@ def test_data_inclusion_client(settings, respx_mock):
             "equipement-et-alimentation",
             "logement-hebergement",
             "mobilite",
-            "numerique",
             "remobilisation",
         ],
     }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Trop de serices en thématique Numérique, pas adapté selon le métier.

## :cake: Comment ? <!-- optionnel -->

On retire de la liste des thèmes de recherche.

## :rotating_light: À vérifier

- NA Mettre à jour le CHANGELOG_breaking_changes.md ?
- NA Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Idéalement, voir sur des fiches de poste que l'on n'a plus de thématiques "numérique" proposées.

