### PR TITLE
Vie privée : Allonger la durée d'inactivité à 24 mois avant la notification des comptes candidats sans candidature inactifs

### DIFF
--- a/itou/archive/management/commands/notify_archive_jobseekers.py
+++ b/itou/archive/management/commands/notify_archive_jobseekers.py
@@ -18,8 +18,9 @@ from itou.utils.command import BaseCommand
 
 logger = logging.getLogger(__name__)
 
-INACTIVITY_PERIOD = datetime.timedelta(days=365)
 GRACE_PERIOD = datetime.timedelta(days=30)
+INACTIVITY_PERIOD = datetime.timedelta(days=365) * 2 - GRACE_PERIOD
+
 BATCH_SIZE = 100
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

mise en conformité AIPD

