### PR TITLE
Interface: ajout de la classe .stretched-link manquante sur les cartes de job_description

### DIFF
--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -33,9 +33,10 @@
                 <div class="d-flex flex-column flex-md-row justify-content-md-between">
                     <div class="order-2 order-md-1">
                         <a href="{% url_add_query job_description.get_absolute_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
-                           class="fw-bold text-decoration-none {% if job_description.is_external %}has-external-link{% else %}stretched-link{% endif %}"
+                           class="fw-bold text-decoration-none stretched-link"
                            {% if job_description.is_external %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte-externe" %} rel="noopener" target="_blank" aria-label="Visiter l'offre sur le site d'origine" {% else %} {% matomo_event "candidature" "clic" "clic-card-fichedeposte" %} aria-label="Aller vers la description de ce poste" {% endif %}>
                             {{ job_description.display_name | capfirst }}
+                            {% if job_description.is_external %}<i class="ri-external-link-line" aria-hidden="true"></i>{% endif %}
                         </a>
                         {% if job_description.is_overwhelmed %}
                             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car on ne comprenait pas bien que l'item de job était cliquable

Au passage, remplacement de la classe `.has-external-link` par une icône, car les deux classes (.has-external-link et .stretched-link) agissaient sur le même pseudo-élément `::after`

