### PR TITLE
[Prolongations] Affichage du _spinner_ sur la totalité du formulaire

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -195,6 +195,7 @@ class CreateProlongationForm(forms.ModelForm):
                 "hx-params": "not end_at",  # Clear "end_at" when switching reason
                 "hx-swap": "outerHTML",
                 "hx-target": "#mainForm",
+                "hx-indicator": "#mainForm",  # Add a spinner to another element, here the main form instead of a field
             }
         )
 

--- a/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation.ambr
@@ -75,7 +75,7 @@
 # ---
 # name: TestApprovalProlongation.test_prolongation_approval_view_with_disabled_values[RQTH & SENIOR disabled]
   '''
-  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-indicator="#mainForm" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
       
           
           
@@ -114,7 +114,7 @@
 # ---
 # name: TestApprovalProlongation.test_prolongation_approval_view_with_disabled_values[RQTH disabled]
   '''
-  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
+  <div class="form-group form-group-required"><label class="form-label">Motif</label><div class="" hx-indicator="#mainForm" hx-params="not end_at" hx-post="/approvals/declare_prolongation/[PK of Approval]/prolongation_form_for_reason?back_url=%2Fdashboard%2F" hx-swap="outerHTML" hx-target="#mainForm" hx-trigger="change" id="id_reason" required="">
       
           
           


### PR DESCRIPTION
## :thinking: Pourquoi ?

Affichage du _spinner_ sur la totalité du formulaire et non seulement sur le champ qui a déclenché l'événement.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :computer: Captures d'écran

Avant
![image](https://github.com/user-attachments/assets/3c204bea-6b10-4447-a062-8e62c90453eb)


Après
![image](https://github.com/user-attachments/assets/3caa2dec-cb82-4367-9636-3b3f102a4a8a)


<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
