### PR TITLE
get_di_services : Amélioration de la sélection des services + mention de la source

### DIFF
--- a/itou/templates/companies/hx_dora_services.html
+++ b/itou/templates/companies/hx_dora_services.html
@@ -35,6 +35,9 @@
                                                     {% for thematique in service.thematiques_display %}
                                                         <span class="badge badge-sm bg-info-lighter text-info text-uppercase text-decoration-none">{{ thematique }}</span>
                                                     {% endfor %}
+                                                    <div class="float-lg-end">
+                                                        <span class="text-secondary fs-xs text-decoration-none">Source : {{ service.source|title }}</span>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -89,6 +89,8 @@ def get_data_inclusion_services(code_insee):
 
         results = []
         department = code_insee[:2]
+        if code_insee.startswith("97") or code_insee.startswith("98"):
+            department = code_insee[:3]
         if department in ["59", "67"]:
             for svc in services:
                 if svc["source"] == "soliguide":

--- a/tests/www/companies_views/__snapshots__/test_dora_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_dora_views.ambr
@@ -11,6 +11,9 @@
                                                       
                                                           <span class="badge badge-sm bg-info-lighter text-info text-uppercase text-decoration-none">A</span>
                                                       
+                                                      <div class="float-lg-end">
+                                                          <span class="text-secondary fs-xs text-decoration-none">Source : Dora</span>
+                                                      </div>
                                                   </div>
                                               </div>
   '''
@@ -31,6 +34,9 @@
                                                       
                                                           <span class="badge badge-sm bg-info-lighter text-info text-uppercase text-decoration-none">A</span>
                                                       
+                                                      <div class="float-lg-end">
+                                                          <span class="text-secondary fs-xs text-decoration-none">Source : Dora</span>
+                                                      </div>
                                                   </div>
                                               </div>
   '''

--- a/tests/www/companies_views/test_dora_views.py
+++ b/tests/www/companies_views/test_dora_views.py
@@ -14,51 +14,62 @@ def test_displayable_thematique():
 
 def test_get_data_inclusion_services(settings, respx_mock):
     settings.API_DATA_INCLUSION_BASE_URL = "https://fake.api.gouv.fr/"
+    API_TEST_SERVICES = [
+        {
+            "service": {
+                "id": "svc1",
+                "source": "dora",
+                "thematiques": ["a--b"],
+                "modes_accueil": ["en presentiel", "a-distance"],
+                "lien_source": "https://fake.api.gouv.fr/services/svc1",
+            },
+            "distance": 1,
+        },
+        {
+            "service": {
+                "id": "svc2",
+                "source": "fake",
+                "thematiques": ["a--b", "c--d"],
+                "modes_accueil": ["en-presentiel"],
+                "lien_source": "https://fake.api.gouv.fr/services/svc2",
+            },
+            "distance": 3,
+        },
+        {
+            "service": {
+                "id": "svc3",
+                "source": "truc",
+                "thematiques": ["c--d", "f--b"],
+                "modes_accueil": ["en-presentiel"],
+            },
+            "distance": 2,
+        },
+        {
+            "service": {
+                "id": "svc4",
+                "source": "fake",
+                "thematiques": ["d--e"],
+                "modes_accueil": ["en-presentiel"],
+                "lien_source": "https://fake.api.gouv.fr/services/svc4",
+            },
+            "distance": 5,
+        },
+        {
+            "service": {
+                "id": "svc5",
+                "source": "soliguide",
+                "thematiques": ["c--e"],
+                "modes_accueil": ["en-presentiel"],
+                "lien_source": "https://fake.api.gouv.fr/services/svc4",
+            },
+            "distance": 1,
+        },
+    ]
     api_mock = respx_mock.get("https://fake.api.gouv.fr/search/services")
     api_mock.respond(
         200,
         json={
-            "items": [
-                {
-                    "service": {
-                        "id": "svc1",
-                        "source": "dora",
-                        "thematiques": ["a--b"],
-                        "modes_accueil": ["a-distance"],
-                        "lien_source": "https://fake.api.gouv.fr/services/svc1",
-                    },
-                    "distance": 1,
-                },
-                {
-                    "service": {
-                        "id": "svc2",
-                        "source": "fake",
-                        "thematiques": ["a--b"],
-                        "modes_accueil": ["en-presentiel"],
-                        "lien_source": "https://fake.api.gouv.fr/services/svc2",
-                    },
-                    "distance": 3,
-                },
-                {
-                    "service": {
-                        "id": "svc3",
-                        "source": "dora",
-                        "thematiques": ["a--b"],
-                        "modes_accueil": ["en-presentiel", "a-distance"],
-                    },
-                    "distance": 2,
-                },
-                {
-                    "service": {
-                        "id": "svc4",
-                        "source": "fake",
-                        "thematiques": ["a--b"],
-                        "modes_accueil": ["en-presentiel"],
-                        "lien_source": "https://fake.api.gouv.fr/services/svc4",
-                    },
-                    "distance": 5,
-                },
-            ]
+            "items": API_TEST_SERVICES,
         },
     )
 
@@ -69,19 +80,49 @@ def test_get_data_inclusion_services(settings, respx_mock):
             "dora_service_redirect_url": "/company/dora-service-redirect/fake/svc4",
             "id": "svc4",
             "lien_source": "https://fake.api.gouv.fr/services/svc4",
-            "modes_accueil": ["en-presentiel"],
+            "modes_accueil": [
+                "en-presentiel",
+            ],
             "source": "fake",
-            "thematiques": ["a--b"],
-            "thematiques_display": {"A"},
+            "thematiques": [
+                "d--e",
+            ],
+            "thematiques_display": {
+                "D",
+            },
+        },
+        {
+            "dora_service_redirect_url": "/company/dora-service-redirect/truc/svc3",
+            "id": "svc3",
+            "modes_accueil": [
+                "en-presentiel",
+            ],
+            "source": "truc",
+            "thematiques": [
+                "c--d",
+                "f--b",
+            ],
+            "thematiques_display": {
+                "C",
+                "F",
+            },
         },
         {
             "dora_service_redirect_url": "/company/dora-service-redirect/fake/svc2",
             "id": "svc2",
             "lien_source": "https://fake.api.gouv.fr/services/svc2",
-            "modes_accueil": ["en-presentiel"],
+            "modes_accueil": [
+                "en-presentiel",
+            ],
             "source": "fake",
-            "thematiques": ["a--b"],
-            "thematiques_display": {"A"},
+            "thematiques": [
+                "a--b",
+                "c--d",
+            ],
+            "thematiques_display": {
+                "A",
+                "C",
+            },
         },
     ]
     with freezegun.freeze_time("2024-01-01") as frozen_datetime:
@@ -97,6 +138,64 @@ def test_get_data_inclusion_services(settings, respx_mock):
         random.seed(0)  # ensure the mock data is stable
         assert views.get_data_inclusion_services("75056") == mocked_final_response
         assert api_mock.call_count == 2
+
+    # Test with Soliguide experiment
+    with freezegun.freeze_time("2025-01-01") as frozen_datetime:  # note the different date
+        result = views.get_data_inclusion_services("59056")
+        # we mandatorily have a soliguide service (test random.seed is fixed so we know where)
+        assert result[1]["source"] == "soliguide"
+        # all thematiques are different
+        assert result[0]["thematiques_display"] == {"D"}
+        assert result[1]["thematiques_display"] == {"C"}
+        assert result[2]["thematiques_display"] == {"C", "A"}
+
+    # Test with fewer values or no answer
+    with freezegun.freeze_time("2025-02-01") as frozen_datetime:  # note the different date
+        api_mock.respond(
+            200,
+            json={
+                "items": API_TEST_SERVICES[:1],
+            },
+        )
+        assert views.get_data_inclusion_services("59056") == []
+
+    with freezegun.freeze_time("2025-02-02") as frozen_datetime:  # note the different date
+        api_mock.respond(
+            200,
+            json={
+                "items": API_TEST_SERVICES[:2],
+            },
+        )
+        assert views.get_data_inclusion_services("59056") == [
+            {
+                "dora_service_redirect_url": "/company/dora-service-redirect/fake/svc2",
+                "id": "svc2",
+                "lien_source": "https://fake.api.gouv.fr/services/svc2",
+                "modes_accueil": [
+                    "en-presentiel",
+                ],
+                "source": "fake",
+                "thematiques": [
+                    "a--b",
+                    "c--d",
+                ],
+                "thematiques_display": {
+                    "A",
+                    "C",
+                },
+            },
+        ]
+
+    with freezegun.freeze_time("2025-02-03") as frozen_datetime:  # note the different date
+        api_mock.respond(
+            200,
+            json={
+                "items": API_TEST_SERVICES[:3],
+            },
+        )
+        result = views.get_data_inclusion_services("59056")
+        assert result[0]["thematiques_display"] == {"C", "F"}
+        assert result[1]["thematiques_display"] == {"C", "A"}
 
     with freezegun.freeze_time("2024-01-01") as frozen_datetime:
         api_mock.mock(side_effect=httpcore.TimeoutException)


### PR DESCRIPTION
## :thinking: Pourquoi ?

random.shuffle() was returning services that were way too similar to each other.

- add a special case where we WANT a soliguide service to be selected on a few given departments; in any other case, just pick one.

- make sure that the other selected services's themes are as far as possible from the others.

- make sure it can't crash.

- don't do anything too complicated with for instance a distance function, a bitmap  or something. We want an will always only want 3 items.


## :cake: Comment ? <!-- optionnel -->
[On est partis sur ça](https://www.notion.so/gip-inclusion/Int-gration-Les-Emplois-correction-de-bug-modif-source-1d55f321b604801ea801c6c8c63ad5ee?pvs=4) pour garder une implémentation la plus simple possible, meme si ça fait un peu brouillon.

## Screenshots
![image](https://github.com/user-attachments/assets/649d1414-2699-4d7d-931c-0ea1453c6fe0)

![image](https://github.com/user-attachments/assets/bc395fa0-03da-4656-8fa7-0ea39e55a105)



## :rotating_light: À vérifier

- KO Mettre à jour le CHANGELOG_breaking_changes.md ?
- KO Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Tester sur une recette jetable (Antoine Caldaguès) que ça fonctionne.
