### PR TITLE
[GEN-2321] Stabilité: traitement des logs de Import EA EATT

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -6,6 +6,7 @@ https://docs.djangoproject.com/en/dev/ref/settings
 import datetime
 import json
 import os
+import re
 import warnings
 
 from botocore.config import Config
@@ -328,7 +329,14 @@ LOGGING = {
     },
 }
 
-DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE = r"django_datadog_logger\.middleware\.request_log"
+DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE = re.compile(
+    r"""
+    ^(
+        django_datadog_logger\.middleware\.request_log  # Built-in datadog logger.
+        |itou(\..+)?  # Itou root logger and children.
+    )$""",
+    re.VERBOSE,
+)
 
 AUTH_USER_MODEL = "users.User"
 

--- a/tests/companies/__snapshots__/test_import_ea_eatt.ambr
+++ b/tests/companies/__snapshots__/test_import_ea_eatt.ambr
@@ -1,4 +1,114 @@
 # serializer version: 1
+# name: test_clean_old_archives[logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 1] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': "Going to delete the old archive 'FLUX_EA2_ITOU_20240802.zip'",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': "Old archive 'FLUX_EA2_ITOU_20240802.zip' was deleted",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': "Going to delete the old archive 'FLUX_EA2_ITOU_20240801.zip'",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': "Old archive 'FLUX_EA2_ITOU_20240801.zip' was deleted",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 1] sftp session closed.',
+      'module': 'sftp',
+    }),
+  ])
+# ---
+# name: test_clean_old_archives_dry_run[logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'clean_old_archives',
+      'levelno': 20,
+      'message': "Going to delete the old archive 'FLUX_EA2_ITOU_20250512.zip'",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+  ])
+# ---
 # name: test_process_file_from_archive[data]
   list([
     tuple(
@@ -33,37 +143,76 @@
     ),
   ])
 # ---
-# name: test_process_file_from_archive[output]
-  '''
-  Loaded 3 EA_EATT from export.
-  2 EA_EATT will be created.
-  0 EA_EATT will be updated when needed.
-  0 EA_EATT will be deleted when possible.
-  EA_EATT siret=00000000000001 will be created.
-  EA_EATT siret=00000000000001 has been created with siae.id=[ID].
-  EA_EATT siret=00000000000001 will be created.
-  EA_EATT siret=00000000000001 has been created with siae.id=[ID].
-  EA_EATT siret=00000000000002 will not been created as it has no email.
-  0 EA_EATT can and will be deleted.
-  0 EA_EATT cannot be deleted as they have data.
-  --------------------------------------------------------------------------------
-  Rows in file: 5
-  Rows after kind filter: 4
-  Rows after deduplication: 3
-  Rows used: 3
-   > With a SIRET: 3
-   > With an empty email: 0
-   > Creatable: 2
-   >> Created: 2
-   >> Not created because of missing email: 1
-   > Updatable: 0
-   >> Updated: 0
-   > Deletable: 0
-   >> Deleted: 0
-   >> Undeletable: 0
-   >> Skipped: 0
-  --------------------------------------------------------------------------------
-  Done.
-  
-  '''
+# name: test_process_file_from_archive[logs]
+  list([
+    dict({
+      'funcName': 'process_file',
+      'info_stats': dict({
+        'creatable_sirets': 2,
+        'deletable_sirets': 0,
+        'not_created_because_of_missing_email': 1,
+        'rows_after_deduplication': 3,
+        'rows_after_kind_filter': 4,
+        'rows_in_file': 5,
+        'rows_used': 3,
+        'rows_with_a_siret': 3,
+        'rows_with_empty_email': 0,
+        'structures_created': 2,
+        'structures_deletable_skipped': 0,
+        'structures_deleted': 0,
+        'structures_undeletable': 0,
+        'structures_updated': 0,
+        'updatable_sirets': 0,
+      }),
+      'levelno': 20,
+      'message': '2 structures created, 0 structures updated, 0 structures deleted',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'process_file',
+      'levelno': 30,
+      'message': '1 structures not created because of missing email',
+      'module': 'import_ea_eatt',
+    }),
+  ])
+# ---
+# name: test_retrieve_archive_of_the_week[logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Files matching for this monday '20250512': FLUX_EA2_ITOU_20250512.zip",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Found the archive_of_the_week: 'FLUX_EA2_ITOU_20250512.zip'",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+  ])
 # ---

--- a/tests/companies/__snapshots__/test_import_ea_eatt.ambr
+++ b/tests/companies/__snapshots__/test_import_ea_eatt.ambr
@@ -35,25 +35,27 @@
 # ---
 # name: test_process_file_from_archive[output]
   '''
-  Loaded 2 EA_EATT from export.
-  1 EA_EATT will be created.
+  Loaded 3 EA_EATT from export.
+  2 EA_EATT will be created.
   0 EA_EATT will be updated when needed.
   0 EA_EATT will be deleted when possible.
   EA_EATT siret=00000000000001 will be created.
   EA_EATT siret=00000000000001 has been created with siae.id=[ID].
   EA_EATT siret=00000000000001 will be created.
   EA_EATT siret=00000000000001 has been created with siae.id=[ID].
+  EA_EATT siret=00000000000002 will not been created as it has no email.
   0 EA_EATT can and will be deleted.
   0 EA_EATT cannot be deleted as they have data.
   --------------------------------------------------------------------------------
-  Rows in file: 4
-  Rows after kind filter: 3
-  Rows after deduplication: 2
-  Rows used: 2
-   > With a SIRET: 2
+  Rows in file: 5
+  Rows after kind filter: 4
+  Rows after deduplication: 3
+  Rows used: 3
+   > With a SIRET: 3
    > With an empty email: 0
-   > Creatable: 1
+   > Creatable: 2
    >> Created: 2
+   >> Not created because of missing email: 1
    > Updatable: 0
    >> Updated: 0
    > Deletable: 0

--- a/tests/companies/test_import_ea_eatt.py
+++ b/tests/companies/test_import_ea_eatt.py
@@ -51,6 +51,9 @@ def archive_file_fixture():
         # EA duplicate (by SIRET) - Should be ignored
         "ITOU|Entreprise Adaptée|00000001|4|00000000000001|Dumas SA|legerdenise@example.org"
         "|00000000000001|Dumas SA|4||1||Rue|DE LA MOTTE|77550|77296|",
+        # EA with missing email
+        "ITOU|Entreprise Adaptée|00000001|5|00000000000002|Nomail SA|"
+        "|00000000000002|Nomail SA|5||1||Rue|DE LA MOTTE|77550|77296|",
         # File footer
         "Z|ASP|EA|20241231|235959|4|7|",
     ]

--- a/tests/utils/test_logger.py
+++ b/tests/utils/test_logger.py
@@ -1,0 +1,21 @@
+import pytest
+from django.conf import settings
+
+
+@pytest.mark.parametrize(
+    "logger,match",
+    [
+        ("django_datadog_logger.middleware", None),
+        ("django_datadog_logger.middleware.request_log", "django_datadog_logger.middleware.request_log"),
+        ("django_datadog_logger.middleware.request_log.foo", None),
+        ("itou", "itou"),
+        ("itou.", None),
+        ("itou.eligibility", "itou.eligibility"),
+        ("itou.eligibility.tasks", "itou.eligibility.tasks"),
+    ],
+)
+def test_extra_kwargs_in_logger(logger, match):
+    if match:
+        assert settings.DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE.match(logger).string == match
+    else:
+        assert settings.DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE.match(logger) is None


### PR DESCRIPTION
## :thinking: Pourquoi ?

capturer les logs de la `command` dans le logger, en passant les données variables en `kwargs`

## :rotating_light: À vérifier

Non Mettre à jour le CHANGELOG_breaking_changes.md ?
Non Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?


