### PR TITLE
Tech: empêcher l'affichage d'un PASS IAE expiré comme valide

### DIFF
--- a/itou/utils/templatetags/badges.py
+++ b/itou/utils/templatetags/badges.py
@@ -43,10 +43,11 @@ def job_application_state_badge(job_application, *, hx_swap_oob=False, extra_cla
 def approval_state_badge(
     approval, *, force_valid=False, in_approval_box=False, span_extra_class="badge-sm", icon_extra_class=""
 ):
-    # If force_valid is set to True, ignore the provided approval and display a VALID state
+    # If force_valid is set to True & approval.is_valid(), ignore the provided approval and display a VALID state
     # It is mainly used to show a VALID state to employers instead of SUSPENDED
     # which can be confusing.
-    approval_state = ApprovalStatus.VALID if force_valid else approval.state
+    # If the approval is expired, force_valid is ignored.
+    approval_state = ApprovalStatus.VALID if force_valid and approval.is_valid() else approval.state
     if in_approval_box:
         span_class = {
             ApprovalStatus.EXPIRED: "bg-danger text-white",

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1609,15 +1609,18 @@ def test_approval_state_badge(snapshot):
     )
     assert approval.state == ApprovalStatus.EXPIRED
     assert badges.approval_state_badge(approval) == snapshot(name="expired")
+    assert badges.approval_state_badge(approval, force_valid=True) == snapshot(name="expired")
 
     approval.start_at = today + datetime.timedelta(days=10)
     approval.end_at = today + datetime.timedelta(days=100)
     assert approval.state == ApprovalStatus.FUTURE
     assert badges.approval_state_badge(approval) == snapshot(name="future")
+    assert badges.approval_state_badge(approval, force_valid=True) == snapshot(name="valid")
 
     approval.start_at = today - datetime.timedelta(days=10)
     assert approval.state == ApprovalStatus.VALID
     assert badges.approval_state_badge(approval) == snapshot(name="valid")
+    assert badges.approval_state_badge(approval, force_valid=True) == snapshot(name="valid")
 
     SuspensionFactory(
         approval=approval,
@@ -1627,6 +1630,7 @@ def test_approval_state_badge(snapshot):
     del approval.is_suspended  # Invalidate cache
     assert approval.state == ApprovalStatus.SUSPENDED
     assert badges.approval_state_badge(approval) == snapshot(name="suspended")
+    assert badges.approval_state_badge(approval, force_valid=True) == snapshot(name="valid")
 
 
 @pytest.mark.parametrize("is_eligible", [True, False])


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour s'éviter des soucis.

Actuellement on n'utilise `force_valid=True` qu'avec des PASS IAE non expirés mais il ne faudrait pas que quelqu'un se trompe :grimacing: 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
