### PR TITLE
Fiches salarié : Correction des actions "Annuler" et "Retour" pour le tunnel "Créer une fiche salarié"

### DIFF
--- a/itou/templates/employee_record/add.html
+++ b/itou/templates/employee_record/add.html
@@ -66,9 +66,8 @@
                                 </p>
                             </div>
                             <hr>
-                            {% url "employee_record_views:list" as reset_url %}
                             {% if wizard_steps.prev %}
-                                {% itou_buttons_form primary_label=wizard_steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url secondary_name="wizard_goto_step" secondary_value=wizard_steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_name="création" %}
+                                {% itou_buttons_form primary_label=wizard_steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url secondary_url=wizard_steps.prev matomo_category="fiches-salarié" matomo_action="submit" matomo_name="création" %}
                             {% else %}
                                 {% itou_buttons_form primary_label=wizard_steps.next|yesno:"Suivant,Confirmer" reset_url=reset_url %}
                             {% endif %}

--- a/itou/www/apply/views/batch_views.py
+++ b/itou/www/apply/views/batch_views.py
@@ -201,7 +201,7 @@ def _start_refuse_wizard(request, *, application_ids, next_url, from_detail_view
     if not application_ids:
         return HttpResponseRedirect(next_url)
 
-    return RefuseWizardView.initiliaze_session_and_start(
+    return RefuseWizardView.initialize_session_and_start(
         request,
         reset_url=next_url,
         extra_session_data={

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -67,7 +67,7 @@ STEPS = [
 
 @check_user(lambda user: user.is_employer)
 def start_add_wizard(request):
-    return AddView.initiliaze_session_and_start(request, reset_url=get_safe_url(request, "reset_url"))
+    return AddView.initialize_session_and_start(request, reset_url=get_safe_url(request, "reset_url"))
 
 
 class AddViewStep(enum.StrEnum):

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -94,7 +94,7 @@ class AddView(UserPassesTestMixin, WizardView):
         hiring_of_the_company = JobApplication.objects.accepted().filter(to_company=self.company)
         if step == AddViewStep.CHOOSE_EMPLOYEE:
             employees = []
-            # Add job seekers in order, whithout duplicates
+            # Add job seekers in order, without duplicates
             for job_app in hiring_of_the_company.eligible_as_employee_record(self.company).select_related(
                 "job_seeker"
             ):

--- a/itou/www/utils/wizard.py
+++ b/itou/www/utils/wizard.py
@@ -25,7 +25,7 @@ class WizardView(TemplateView):
     @classmethod
     def initialize_session_and_start(cls, request, reset_url, extra_session_data=None):
         if reset_url is None:
-            # This is somewhat extreme but will force developpers to always provide a proper next_url
+            # This is somewhat extreme but will force developers to always provide a proper next_url
             raise Http404
         session_data = {
             "config": {

--- a/itou/www/utils/wizard.py
+++ b/itou/www/utils/wizard.py
@@ -23,7 +23,7 @@ class WizardView(TemplateView):
     template_name = None
 
     @classmethod
-    def initiliaze_session_and_start(cls, request, reset_url, extra_session_data=None):
+    def initialize_session_and_start(cls, request, reset_url, extra_session_data=None):
         if reset_url is None:
             # This is somewhat extreme but will force developpers to always provide a proper next_url
             raise Http404

--- a/tests/www/employee_record_views/__snapshots__/test_add.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_add.ambr
@@ -521,7 +521,6 @@
                               </div>
                               <hr/>
                               
-                              
                                   
   
   <div class="row">
@@ -541,9 +540,9 @@
               
                   <div class="form-group col col-lg-auto order-1 order-lg-2">
                       
-                          <button aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" name="wizard_goto_step" type="submit" value="/employee_record/add/[UUID of session]/choose-employee">
+                          <a aria-label="Retourner à l’étape précédente" class="btn btn-block btn-outline-primary" href="/employee_record/add/[UUID of session]/choose-employee">
                               <span>Retour</span>
-                          </button>
+                          </a>
                       
                   </div>
               
@@ -952,7 +951,6 @@
                                   </p>
                               </div>
                               <hr/>
-                              
                               
                                   
   


### PR DESCRIPTION
## :thinking: Pourquoi ?

Vu ce matin en atelier métier.

Le `secondary_name="wizard_goto_step" secondary_value=wizard_steps.prev` faisait qu'au clic on validais le formulaire et on étais donc envoyé vers le tunnel de création de la FS.

Le `reset_url` est obligatoire dans notre `WizardView` donc autant garder les filtres sélectionnés par l'utilisateur.

J'en profite pour corriger des typo qui traînent :).