### PR TITLE
Extraire un auxilaire iae_has_enough_criteria

### DIFF
--- a/itou/eligibility/enums.py
+++ b/itou/eligibility/enums.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from itou.companies.enums import CompanyKind
 from itou.users.enums import KIND_EMPLOYER, KIND_PRESCRIBER
 
 
@@ -18,6 +19,15 @@ class AdministrativeCriteriaLevel(models.TextChoices):
 class AdministrativeCriteriaLevelPrefix(models.TextChoices):
     LEVEL_1_PREFIX = "level_1_"
     LEVEL_2_PREFIX = "level_2_"
+
+
+ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND = {
+    CompanyKind.AI: 2,
+    CompanyKind.ETTI: 2,
+    CompanyKind.ACI: 3,
+    CompanyKind.EI: 3,
+    CompanyKind.EITI: 3,
+}
 
 
 class AuthorKind(models.TextChoices):

--- a/itou/eligibility/utils.py
+++ b/itou/eligibility/utils.py
@@ -1,5 +1,16 @@
 from collections import Counter
 
+from itou.eligibility.enums import ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND, AdministrativeCriteriaLevel
+
+
+def iae_has_enough_criteria(criteria, company_kind):
+    level_2_count = 0
+    for criterion in criteria:
+        if criterion.level == AdministrativeCriteriaLevel.LEVEL_1:
+            return True
+        level_2_count += 1
+    return level_2_count >= ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[company_kind]
+
 
 def geiq_allowance_amount(is_authorized_prescriber, administrative_criteria) -> int:
     """Amount of granted allowance for job seeker.

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from itou.companies.enums import CompanyKind
 from itou.eligibility import enums as eligibilty_enums
 from itou.eligibility.models import AdministrativeCriteria
+from itou.eligibility.utils import iae_has_enough_criteria
 
 
 class AdministrativeCriteriaForm(forms.Form):
@@ -61,23 +62,13 @@ class AdministrativeCriteriaForm(forms.Form):
         if self.is_authorized_prescriber or not self.siae:
             return selected_objects
 
-        level_1 = [
-            obj for obj in selected_objects if obj.level == eligibilty_enums.AdministrativeCriteriaLevel.LEVEL_1
-        ]
-        level_2 = [
-            obj for obj in selected_objects if obj.level == eligibilty_enums.AdministrativeCriteriaLevel.LEVEL_2
-        ]
-
-        # For ETTI and AI: 1 criterion level 1 OR 2 level 2 criteria.
-        if self.siae.kind == CompanyKind.ETTI or self.siae.kind == CompanyKind.AI:
-            len_valid = len(level_1) or len(level_2) >= 2
-            if not len_valid:
-                raise forms.ValidationError(self.ERROR_CRITERIA_NUMBER_ETTI_AI)
-        # Other: 1 criterion level 1 OR 3 level 2 criteria.
-        else:
-            len_valid = len(level_1) or len(level_2) >= 3
-            if not len_valid:
-                raise forms.ValidationError(self.ERROR_CRITERIA_NUMBER)
+        if not iae_has_enough_criteria(selected_objects, self.siae.kind):
+            message = (
+                self.ERROR_CRITERIA_NUMBER_ETTI_AI
+                if self.siae.kind in [CompanyKind.AI, CompanyKind.ETTI]
+                else self.ERROR_CRITERIA_NUMBER
+            )
+            raise forms.ValidationError(message)
 
         return selected_objects
 
@@ -90,8 +81,7 @@ class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
         self.job_application = job_application
 
         self.siae = siae
-        if self.siae.kind == CompanyKind.ETTI or self.siae.kind == CompanyKind.AI:
-            self.num_level2_admin_criteria = 2
-        else:
-            self.num_level2_admin_criteria = 3
+        self.num_level2_admin_criteria = eligibilty_enums.ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[
+            siae.kind
+        ]
         super().__init__(user, siae, **kwargs)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Centraliser une règle de gestion, afin de la clarifier, d’en faciliter la maintenance, et de pouvoir la réutiliser.
