### PR TITLE
Éligibilité : mise à jour du texte expliquant pourquoi certains critères ne peuvent être certifiés [GEN-2258]

### DIFF
--- a/itou/templates/apply/includes/certification_info_box.html
+++ b/itou/templates/apply/includes/certification_info_box.html
@@ -8,7 +8,7 @@
                 aria-controls="collapse-certif-help-text">
             <div>
                 <i class="ri-lightbulb-line fw-medium pe-2" aria-hidden="true"></i>
-                <span>Pourquoi certains de mes critères peuvent-ils être certifiés ?</span>
+                <span>Pourquoi certains critères peuvent-ils être certifiés ?</span>
             </div>
         </button>
         <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -323,7 +323,7 @@ class TestCertifiedBadgeIae:
             "itou.utils.apis.api_particulier._request",
             return_value=RESPONSES[AdministrativeCriteriaKind.RSA][ResponseKind.CERTIFIED],
         )
-        certified_help_text = "Pourquoi certains de mes critères peuvent-ils être certifiés"
+        certified_help_text = "Pourquoi certains critères peuvent-ils être certifiés"
         # No certifiable criteria
         diagnosis = IAEEligibilityDiagnosisFactory(
             certifiable=True,
@@ -468,7 +468,7 @@ class TestCertifiedBadgeGEIQ:
 
     def test_info_box(self, mocker):
         """Information box about why some criteria are certifiable."""
-        certified_help_text = "Pourquoi certains de mes critères peuvent-ils être certifiés"
+        certified_help_text = "Pourquoi certains critères peuvent-ils être certifiés"
         diagnosis = GEIQEligibilityDiagnosisFactory(
             certifiable=True,
             criteria_kinds=[AdministrativeCriteriaKind.CAP_BEP],


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter l’intégration des badges « critères non certifié ».