### PR TITLE
Utiliser le SessionNamespace pour sécuriser l’édition des fiches de poste [GEN-2311]

### DIFF
--- a/itou/templates/companies/edit_job_description_details.html
+++ b/itou/templates/companies/edit_job_description_details.html
@@ -68,9 +68,8 @@
                                 {% bootstrap_field form.is_qpv_mandatory %}
                             {% endif %}
 
-                            {% url "companies_views:edit_job_description" as secondary_url %}
                             {% url "companies_views:job_description_list" as reset_url %}
-                            {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="edit-description-fiche-poste" %}
+                            {% itou_buttons_form primary_label="Suivant" secondary_url=back_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="edit-description-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/edit_job_description_preview.html
+++ b/itou/templates/companies/edit_job_description_preview.html
@@ -49,9 +49,8 @@
 
                         <form method="post" class="js-prevent-multiple-submit">
                             {% csrf_token %}
-                            {% url "companies_views:edit_job_description_details" as secondary_url %}
                             {% url "companies_views:job_description_list" as reset_url %}
-                            {% itou_buttons_form primary_label="Enregistrer" primary_aria_label="Enregistrer" secondary_url=secondary_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="publier-fiche-poste" %}
+                            {% itou_buttons_form primary_label="Enregistrer" primary_aria_label="Enregistrer" secondary_url=back_url reset_url=reset_url matomo_category="employeurs" matomo_action="submit" matomo_name="publier-fiche-poste" %}
                         </form>
                     </div>
                 </div>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -43,7 +43,7 @@
         {% endfragment %}
         {% fragment as c_title__cta %}
             {% if can_update_job_description %}
-                <a href="{% url "companies_views:update_job_description" job_description_id=job.pk %}"
+                <a href="{% url "companies_views:edit_job_description" job_description_id=job.pk %}"
                    class="btn btn-lg btn-primary btn-ico"
                    aria-label="Modifier la fiche de poste"
                    {% matomo_event "employeurs" "clic" "edit-fiche-de-poste" %}>

--- a/itou/www/companies_views/urls.py
+++ b/itou/www/companies_views/urls.py
@@ -16,8 +16,38 @@ urlpatterns = [
     ),
     path("job_description_list", views.job_description_list, name="job_description_list"),
     path("edit_job_description", views.edit_job_description, name="edit_job_description"),
+    path("edit_job_description/<uuid:edit_session_id>", views.edit_job_description, name="edit_job_description"),
+    path("edit_job_description/<int:job_description_id>", views.edit_job_description, name="edit_job_description"),
+    path(
+        "edit_job_description/<int:job_description_id>/<uuid:edit_session_id>",
+        views.edit_job_description,
+        name="edit_job_description",
+    ),
+    # TODO (François): Remove URL without parameter after a week.
     path("edit_job_description_details", views.edit_job_description_details, name="edit_job_description_details"),
+    path(
+        "edit_job_description_details/<uuid:edit_session_id>",
+        views.edit_job_description_details,
+        name="edit_job_description_details",
+    ),
+    path(
+        "edit_job_description_details/<int:job_description_id>/<uuid:edit_session_id>",
+        views.edit_job_description_details,
+        name="edit_job_description_details",
+    ),
+    # TODO (François): Remove URL without parameter after a week.
     path("edit_job_description_preview", views.edit_job_description_preview, name="edit_job_description_preview"),
+    path(
+        "edit_job_description_preview/<uuid:edit_session_id>",
+        views.edit_job_description_preview,
+        name="edit_job_description_preview",
+    ),
+    path(
+        "edit_job_description_preview/<int:job_description_id>/<uuid:edit_session_id>",
+        views.edit_job_description_preview,
+        name="edit_job_description_preview",
+    ),
+    # TODO(François): Remove URL after a week.
     path(
         "update_job_description/<int:job_description_id>", views.update_job_description, name="update_job_description"
     ),

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -190,7 +190,7 @@ def test_step_1_same_company(client):
     )
     assertNotContains(
         response,
-        reverse("companies_views:update_job_description", kwargs={"job_description_id": job.pk}),
+        reverse("companies_views:edit_job_description", kwargs={"job_description_id": job.pk}),
     )
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Protéger le parcours des problèmes d’une session modifiée dans des onglets multiples.

## :cake: Comment ? <!-- optionnel -->

En écrivant l’ID de la session dans l’URL.

J’en ai profité pour ajouter `job_description_id` dans les URLs, afin de mieux indiquer si le parcours est une création de fiche de poste ou une mise à jour.

`test_empty_session_during_edit` a été supprimé, puisque la `SessionNamespace` requiert dorénavant une `edit_session_id`.

## :desert_island: Comment tester ?

Créer une fiche de poste.
Mettre à jour une fiche de poste.
