### PR TITLE
Fiche salarié : faciliter le nouvel envoi de la fiche si le SIRET de l'entreprise a changé

### DIFF
--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -551,6 +551,14 @@ class Company(AddressMixin, OrganizationAbstract):
             f"{active_suspension_dates.lower:%d/%m/%Y} et le sera jusqu'au {active_suspension_dates.upper:%d/%m/%Y}."
         )
 
+    def siret_from_asp_source(self):
+        """
+        Fetch SIRET number of authoritative SIAE from ASP source
+        """
+        if self.canonical_company.source == Company.SOURCE_ASP:
+            return self.canonical_company.siret
+        raise ValidationError("Could not find authoritative SIAE from ASP source")
+
 
 class CompanyMembership(MembershipAbstract):
     """Intermediary model between `User` and `Company`."""

--- a/itou/employee_record/management/commands/resend_employee_records.py
+++ b/itou/employee_record/management/commands/resend_employee_records.py
@@ -24,7 +24,7 @@ class Command(BaseCommand):
             self.stdout.write(f"{siae} can't uses employee records")
             return
 
-        asp_siret = EmployeeRecord.siret_from_asp_source(siae)
+        asp_siret = EmployeeRecord.job_application.to_company.siret_from_asp_source()
 
         to_resend = (
             EmployeeRecord.objects.filter(

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -119,7 +119,11 @@ class EmployeeRecordWorkflow(xwf_models.Workflow):
     CAN_BE_DISABLED_STATES = [Status.NEW, Status.REJECTED, Status.PROCESSED]
     CAN_BE_ARCHIVED_STATES = [Status.NEW, Status.READY, Status.REJECTED, Status.PROCESSED, Status.DISABLED]
     transitions = (
-        (EmployeeRecordTransition.READY, [Status.NEW, Status.REJECTED, Status.DISABLED], Status.READY),
+        (
+            EmployeeRecordTransition.READY,
+            [Status.NEW, Status.REJECTED, Status.DISABLED, Status.PROCESSED],
+            Status.READY,
+        ),
         (EmployeeRecordTransition.WAIT_FOR_ASP_RESPONSE, Status.READY, Status.SENT),
         (EmployeeRecordTransition.REJECT, Status.SENT, Status.REJECTED),
         (EmployeeRecordTransition.PROCESS, Status.SENT, Status.PROCESSED),

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -316,7 +316,7 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
 
     def _fill_denormalized_fields(self):
         # If the SIAE is an antenna, the SIRET will be rejected by the ASP so we have to use the mother's one
-        self.siret = self.siret_from_asp_source(self.job_application.to_company)
+        self.siret = self.job_application.to_company.siret_from_asp_source()
         self.asp_id = self.job_application.to_company.convention.asp_id
         self.asp_measure = SiaeMeasure.from_siae_kind(self.job_application.to_company.kind)
         self.approval_number = self.job_application.approval.number
@@ -474,15 +474,6 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
         Mapping between ASP and itou models for SIAE kind ("Mesure")
         """
         return SiaeMeasure.from_siae_kind(self.job_application.to_company.kind)
-
-    @staticmethod
-    def siret_from_asp_source(siae):
-        """
-        Fetch SIRET number of authoritative SIAE from ASP source
-        """
-        if siae.canonical_company.source == Company.SOURCE_ASP:
-            return siae.canonical_company.siret
-        raise ValidationError("Could not find authoritative SIAE from ASP source")
 
     @classmethod
     def from_job_application(cls, job_application, clean=True):

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -5,7 +5,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Exists, F, Max, OuterRef
+from django.db.models import Exists, F, Max, OuterRef, Subquery
 from django.db.models.functions import Greatest
 from django.db.models.manager import Manager
 from django.db.models.query import Q, QuerySet
@@ -188,6 +188,15 @@ class EmployeeRecordQuerySet(models.QuerySet):
             ),
         ).filter(
             last_employee_record_snapshot__lt=F("job_application__approval__updated_at"),
+        )
+
+    def with_siret_from_asp_source(self):
+        return self.annotate(
+            siret_from_asp_source=Subquery(
+                Company.objects.filter(
+                    source=Company.SOURCE_ASP, convention=OuterRef("job_application__to_company__convention")
+                ).values("siret")
+            )
         )
 
 

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -475,6 +475,14 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
         """
         return SiaeMeasure.from_siae_kind(self.job_application.to_company.kind)
 
+    def has_siret_different_from_asp_source(self):
+        siret_from_asp_source = (
+            self.siret_from_asp_source
+            if hasattr(self, "siret_from_asp_source")
+            else self.job_application.to_company.siret_from_asp_source()
+        )
+        return self.siret != siret_from_asp_source
+
     @classmethod
     def from_job_application(cls, job_application, clean=True):
         """

--- a/itou/templates/employee_record/includes/list_header.html
+++ b/itou/templates/employee_record/includes/list_header.html
@@ -17,7 +17,7 @@
                 </div>
                 <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
                     <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}?reset_url={{ request.get_full_path|urlencode }}">
-                        <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
+                        <i class="ri-file-add-line ri-lg" aria-hidden="true"></i>
                         <span>Créer une fiche salarié</span>
                     </a>
                 </div>
@@ -28,7 +28,7 @@
             <h2 class="mb-0">Fiches salarié ASP</h2>
             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur les collaborateurs">
                 <a class="btn btn-primary btn-ico" href="{% url "employee_record_views:add" %}?reset_url={{ request.get_full_path|urlencode }}">
-                    <i class="ri-user-add-line ri-lg" aria-hidden="true"></i>
+                    <i class="ri-file-add-line ri-lg" aria-hidden="true"></i>
                     <span>Créer une fiche salarié</span>
                 </a>
             </div>

--- a/itou/templates/employee_record/includes/list_header.html
+++ b/itou/templates/employee_record/includes/list_header.html
@@ -34,4 +34,29 @@
             </div>
         </div>
     {% endif %}
+    {% if show_siret_has_changed_warning %}
+        <div id="changed-siret-warning" class="alert alert-warning alert-dismissible-once d-none" role="status">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-0">
+                        <strong>Incohérence de numéro SIRET détectée</strong>
+                    </p>
+                    <p class="mb-0">
+                        Le numéro SIRET associé à certaines fiches salarié "Intégrées" est différent de votre numéro SIRET actuel.
+                        Cela peut empêcher l'affichage de ces fiches dans votre espace Extranet IAE 2.0 de l'ASP.
+                        Si vous avez besoin de les récupérer, cliquez sur "<b>Renvoyer cette fiche salarié</b>".
+                        <a href="{{ ITOU_HELP_CENTER_URL }}/articles/15266700470289--Mettre-%C3%A0-jour-une-fiche-salari%C3%A9"
+                           rel="noopener"
+                           target="_blank"
+                           aria-label="Consulter la documentation sur la mise à jour de fiche salarié (ouverture dans un nouvel onglet)"
+                           class="has-external-link">Consulter le mode d'emploi</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 </div>

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -84,6 +84,26 @@
                 </div>
             </div>
         {% endif %}
+        {# SIRET has changed #}
+        {% if employee_record.status == "PROCESSED" and employee_record.has_siret_different_from_asp_source %}
+            <div class="alert alert-warning" role="status">
+                <div class="row">
+                    <div class="col-auto pe-0">
+                        <i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>
+                    </div>
+                    <div class="col">
+                        <p class="mb-2">
+                            <strong>Actualisation du numéro SIRET</strong>
+                        </p>
+                        <p class="mb-0">
+                            Le numéro SIRET associé à cette fiche salarié est différent de votre numéro SIRET actuel.
+                            Si ce salarié est toujours présent dans vos effectifs, vous pouvez renvoyer cette fiche salarié afin de retrouver ses informations dans votre espace Extranet IAE 2.0 de l'ASP.
+                            Si ce salarié ne fait plus partie de votre entreprise, vous pouvez désactiver sa fiche salarié.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        {% endif %}
         {# Actions #}
         {% if employee_record.job_application.job_seeker.jobseeker_profile.lack_of_nir_reason == "NIR_ASSOCIATED_TO_OTHER" %}
             <div class="alert alert-warning" role="status">

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -134,8 +134,13 @@
                        aria-label="Réactiver la fiche salarié de {{ employee_record.job_application.job_seeker.get_full_name }}">Réactiver</a>
                 {% endif %}
                 <a href="{% url "employee_record_views:summary" employee_record.id %}?back_url={{ current_url|urlencode }}"
-                   class="btn {% if employee_record.status == "NEW" or employee_record.status == "REJECTED" %}btn-outline-primary{% else %}btn-primary{% endif %} btn-block w-100 w-md-auto"
+                   class="btn {% if employee_record.status == "NEW" or employee_record.status == "REJECTED" or employee_record.status == "PROCESSED" %}btn-outline-primary{% else %}btn-primary{% endif %} btn-block w-100 w-md-auto"
                    aria-label="Voir la fiche salarié de {{ employee_record.job_application.job_seeker.get_full_name }}">Voir la fiche salarié</a>
+                {% if employee_record.status == "PROCESSED" %}
+                    <div class="dropdown w-md-auto">
+                        {% include "employee_record/includes/send_back_dropdown.html" with employee_record=employee_record csrf_token=csrf_token extra_class="btn-primary w-100 w-md-auto dropdown-toggle" only %}
+                    </div>
+                {% endif %}
                 {% if employee_record.status == "NEW" %}
                     <a href="{% url "employee_record_views:create" employee_record.job_application.id %}?from_status={{ employee_record.status }}"
                        class="btn btn-primary btn-block w-100 w-md-auto"

--- a/itou/templates/employee_record/includes/list_results.html
+++ b/itou/templates/employee_record/includes/list_results.html
@@ -4,7 +4,7 @@
 <div id="employee-records-container">
     <div class="employee-records-list">
         {% for employee_record in navigation_pages %}
-            {% include "employee_record/includes/list_item.html" with employee_record=employee_record current_url=request.get_full_path only %}
+            {% include "employee_record/includes/list_item.html" with employee_record=employee_record current_url=request.get_full_path csrf_token=csrf_token only %}
         {% empty %}
             <div class="c-box c-box--results my-3 my-md-4">
                 <div class="c-box--results__body">

--- a/itou/templates/employee_record/includes/send_back_dropdown.html
+++ b/itou/templates/employee_record/includes/send_back_dropdown.html
@@ -1,0 +1,10 @@
+<button class="btn {{ extra_class }} dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" aria-controls="sendBackRecordDropDown-{{ employee_record.pk }}">
+    Renvoyer cette fiche salarié
+</button>
+<div class="dropdown-menu" id="sendBackRecordDropDown-{{ employee_record.pk }}">
+    <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.pk %}" class="js-prevent-multiple-submit">
+        {% csrf_token %}
+        <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
+    </form>
+    <a class="dropdown-item" href="{% url "employee_record_views:create" employee_record.job_application.pk %}">Modifier et renvoyer</a>
+</div>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -27,16 +27,7 @@
             <div class="form-row align-items-center gx-3">
                 {% if employee_record.status == "PROCESSED" %}
                     <div class="form-group col-12 col-lg-auto">
-                        <button id="send_back_button" class="btn btn-lg btn-white btn-block w-lg-auto dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">
-                            Renvoyer cette fiche salarié
-                        </button>
-                        <div class="dropdown-menu">
-                            <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.pk %}" class="js-prevent-multiple-submit">
-                                {% csrf_token %}
-                                <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
-                            </form>
-                            <a class="dropdown-item" href="{% url "employee_record_views:create" employee_record.job_application.pk %}">Modifier et renvoyer</a>
-                        </div>
+                        {% include "employee_record/includes/send_back_dropdown.html" with employee_record=employee_record csrf_token=csrf_token extra_class="btn-lg btn-white btn-block w-lg-auto" only %}
                     </div>
                 {% elif employee_record.status == "NEW" %}
                     <div class="form-group col-12 col-lg-auto">

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -21,6 +21,45 @@
     {% endcomponent_title %}
 {% endblock %}
 
+{% block title_extra %}
+    {% if employee_record.status != "READY" and employee_record.status != "SENT" and employee_record.status != "ARCHIVED" %}
+        <div class="c-box c-box--action">
+            <div class="form-row align-items-center gx-3">
+                {% if employee_record.status == "NEW" %}
+                    <div class="form-group col-12 col-lg-auto">
+                        <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=NEW" class="btn btn-lg btn-white btn-block btn-ico">
+                            <i class="ri-file-edit-line font-weight-medium" aria-hidden="true"></i>
+                            <span>Compléter</span>
+                        </a>
+                    </div>
+                {% elif employee_record.status == "REJECTED" %}
+                    <div class="form-group col-12 col-lg-auto">
+                        <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=REJECTED" class="btn btn-lg btn-white btn-block btn-ico">
+                            <i class="ri-pencil-line font-weight-medium" aria-hidden="true"></i>
+                            <span>Modifier</span>
+                        </a>
+                    </div>
+                {% elif employee_record.status == "DISABLED" %}
+                    <div class="form-group col-12 col-lg-auto">
+                        <a href="{% url "employee_record_views:reactivate" employee_record.pk %}" class="btn btn-lg btn-white btn-block btn-ico">
+                            <i class="ri-reset-right-line font-weight-medium" aria-hidden="true"></i>
+                            <span>Réactiver</span>
+                        </a>
+                    </div>
+                {% endif %}
+                {% if employee_record.status == "REJECTED" or employee_record.status == "PROCESSED" %}
+                    <div class="form-group col-12 col-lg-auto">
+                        <a href="{% url "employee_record_views:disable" employee_record.pk %}" class="btn btn-lg btn-outline-white btn-block btn-ico">
+                            <i class="ri-file-close-line font-weight-medium" aria-hidden="true"></i>
+                            <span>Désactiver</span>
+                        </a>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+{% endblock title_extra %}
+
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
@@ -29,20 +68,6 @@
                     <div class="c-box">{% include "employee_record/includes/employee_record_summary.html" %}</div>
                 </div>
                 <div class="col-12 col-lg-4 order-1 order-lg-2 mb-3">
-                    {% if employee_record.status != "READY" and employee_record.status != "SENT" and employee_record.status != "ARCHIVED" %}
-                        <div class="c-box mb-4">
-                            {% if employee_record.status == "NEW" %}
-                                <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=NEW" class="btn btn-block btn-primary my-2">Compléter la fiche salarié</a>
-                            {% elif employee_record.status == "REJECTED" %}
-                                <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=REJECTED" class="btn btn-block btn-primary my-2">Modifier la fiche salarié</a>
-                            {% elif employee_record.status == "DISABLED" %}
-                                <a href="{% url "employee_record_views:reactivate" employee_record.pk %}" class="btn btn-block btn-outline-primary my-2">Réactiver la fiche salarié</a>
-                            {% endif %}
-                            {% if employee_record.status == "REJECTED" or employee_record.status == "PROCESSED" %}
-                                <a href="{% url "employee_record_views:disable" employee_record.pk %}" class="btn btn-block btn-outline-primary my-2">Désactiver la fiche salarié</a>
-                            {% endif %}
-                        </div>
-                    {% endif %}
                     <div class="c-box">
                         <p>
                             <b>PASS IAE :</b>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -47,7 +47,7 @@
                         </a>
                     </div>
                 {% endif %}
-                {% if employee_record.status == "REJECTED" or employee_record.status == "PROCESSED" %}
+                {% if employee_record.disable.is_available %}
                     <div class="form-group col-12 col-lg-auto">
                         <a href="{% url "employee_record_views:disable" employee_record.pk %}" class="btn btn-lg btn-outline-white btn-block btn-ico">
                             <i class="ri-file-close-line font-weight-medium" aria-hidden="true"></i>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -25,7 +25,20 @@
     {% if employee_record.status != "READY" and employee_record.status != "SENT" and employee_record.status != "ARCHIVED" %}
         <div class="c-box c-box--action">
             <div class="form-row align-items-center gx-3">
-                {% if employee_record.status == "NEW" %}
+                {% if employee_record.status == "PROCESSED" %}
+                    <div class="form-group col-12 col-lg-auto">
+                        <button id="send_back_button" class="btn btn-lg btn-white btn-block w-lg-auto dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown">
+                            Renvoyer cette fiche salarié
+                        </button>
+                        <div class="dropdown-menu">
+                            <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.pk %}" class="js-prevent-multiple-submit">
+                                {% csrf_token %}
+                                <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
+                            </form>
+                            <a class="dropdown-item" href="{% url "employee_record_views:create" employee_record.job_application.pk %}">Modifier et renvoyer</a>
+                        </div>
+                    </div>
+                {% elif employee_record.status == "NEW" %}
                     <div class="form-group col-12 col-lg-auto">
                         <a href="{% url "employee_record_views:create" employee_record.job_application.pk %}?from_status=NEW" class="btn btn-lg btn-white btn-block btn-ico">
                             <i class="ri-file-edit-line font-weight-medium" aria-hidden="true"></i>

--- a/itou/templates/employee_record/summary.html
+++ b/itou/templates/employee_record/summary.html
@@ -19,6 +19,27 @@
             </h1>
         {% endfragment %}
     {% endcomponent_title %}
+
+    {% if employee_record.status == "PROCESSED" and employee_record.has_siret_different_from_asp_source %}
+        <div class="alert alert-warning alert-dismissible fade show" role="status">
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+            <div class="row">
+                <div class="col-auto pe-0">
+                    <i class="ri-information-line ri-xl text-warning" aria-hidden="true"></i>
+                </div>
+                <div class="col">
+                    <p class="mb-0">
+                        <strong>Incohérence de numéro SIRET détectée</strong>
+                    </p>
+                    <p class="mb-0">
+                        Le numéro SIRET associé à cette fiche salarié est différent de votre numéro SIRET actuel.
+                        Si ce salarié est toujours présent dans vos effectifs, vous pouvez renvoyer cette fiche salarié afin de retrouver ses informations dans votre espace Extranet IAE 2.0 de l'ASP.
+                        Si ce salarié ne fait plus partie de votre entreprise, vous pouvez désactiver sa fiche salarié.
+                    </p>
+                </div>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block title_extra %}

--- a/itou/utils/perms/employee_record.py
+++ b/itou/utils/perms/employee_record.py
@@ -3,7 +3,6 @@ from django.shortcuts import get_object_or_404
 from django.template import loader
 from django.utils.html import format_html
 
-from itou.employee_record.enums import Status
 from itou.job_applications.models import JobApplication
 from itou.users.enums import LackOfNIRReason
 from itou.utils.perms.company import get_current_company_or_404
@@ -19,11 +18,7 @@ def tunnel_step_is_allowed(job_application):
     if not employee_record:
         return True
 
-    return employee_record.status in [
-        Status.NEW,
-        Status.REJECTED,
-        Status.DISABLED,
-    ]
+    return employee_record.ready.is_available()
 
 
 def siae_is_allowed(job_application, siae):

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -480,11 +480,16 @@ def create_step_5(request, job_application_id, template_name="employee_record/cr
     employee_record = job_application.employee_record.full_fetch().latest("created_at")
 
     if request.method == "POST" and not job_application.hiring_starts_in_future:
-        back_url = f"{reverse('employee_record_views:list')}?status={employee_record.status}"
+        previous_status = employee_record.status
+        back_url = f"{reverse('employee_record_views:list')}?status={previous_status}"
         employee_record.ready(user=request.user)
-        toast_title, toast_message = (
-            "La création de cette fiche salarié est terminée",
-            "Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts.",
+        toast_title = (
+            "La fiche salarié a été renvoyée"
+            if previous_status == Status.PROCESSED
+            else "La création de cette fiche salarié est terminée"
+        )
+        toast_message = (
+            "Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts."
         )
         messages.success(
             request,

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -324,6 +324,15 @@ class TestCompanyModel:
         with pytest.raises(ValidationError):
             company.add_or_activate_membership(non_employer)
 
+    def test_siret_from_asp_source(self):
+        company = CompanyFactory(with_membership=True, source=Company.SOURCE_ASP)
+        antenna = CompanyFactory(
+            with_membership=True, convention=company.convention, source=Company.SOURCE_USER_CREATED
+        )
+
+        assert company.siret != antenna.siret
+        assert antenna.siret_from_asp_source() == company.siret
+
 
 class TestCompanyQuerySet:
     def test_with_count_recent_received_job_applications(self):

--- a/tests/employee_record/__snapshots__/test_admin.ambr
+++ b/tests/employee_record/__snapshots__/test_admin.ambr
@@ -38,6 +38,8 @@
   <div class="submit-row" id="employee-record-transitions">
               <p>Changer l'état de la fiche salarié :</p>
               
+                  <input class="danger js-with-confirm" name="transition_ready" type="submit" value="Complétée"/>
+              
                   <input class="danger js-with-confirm" name="transition_disable" type="submit" value="Désactivée"/>
               
           </div>

--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -667,6 +667,18 @@ class TestEmployeeRecordQueryset:
             == employee_record_2
         )
 
+    def test_with_siret_from_asp_source(self):
+        employee_record = EmployeeRecordFactory()
+        company = employee_record.job_application.to_company
+        EmployeeRecordFactory(
+            job_application__to_company__convention=company.convention,
+            job_application__to_company__source=Company.SOURCE_USER_CREATED,
+        )
+
+        assert set(
+            EmployeeRecord.objects.with_siret_from_asp_source().values_list("siret_from_asp_source", flat=True)
+        ) == {company.siret}
+
 
 @pytest.mark.parametrize("factory", [BareEmployeeRecordFactory, BareEmployeeRecordUpdateNotificationFactory])
 @pytest.mark.parametrize(

--- a/tests/utils/perms/tests.py
+++ b/tests/utils/perms/tests.py
@@ -55,6 +55,7 @@ class TestEmployeeRecord:
             employee_record_enums.Status.NEW,
             employee_record_enums.Status.REJECTED,
             employee_record_enums.Status.DISABLED,
+            employee_record_enums.Status.PROCESSED,
         ],
     )
     def test_tunnel_step_is_allowed_with_valid_status(self, status):
@@ -66,7 +67,6 @@ class TestEmployeeRecord:
         [
             employee_record_enums.Status.READY,
             employee_record_enums.Status.SENT,
-            employee_record_enums.Status.PROCESSED,
             employee_record_enums.Status.ARCHIVED,
         ],
     )

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -517,3 +517,6 @@
               </form>
   '''
 # ---
+# name: TestResendProcessedEmployeeRecord.test_resubmit_processed_record
+  Message(level=25, message="La fiche salarié a été renvoyée||Vous pouvez suivre l'avancement de son traitement par l'ASP en sélectionnant les différents statuts.", extra_tags='toast')
+# ---

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -79,7 +79,7 @@
 # ---
 # name: TestListEmployeeRecords.test_new_employee_records_sorted[employee records]
   dict({
-    'num_queries': 12,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -319,6 +319,27 @@
           'list_employee_records[www/employee_record_views/views.py]',
         ]),
         'sql': '''
+          SELECT %s AS "a"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          WHERE ("job_applications_jobapplication"."to_company_id" = %s
+                 AND "employee_record_employeerecord"."status" = %s
+                 AND NOT ("employee_record_employeerecord"."siret" =
+                            (SELECT U0."siret"
+                             FROM "companies_company" U0
+                             WHERE (NOT (U0."siret" = %s)
+                                    AND U0."convention_id" = ("companies_company"."convention_id")
+                                    AND U0."source" = %s)
+                             ORDER BY RANDOM() ASC)))
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'list_employee_records[www/employee_record_views/views.py]',
+        ]),
+        'sql': '''
           SELECT "job_applications_jobapplication"."job_seeker_id"
           FROM "job_applications_jobapplication"
           INNER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
@@ -351,6 +372,7 @@
           SELECT COUNT(*) AS "__count"
           FROM "employee_record_employeerecord"
           INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
           WHERE ("job_applications_jobapplication"."to_company_id" = %s
                  AND "employee_record_employeerecord"."status" IN (%s))
         ''',
@@ -409,6 +431,13 @@
                  "employee_record_employeerecord"."asp_measure",
                  "employee_record_employeerecord"."siret",
                  "employee_record_employeerecord"."processed_as_duplicate",
+          
+            (SELECT U0."siret"
+             FROM "companies_company" U0
+             WHERE (NOT (U0."siret" = %s)
+                    AND U0."convention_id" = ("companies_company"."convention_id")
+                    AND U0."source" = %s)
+             ORDER BY RANDOM() ASC) AS "siret_from_asp_source",
                  "job_applications_jobapplication"."id",
                  "job_applications_jobapplication"."job_seeker_id",
                  "job_applications_jobapplication"."eligibility_diagnosis_id",
@@ -543,15 +572,15 @@
                  "asp_country"."name",
                  "asp_country"."group",
                  "asp_country"."department",
-                 T8."id",
-                 T8."start_date",
-                 T8."end_date",
-                 T8."code",
-                 T8."name",
-                 T8."normalized_name",
-                 T8."created_at",
-                 T8."city_id",
-                 T8."ignore",
+                 T9."id",
+                 T9."start_date",
+                 T9."end_date",
+                 T9."code",
+                 T9."name",
+                 T9."normalized_name",
+                 T9."created_at",
+                 T9."city_id",
+                 T9."ignore",
                  "prescribers_prescriberorganization"."id",
                  "prescribers_prescriberorganization"."address_line_1",
                  "prescribers_prescriberorganization"."address_line_2",
@@ -653,7 +682,7 @@
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           LEFT OUTER JOIN "asp_commune" ON ("users_jobseekerprofile"."birth_place_id" = "asp_commune"."id")
           LEFT OUTER JOIN "asp_country" ON ("users_jobseekerprofile"."birth_country_id" = "asp_country"."id")
-          LEFT OUTER JOIN "asp_commune" T8 ON ("users_jobseekerprofile"."hexa_commune_id" = T8."id")
+          LEFT OUTER JOIN "asp_commune" T9 ON ("users_jobseekerprofile"."hexa_commune_id" = T9."id")
           LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
           LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
           LEFT OUTER JOIN "companies_siaefinancialannex" ON ("employee_record_employeerecord"."financial_annex_id" = "companies_siaefinancialannex"."id")

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -46,7 +46,7 @@
                   </div>
                   <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
                       <a class="btn btn-primary btn-ico" href="/employee_record/add/?reset_url=/employee_record/list%3Fstatus%3DNEW%26status%3DREJECTED%26order%3D">
-                          <i aria-hidden="true" class="ri-user-add-line ri-lg"></i>
+                          <i aria-hidden="true" class="ri-file-add-line ri-lg"></i>
                           <span>Créer une fiche salarié</span>
                       </a>
                   </div>
@@ -68,7 +68,7 @@
                   </div>
                   <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
                       <a class="btn btn-primary btn-ico" href="/employee_record/add/?reset_url=/employee_record/list%3Fstatus%3DNEW%26status%3DREJECTED%26order%3D">
-                          <i aria-hidden="true" class="ri-user-add-line ri-lg"></i>
+                          <i aria-hidden="true" class="ri-file-add-line ri-lg"></i>
                           <span>Créer une fiche salarié</span>
                       </a>
                   </div>

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -9,6 +9,7 @@
                   
                   <a aria-label="Voir la fiche salarié de Jane DOE" class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/employee_record/summary/[PK of EmployeeRecord]?back_url=/employee_record/list%3Fstatus%3DNEW">Voir la fiche salarié</a>
                   
+                  
                       <a aria-label="Compléter la fiche salarié de Jane DOE" class="btn btn-primary btn-block w-100 w-md-auto" href="/employee_record/create/[PK of JobApplication]?from_status=NEW">Compléter</a>
                   
               </div>
@@ -670,4 +671,34 @@
       }),
     ]),
   })
+# ---
+# name: TestListEmployeeRecords.test_processed_employee_record_can_be_sent_back
+  '''
+  <div class="c-box--results__footer">
+          
+              <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
+                  
+                      <a aria-label="Désactiver la fiche salarié de Jane DOE" class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/employee_record/disable/[PK of EmployeeRecord]">Désactiver</a>
+                  
+                  <a aria-label="Voir la fiche salarié de Jane DOE" class="btn btn-outline-primary btn-block w-100 w-md-auto" href="/employee_record/summary/[PK of EmployeeRecord]?back_url=/employee_record/list%3Fstatus%3DPROCESSED">Voir la fiche salarié</a>
+                  
+                      <div class="dropdown w-md-auto">
+                          <button aria-controls="sendBackRecordDropDown-[Pk of EmployeeRecord]" aria-expanded="false" aria-haspopup="true" class="btn btn-primary w-100 w-md-auto dropdown-toggle dropdown-toggle" data-bs-toggle="dropdown" type="button">
+      Renvoyer cette fiche salarié
+  </button>
+  <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      <form action="/employee_record/create_step_5/[PK of JobApplication]" class="js-prevent-multiple-submit" method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button aria-label="Renvoyer la fiche salarié sans modification" class="dropdown-item" type="submit">Renvoyer</button>
+      </form>
+      <a class="dropdown-item" href="/employee_record/create/[PK of JobApplication]">Modifier et renvoyer</a>
+  </div>
+  
+                      </div>
+                  
+                  
+              </div>
+          
+      </div>
+  '''
 # ---

--- a/tests/www/employee_record_views/__snapshots__/test_summary.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_summary.ambr
@@ -231,6 +231,19 @@
           <div class="c-box c-box--action">
               <div class="form-row align-items-center gx-3">
                   
+                      <div class="form-group col-12 col-lg-auto">
+                          <button aria-expanded="false" aria-haspopup="true" class="btn btn-lg btn-white btn-block w-lg-auto dropdown-toggle" data-bs-toggle="dropdown" id="send_back_button" type="button">
+                              Renvoyer cette fiche salarié
+                          </button>
+                          <div class="dropdown-menu">
+                              <form action="/employee_record/create_step_5/[Pk of JobApplication]" class="js-prevent-multiple-submit" method="post">
+                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                  <button aria-label="Renvoyer la fiche salarié sans modification" class="dropdown-item" type="submit">Renvoyer</button>
+                              </form>
+                              <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
+                          </div>
+                      </div>
+                  
                   
                       <div class="form-group col-12 col-lg-auto">
                           <a class="btn btn-lg btn-outline-white btn-block btn-ico" href="/employee_record/disable/[Pk of EmployeeRecord]">

--- a/tests/www/employee_record_views/__snapshots__/test_summary.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_summary.ambr
@@ -1,0 +1,412 @@
+# serializer version: 1
+# name: TestSummaryEmployeeRecords.test_action_bar[ARCHIVED]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-emploi-lightest text-primary">
+          Archivée le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar[DISABLED]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-emploi-lightest text-primary">
+          Désactivée le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+          <div class="c-box c-box--action">
+              <div class="form-row align-items-center gx-3">
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-white btn-block btn-ico" href="/employee_record/reactivate/[Pk of EmployeeRecord]">
+                              <i aria-hidden="true" class="ri-reset-right-line font-weight-medium"></i>
+                              <span>Réactiver</span>
+                          </a>
+                      </div>
+                  
+                  
+              </div>
+          </div>
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar[NEW]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-emploi">Nouvelle à compléter</span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+          <div class="c-box c-box--action">
+              <div class="form-row align-items-center gx-3">
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-white btn-block btn-ico" href="/employee_record/create/[Pk of JobApplication]?from_status=NEW">
+                              <i aria-hidden="true" class="ri-file-edit-line font-weight-medium"></i>
+                              <span>Compléter</span>
+                          </a>
+                      </div>
+                  
+                  
+              </div>
+          </div>
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar[PROCESSED]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-success">
+          Intégrée par l'ASP le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+          <div class="c-box c-box--action">
+              <div class="form-row align-items-center gx-3">
+                  
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-outline-white btn-block btn-ico" href="/employee_record/disable/[Pk of EmployeeRecord]">
+                              <i aria-hidden="true" class="ri-file-close-line font-weight-medium"></i>
+                              <span>Désactiver</span>
+                          </a>
+                      </div>
+                  
+              </div>
+          </div>
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar[READY]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-secondary">
+          Complétée le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar[REJECTED]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-danger">
+          Retour en erreur le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+          <div class="c-box c-box--action">
+              <div class="form-row align-items-center gx-3">
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-white btn-block btn-ico" href="/employee_record/create/[Pk of JobApplication]?from_status=REJECTED">
+                              <i aria-hidden="true" class="ri-pencil-line font-weight-medium"></i>
+                              <span>Modifier</span>
+                          </a>
+                      </div>
+                  
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-outline-white btn-block btn-ico" href="/employee_record/disable/[Pk of EmployeeRecord]">
+                              <i aria-hidden="true" class="ri-file-close-line font-weight-medium"></i>
+                              <span>Désactiver</span>
+                          </a>
+                      </div>
+                  
+              </div>
+          </div>
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar[SENT]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-warning">
+          Envoyée à l'ASP le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+  
+                          </div>
+  '''
+# ---

--- a/tests/www/employee_record_views/__snapshots__/test_summary.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_summary.ambr
@@ -37,6 +37,8 @@
   </div>
   
   
+      
+  
                               
                                   
   
@@ -86,6 +88,8 @@
       
   </div>
   
+  
+      
   
                               
                                   
@@ -148,6 +152,8 @@
       
   </div>
   
+  
+      
   
                               
                                   
@@ -219,6 +225,8 @@
       
   </div>
   
+  
+      
   
                               
                                   
@@ -298,6 +306,8 @@
   </div>
   
   
+      
+  
                               
                                   
   
@@ -347,6 +357,8 @@
       
   </div>
   
+  
+      
   
                               
                                   
@@ -418,6 +430,159 @@
       
   </div>
   
+  
+      
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar_with_changed_siret[PROCESSED]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-success">
+          Intégrée par l'ASP le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+      
+          <div class="alert alert-warning alert-dismissible fade show" role="status">
+              <button aria-label="Fermer" class="btn-close" data-bs-dismiss="alert" type="button"></button>
+              <div class="row">
+                  <div class="col-auto pe-0">
+                      <i aria-hidden="true" class="ri-information-line ri-xl text-warning"></i>
+                  </div>
+                  <div class="col">
+                      <p class="mb-0">
+                          <strong>Incohérence de numéro SIRET détectée</strong>
+                      </p>
+                      <p class="mb-0">
+                          Le numéro SIRET associé à cette fiche salarié est différent de votre numéro SIRET actuel.
+                          Si ce salarié est toujours présent dans vos effectifs, vous pouvez renvoyer cette fiche salarié afin de retrouver ses informations dans votre espace Extranet IAE 2.0 de l'ASP.
+                          Si ce salarié ne fait plus partie de votre entreprise, vous pouvez désactiver sa fiche salarié.
+                      </p>
+                  </div>
+              </div>
+          </div>
+      
+  
+                              
+                                  
+  
+  
+  
+                              
+                              
+      
+          <div class="c-box c-box--action">
+              <div class="form-row align-items-center gx-3">
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <button aria-controls="sendBackRecordDropDown-[Pk of EmployeeRecord]" aria-expanded="false" aria-haspopup="true" class="btn btn-lg btn-white btn-block w-lg-auto dropdown-toggle" data-bs-toggle="dropdown" type="button">
+      Renvoyer cette fiche salarié
+  </button>
+  <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      <form action="/employee_record/create_step_5/[Pk of JobApplication]" class="js-prevent-multiple-submit" method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button aria-label="Renvoyer la fiche salarié sans modification" class="dropdown-item" type="submit">Renvoyer</button>
+      </form>
+      <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
+  </div>
+  
+                      </div>
+                  
+                  
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-outline-white btn-block btn-ico" href="/employee_record/disable/[Pk of EmployeeRecord]">
+                              <i aria-hidden="true" class="ri-file-close-line font-weight-medium"></i>
+                              <span>Désactiver</span>
+                          </a>
+                      </div>
+                  
+              </div>
+          </div>
+      
+  
+                          </div>
+  '''
+# ---
+# name: TestSummaryEmployeeRecords.test_action_bar_with_changed_siret[READY]
+  '''
+  <div class="s-title-02__col col-12">
+                              
+      
+  
+  
+      <div class="c-prevstep">
+          <a aria-label="Retour à la liste" class="btn btn-ico btn-link ps-0" href="/employee_record/list">
+              <i aria-hidden="true" class="ri-arrow-drop-left-line ri-xl fw-medium"></i>
+              <span>
+                  Retour
+                  à la liste
+              </span>
+          </a>
+      </div>
+  
+  
+  
+                              
+      
+  <div class="c-title">
+      <div class="c-title__main">
+              <h1>
+                  Fiche salarié ASP : Lauren MATA
+                  
+      <span class="badge rounded-pill badge-base text-nowrap bg-secondary">
+          Complétée le 29/04/2025 13:11
+      </span>
+  
+  
+              </h1>
+          </div>
+      
+      
+  </div>
+  
+  
+      
   
                               
                                   

--- a/tests/www/employee_record_views/__snapshots__/test_summary.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_summary.ambr
@@ -232,16 +232,17 @@
               <div class="form-row align-items-center gx-3">
                   
                       <div class="form-group col-12 col-lg-auto">
-                          <button aria-expanded="false" aria-haspopup="true" class="btn btn-lg btn-white btn-block w-lg-auto dropdown-toggle" data-bs-toggle="dropdown" id="send_back_button" type="button">
-                              Renvoyer cette fiche salarié
-                          </button>
-                          <div class="dropdown-menu">
-                              <form action="/employee_record/create_step_5/[Pk of JobApplication]" class="js-prevent-multiple-submit" method="post">
-                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                  <button aria-label="Renvoyer la fiche salarié sans modification" class="dropdown-item" type="submit">Renvoyer</button>
-                              </form>
-                              <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
-                          </div>
+                          <button aria-controls="sendBackRecordDropDown-[Pk of EmployeeRecord]" aria-expanded="false" aria-haspopup="true" class="btn btn-lg btn-white btn-block w-lg-auto dropdown-toggle" data-bs-toggle="dropdown" type="button">
+      Renvoyer cette fiche salarié
+  </button>
+  <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      <form action="/employee_record/create_step_5/[Pk of JobApplication]" class="js-prevent-multiple-submit" method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button aria-label="Renvoyer la fiche salarié sans modification" class="dropdown-item" type="submit">Renvoyer</button>
+      </form>
+      <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
+  </div>
+  
                       </div>
                   
                   

--- a/tests/www/employee_record_views/__snapshots__/test_summary.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_summary.ambr
@@ -168,6 +168,13 @@
                       </div>
                   
                   
+                      <div class="form-group col-12 col-lg-auto">
+                          <a class="btn btn-lg btn-outline-white btn-block btn-ico" href="/employee_record/disable/[Pk of EmployeeRecord]">
+                              <i aria-hidden="true" class="ri-file-close-line font-weight-medium"></i>
+                              <span>Désactiver</span>
+                          </a>
+                      </div>
+                  
               </div>
           </div>
       

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -221,6 +221,55 @@ class TestListEmployeeRecords:
             == snapshot()
         )
 
+    def test_processed_employee_record_can_be_sent_back(self, client, snapshot):
+        client.force_login(self.user)
+
+        self.employee_record.status = Status.PROCESSED
+        self.employee_record.save()
+
+        response = client.get(self.URL, data={"status": Status.PROCESSED})
+        assert (
+            str(
+                parse_response_to_soup(
+                    response,
+                    selector=".employee-records-list .c-box--results__footer",
+                    replace_in_attr=[
+                        (
+                            "href",
+                            f"/employee_record/disable/{self.employee_record.pk}",
+                            "/employee_record/disable/[PK of EmployeeRecord]",
+                        ),
+                        (
+                            "href",
+                            f"/employee_record/summary/{self.employee_record.pk}",
+                            "/employee_record/summary/[PK of EmployeeRecord]",
+                        ),
+                        (
+                            "href",
+                            f"/employee_record/create/{self.job_application.pk}",
+                            "/employee_record/create/[PK of JobApplication]",
+                        ),
+                        (
+                            "action",
+                            f"/employee_record/create_step_5/{self.job_application.pk}",
+                            "/employee_record/create_step_5/[PK of JobApplication]",
+                        ),
+                        (
+                            "id",
+                            f"sendBackRecordDropDown-{self.employee_record.pk}",
+                            "sendBackRecordDropDown-[Pk of EmployeeRecord]",
+                        ),
+                        (
+                            "aria-controls",
+                            f"sendBackRecordDropDown-{self.employee_record.pk}",
+                            "sendBackRecordDropDown-[Pk of EmployeeRecord]",
+                        ),
+                    ],
+                )
+            )
+            == snapshot
+        )
+
     @override_settings(TALLY_URL="https://tally.so")
     def test_employee_records_with_nir_associated_to_other(self, client, snapshot):
         client.force_login(self.user)

--- a/tests/www/employee_record_views/test_summary.py
+++ b/tests/www/employee_record_views/test_summary.py
@@ -110,6 +110,16 @@ class TestSummaryEmployeeRecords:
                     f"/employee_record/disable/{self.employee_record.pk}",
                     "/employee_record/disable/[Pk of EmployeeRecord]",
                 ),
+                (
+                    "id",
+                    f"sendBackRecordDropDown-{self.employee_record.pk}",
+                    "sendBackRecordDropDown-[Pk of EmployeeRecord]",
+                ),
+                (
+                    "aria-controls",
+                    f"sendBackRecordDropDown-{self.employee_record.pk}",
+                    "sendBackRecordDropDown-[Pk of EmployeeRecord]",
+                ),
             ],
         )
 

--- a/tests/www/employee_record_views/test_summary.py
+++ b/tests/www/employee_record_views/test_summary.py
@@ -101,6 +101,11 @@ class TestSummaryEmployeeRecords:
                     "/employee_record/create/[Pk of JobApplication]",
                 ),
                 (
+                    "action",
+                    f"/employee_record/create_step_5/{self.employee_record.job_application_id}",
+                    "/employee_record/create_step_5/[Pk of JobApplication]",
+                ),
+                (
                     "href",
                     f"/employee_record/disable/{self.employee_record.pk}",
                     "/employee_record/disable/[Pk of EmployeeRecord]",


### PR DESCRIPTION
## :thinking: Pourquoi ?

On veut faciliter le renvoi de la fiche salarié lorsque si l'entreprise a un nouveau SIRET.

En fait, on généralise un petit peu, puisque renvoyer des FS peut être utile dans d'autres cas (fiche supprimée côté ASP par exemple).
On affiche donc un bouton "Renvoyer la fiche salarié" sur toutes les FS *Intégrées*.

**Points de vigilance :**
- le siret est celui de l'entreprise mère (`employee_record.siret_from_asp_source`)

En pratique, le bouton `Renvoyer > Avec modification` est un lien vers `employee_record_views:create` (qui gère également la modification).
Le bouton `Renvoyer > Sans modification` est directement un POST vers la dernière étape du même processus. J'ai trouvé que c'était le plus simple, mais c'est questionnable sans souci.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/391f8d8b-1989-4502-b67b-c12df7be9377)


<!--
# Catégories changelog

 +--------------------------|--------------------------+
 | API                      | Notifications            |
 | Accessibilité            | Page d’accueil           |
 | Admin                    | PASS IAE                 |
 | Annexes financières      | Performances             |
 | Candidature              | Pilotage                 |
 | Connexion                | Profil salarié           |
 | Contrôle a posteriori    | Prescripteur             |
 | Demandes de prolongation | Recherche employeur      |
 | Demandeur d’emploi       | Recherche fiche de poste |
 | Employeur                | Recherche prescripteur   |
 | Fiche de poste           | Stabilité                |
 | Fiche entreprise         | Statistiques             |
 | Fiches salarié           | Tableau de bord          |
 | GEIQ                     | UX/UI                    |
 | Inscription              | Vie privée               |
 +--------------------------|--------------------------+

-->
