### PR TITLE
RDV Insertion : Création d’un groupe pour un accès restreint à l’interface administateur

### DIFF
--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -127,6 +127,11 @@ def get_permissions_dict():
         "gps-admin-readonly": {**{model: PERMS_READ for model in group_gps_admin_permissions}},
         "pilotage-admin": {**group_pilotage_admin_permissions},
         "pilotage-admin-readonly": {**{model: PERMS_READ for model in group_pilotage_admin_permissions}},
+        "rdvi": {
+            companies_models.Company: PERMS_READ,
+            companies_models.CompanyMembership: PERMS_READ,
+            users_models.User: PERMS_READ,
+        },
     }
 
 

--- a/tests/users/__snapshots__/test_sync_group_and_perms.ambr
+++ b/tests/users/__snapshots__/test_sync_group_and_perms.ambr
@@ -223,6 +223,7 @@
     'group name=itou-admin-readonly created',
     'group name=pilotage-admin created',
     'group name=pilotage-admin-readonly created',
+    'group name=rdvi created',
     'All done!',
   ])
 # ---
@@ -266,6 +267,13 @@
     'view_prescribermembership',
     'view_prescriberorganization',
     'hijack_user',
+    'view_user',
+  ])
+# ---
+# name: test_command[rdvi]
+  list([
+    'view_company',
+    'view_companymembership',
     'view_user',
   ])
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les membres de l’équipe RDV Insertion mettent en correspondance les entreprises des Emplois avec les entreprises de RDV-I. Comme nous n’avons pas d’identifiant en commun, les correspondances se basent sur les noms et les membres.

Une fois une entreprises identifiées, les autres entreprises d’un groupe sont repérées à l’aide des membres.

## :desert_island: Comment tester ?

1. Lancer la commande `sync_group_and_perms`
1. Se connecter à l’admin
2. Créer un nouvel utilisateur
3. Ajouter l’utilisateur au groupe rdvi
4. Se connecter sur le compte du nouvel utilisateur (ou le détourner)
5. Accéder à l’admin et vérifier que l’utilisateur n’a accès qu’en lecture, aux entreprises et aux utilisateurs (ainsi que l’encart membre des entreprises).

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/ed354994-b28e-450e-a812-7b0766efbda7)
