### PR TITLE
Pilotage : Réparer le TB "Suivi des prescriptions des AHI" pour la DIHAL

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -241,7 +241,7 @@ METABASE_DASHBOARDS = {
     # Institution stats - DIHAL - nation level.
     #
     "stats_dihal_state": {
-        "dashboard_id": 310,
+        "dashboard_id": 549,
         "tally_popup_form_id": "w2az2j",
         "tally_embed_form_id": "3Nlvzl",
     },

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -776,7 +776,7 @@ def stats_dihal_state(request):
     context = {
         "page_title": "Suivi des prescriptions des AHI",
     }
-    return render_stats(request=request, context=context, params=get_params_for_whole_country())
+    return render_stats(request=request, context=context)
 
 
 def stats_drihl_state(request):


### PR DESCRIPTION
## :thinking: Pourquoi ?

C'est cassé, le filtre géographique pour la France entière est trop long.