### PR TITLE
Recherche employeur : Fin de la pénalisation des entreprises recrutant sans fiche de poste dans les résultats de la recherche employeur [GEN-1728]

### DIFF
--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -126,20 +126,20 @@ def test_update_companies_job_app_score(caplog):
 
     stdout = io.StringIO()
     management.call_command("update_companies_job_app_score")
-    # company_1 did not change (from None to None)
-    assert caplog.messages[0] == "Updated 1 companies"
+    assert caplog.messages[0] == "Updated 2 companies"
 
     company_1.refresh_from_db()
     company_2.refresh_from_db()
 
-    assert company_1.job_app_score is None
+    assert company_1.job_app_score is not None
+    assert company_1.job_app_score == company_1.job_applications_received.count()
     assert company_2.job_app_score is not None
     assert (
         company_2.job_app_score
         == company_2.job_applications_received.count() / company_2.job_description_through.count()
     )
 
-    # Deleting job descriptions should bring score back to None.
+    # Deleting job descriptions should bring score back to job_applications_received.count().
     for jd in company_2.job_description_through.all():
         jd.delete()
     caplog.clear()
@@ -150,8 +150,10 @@ def test_update_companies_job_app_score(caplog):
     company_1.refresh_from_db()
     company_2.refresh_from_db()
 
-    assert company_1.job_app_score is None
-    assert company_2.job_app_score is None
+    assert company_1.job_app_score is not None
+    assert company_1.job_app_score == company_1.job_applications_received.count()
+    assert company_2.job_app_score is not None
+    assert company_2.job_app_score == company_2.job_applications_received.count()
 
 
 @freeze_time("2023-05-01")

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -364,7 +364,7 @@ class TestCompanyQuerySet:
         JobApplicationFactory(to_company=company)
         JobApplicationFactory(to_company=company)
 
-        expected_score = None
+        expected_score = 2.0
         result = Company.objects.with_computed_job_app_score().get(pk=company.pk)
 
         assert expected_score == result.computed_job_app_score


### PR DESCRIPTION
## :thinking: Pourquoi ?

La logique officielle de notre recherche employeur est de répartir à peu près équitablement les candidatures entre les entreprises, en mettant toujours en avant en première page les entreprises ayant reçu aucune ou peu de candidatures récentes. Dès qu'elles recoivent des candidatures elles sont repoussées à des pages ultérieures et le cycle continue.

Pourtant historiquement on montre systématiquement d'abord (donc en première page) les entreprises ayant au moins une fiche de poste active et seulement ensuite les entreprises sans fiche de poste active.

Autrement dit, si on a déjà envoyé récemment un très grand nombre de candidatures à une entreprise A ayant au moins une fiche de poste active, et qu'on a envoyé aucune candidature à une entreprise B recrutant sans fiche de poste, on continue de montrer A toujours avant B ! C'est en sérieuse contradiction avec notre logique globale.

La cause racine est je pense technique et en fait involontaire, une histoire de division par zéro.

Ce correctif est d'actualité car l'imminente dépublication automatique des fiches de poste va faire exploser le volume des entreprises sans fiche de poste active.

## :cake: Comment ? 

En traitant correctement le cas de l'entreprise sans fiche de poste active, qui sera maintenant mis au même niveau qu'une entreprise ayant 1 fiche de poste active et le même nombre de candidatures récentes.