### PR TITLE
Tech: ajout d'un petit helper `check_date_order_constraint`

### DIFF
--- a/itou/geiq/models.py
+++ b/itou/geiq/models.py
@@ -6,6 +6,7 @@ from itou.files.models import File
 from itou.geiq.enums import ReviewState
 from itou.institutions.models import Institution
 from itou.users.enums import Title
+from itou.utils.models import check_nullable_date_order_constraint
 
 
 class ImplementationAssessmentCampaign(models.Model):
@@ -104,14 +105,12 @@ class ImplementationAssessment(models.Model):
                     )
                 ),
             ),
-            models.CheckConstraint(
+            check_nullable_date_order_constraint(
+                "submitted_at",
+                "reviewed_at",
                 name="reviewed_at_only_after_submitted_at",
                 violation_error_message=(
                     "Impossible d'avoir une date de contrôle sans une date de soumission antérieure"
-                ),
-                condition=(
-                    models.Q(reviewed_at__isnull=True)
-                    | models.Q(submitted_at__isnull=False, reviewed_at__gte=models.F("submitted_at"))
                 ),
             ),
             models.CheckConstraint(

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -20,7 +20,7 @@ from itou.siae_evaluations.constants import CAMPAIGN_VIEWABLE_DURATION
 from itou.siae_evaluations.emails import CampaignEmailFactory, SIAEEmailFactory
 from itou.users.enums import KIND_EMPLOYER
 from itou.utils.emails import send_email_messages
-from itou.utils.models import InclusiveDateRangeField
+from itou.utils.models import InclusiveDateRangeField, check_nullable_date_order_constraint
 from itou.utils.validators import validate_html
 
 
@@ -506,13 +506,13 @@ class EvaluatedSiae(models.Model):
         verbose_name_plural = "entreprises contrôlées"
         unique_together = ("evaluation_campaign", "siae")
         constraints = [
-            models.CheckConstraint(
+            check_nullable_date_order_constraint(
+                "reviewed_at",
+                "final_reviewed_at",
                 name="final_reviewed_at_only_after_reviewed_at",
                 violation_error_message=(
                     "Impossible d'avoir une date de contrôle définitif sans une date de premier contrôle antérieure"
                 ),
-                condition=models.Q(final_reviewed_at__isnull=True)
-                | models.Q(reviewed_at__isnull=False, final_reviewed_at__gte=F("reviewed_at")),
             ),
         ]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour facilement indiquer l'ordonnancement de deux champs dates.
Comme je compte en [rajouter 6 sur le bilan d'exécution GEIQ](https://github.com/gip-inclusion/les-emplois/blob/xfernandez/geiq_assessments/itou/geiq_assessments/models.py#L148-L197), autant éviter un peu les redites :grimacing: 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
