### PR TITLE
UI : visibilité du menu latéral sur des largeurs plus étroites

### DIFF
--- a/itou/static/css/breakpoint-override.css
+++ b/itou/static/css/breakpoint-override.css
@@ -1,0 +1,61 @@
+.l-authenticated #offcanvasNav {
+  width: 260px;
+}
+
+/* Override for the offcanvas that should appear below md */
+@media (min-width: 768px) {
+  /* This makes the offcanvas visible as a sidebar on md and up */
+  #offcanvasNav.offcanvas {
+    visibility: visible !important;
+    transform: none !important;
+    position: fixed !important;
+    left: 0;
+    right: auto;
+    box-shadow: none;
+    background-color: #f8f8f8;
+    transition: none !important;
+  }
+
+  /* Hide the burger menu button on md and up */
+  .s-header__col--burger,
+  .s-header-authenticated__col--burger {
+    display: none !important;
+  }
+
+  /* Show desktop nav on md and up */
+  .s-header__col--nav,
+  .s-header-authenticated__col--nav {
+    display: flex !important;
+  }
+
+  /* Hide the authenticated header on md and up to match the existing behavior */
+  .s-header-authenticated {
+    display: none;
+  }
+}
+
+/* Fix authenticated layout with the offcanvas sidebar */
+@media (min-width: 768px) {
+  .l-authenticated .global-messages-container {
+    margin-left: 260px;
+  }
+
+  .l-authenticated > .s-main .container {
+    margin-left: 260px;
+    max-width: calc(100% - 260px);
+  }
+}
+
+@media (min-width: 1024px) {
+  .l-authenticated #offcanvasNav {
+    width: 320px;
+  }
+  .l-authenticated .global-messages-container {
+    margin-left: 320px;
+  }
+  .l-authenticated > .s-main .container {
+    margin-left: 320px;
+    max-width: calc(100% - 320px);
+  }
+
+}

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -174,7 +174,7 @@
                             <form method="get" action="{% url "search:employers_results" %}" role="search" class="mt-3 mt-md-4">
                                 {% include "search/includes/siaes_search_form.html" with form=siae_search_form is_home=False only %}
                             </form>
-                            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 row-cols-xxxl-4 mt-3 mt-md-5">
+                            <div class="row row-cols-1 row-cols-md-1 row-cols-lg-2 row-cols-xl-3 row-cols-xxxl-4 mt-3 mt-md-5">
                                 {% if user.is_staff %}
                                     {% include "dashboard/includes/admin_card.html" %}
                                     {% if user.is_itou_admin %}

--- a/itou/templates/layout/_header_authenticated.html
+++ b/itou/templates/layout/_header_authenticated.html
@@ -133,7 +133,7 @@
                     </div>
                 {% endif %}
             </div>
-            <div class="border-start border-nuance-08 d-xl-none">
+            <div class="border-start border-nuance-08 d-md-none">
                 <button type="button" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" aria-label="Fermer">
                     <i class="ri-close-line" aria-hidden="true"></i>
                 </button>

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -37,6 +37,7 @@
         <link rel="stylesheet" href="{% static "vendor/easymde/easymde.min.css" %}">
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}">
         <link rel="stylesheet" href="{% static "css/itou.css" %}">
+        <link rel="stylesheet" href="{% static "css/breakpoint-override.css" %}">
         {% block extra_head %}{% endblock %}
     </head>
     <body class="{% if user.is_authenticated %}l-authenticated {% endif %}{% block body_class %}{% endblock %}">

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -16,7 +16,7 @@
                       </div>
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>
@@ -288,7 +288,7 @@
                       </div>
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>
@@ -598,7 +598,7 @@
                       
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>
@@ -838,7 +838,7 @@
                       </div>
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>
@@ -1081,7 +1081,7 @@
                       </div>
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>
@@ -1362,7 +1362,7 @@
                       </div>
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>
@@ -1630,7 +1630,7 @@
                       
                   
               </div>
-              <div class="border-start border-nuance-08 d-xl-none">
+              <div class="border-start border-nuance-08 d-md-none">
                   <button aria-label="Fermer" class="btn-link ps-4 pt-5 pe-2 me-n2" data-bs-dismiss="offcanvas" type="button">
                       <i aria-hidden="true" class="ri-close-line"></i>
                   </button>

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -634,7 +634,7 @@
   </div>
   
                               </form>
-                              <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 row-cols-xxxl-4 mt-3 mt-md-5">
+                              <div class="row row-cols-1 row-cols-md-1 row-cols-lg-2 row-cols-xl-3 row-cols-xxxl-4 mt-3 mt-md-5">
                                   
                                       <div class="col mb-3 mb-md-5">
       <div class="c-box p-0 h-100">
@@ -773,7 +773,7 @@
   </div>
   
                               </form>
-                              <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 row-cols-xxxl-4 mt-3 mt-md-5">
+                              <div class="row row-cols-1 row-cols-md-1 row-cols-lg-2 row-cols-xl-3 row-cols-xxxl-4 mt-3 mt-md-5">
                                   
                                       <div class="col mb-3 mb-md-5">
       <div class="c-box p-0 h-100">


### PR DESCRIPTION
🛑 Cette PR n'a pas vocation à être mergée mais juste à faire tourner une recette jetable. Elle sert à regarder à quoi ça ressemble d'avoir le menu plus souvent visible.

## :thinking: Pourquoi ?

Le menu latéral est caché pour tous les écrans un peu étroits. Une crainte est que beaucoup d'utilisateurs ne connaissent pas son existence (et ratent le burger en haut à droite).

## :cake: Comment ? <!-- optionnel -->

Un override de la feuille de style du thème, un peu sale, etc.

## :desert_island: Comment tester ?

Purement visuel.
