### PR TITLE
Changelog : Utiliser le token GitHub des actions

### DIFF
--- a/.github/workflows/mkchangelog.yml
+++ b/.github/workflows/mkchangelog.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   generate-changelog:
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: 💂 Install Python
@@ -18,4 +20,4 @@ jobs:
     - name: 📥 Generate changelog
       run: scripts/mkchangelog --publish
       env:
-        GH_TOKEN: ${{ secrets.ITOU_TECH_GH_TOKEN }}
+        GH_TOKEN: "${{ github.token }}"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les actions GitHub ont déjà un token défini pour leur exécution. L’utiliser évite la gestion d’un token séparé.

## :cake: Comment ? <!-- optionnel -->

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token