### PR TITLE
Vie Privée: supprimer les emails des candidats de Brevo

### DIFF
--- a/itou/users/management/commands/send_users_to_brevo.py
+++ b/itou/users/management/commands/send_users_to_brevo.py
@@ -1,10 +1,7 @@
 import datetime
 import logging
-from itertools import batched
 
-import httpx
 from allauth.account.models import EmailAddress
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 from sentry_sdk.crons import monitor
@@ -19,16 +16,16 @@ from itou.prescribers.enums import PrescriberAuthorizationStatus
 from itou.prescribers.models import PrescriberMembership
 from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
+from itou.utils.brevo import (
+    BREVO_CANDIDATS_AUTONOMES_BLOQUES_LIST_ID,
+    BREVO_CANDIDATS_LIST_ID,
+    BREVO_LES_EMPLOIS_LIST_ID,
+    BrevoClient,
+)
 from itou.utils.command import BaseCommand
 
 
 logger = logging.getLogger(__name__)
-
-# https://app.brevo.com/contact/list-listing
-BREVO_LES_EMPLOIS_LIST_ID = 31
-BREVO_CANDIDATS_LIST_ID = 82
-BREVO_CANDIDATS_AUTONOMES_BLOQUES_LIST_ID = 83
-BREVO_API_URL = "https://api.brevo.com/v3"
 
 
 def professional_serializer(user, brevo_type):
@@ -66,43 +63,6 @@ def job_seeker_serializer(user):
             "date_inscription": timezone.localdate(user.date_joined).isoformat(),
         },
     }
-
-
-class BrevoClient:
-    IMPORT_BATCH_SIZE = 1000
-
-    def __init__(self):
-        self.client = httpx.Client(
-            headers={
-                "accept": "application/json",
-                "api-key": settings.BREVO_API_KEY,
-            }
-        )
-
-    def _import_contacts(self, users, list_id, serializer):
-        response = self.client.post(
-            f"{BREVO_API_URL}/contacts/import",
-            headers={"Content-Type": "application/json"},
-            json={
-                "listIds": [list_id],
-                "emailBlacklist": False,
-                "smsBlacklist": False,
-                "updateExistingContacts": False,  # Don't update because we don't want to update emailBlacklist
-                "emptyContactsAttributes": False,
-                "jsonBody": [serializer(user) for user in users],
-            },
-        )
-        if response.status_code != 202:
-            logger.error(
-                "Brevo API: Some emails were not imported, status_code=%d, content=%s",
-                response.status_code,
-                response.content.decode(),
-            )
-
-    def import_users(self, users, list_id, serializer):
-        for batch in batched(users, self.IMPORT_BATCH_SIZE):
-            if batch:
-                self._import_contacts(batch, list_id, serializer)
 
 
 class Command(BaseCommand):

--- a/itou/utils/brevo.py
+++ b/itou/utils/brevo.py
@@ -1,0 +1,52 @@
+import logging
+from itertools import batched
+
+import httpx
+from django.conf import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+# https://app.brevo.com/contact/list-listing
+BREVO_LES_EMPLOIS_LIST_ID = 31
+BREVO_CANDIDATS_LIST_ID = 82
+BREVO_CANDIDATS_AUTONOMES_BLOQUES_LIST_ID = 83
+BREVO_API_URL = "https://api.brevo.com/v3"
+
+
+class BrevoClient:
+    IMPORT_BATCH_SIZE = 1000
+
+    def __init__(self):
+        self.client = httpx.Client(
+            headers={
+                "accept": "application/json",
+                "api-key": settings.BREVO_API_KEY,
+            }
+        )
+
+    def _import_contacts(self, users, list_id, serializer):
+        response = self.client.post(
+            f"{BREVO_API_URL}/contacts/import",
+            headers={"Content-Type": "application/json"},
+            json={
+                "listIds": [list_id],
+                "emailBlacklist": False,
+                "smsBlacklist": False,
+                "updateExistingContacts": False,  # Don't update because we don't want to update emailBlacklist
+                "emptyContactsAttributes": False,
+                "jsonBody": [serializer(user) for user in users],
+            },
+        )
+        if response.status_code != 202:
+            logger.error(
+                "Brevo API: Some emails were not imported, status_code=%d, content=%s",
+                response.status_code,
+                response.content.decode(),
+            )
+
+    def import_users(self, users, list_id, serializer):
+        for batch in batched(users, self.IMPORT_BATCH_SIZE):
+            if batch:
+                self._import_contacts(batch, list_id, serializer)

--- a/itou/utils/brevo.py
+++ b/itou/utils/brevo.py
@@ -50,3 +50,19 @@ class BrevoClient:
         for batch in batched(users, self.IMPORT_BATCH_SIZE):
             if batch:
                 self._import_contacts(batch, list_id, serializer)
+
+    def _delete_contact(self, email):
+        response = self.client.delete(
+            f"{BREVO_API_URL}/contacts/{email}?identifierType=email_id",
+            headers={"Content-Type": "application/json"},
+        )
+        if response.status_code != 204:
+            logger.error(
+                "Brevo API: Something went wrong when trying to delete email",
+                extra={"status_code": response.status_code, "content": response.content.decode(), "email": email},
+            )
+
+        return {email: response.status_code}
+
+    def delete_users(self, users):
+        return [self._delete_contact(user.email) for user in users]

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -21,14 +21,14 @@ from itou.job_applications.models import JobApplication
 from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.enums import IdentityCertificationAuthorities, IdentityProvider
 from itou.users.management.commands import send_check_authorized_members_email
-from itou.users.management.commands.send_users_to_brevo import (
+from itou.users.models import User
+from itou.utils.apis.pole_emploi import PoleEmploiAPIBadResponse
+from itou.utils.brevo import (
     BREVO_API_URL,
     BREVO_CANDIDATS_AUTONOMES_BLOQUES_LIST_ID,
     BREVO_CANDIDATS_LIST_ID,
     BREVO_LES_EMPLOIS_LIST_ID,
 )
-from itou.users.models import User
-from itou.utils.apis.pole_emploi import PoleEmploiAPIBadResponse
 from itou.utils.mocks.pole_emploi import API_RECHERCHE_ERROR, API_RECHERCHE_RESULT_KNOWN
 from tests.approvals.factories import ApprovalFactory
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
@@ -931,7 +931,7 @@ class TestCommandSendUsersToBrevo:
                 'HTTP Request: POST https://api.brevo.com/v3/contacts/import "HTTP/1.1 400 Bad Request"',
             ),
             (
-                "itou.users.management.commands.send_users_to_brevo",
+                "itou.utils.brevo",
                 logging.ERROR,
                 "Brevo API: Some emails were not imported, status_code=400, content={}",
             ),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Supprimmer les emalis des candidats lors de leur archivage

## :cake: Comment ? <!-- optionnel -->

* mutualisation de `BrevoClient` et ajout des méthodes de suppression
* TODO : ordonnancer l'appel à `BrevoClient` et traçant les retours

## :rotating_light: À vérifier

Non Mettre à jour le CHANGELOG_breaking_changes.md ?
Non Ajouter l'étiquette « Bug » ?




