### PR TITLE
Makefile : ignorer les changements dans `requirements/dev.txt` dans les appels récursifs à  `make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ shell_on_postgres_container:
 
 .PHONY: dumpcreate dumprestore resetdb restore_latest_backup
 
-dumpcreate: $(VIRTUALENV)
+dumpcreate: $(VIRTUAL_ENV)
 	dropdb --if-exists $(PGDATABASE)
 	createdb $(PGDATABASE)
 	python manage.py migrate
@@ -117,7 +117,7 @@ dumpcreate: $(VIRTUALENV)
 	pg_dump --format=c --dbname=$(PGDATABASE) --file=$(DBDUMP)
 
 # There are no dependencies on fixtures, allowing developers to manage their DB dump manually.
-dumprestore: $(VIRTUALENV)
+dumprestore: $(VIRTUAL_ENV)
 	dropdb --if-exists $(PGDATABASE)
 	createdb $(PGDATABASE)
 	pg_restore --dbname=$(PGDATABASE) $(DBDUMP)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ LINTER_CHECKED_DIRS := config itou scripts tests
 PGDATABASE ?= itou
 REQUIREMENTS_PATH ?= requirements/dev.txt
 PIP_COMPILE_OPTIONS :=
+NETWORK_MODE := online
 
 ifdef $(XDG_CACHE_HOME)
 	CACHEDIR := $(XDG_CACHE_HOME)
@@ -28,9 +29,13 @@ runserver: $(VIRTUAL_ENV)
 	python manage.py runserver $(RUNSERVER_DOMAIN)
 
 $(VIRTUAL_ENV): $(REQUIREMENTS_PATH)
+ifeq "$(NETWORK_MODE)" "online"
 	uv venv
 	uv pip sync --require-hashes $^
 	touch $@
+else
+	@echo "Skipping virtualenv dependencies sync due to NETWORK_MODE=$(NETWORK_MODE)."
+endif
 
 venv: $(VIRTUAL_ENV)
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ Vous pouvez y accéder à l'adresse http://100.1.2.3:8000/ depuis n'importe quel
 $ make resetdb
 ```
 
+## Utiliser les commandes `make` sans connexion à internet
+
+Si vous développez hors ligne et que le fichier de dépendances
+(`requirements/dev.txt`) a changé, les commandes `make` vont planter, puisque
+lorsque ce fichier change, `uv` va être lancé pour mettre à jour les dépendances
+dans le `.venv`.
+
+Pour passer outre, vous pouvez utiliser `make` avec la variable `NETWORK_MODE` :
+```sh
+$ make NETWORK_MODE=offline resetdb
+```
+
 ## Charger une base de données de production
 
 Inspirez-vous de la suite de commandes suivante :


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il arrive de travailler hors ligne, et dès qu'il y a un changement dans `requirements/dev.txt`, `uv` se lance pour mettre à jour les dépendances et plante s'il n'y a pas de réseau.

On peut utiliser l'option `-o requirements/dev.txt` pour ignorer les changements, mais il y a des appels récursifs à `make`.

Je propose donc d'ajouter cette option aux appels récursifs (qui ne concernent que des cibles de réinitialisation/dump de la base de données).

J'ai aussi remarqué qu'il y a une variable `VIRTUALENV`, probablement une coquille, cela devrait être `VIRTUAL_ENV` ?

