### PR TITLE
admin: Ajouter les certificateur d’identité au profil demandeur d’emploi

### DIFF
--- a/itou/users/migrations/0026_identitycertification.py
+++ b/itou/users/migrations/0026_identitycertification.py
@@ -21,9 +21,16 @@ class Migration(migrations.Migration):
                             ("api_particulier", "API Particulier"),
                         ],
                         max_length=32,
+                        verbose_name="certificateur",
                     ),
                 ),
-                ("certified_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "certified_at",
+                    models.DateTimeField(
+                        default=django.utils.timezone.now,
+                        verbose_name="profil demandeur d'emploi",
+                    ),
+                ),
                 (
                     "jobseeker_profile",
                     models.ForeignKey(

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1422,8 +1422,15 @@ class IdentityCertification(models.Model):
         related_name="identity_certifications",
         on_delete=models.CASCADE,
     )
-    certifier = models.CharField(max_length=32, choices=IdentityCertificationAuthorities)
-    certified_at = models.DateTimeField(default=timezone.now)
+    certifier = models.CharField(
+        max_length=32,
+        choices=IdentityCertificationAuthorities,
+        verbose_name="certificateur",
+    )
+    certified_at = models.DateTimeField(
+        default=timezone.now,
+        verbose_name=JobSeekerProfile._meta.verbose_name,
+    )
 
     objects = IdentityCertificationManager()
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suivre les certifications dans l’admin.
