### PR TITLE
Inscription: Sécuriser l’inscription des OPCS pour éviter les offres frauduleuses [GEN-2373]

### DIFF
--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -805,6 +805,7 @@ class FacilitatorBaseMixin:
             geocoding_score=org_data["geocoding_score"],
             coords=lat_lon_to_coords(org_data.get("latitude"), org_data.get("longitude")),
             created_by=None,
+            is_searchable=False,  # Wait for admin to check the company
         )
 
 

--- a/tests/www/signup/test_siae.py
+++ b/tests/www/signup/test_siae.py
@@ -336,6 +336,7 @@ class TestCompanySignup:
         company = Company.objects.get(siret=FAKE_SIRET)
         assert company.has_admin(user)
         assert 1 == company.members.count()
+        assert company.is_searchable is False
 
         # No sent email.
         assert len(mailoutbox) == 0


### PR DESCRIPTION
## :thinking: Pourquoi ?

Difficile à tester en local vu qu'on bloque ProConnect.
Je peux néanmoins configurer une recette jetable sur la démo de ProConnect pour tester le fonctionnement, mais je pense que le changement est suffisamment petit pour qu'on s'en passe.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
