### PR TITLE
Mise a jour des préfixes de catégories de changelog dans le PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,22 +20,21 @@
 <!--
 # Catégories changelog
 
- +--------------------------|--------------------------+
- | API                      | Notifications            |
- | Accessibilité            | Page d’accueil           |
- | Admin                    | PASS IAE                 |
- | Annexes financières      | Performances             |
- | Candidature              | Pilotage                 |
- | Connexion                | Profil salarié           |
- | Contrôle a posteriori    | Prescripteur             |
- | Demandes de prolongation | Recherche employeur      |
- | Demandeur d’emploi       | Recherche fiche de poste |
- | Employeur                | Recherche prescripteur   |
- | Fiche de poste           | Stabilité                |
- | Fiche entreprise         | Statistiques             |
- | Fiches salarié           | Tableau de bord          |
- | GEIQ                     | UX/UI                    |
- | Inscription              | Vie privée               |
- +--------------------------|--------------------------+
-
+ +-------------------------|--------------------------+
+| API                      | Interface                |
+| Accessibilité            | Notifications            |
+| Admin                    | Page d’accueil           |
+| Annexes financières      | PASS IAE                 |
+| Candidature              | Performances             |
+| Connexion                | Pilotage                 |
+| Contrôle a posteriori    | Prescripteur             |
+| Demandes de prolongation | Profil salarié           |
+| Demandeur d’emploi       | Recherche employeur      |
+| Employeur                | Recherche fiche de poste |
+| Fiche de poste           | Recherche prescripteur   |
+| Fiche entreprise         | Stabilité                |
+| Fiches salarié           | Statistiques             |
+| GEIQ                     | Tableau de bord          |
+| Inscription              | Vie privée               |
++--------------------------|--------------------------+
 -->


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour ne pas utiliser une autre catégorie moins adaptée (genre Stabilité) lorsqu’il est question de refactoring.
Comme [ici](https://github.com/gip-inclusion/les-emplois/pull/5972) ou [là](https://github.com/gip-inclusion/les-emplois/pull/5928) par exemple

