### PR TITLE
Admin: utilisation de la permission `change_company` pour l'affichage du bouton de transfert d'entreprise

### DIFF
--- a/itou/templates/admin/companies/change_company_form.html
+++ b/itou/templates/admin/companies/change_company_form.html
@@ -2,8 +2,7 @@
 
 {% block object-tools-items %}
 
-    {% if request.user.is_itou_admin %}
-        {# Change to if has_change_permission in a few weeks #}
+    {% if has_change_permission %}
         <li>
             <a href="{% url 'admin:transfer_company_data' from_company_pk=original.pk %}">Transférer</a>
         </li>

--- a/tests/companies/test_admin.py
+++ b/tests/companies/test_admin.py
@@ -219,12 +219,9 @@ class TestTransferCompanyData:
         response = client.get(reverse("admin:companies_company_change", kwargs={"object_id": company.pk}))
         assertNotContains(response, transfer_url)
 
-        # A superuser, the button appears
-        # TODO(xfernandez): in a few weeks, show the buttons to user with change permission
-        # perms = Permission.objects.filter(codename="change_company")
-        # admin_user.user_permissions.add(*perms)
-        admin_user.is_superuser = True
-        admin_user.save(update_fields=("is_superuser",))
+        # With change permission, the button appears
+        perms = Permission.objects.filter(codename="change_company")
+        admin_user.user_permissions.add(*perms)
         response = client.get(reverse("admin:companies_company_change", kwargs={"object_id": company.pk}))
         assertContains(response, transfer_url)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'utilisation de la fonctionnalité est déjà conditionnée à la permission.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
