### PR TITLE
Candidature: Uniformisation du nom d'un paramètre GET

### DIFF
--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -18,7 +18,7 @@
                 <p>
                     Dernière actualisation du profil : {{ job_seeker.last_checked_at|date }} à {{ job_seeker.last_checked_at|time }}
                     {% if can_view_personal_information and not request.user.is_job_seeker %}
-                        <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
+                        <a class="btn-link ms-3" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker_public_id=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Vérifier le profil</a>
                     {% endif %}
                     {% if new_check_needed %}<i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>{% endif %}
                 </p>

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -49,7 +49,7 @@
                 {% else %}
                     <div class="form-group col-12 col-lg-auto">
                         {% url 'apply:start' company_pk=siae.pk as apply_url %}
-                        <a href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
+                        <a href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
                            class="btn btn-lg btn-white btn-block btn-ico"
                            {% matomo_event "candidature" "clic" "start_application" %}
                            aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
@@ -214,7 +214,7 @@
                                 <div class="d-flex justify-content-end mt-3">
                                     {% url 'apply:start' company_pk=siae.pk as apply_url %}
                                     <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
-                                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
+                                       href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
                                        {% matomo_event "candidature" "clic" "start_application" %}
                                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                                         <i class="ri-draft-line" aria-hidden="true"></i>

--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -11,7 +11,7 @@
                     <i class="ri-community-line fw-medium me-1" aria-hidden="true"></i>
                     <span class="fw-bold">{{ job_description.market_context_description | default:"Entreprise anonyme" }}</span>
                 {% else %}
-                    <a href="{% url_add_query job_description.company.get_card_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
+                    <a href="{% url_add_query job_description.company.get_card_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        class="btn-ico btn-link"
                        {% matomo_event "candidature" "clic" "clic-structure-fichedeposte" %}>
                         <i class="ri-community-line fw-medium" aria-hidden="true"></i>
@@ -32,7 +32,7 @@
             <li class="list-group-item list-group-item-action">
                 <div class="d-flex flex-column flex-md-row justify-content-md-between">
                     <div class="order-2 order-md-1">
-                        <a href="{% url_add_query job_description.get_absolute_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
+                        <a href="{% url_add_query job_description.get_absolute_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                            class="fw-bold text-decoration-none {% if job_description.is_external %}has-external-link{% else %}stretched-link{% endif %}"
                            {% if job_description.is_external %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte-externe" %} rel="noopener" target="_blank" aria-label="Visiter l'offre sur le site d'origine" {% else %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte" %} aria-label="Aller vers la description de ce poste" {% endif %}>
                             {{ job_description.display_name | capfirst }}

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -52,7 +52,7 @@
                 </div>
             {% else %}
                 <div>
-                    <a href="{% url_add_query siae.get_card_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
+                    <a href="{% url_add_query siae.get_card_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        class="btn btn-outline-primary btn-block w-100 w-md-auto white-space-nowrap"
                        {% matomo_event "candidature" "clic" "clic-structure" %}>Voir la fiche de l'entreprise</a>
                 </div>
@@ -80,7 +80,7 @@
                     <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
                     {% url 'apply:start' company_pk=siae.pk as apply_url %}
                     <a class="btn btn-ico btn-primary"
-                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
+                       href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                         <i class="ri ri-draft-line" aria-hidden="true"></i>
@@ -163,7 +163,7 @@
                     <p class="mb-3 mb-md-0">Cette structure vous intéresse ?</p>
                     {% url 'apply:start' company_pk=siae.pk as apply_url %}
                     <a class="btn btn-ico btn-primary"
-                       href="{% url_add_query apply_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
+                       href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
                         <i class="ri ri-draft-line" aria-hidden="true"></i>

--- a/itou/templates/companies/includes/_company_info.html
+++ b/itou/templates/companies/includes/_company_info.html
@@ -35,9 +35,9 @@
             {% else %}
                 {% url 'companies_views:card' siae_id=company.pk as company_url %}
                 {% if back_url|default:'' and not open_in_tab|default:False %}
-                    {% url_add_query company_url job_seeker=job_seeker.public_id|default:'' back_url=back_url as company_url_params %}
+                    {% url_add_query company_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=back_url as company_url_params %}
                 {% else %}
-                    {% url_add_query company_url job_seeker=job_seeker.public_id|default:'' as company_url_params %}
+                    {% url_add_query company_url job_seeker_public_id=job_seeker.public_id|default:'' as company_url_params %}
                 {% endif %}
                 <a href="{{ company_url_params }}" class="btn btn-secondary btn-block mt-4" {% if open_in_tab|default:False %}target="_blank"{% endif %}>Voir la fiche de l'entreprise</a>
             {% endif %}

--- a/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
@@ -8,9 +8,9 @@
                class="fw-bold text-decoration-none stretched-link">{{ job.display_name }}</a>
         {% else %}
             {% if job.pk %}
-                {% url_add_query job.get_absolute_url job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path as job_url %}
+                {% url_add_query job.get_absolute_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path as job_url %}
             {% else %}
-                {% url_add_query "#" job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path as job_url %}
+                {% url_add_query "#" job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path as job_url %}
             {% endif %}
             <a href="{{ job_url }}" class="fw-bold text-decoration-none stretched-link" {% matomo_event "candidature" "clic" "clic-metiers" %}>{{ job.display_name }}</a>
         {% endif %}

--- a/itou/templates/companies/includes/_siae_jobdescription.html
+++ b/itou/templates/companies/includes/_siae_jobdescription.html
@@ -10,7 +10,7 @@
                        class="fw-bold stretched-link order-2 order-md-1">{{ job.display_name }}</a>
 
                 {% else %}
-                    <a href="{% url_add_query job.get_absolute_url job_seeker=job_seeker.public_id|default:"" back_url=back_url|default:request.get_full_path %}"
+                    <a href="{% url_add_query job.get_absolute_url job_seeker_public_id=job_seeker.public_id|default:"" back_url=back_url|default:request.get_full_path %}"
                        class="fw-bold stretched-link order-2 order-md-1"
                        {% matomo_event "candidature" "clic" "clic-metiers" %}>{{ job.display_name }}</a>
                 {% endif %}

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -70,7 +70,7 @@
                     {% else %}
                         <div class="form-group col-12 col-lg-auto">
                             {% url "apply:start" company_pk=siae.pk as apply_url %}
-                            <a href="{% url_add_query apply_url job_description_id=job.pk job_seeker=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
+                            <a href="{% url_add_query apply_url job_description_id=job.pk job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                                class="btn btn-lg btn-white btn-block btn-ico"
                                {% matomo_event "candidature" "clic" "start_application" %}
                                aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -19,7 +19,8 @@
     <div class="c-box my-4">
         <h2>
             Informations personnelles
-            <a class="btn btn-outline-primary float-end" href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Mettre à jour</a>
+            <a class="btn btn-outline-primary float-end"
+               href="{% url "job_seekers_views:update_job_seeker_start" %}{% querystring job_seeker_public_id=job_seeker.public_id from_url=request.get_full_path|urlencode %}">Mettre à jour</a>
         </h2>
 
         {% include "apply/includes/profile_infos.html" %}

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -22,9 +22,9 @@
         {% fragment as c_title__cta %}
             {% url 'search:employers_results' as search_url %}
             {% if can_view_personal_information %}
-                {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
+                {% url_add_query search_url job_seeker_public_id=job_seeker.public_id city=job_seeker.city_slug as url_query %}
             {% else %}
-                {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
+                {% url_add_query search_url job_seeker_public_id=job_seeker.public_id as url_query %}
             {% endif %}
             {% if can_edit_iae_eligibility %}
                 <a href="{% url 'eligibility_views:update' public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}" class="btn btn-lg btn-ico btn-secondary">

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -44,9 +44,9 @@
                             <td class="text-end {% if request.current_organization.is_authorized %}w-100px{% else %}w-50px{% endif %}">
                                 {% url "search:employers_results" as search_url %}
                                 {% if job_seeker.user_can_view_personal_information %}
-                                    {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
+                                    {% url_add_query search_url job_seeker_public_id=job_seeker.public_id city=job_seeker.city_slug as url_query %}
                                 {% else %}
-                                    {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
+                                    {% url_add_query search_url job_seeker_public_id=job_seeker.public_id as url_query %}
                                 {% endif %}
                                 <a class="btn btn-sm btn-link btn-ico-only" href="{{ url_query }}" data-bs-toggle="tooltip" data-bs-title="Postuler pour ce candidat" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %}>
                                     <i class="ri-draft-line" aria-label="Postuler pour ce candidat"></i>

--- a/itou/templates/job_seekers_views/job_applications.html
+++ b/itou/templates/job_seekers_views/job_applications.html
@@ -22,9 +22,9 @@
         {% fragment as c_title__cta %}
             {% url 'search:employers_results' as search_url %}
             {% if can_view_personal_information %}
-                {% url_add_query search_url job_seeker=job_seeker.public_id city=job_seeker.city_slug as url_query %}
+                {% url_add_query search_url job_seeker_public_id=job_seeker.public_id city=job_seeker.city_slug as url_query %}
             {% else %}
-                {% url_add_query search_url job_seeker=job_seeker.public_id as url_query %}
+                {% url_add_query search_url job_seeker_public_id=job_seeker.public_id as url_query %}
             {% endif %}
             <a href="{{ url_query }}" {% matomo_event "candidature" "clic" "postuler-pour-ce-candidat" %} class="btn btn-lg btn-primary btn-ico">
                 <i class="ri-draft-line fw-medium" aria-hidden="true"></i>

--- a/itou/templates/search/includes/siaes_search_content.html
+++ b/itou/templates/search/includes/siaes_search_content.html
@@ -8,7 +8,7 @@
                         <div class="col-12">
                             {% include "search/includes/siaes_search_subtitle.html" %}
                             <div class="d-block w-100">
-                                <form hx-get="{% url_add_query request.path job_seeker=job_seeker.public_id|default:'' %}"
+                                <form hx-get="{% url_add_query request.path job_seeker_public_id=job_seeker.public_id|default:'' %}"
                                       hx-trigger="change delay:.5s"
                                       hx-include="#id_city"
                                       hx-indicator="#job-search-results"

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -67,7 +67,8 @@ def _check_job_seeker_approval(request, job_seeker, siae):
 def _get_job_seeker_to_apply_for(request):
     job_seeker = None
 
-    if job_seeker_public_id := request.GET.get("job_seeker"):
+    # FIXME(alaurent) Remove or clause in a week
+    if job_seeker_public_id := request.GET.get("job_seeker_public_id") or request.GET.get("job_seeker"):
         try:
             job_seeker = User.objects.filter(kind=UserKind.JOB_SEEKER, public_id=job_seeker_public_id).get()
         except (
@@ -972,4 +973,6 @@ class ApplyForJobSeekerMixin:
         }
 
     def get_job_seeker_query_string(self):
-        return {"job_seeker": self.request.GET.get("job_seeker")} if self.request.GET.get("job_seeker", None) else {}
+        # FIXME(alaurent) remove or clause in a week
+        job_seeker_public_id = self.request.GET.get("job_seeker_public_id") or self.request.GET.get("job_seeker")
+        return {"job_seeker_public_id": job_seeker_public_id} if job_seeker_public_id else {}

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -307,7 +307,7 @@ class JobSeekerBaseView(ExpectedJobSeekerSessionMixin, TemplateView):
             return reverse("gps:group_list")
         if self.standalone_creation and self.is_job_seeker_in_user_jobseekers_list(job_seeker) and not created:
             params = {
-                "job_seeker": job_seeker.public_id,
+                "job_seeker_public_id": job_seeker.public_id,
                 "city": job_seeker.city_slug if can_view_personal_information(self.request, job_seeker) else "",
             }
             return add_url_params(reverse("search:employers_results"), params)
@@ -863,8 +863,10 @@ class UpdateJobSeekerStartView(View):
         super().setup(request, *args, **kwargs)
 
         try:
+            # FIXME(alaurent) remove or clause in a week
             job_seeker = get_object_or_404(
-                User.objects.filter(kind=UserKind.JOB_SEEKER), public_id=request.GET.get("job_seeker")
+                User.objects.filter(kind=UserKind.JOB_SEEKER),
+                public_id=request.GET.get("job_seeker_public_id") or request.GET.get("job_seeker"),
             )
         except ValidationError:
             raise Http404("Aucun candidat n'a été trouvé")

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -40,11 +40,7 @@ class EmployerSearchBaseView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, Form
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        # An extra GET parameter is used: job_seeker.
-        # It is not part of the form so we pop it.
-        params_get = self.request.GET.copy()
-        params_get.pop("job_seeker", None)
-        kwargs["data"] = params_get or None
+        kwargs["data"] = self.request.GET or None
         return kwargs
 
     def get(self, request, *args, **kwargs):

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -214,7 +214,7 @@ class TestProcessViews:
         employer = company.members.first()
         client.force_login(employer)
 
-        back_url = f"{reverse('apply:list_for_siae')}?job_seeker={job_application.job_seeker.id}"
+        back_url = f"{reverse('apply:list_for_siae')}?job_seeker_public_id={job_application.job_seeker.id}"
         url = add_url_params(
             reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk}),
             {"back_url": back_url},

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -478,7 +478,7 @@ class TestHire:
         prescriber = PrescriberFactory()
         client.force_login(company.members.first())
         params = {
-            "job_seeker": prescriber.public_id,
+            "job_seeker_public_id": prescriber.public_id,
             "from_url": reverse("dashboard:index"),
         }
         url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -3811,7 +3811,7 @@ class TestLastCheckedAtView:
         assert response.status_code == 200
 
         params = {
-            "job_seeker": self.job_seeker.public_id,
+            "job_seeker_public_id": self.job_seeker.public_id,
             "from_url": url,
         }
         update_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -3880,7 +3880,7 @@ class UpdateJobSeekerTestMixin:
         )
 
         params = {
-            "job_seeker": self.job_seeker.public_id,
+            "job_seeker_public_id": self.job_seeker.public_id,
             "from_url": from_url,
         }
         self.start_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -4475,7 +4475,7 @@ class TestUpdateJobSeekerStep3View:
 
         # START to setup jobseeker session
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse(
                 "apply:application_jobs",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
@@ -5275,7 +5275,7 @@ class TestCheckJobSeekerInformationsForHire:
         assertTemplateNotUsed(response, "approvals/includes/box.html")
         assertContains(response, "Éligibilité IAE à valider")
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": url_check_infos,
         }
         url_update = f"""
@@ -5314,7 +5314,7 @@ class TestCheckJobSeekerInformationsForHire:
         assertContains(response, "Informations personnelles de Son Prénom SON NOM DE FAMILLE")
         assertTemplateNotUsed(response, "approvals/includes/box.html")
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": url_check_infos,
         }
         url_update = f"""

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -43,7 +43,7 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:list"))
-        next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
+        next_url = f"{reverse('search:employers_results')}?job_seeker_public_id={job_seeker.public_id}"
         assertContains(
             response,
             f"""
@@ -64,7 +64,7 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
-        next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
+        next_url = f"{reverse('search:employers_results')}?job_seeker_public_id={job_seeker.public_id}"
         assertContains(
             response,
             (
@@ -92,7 +92,7 @@ class TestApplyAsPrescriber:
 
         # Has link to company card with job_seeker public_id
         company_url_with_job_seeker_id = (
-            f"{guerande_company.get_card_url()}?job_seeker={job_seeker.public_id}"
+            f"{guerande_company.get_card_url()}?job_seeker_public_id={job_seeker.public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(
@@ -104,7 +104,8 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         apply_company_url = (
-            reverse("apply:start", kwargs={"company_pk": guerande_company.pk}) + f"?job_seeker={job_seeker.public_id}"
+            reverse("apply:start", kwargs={"company_pk": guerande_company.pk})
+            + f"?job_seeker_public_id={job_seeker.public_id}"
         )
         response = client.get(apply_company_url)
 
@@ -203,7 +204,7 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:list"))
-        next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
+        next_url = f"{reverse('search:employers_results')}?job_seeker_public_id={job_seeker.public_id}"
         assertContains(response, "A… Z…")
         assertContains(
             response,
@@ -225,7 +226,7 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
-        next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
+        next_url = f"{reverse('search:employers_results')}?job_seeker_public_id={job_seeker.public_id}"
         assertContains(response, "A… Z…")
         assertContains(
             response,
@@ -253,7 +254,7 @@ class TestApplyAsPrescriber:
 
         # Has link to company card with job_seeker public_id
         company_url_with_job_seeker_id = (
-            f"{guerande_company.get_card_url()}?job_seeker={job_seeker.public_id}"
+            f"{guerande_company.get_card_url()}?job_seeker_public_id={job_seeker.public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(
@@ -265,7 +266,8 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         apply_company_url = (
-            reverse("apply:start", kwargs={"company_pk": guerande_company.pk}) + f"?job_seeker={job_seeker.public_id}"
+            reverse("apply:start", kwargs={"company_pk": guerande_company.pk})
+            + f"?job_seeker_public_id={job_seeker.public_id}"
         )
         response = client.get(apply_company_url)
 
@@ -346,7 +348,7 @@ class TestApplyAsPrescriber:
         # ----------------------------------------------------------------------
 
         apply_company_url_incorrect_uuid = (
-            reverse("apply:start", kwargs={"company_pk": company.pk}) + "?job_seeker=123"
+            reverse("apply:start", kwargs={"company_pk": company.pk}) + "?job_seeker_public_id=123"
         )
         response = client.get(apply_company_url_incorrect_uuid)
         assert response.status_code == 404
@@ -356,7 +358,7 @@ class TestApplyAsPrescriber:
 
         apply_job_description_url_incorrect_uuid = (
             reverse("apply:start", kwargs={"company_pk": company.pk})
-            + f"?job_description_id={job_description.pk}&job_seeker=123"
+            + f"?job_description_id={job_description.pk}&job_seeker_public_id=123"
         )
 
         response = client.get(apply_job_description_url_incorrect_uuid)
@@ -398,7 +400,7 @@ class TestApplyAsCompany:
         # ----------------------------------------------------------------------
 
         response = client.get(reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id}))
-        next_url = f"{reverse('search:employers_results')}?job_seeker={job_seeker.public_id}"
+        next_url = f"{reverse('search:employers_results')}?job_seeker_public_id={job_seeker.public_id}"
         assertContains(
             response,
             (
@@ -425,7 +427,7 @@ class TestApplyAsCompany:
 
         # Has link to company card with job_seeker public_id
         company_url_with_job_seeker_id = (
-            f"{other_company.get_card_url()}?job_seeker={job_seeker.public_id}"
+            f"{other_company.get_card_url()}?job_seeker_public_id={job_seeker.public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(
@@ -437,7 +439,8 @@ class TestApplyAsCompany:
         # ----------------------------------------------------------------------
 
         apply_company_url = (
-            reverse("apply:start", kwargs={"company_pk": other_company.pk}) + f"?job_seeker={job_seeker.public_id}"
+            reverse("apply:start", kwargs={"company_pk": other_company.pk})
+            + f"?job_seeker_public_id={job_seeker.public_id}"
         )
         response = client.get(apply_company_url)
 
@@ -514,7 +517,7 @@ class TestApplyAsCompany:
         # ----------------------------------------------------------------------
 
         apply_company_url_incorrect_uuid = (
-            reverse("apply:start", kwargs={"company_pk": other_company.pk}) + "?job_seeker=123"
+            reverse("apply:start", kwargs={"company_pk": other_company.pk}) + "?job_seeker_public_id=123"
         )
         response = client.get(apply_company_url_incorrect_uuid)
         assert response.status_code == 404
@@ -524,7 +527,7 @@ class TestApplyAsCompany:
 
         apply_job_description_url_incorrect_uuid = (
             reverse("apply:start", kwargs={"company_pk": other_company.pk})
-            + f"?job_description_id={job_description.pk}&job_seeker=123"
+            + f"?job_description_id={job_description.pk}&job_seeker_public_id=123"
         )
 
         response = client.get(apply_job_description_url_incorrect_uuid)
@@ -548,7 +551,8 @@ class TestApplyAsJobSeeker:
         # ----------------------------------------------------------------------
 
         apply_company_url_other_uuid = (
-            reverse("apply:start", kwargs={"company_pk": company.pk}) + f"?job_seeker={other_job_seeker.public_id}"
+            reverse("apply:start", kwargs={"company_pk": company.pk})
+            + f"?job_seeker_public_id={other_job_seeker.public_id}"
         )
         response = client.get(apply_company_url_other_uuid, follow=True)
         assert response.request["PATH_INFO"] == check_info_url
@@ -560,7 +564,7 @@ class TestApplyAsJobSeeker:
 
         apply_job_description_url_other_uuid = (
             reverse("apply:start", kwargs={"company_pk": company.pk})
-            + f"?job_description_id={job_description.pk}&job_seeker=123"
+            + f"?job_description_id={job_description.pk}&job_seeker_public_id=123"
         )
 
         response = client.get(apply_job_description_url_other_uuid, follow=True)

--- a/tests/www/companies_views/test_card_views.py
+++ b/tests/www/companies_views/test_card_views.py
@@ -290,7 +290,10 @@ class TestCardView:
         EXIT_URL_EMPLOYER = reverse("apply:list_prescriptions")
         EXIT_URL_PRESCRIBER = reverse("job_seekers_views:list")
 
-        url = reverse("companies_views:card", kwargs={"siae_id": company.pk}) + f"?job_seeker={job_seeker_public_id}"
+        url = (
+            reverse("companies_views:card", kwargs={"siae_id": company.pk})
+            + f"?job_seeker_public_id={job_seeker_public_id}"
+        )
 
         # If anonymous user, return a 200 without the banner
         response = client.get(url)
@@ -325,25 +328,26 @@ class TestCardView:
 
         # Has link to job description with job_seeker public_id
         job_description_url_with_job_seeker_id = (
-            f"{job_description.get_absolute_url()}?job_seeker={job_seeker_public_id}"
+            f"{job_description.get_absolute_url()}?job_seeker_public_id={job_seeker_public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(response, job_description_url_with_job_seeker_id)
 
         # Has link to apply with job_seeker public_id
         apply_url_with_job_seeker_id = add_url_params(
-            reverse("apply:start", kwargs={"company_pk": company.pk}), {"job_seeker": job_seeker_public_id}
+            reverse("apply:start", kwargs={"company_pk": company.pk}), {"job_seeker_public_id": job_seeker_public_id}
         )
         assertContains(response, apply_url_with_job_seeker_id, count=2)
 
         # When UUID is broken in GET parameters
-        broken_url = reverse("companies_views:card", kwargs={"siae_id": company.pk}) + "?job_seeker=123"
+        broken_url = reverse("companies_views:card", kwargs={"siae_id": company.pk}) + "?job_seeker_public_id=123"
         response = client.get(broken_url)
         assert response.status_code == 404
 
         # When uuid is not a job_seeker one
         not_job_seeker_url = (
-            reverse("companies_views:card", kwargs={"siae_id": company.pk}) + f"?job_seeker={prescriber.public_id}"
+            reverse("companies_views:card", kwargs={"siae_id": company.pk})
+            + f"?job_seeker_public_id={prescriber.public_id}"
         )
         response = client.get(not_job_seeker_url)
         assert response.status_code == 404
@@ -487,7 +491,7 @@ class TestJobDescriptionCardView:
 
         url = (
             reverse("companies_views:job_description_card", kwargs={"job_description_id": job_description.pk})
-            + f"?job_seeker={job_seeker_public_id}"
+            + f"?job_seeker_public_id={job_seeker_public_id}"
         )
 
         # If anonymous user, return a 200 without banner
@@ -524,7 +528,7 @@ class TestJobDescriptionCardView:
 
         # Has link to company card with job_seeker public_id
         company_url_with_job_seeker_id = (
-            f"{company.get_card_url()}?job_seeker={job_seeker_public_id}"
+            f"{company.get_card_url()}?job_seeker_public_id={job_seeker_public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(response, company_url_with_job_seeker_id)
@@ -532,14 +536,14 @@ class TestJobDescriptionCardView:
         # Has link to apply with job_seeker public_id
         apply_url_with_job_seeker_id = (
             f"{reverse('apply:start', kwargs={'company_pk': company.pk})}"
-            f"?job_description_id={job_description.pk}&amp;job_seeker={job_seeker_public_id}"
+            f"?job_description_id={job_description.pk}&amp;job_seeker_public_id={job_seeker_public_id}"
         )
         assertContains(response, apply_url_with_job_seeker_id)
 
         # When UUID is broken in GET parameters
         broken_url = (
             reverse("companies_views:job_description_card", kwargs={"job_description_id": job_description.pk})
-            + "?job_seeker=123"
+            + "?job_seeker_public_id=123"
         )
         response = client.get(broken_url)
         assert response.status_code == 404
@@ -547,7 +551,7 @@ class TestJobDescriptionCardView:
         # When uuid is not a job_seeker one
         not_job_seeker_url = (
             reverse("companies_views:job_description_card", kwargs={"job_description_id": job_description.pk})
-            + f"?job_seeker={prescriber.public_id}"
+            + f"?job_seeker_public_id={prescriber.public_id}"
         )
         response = client.get(not_job_seeker_url)
         assert response.status_code == 404

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -29,7 +29,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -274,7 +274,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -503,7 +503,7 @@
                           <span>Valider son éligibilité IAE</span>
                       
                   </a>
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -690,7 +690,7 @@
                           <span>Mettre à jour son éligibilité IAE</span>
                       
                   </a>
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -960,7 +960,7 @@
               
                   
               
-              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+              <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                   <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                   <span>Postuler pour ce candidat</span>
               </a>
@@ -1906,7 +1906,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -2159,7 +2159,7 @@
                           <span>Valider son éligibilité IAE</span>
                       
                   </a>
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -2386,7 +2386,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -2567,7 +2567,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -2798,7 +2798,7 @@
                           <span>Mettre à jour son éligibilité IAE</span>
                       
                   </a>
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -3023,7 +3023,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>
@@ -3204,7 +3204,7 @@
                   
               
               
-                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
+                  <a class="btn btn-lg btn-primary btn-ico" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=7614fc4b-aef9-4694-ab17-12324300180a&amp;city=rennes-35">
                       <i aria-hidden="true" class="ri-draft-line fw-medium"></i>
                       <span>Postuler pour ce candidat</span>
                   </a>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -1457,7 +1457,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=11111111-1111-1111-1111-111111111111&amp;city=brest-29">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   
@@ -1503,7 +1503,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=22222222-2222-2222-2222-222222222222&amp;city=brest-29">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   
@@ -1549,7 +1549,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=33333333-3333-3333-3333-333333333333&amp;city=brest-29">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   
@@ -1587,7 +1587,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=44444444-4444-4444-4444-444444444444">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=44444444-4444-4444-4444-444444444444">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   
@@ -2425,7 +2425,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=11111111-1111-1111-1111-111111111111&amp;city=brest-29">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   
@@ -2471,7 +2471,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=22222222-2222-2222-2222-222222222222&amp;city=brest-29">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   
@@ -2517,7 +2517,7 @@
                                   
                                       
                                   
-                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker=33333333-3333-3333-3333-333333333333&amp;city=brest-29">
+                                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&amp;city=brest-29">
                                       <i aria-label="Postuler pour ce candidat" class="ri-draft-line"></i>
                                   </a>
                                   

--- a/tests/www/job_seekers_views/test_create_or_update.py
+++ b/tests/www/job_seekers_views/test_create_or_update.py
@@ -461,7 +461,7 @@ class TestStandaloneCreateAsPrescriber:
                     reverse(
                         "search:employers_results",
                     ),
-                    {"job_seeker": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
+                    {"job_seeker_public_id": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
                 )
             case "in_list_organization":
                 existing_job_seeker.created_by = other_user
@@ -470,7 +470,7 @@ class TestStandaloneCreateAsPrescriber:
                     reverse(
                         "search:employers_results",
                     ),
-                    {"job_seeker": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
+                    {"job_seeker_public_id": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
                 )
             case "in_list_application":
                 existing_job_seeker.created_by = other_user_in_other_organization
@@ -479,7 +479,7 @@ class TestStandaloneCreateAsPrescriber:
                     reverse(
                         "search:employers_results",
                     ),
-                    {"job_seeker": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
+                    {"job_seeker_public_id": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
                 )
                 JobApplicationFactory(
                     job_seeker=existing_job_seeker,
@@ -539,7 +539,7 @@ class TestStandaloneCreateAsPrescriber:
                     reverse(
                         "search:employers_results",
                     ),
-                    {"job_seeker": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
+                    {"job_seeker_public_id": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
                 )
             case "in_list_organization":
                 existing_job_seeker.created_by = other_user
@@ -548,7 +548,7 @@ class TestStandaloneCreateAsPrescriber:
                     reverse(
                         "search:employers_results",
                     ),
-                    {"job_seeker": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
+                    {"job_seeker_public_id": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
                 )
             case "in_list_application":
                 existing_job_seeker.created_by = other_user_in_other_organization
@@ -557,7 +557,7 @@ class TestStandaloneCreateAsPrescriber:
                     reverse(
                         "search:employers_results",
                     ),
-                    {"job_seeker": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
+                    {"job_seeker_public_id": existing_job_seeker.public_id, "city": existing_job_seeker.city_slug},
                 )
                 JobApplicationFactory(
                     job_seeker=existing_job_seeker,
@@ -831,7 +831,7 @@ class TestUpdateAsOther:
         client.force_login(institution_member)
 
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse("dashboard:index"),
         }
         start_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -845,7 +845,7 @@ class TestUpdateAsOther:
         client.force_login(user)
 
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse("dashboard:index"),
         }
         start_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -856,7 +856,7 @@ class TestUpdateAsOther:
         job_seeker = JobSeekerFactory()
 
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse("dashboard:index"),
         }
         start_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -877,7 +877,7 @@ class TestUpdateForJobSeeker:
             kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
         )
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "company": company_pk,
             "from_url": from_url,
         }
@@ -925,7 +925,7 @@ class TestUpdateForSender:
             from_url = None
 
         params = {
-            "job_seeker": job_seeker_public_id,
+            "job_seeker_public_id": job_seeker_public_id,
             "from_url": from_url,
         }
         start_url = add_url_params(reverse("job_seekers_views:update_job_seeker_start"), params)
@@ -992,7 +992,7 @@ class TestUpdateForSender:
 
         # Init session
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse(
                 "apply:application_jobs",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
@@ -1039,7 +1039,7 @@ class TestUpdateForSender:
 
         # Init session
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse(
                 "apply:application_jobs",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},
@@ -1082,7 +1082,7 @@ class TestUpdateForSender:
 
         # Init session
         params = {
-            "job_seeker": job_seeker.public_id,
+            "job_seeker_public_id": job_seeker.public_id,
             "from_url": reverse(
                 "apply:application_jobs",
                 kwargs={"company_pk": company.pk, "job_seeker_public_id": job_seeker.public_id},

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -258,7 +258,7 @@ def test_apply_for_button_as_authorized_prescriber(client):
         response,
         (
             f'<a href="{reverse("search:employers_results")}'
-            f'?job_seeker={job_application.job_seeker.public_id}&city={job_application.job_seeker.city_slug}"'
+            f'?job_seeker_public_id={job_application.job_seeker.public_id}&city={job_application.job_seeker.city_slug}"'
             'data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"'
             'data-matomo-option="postuler-pour-ce-candidat" class="btn btn-lg btn-primary btn-ico">'
             '<i class="ri-draft-line fw-medium" aria-hidden="true"></i>'
@@ -277,7 +277,7 @@ def test_apply_for_button_as_authorized_prescriber(client):
         response,
         (
             f'<a href="{reverse("search:employers_results")}'
-            f'?job_seeker={job_application_without_address.job_seeker.public_id}" '
+            f'?job_seeker_public_id={job_application_without_address.job_seeker.public_id}" '
             'data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"'
             'data-matomo-option="postuler-pour-ce-candidat" class="btn btn-lg btn-primary btn-ico">'
             '<i class="ri-draft-line fw-medium" aria-hidden="true"></i>'
@@ -309,7 +309,7 @@ def test_apply_for_button_as_unauthorized_prescriber(client):
         response,
         (
             f'<a href="{reverse("search:employers_results")}'
-            f'?job_seeker={job_application.job_seeker.public_id}"'
+            f'?job_seeker_public_id={job_application.job_seeker.public_id}"'
             'data-matomo-event="true" data-matomo-category="candidature" data-matomo-action="clic"'
             'data-matomo-option="postuler-pour-ce-candidat" class="btn btn-lg btn-primary btn-ico">'
             '<i class="ri-draft-line fw-medium" aria-hidden="true"></i>'

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -45,7 +45,7 @@ def assert_contains_button_apply_for(response, job_seeker, with_city=True):
                 data-matomo-event="true"
                 data-matomo-category="candidature" data-matomo-action="clic"
                 data-matomo-option="postuler-pour-ce-candidat"
-                href="{reverse("search:employers_results")}?job_seeker={job_seeker.public_id}{city}">
+                href="{reverse("search:employers_results")}?job_seeker_public_id={job_seeker.public_id}{city}">
                 <i class="ri-draft-line" aria-label="Postuler pour ce candidat"></i>
             </a>
         """,

--- a/tests/www/search/tests.py
+++ b/tests/www/search/tests.py
@@ -489,13 +489,14 @@ class TestSearchCompany:
         client.force_login(prescriber)
 
         response = client.get(
-            self.URL, {"city": guerande.slug, "distance": 100, "job_seeker": job_application.job_seeker.public_id}
+            self.URL,
+            {"city": guerande.slug, "distance": 100, "job_seeker_public_id": job_application.job_seeker.public_id},
         )
         assertContains(response, f"Vous postulez actuellement pour {job_application.job_seeker.get_full_name()}")
 
         # Has link to company card with job_seeker public_id
         company_url_with_job_seeker_id = (
-            f"{guerande_company.get_card_url()}?job_seeker={job_seeker_public_id}"
+            f"{guerande_company.get_card_url()}?job_seeker_public_id={job_seeker_public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(
@@ -505,20 +506,22 @@ class TestSearchCompany:
 
         # Has link to job description with job_seeker public_id
         job_description_url_with_job_seeker_id = (
-            f"{job_description.get_absolute_url()}?job_seeker={job_seeker_public_id}"
+            f"{job_description.get_absolute_url()}?job_seeker_public_id={job_seeker_public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(response, job_description_url_with_job_seeker_id)
 
         # Has link to apply to company with job_seeker public_id
         apply_url_with_job_seeker_id = (
-            f"{reverse('apply:start', kwargs={'company_pk': guerande_company.pk})}?job_seeker={job_seeker_public_id}"
+            f"{reverse('apply:start', kwargs={'company_pk': guerande_company.pk})}"
+            f"?job_seeker_public_id={job_seeker_public_id}"
         )
         assertContains(response, apply_url_with_job_seeker_id)
 
         # Has button to reset filters with job_seeker public_id
         reset_button = (
-            f'<a href="{reverse("search:employers_results")}?city={guerande.slug}&job_seeker={job_seeker_public_id}" '
+            f'<a href="{reverse("search:employers_results")}?city={guerande.slug}'
+            f'&job_seeker_public_id={job_seeker_public_id}" '
             'class="btn btn-ico btn-dropdown-filter" aria-label="Réinitialiser les filtres actifs">'
             '<i class="ri-eraser-line fw-medium" aria-hidden="true"></i>'
             "<span>Effacer tout</span></a>"
@@ -1298,7 +1301,7 @@ class TestJobDescriptionSearchView:
 
         # Has link to company card with job_seeker public_id
         company_url_with_job_seeker_id = (
-            f"{guerande_company.get_card_url()}?job_seeker={job_seeker_public_id}"
+            f"{guerande_company.get_card_url()}?job_seeker_public_id={job_seeker_public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(
@@ -1308,7 +1311,7 @@ class TestJobDescriptionSearchView:
 
         # Has link to job description with job_seeker public_id
         job_description_url_with_job_seeker_id = (
-            f"{job_description.get_absolute_url()}?job_seeker={job_seeker_public_id}"
+            f"{job_description.get_absolute_url()}?job_seeker_public_id={job_seeker_public_id}"
             f"&amp;back_url={quote(response.wsgi_request.get_full_path())}"
         )
         assertContains(response, job_description_url_with_job_seeker_id)
@@ -1316,7 +1319,7 @@ class TestJobDescriptionSearchView:
         # Has button to reset filters with job_seeker public_id
         reset_button = (
             f'<a href="{reverse("search:job_descriptions_results")}?city={guerande.slug}'
-            f'&job_seeker={job_seeker_public_id}" '
+            f'&job_seeker_public_id={job_seeker_public_id}" '
             'class="btn btn-ico btn-dropdown-filter" aria-label="Réinitialiser les filtres actifs">'
             '<i class="ri-eraser-line fw-medium" aria-hidden="true"></i>'
             "<span>Effacer tout</span></a>"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce changement va permettre d'utiliser le même nom de paramètre dans les différentes vues utilisées dans le parcours de candidature, et donc de simplifier la récupération de l'information.

Comme il n'y a pas de changement des schémas d'url mais juste d'un nom de paramètre GET, les `or ...` suffisent à garantir la rétrocompatibilité le temps que tout le monde soit déconnecté

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
