### PR TITLE
Fiche de poste: Mise à jour de l'ordonnancement des fiches

### DIFF
--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -586,9 +586,6 @@ class JobDescriptionQuerySet(models.QuerySet):
         )
         return annotation
 
-    def order_by_most_recent(self):
-        return self.order_by("-updated_at", "-created_at")
-
     def active(self):
         subquery = Subquery(
             Company.unfiltered_objects.filter(

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_not_required
 from django.core.cache import caches
 from django.core.exceptions import BadRequest, PermissionDenied
 from django.db.models import Count, Q
+from django.db.models.functions import Coalesce
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -197,7 +198,7 @@ def job_description_list(request, template_name="companies/job_description_list.
         JobDescription.objects.filter(company__pk=company.pk)
         .select_related("location", "company")
         .prefetch_related("appellation", "appellation__rome")
-        .order_by_most_recent()
+        .order_by("-is_active", Coalesce("last_employer_update_at", "updated_at").desc(), "-created_at")
     )
     page = int(request.GET.get("page") or 1)
 

--- a/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
@@ -956,8 +956,8 @@
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
           WHERE "companies_jobdescription"."company_id" = %s
-          ORDER BY "companies_jobdescription"."updated_at" DESC,
-                   "companies_jobdescription"."created_at" DESC
+          ORDER BY "companies_jobdescription"."is_active" DESC,
+                   COALESCE("companies_jobdescription"."last_employer_update_at", "companies_jobdescription"."updated_at") DESC, "companies_jobdescription"."created_at" DESC
           LIMIT 4
         ''',
       }),


### PR DESCRIPTION
L'ordre est à présent basé sur :

1. Statut actif (FDP actives en premier)
2. Date de mise à jour (si définie, la dernière mise à jour employeur prend le dessus sur `updated_at`)
3. Date de création

## :thinking: Pourquoi ?

Pour avoir un fonctionnement plus cohérent dans le listing des FDP et présenter les actives en priorité aux employeurs.

Cf. https://gip-inclusion.slack.com/archives/CU8ATF54L/p1745850440314969?thread_ts=1741943558.714919&cid=CU8ATF54L
