### PR TITLE
Contrôle a posteriori : Réusinage du badge d’état des candidatures pour les SIAE [GEN-2345]

### DIFF
--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -724,16 +724,6 @@ class EvaluatedJobApplication(models.Model):
         )
         return not state_is_from_phase2
 
-    def compute_state_for_siae(self):
-        real_state = self.compute_state()
-        if self.hide_state_from_siae():
-            submitted_state = evaluation_enums.EvaluatedJobApplicationsState.SUBMITTED
-            real_state_priority = self.STATES_PRIORITY.index(real_state)
-            submitted_state_priority = self.STATES_PRIORITY.index(submitted_state)
-            if real_state_priority < submitted_state_priority:
-                return submitted_state
-        return real_state
-
     @property
     def should_select_criteria(self):
         if not self.evaluated_siae.submission_freezed_at:

--- a/itou/siae_evaluations/templatetags/siae_evaluations_siae_tags.py
+++ b/itou/siae_evaluations/templatetags/siae_evaluations_siae_tags.py
@@ -1,0 +1,86 @@
+from django import template
+from django.utils.html import format_html
+
+from itou.siae_evaluations.enums import EvaluatedJobApplicationsState
+from itou.siae_evaluations.models import EvaluatedJobApplication
+
+
+register = template.Library()
+
+
+def badge(content, background_class, text_class):
+    return format_html(
+        '<span class="badge badge-sm rounded-pill text-nowrap {} {}">{}</span>',
+        background_class,
+        text_class,
+        content,
+    )
+
+
+def danger_badge(content):
+    return badge(content, "bg-danger", "text-white")
+
+
+def info_badge(content):
+    return badge(content, "bg-info", "text-white")
+
+
+def success_badge(content):
+    return badge(content, "bg-success", "text-white")
+
+
+def success_lighter_badge(content):
+    return badge(content, "bg-success-lighter", "text-success")
+
+
+def warning_badge(content):
+    return badge(content, "bg-accent-03", "text-primary")
+
+
+ACCEPTED_BADGE = success_badge("Validé")
+PENDING_AFTER_REVIEW_BADGE = warning_badge("Nouveaux justificatifs à traiter")
+REFUSED_BADGE = danger_badge("Problème constaté")
+SUBMITTED_BADGE = success_lighter_badge("Transmis")
+TODO_BADGE = warning_badge("À traiter")
+UPLOADED_BADGE = warning_badge("Justificatifs téléversés")
+
+BADGES = {
+    EvaluatedJobApplicationsState.PENDING: TODO_BADGE,
+    EvaluatedJobApplicationsState.PROCESSING: info_badge("En cours"),
+    EvaluatedJobApplicationsState.SUBMITTED: SUBMITTED_BADGE,
+    EvaluatedJobApplicationsState.UPLOADED: UPLOADED_BADGE,
+    # When the institution evaluation is in progress, the institution updates
+    # the job application state. Don’t reveal the new state before the review
+    # is published.
+    EvaluatedJobApplicationsState.ACCEPTED: SUBMITTED_BADGE,
+    EvaluatedJobApplicationsState.REFUSED: SUBMITTED_BADGE,
+}
+
+REVIEWED_BADGES = {
+    EvaluatedJobApplicationsState.ACCEPTED: ACCEPTED_BADGE,
+    EvaluatedJobApplicationsState.UPLOADED: UPLOADED_BADGE,
+    EvaluatedJobApplicationsState.SUBMITTED: SUBMITTED_BADGE,
+    EvaluatedJobApplicationsState.REFUSED: REFUSED_BADGE,
+    EvaluatedJobApplicationsState.REFUSED_2: REFUSED_BADGE,
+    EvaluatedJobApplicationsState.PROCESSING: TODO_BADGE,
+    EvaluatedJobApplicationsState.PENDING: PENDING_AFTER_REVIEW_BADGE,
+}
+
+
+@register.simple_tag
+def evaluated_job_application_state_for_siae(evaluated_job_application):
+    state = evaluated_job_application.compute_state()
+    if evaluated_job_application.evaluated_siae.evaluation_campaign.ended_at:
+        if state in [EvaluatedJobApplicationsState.ACCEPTED, EvaluatedJobApplicationsState.SUBMITTED]:
+            return ACCEPTED_BADGE
+        return REFUSED_BADGE
+
+    if evaluated_job_application.hide_state_from_siae():
+        submitted_state = EvaluatedJobApplicationsState.SUBMITTED
+        real_state_priority = EvaluatedJobApplication.STATES_PRIORITY.index(state)
+        submitted_state_priority = EvaluatedJobApplication.STATES_PRIORITY.index(submitted_state)
+        if real_state_priority < submitted_state_priority:
+            state = submitted_state
+    if evaluated_job_application.evaluated_siae.reviewed_at:
+        return REVIEWED_BADGES[state]
+    return BADGES[state]

--- a/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
+++ b/itou/templates/siae_evaluations/includes/job_seeker_infos_for_siae.html
@@ -1,4 +1,5 @@
 {% load format_filters %}
+{% load siae_evaluations_siae_tags %}
 
 <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
     <div class="c-box--results__summary flex-grow-1">
@@ -10,40 +11,5 @@
             <span>{{ evaluated_job_application.job_application.job_seeker.get_full_name }}</span>
         </div>
     </div>
-    <div>
-        {% with state=evaluated_job_application.compute_state_for_siae %}
-            {% if evaluated_job_application.evaluated_siae.evaluation_campaign.ended_at %}
-                {% if state == "ACCEPTED" or state == "SUBMITTED" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
-                {% else %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
-                {% endif %}
-            {% elif evaluated_job_application.evaluated_siae.reviewed_at %}
-                {% if state == "ACCEPTED" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>
-                {% elif state == "UPLOADED" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Justificatifs téléversés</span>
-                {% elif state == "SUBMITTED" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-success-lighter text-success">Transmis</span>
-                {% elif state == "REFUSED" or state == "REFUSED_2" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-danger text-white">Problème constaté</span>
-                {% elif state == "PROCESSING" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">À traiter</span>
-                {% elif state == "PENDING" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Nouveaux justificatifs à traiter</span>
-                {% endif %}
-            {% else %}
-                {% if state == "PENDING" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">À traiter</span>
-                {% elif state == "PROCESSING" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-info text-white">En cours</span>
-                {% elif state == "UPLOADED" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">Justificatifs téléversés</span>
-                {% elif state == "SUBMITTED" or state == "REFUSED" or state == "ACCEPTED" %}
-                    <span class="badge badge-sm rounded-pill text-nowrap bg-success-lighter text-success">Transmis</span>
-                {% endif %}
-                {# We should never have a REFUSED_2 here because it only exist in phase 3 which happens when we add a reviewed_at on the valuated_siae #}
-            {% endif %}
-        {% endwith %}
-    </div>
+    <div>{% evaluated_job_application_state_for_siae evaluated_job_application %}</div>
 </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter l’ajout d’un état différent lorsqu’une candidature est automatiquement acceptée grâce à un critère certifié.

## :cake: Comment ? <!-- optionnel -->

Voir le message de commit pour le détail.

## :desert_island: Comment tester ?

1. Se connecter en tant qu’ETTI
2. Aller sur le contrôle en cours
3. Suivre le parcours pour vérifier les différents badges
