### PR TITLE
Éligibilité : Mieux indiquer le lien externe dans le bloc d’information sur la certification des critères

### DIFF
--- a/itou/templates/apply/includes/certification_info_box.html
+++ b/itou/templates/apply/includes/certification_info_box.html
@@ -12,7 +12,7 @@
             </div>
         </button>
         <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
-            <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" target="_blank" rel="noreferrer">notre documentation</a>.</span> <i class="ri-external-link-line ri-lg" aria-hidden="true"></i>
+            <span>Nous sommes en train de nous connecter progressivement aux différents services de l’État qui délivrent les justificatifs correspondant aux critères administratifs. Retrouvez le détail des conditions dans <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" class="has-external-link" target="_blank" rel="noreferrer">notre documentation</a>.</span>
         </div>
     </div>
 {% endif %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une icône seule n’est pas liée au lien, et ne sera pas mise à jour avec le thème.

## :computer: Captures d'écran
### Avant

![image](https://github.com/user-attachments/assets/9ec35b16-7077-430d-8654-4765a9969c76)

### Après

![image](https://github.com/user-attachments/assets/4dff53b9-1dd0-4a9e-bf91-cdf94f4a3167)

