### PR TITLE
Interface: Remonter le bandeau “Votre avis nous intéresse” au dessus du bandeau action de la liste de candidatures

### DIFF
--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -27,14 +27,9 @@
             </div>
         {% endif %}
     </div>
-    {% include "apply/includes/siae_actions.html" with batch_mode=False %}
-{% endblock %}
-
-{% block title_messages %}
-    {% include "includes/mon_recap_banner.html" with request=request mon_recap_banner_departments=mon_recap_banner_departments only %}
 
     {% if request.user.is_employer %}
-        <div id="employer-interview-2025-04" class="alert alert-important alert-dismissible-once d-none my-5" role="status">
+        <div id="employer-interview-2025-04" class="alert alert-important alert-dismissible-once d-none" role="status">
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
             <div class="row">
                 <div class="col-auto pe-0">
@@ -54,6 +49,12 @@
             </div>
         </div>
     {% endif %}
+
+    {% include "apply/includes/siae_actions.html" with batch_mode=False %}
+{% endblock %}
+
+{% block title_messages %}
+    {% include "includes/mon_recap_banner.html" with request=request mon_recap_banner_departments=mon_recap_banner_departments only %}
 {% endblock title_messages %}
 
 {% block content %}


### PR DESCRIPTION
## :thinking: Pourquoi ?
Parcque le chef demande
https://www.notion.so/gip-inclusion/Remonter-le-bandeau-Votre-avis-nous-int-resse-au-dessus-du-bandeau-action-de-la-liste-de-candidatu-1df5f321b604804c9854dbe66033f5a2

## :cake: Comment ? <!-- optionnel -->
En déplacant l'alerte dans le mauvais `{% block %}` 🙈 (mais c'est une alerte temporaire, c'est presque pardonnable)

![capture 2025-04-25 à 10 31 10](https://github.com/user-attachments/assets/90676c4c-a8be-4abe-8462-42facb9ce97d)

