### PR TITLE
Employeur : Correctif de la logique Convergence ACI (PHC CVG) pour les antennes [GEN-2411]

### DIFF
--- a/itou/companies/enums.py
+++ b/itou/companies/enums.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.db import models
 
 
@@ -61,7 +60,7 @@ class ContractType(models.TextChoices):
 
     @classmethod
     def choices_for_company(cls, company):
-        return cls.choices_for_company_kind(company.kind, company.siret in settings.ACI_CONVERGENCE_SIRET_WHITELIST)
+        return cls.choices_for_company_kind(company.kind, company.is_aci_convergence)
 
     @classmethod
     def choices_for_company_kind(cls, kind, aci_convergence=False):
@@ -93,7 +92,7 @@ class ContractType(models.TextChoices):
                 choices.remove(cls.FIXED_TERM_I_PHC)
                 choices.remove(cls.FIXED_TERM_I_CVG)
 
-        if kind == CompanyKind.ACI and aci_convergence:
+        if aci_convergence:
             choices[-1:-1] = [
                 cls.FIXED_TERM_I_PHC,
                 cls.FIXED_TERM_I_CVG,

--- a/itou/companies/enums.py
+++ b/itou/companies/enums.py
@@ -60,10 +60,18 @@ class ContractType(models.TextChoices):
 
     @classmethod
     def choices_for_company(cls, company):
-        return cls.choices_for_company_kind(company.kind, company.is_aci_convergence)
+        choices = cls.choices_for_company_kind(company.kind)
+        if company.is_aci_convergence:
+            choices[-1:-1] = cls._choices_from_enums_list(
+                [
+                    cls.FIXED_TERM_I_PHC,
+                    cls.FIXED_TERM_I_CVG,
+                ]
+            )
+        return choices
 
     @classmethod
-    def choices_for_company_kind(cls, kind, aci_convergence=False):
+    def choices_for_company_kind(cls, kind):
         choices = []
 
         match kind:
@@ -91,12 +99,6 @@ class ContractType(models.TextChoices):
                 # These are only for ACI from ACI_CONVERGENCE_SIRET_WHITELIST
                 choices.remove(cls.FIXED_TERM_I_PHC)
                 choices.remove(cls.FIXED_TERM_I_CVG)
-
-        if aci_convergence:
-            choices[-1:-1] = [
-                cls.FIXED_TERM_I_PHC,
-                cls.FIXED_TERM_I_CVG,
-            ]
 
         return cls._choices_from_enums_list(choices)
 

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -491,6 +491,9 @@ class Company(AddressMixin, OrganizationAbstract):
                     return convention_siae
         return self
 
+    @property
+    def is_aci_convergence(self):
+        return self.kind == CompanyKind.ACI and self.siret in settings.ACI_CONVERGENCE_SIRET_WHITELIST
 
     def convention_can_be_accessed_by(self, user):
         """

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -493,7 +493,9 @@ class Company(AddressMixin, OrganizationAbstract):
 
     @property
     def is_aci_convergence(self):
-        return self.kind == CompanyKind.ACI and self.siret in settings.ACI_CONVERGENCE_SIRET_WHITELIST
+        return (
+            self.kind == CompanyKind.ACI and self.canonical_company.siret in settings.ACI_CONVERGENCE_SIRET_WHITELIST
+        )
 
     def convention_can_be_accessed_by(self, user):
         """

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -476,6 +476,22 @@ class Company(AddressMixin, OrganizationAbstract):
         """
         return self.kind == CompanyKind.AI
 
+    @property
+    def canonical_company(self):
+        """
+        Return the canonical company of the current company.
+        If the current company has no parent, it is itself its canonical company.
+        If the current company has a parent, that parent is the canonical company.
+        """
+        if self.convention_id and self.source == self.SOURCE_USER_CREATED:
+            # Iterate on all() to take advantage of a potential prefetch_related upstream
+            # e.g. by populate_metabase_emplois.
+            for convention_siae in self.convention.siaes.all():
+                if convention_siae.source == self.SOURCE_ASP:
+                    return convention_siae
+        return self
+
+
     def convention_can_be_accessed_by(self, user):
         """
         Decides whether the user can show the siae convention or not.

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -469,13 +469,11 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
     @staticmethod
     def siret_from_asp_source(siae):
         """
-        Fetch SIRET number of ASP source structure ("mother" SIAE)
+        Fetch SIRET number of authoritative SIAE from ASP source
         """
-        if siae.source != Company.SOURCE_ASP:
-            main_siae = Company.objects.get(convention=siae.convention, source=Company.SOURCE_ASP)
-            return main_siae.siret
-
-        return siae.siret
+        if siae.canonical_company.source == Company.SOURCE_ASP:
+            return siae.canonical_company.siret
+        raise ValidationError("Could not find authoritative SIAE from ASP source")
 
     @classmethod
     def from_job_application(cls, job_application, clean=True):

--- a/itou/metabase/tables/companies.py
+++ b/itou/metabase/tables/companies.py
@@ -1,6 +1,3 @@
-from django.conf import settings
-
-from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.metabase.tables.utils import (
     MetabaseTable,
@@ -57,7 +54,7 @@ TABLE.add_columns(
             "name": "convergence_france",
             "type": "boolean",
             "comment": "Convergence France (contrats PHC et CVG)",
-            "fn": lambda o: o.kind == CompanyKind.ACI and o.siret in settings.ACI_CONVERGENCE_SIRET_WHITELIST,
+            "fn": lambda o: o.is_aci_convergence,
         },
     ]
 )

--- a/itou/metabase/tables/companies.py
+++ b/itou/metabase/tables/companies.py
@@ -62,17 +62,9 @@ TABLE.add_columns(
     ]
 )
 
-
-def get_parent_company(company):
-    if company.convention_id and company.source == Company.SOURCE_USER_CREATED:
-        # NOTE: siae.convention.siaes should absolutely be prefetched !
-        for convention_siae in company.convention.siaes.all():
-            if convention_siae.source == Company.SOURCE_ASP:
-                return convention_siae
-    return company
-
-
-TABLE.add_columns(get_address_columns(comment_suffix=" de la structure mère", custom_fn=get_parent_company))
+TABLE.add_columns(
+    get_address_columns(comment_suffix=" de la structure mère", custom_fn=(lambda o: o.canonical_company))
+)
 TABLE.add_columns(get_address_columns(name_suffix="_c1", comment_suffix=" de la structure C1"))
 
 TABLE.add_columns(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le dispositif Convergence ACI s'applique actuellement aux entreprises dont le SIRET fait partie d'une liste blanche.

Le SIRET de leurs antennes ne fait a priori pas partie de cette liste blanche du coup elles ne sont pas considérées comme PHC CVG, ce qui cause une frustration légitime.

## :cake: Comment ?

- Un refacto DRY de la logique antenne/parent, qui retouche à du code de Pilotage en passant.
- Un refacto DRY de la logique PHC CVG qui touche aussi à Pilotage.
- Le correctif lui-même.

## Revue
- Tonial qui était au tout début la discussion.
- Rsebille pour le refacto côté Pilotage.