### PR TITLE
[Admin] Permettre aux admins itou d'ajouter un calendrier

### DIFF
--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -81,7 +81,7 @@ def get_permissions_dict():
         jobs_models.Rome: PERMS_READ,
         prescribers_models.PrescriberMembership: PERMS_ADD,
         prescribers_models.PrescriberOrganization: PERMS_ALL,
-        siae_evaluations_models.Calendar: PERMS_READ,
+        siae_evaluations_models.Calendar: PERMS_ADD,
         siae_evaluations_models.EvaluationCampaign: PERMS_READ,
         siae_evaluations_models.EvaluatedSiae: PERMS_READ,
         siae_evaluations_models.EvaluatedJobApplication: PERMS_READ,

--- a/tests/users/__snapshots__/test_sync_group_and_perms.ambr
+++ b/tests/users/__snapshots__/test_sync_group_and_perms.ambr
@@ -192,6 +192,8 @@
     'change_prescriberorganization',
     'delete_prescriberorganization',
     'view_prescriberorganization',
+    'add_calendar',
+    'change_calendar',
     'view_calendar',
     'view_evaluatedadministrativecriteria',
     'view_evaluatedjobapplication',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Demande du métier.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :computer: Captures d'écran <!-- optionnel -->

![image](https://github.com/user-attachments/assets/842386ed-c11a-45ca-b687-d67635d9d911)


<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
