### PR TITLE
Interface : harmonisation de la formulation en "numéro SIRET"

### DIFF
--- a/itou/templates/static/legal/terms.html
+++ b/itou/templates/static/legal/terms.html
@@ -61,7 +61,7 @@
                         L’Utilisateur qui s’est inscrit directement sur le site « Les emplois de l’inclusion » devra ensuite s’identifier à l’aide de son identifiant et de son mot de passe qui lui seront communiqués après son inscription. Le mot de passe doit être choisi par l’utilisateur de façon à ce qu’il ne puisse être deviné par un tiers. Cette information doit être sécurisée, conservée et non-cédée.
                     </p>
                     <p>
-                        L’Utilisateur qui s’inscrit directement sur le site « Les emplois de l’inclusion » doit renseigner sa situation et indiquer son NIR ou son numéro de SIRET ou le numéro SIREN de sa structure.
+                        L’Utilisateur qui s’inscrit directement sur le site « Les emplois de l’inclusion » doit renseigner sa situation et indiquer son NIR ou son numéro SIRET ou le numéro SIREN de sa structure.
                     </p>
                     <p>
                         Pour accéder aux Services, l’Utilisateur peut s’inscrire ou se connecter via d’autres plateformes numériques que l’on retrouve sur le site « Les emplois de l’inclusion ». L’Utilisateur peut s’inscrire ou se connecter via « France Connect », via « France Travail » en renseignant son nom d’utilisateur ou son code SAFIR ou via « Inclusion Connect » en renseignant son nom, prénom, adresse e-mail.

--- a/itou/www/companies_views/forms.py
+++ b/itou/www/companies_views/forms.py
@@ -69,7 +69,7 @@ class CreateCompanyForm(forms.ModelForm):
 
         if existing_siae_query.exists():
             error_message = (
-                "Le numéro de SIRET que vous avez renseigné est déjà utilisé par une structure ou une antenne, "
+                "Le numéro SIRET que vous avez renseigné est déjà utilisé par une structure ou une antenne, "
                 "nous vous invitons à réessayer avec un autre numéro. "
                 "Si besoin vous pouvez consulter "
             )

--- a/itou/www/signup/forms.py
+++ b/itou/www/signup/forms.py
@@ -241,7 +241,7 @@ class CompanySiaeSelectForm(forms.Form):
 
 class CheckAlreadyExistsForm(forms.Form):
     siret = forms.CharField(
-        label="Numéro de SIRET de votre organisation",
+        label="Numéro SIRET de votre organisation",
         # `max_length` is skipped so that we can allow an arbitrary number of spaces in the user-entered value.
         min_length=14,
         help_text=mark_safe(

--- a/tests/www/companies_views/test_create_company_views.py
+++ b/tests/www/companies_views/test_create_company_views.py
@@ -13,7 +13,7 @@ from tests.companies.factories import (
 
 class TestCreateCompanyView:
     STRUCTURE_ALREADY_EXISTS_MSG = escape(
-        "Le numéro de SIRET que vous avez renseigné est déjà utilisé par une structure ou une antenne,"
+        "Le numéro SIRET que vous avez renseigné est déjà utilisé par une structure ou une antenne,"
     )
 
     @staticmethod


### PR DESCRIPTION
## :thinking: Pourquoi ?

La plupart du temps sur le site on trouve la formulation "numéro SIRET", mais à quelques endroit subsistent des "numéro **de** SIRET".

On harmonise.

