### PR TITLE
Accessibilité: Mise a jour du contenu de la page Accessibilité

### DIFF
--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -6,12 +6,13 @@
 {% block title_content %}
     {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
         {% fragment as c_title__main %}
-            <h1>Déclaration d'accessibilité</h1>
+            <h1>Accessibilité</h1>
         {% endfragment %}
         {% fragment as c_title__secondary %}
-            <h2 class="h3">
+            <h2>Déclaration d'accessibilité</h2>
+            <p>
                 <strong>Le GIP Plateforme de l’inclusion</strong> s’engage à rendre ses sites internet et applications accessibles conformément à l’article 47 de la loi n°2005-102 du 11 février 2005.
-            </h2>
+            </p>
             <p>
                 Son schéma pluriannuel décrit les points importants sur lesquels le GIP de la plateforme de l’inclusion s’appuiera pour améliorer l’accessibilité numérique de l’ensemble de ses sites internet et applications. Ce schéma s’accompagne du plans d’action annuels (<a href="https://inclusion.beta.gouv.fr/documents/86/GIP_plateforme_de_linclusion_-_Plan_annuel_daccessibilite_2023.pdf" target="_blank" class="has-external-link">2023</a>) qui détaillent les opérations programmées et mises en œuvre pour l'année courante, ainsi que l’état de suivis de ces actions, détaillé dans le <a href="https://inclusion.beta.gouv.fr/documents/87/GIP_plateforme_de_linclusion_-_Schema_pluriannuel_daccessibilite_2023-2026.pdf" target="_blank" class="has-external-link">schéma pluriannuel d’accessibilité 2023-2026</a>.
             </p>
@@ -27,52 +28,30 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    <h2 class="h2">État de conformité</h2>
+                    <h3>État de conformité</h3>
                     <p>Le site a été audité par la société alter way en novembre 2021.</p>
                     <p>
                         <b>Les emplois de l'inclusion</b> est partiellement conforme avec le référentiel général d'amélioration de l'accessibilité (RGAA), version 4.1.
                     </p>
 
-                    <h2 class="h2 mt-3 mt-lg-5">Résultats des tests</h2>
+                    <h3 class="mt-3 mt-lg-5">Résultats des tests</h3>
                     <p>
-                        L'audit de conformité réalisé révèle que <b>74.50%</b> des critères du RGAA version 4.1 sont respectés.
+                        L'audit de conformité réalisé par la <b>société alter way</b> révèle que <b>74.50%</b> des critères du RGAA version 4.1 sont respectés.
                     </p>
 
-                    <h2 class="h2 mt-3 mt-lg-5">Contenus non accessibles</h2>
-                    <ul>
-                        <li>
-                            De nombreuses anomalies vont pénaliser les utilisateurs en situation de handicap, naviguant ou non à l'aide de technologies d'assistance
-                        </li>
-                        <li>
-                            Les non-conformités les plus bloquantes pour les utilisateurs concernent :
-                            <ul>
-                                <li>Des composants d'interface riches ne respectant pas les recommandations de structuration pour l'accessibilité</li>
-                                <li>Plusieurs boutons &lt;button&gt; dans liens &lt;a&gt;</li>
-                                <li>Champ sans étiquette</li>
-                                <li>Rôle manquant sur quelque région</li>
-                                <li>La page n'est pas bien structurée</li>
-                                <li>
-                                    des contenus avec une structuration (titres et intertitres, paragraphes, listes) incorrecte, ou insuffisante pour une navigation efficace avec un lecteur d'écran
-                                </li>
-                                <li>de nombreux textes et éléments d'interface avec des contrastes insuffisants</li>
-                                <li>utilisation de mots en anglais</li>
-                                <li>titre de la page n'est pas à jour par rapport aux contenus</li>
-                                <li>Version réduite n'est pas totalement adaptable</li>
-                            </ul>
-                        </li>
-                    </ul>
+                    <h3 class="mt-3 mt-lg-5">Établissement de cette déclaration d'accessibilité</h3>
+                    <p>
+                        Cette déclaration a été établie le <b>22/06/2021</b>. Elle a été mise à jour le <b>08/03/2022</b>.
+                    </p>
 
-                    <h2 class="h2 mt-3 mt-lg-5">Établissement de cette déclaration d'accessibilité</h2>
-                    <p>Cette déclaration a été établie le 22/06/2021. Elle a été mise à jour le 08/03/2022.</p>
-
-                    <h2 class="h2 mt-3 mt-lg-5">Technologies utilisées pour la réalisation du site</h2>
+                    <h3 class="mt-3 mt-lg-5">Technologies utilisées pour la réalisation du site</h3>
                     <ul>
                         <li>HTML5</li>
                         <li>CSS</li>
                         <li>JavaScript</li>
                     </ul>
 
-                    <h3 class="h3">Environnement de test</h3>
+                    <h4>Environnement de test</h4>
                     <p>
                         Les vérifications de restitution de contenus ont été réalisées sur la base de la combinaison four-nie par la base de référence du RGAA 4.1, avec les versions suivantes :
                     </p>
@@ -81,7 +60,7 @@
                         <li>Technologie d'assistance : NVDA</li>
                     </ul>
 
-                    <h3 class="h3">Outils pour évaluer l'accessibilité</h3>
+                    <h4>Outils pour évaluer l'accessibilité</h4>
                     <ul>
                         <li>Wave</li>
                         <li>WCAG Color contrast checker</li>
@@ -89,7 +68,7 @@
                         <li>Web Developer Toolbar</li>
                     </ul>
 
-                    <h3 class="h3">Pages du site ayant fait l'objet de la vérification de conformité</h3>
+                    <h4>Pages du site ayant fait l'objet de la vérification de conformité</h4>
                     <ul>
                         <li>Tableau de bord (connexion en tant que "Entreprise d'Insertion")</li>
                         <li>Ma structure &gt; Modifier les informations de l'établissement</li>
@@ -104,13 +83,13 @@
                         </li>
                     </ul>
 
-                    <h2 class="h2 mt-3 mt-lg-5">Amélioration et contact</h2>
+                    <h3 class="mt-3 mt-lg-5">Amélioration et contact</h3>
                     <p>
                         Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez nous contacter pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
                     </p>
                     <ul>
                         <li>
-                            Adresse e-mail : <a href="mailto:{{ ITOU_EMAIL_CONTACT }}">{{ ITOU_EMAIL_CONTACT }}</a>
+                            Formulaire de contact : <a href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/requests/new" target="_blank" class="has-external-link">https://aide.emplois.inclusion.beta.gouv.fr</a>
                         </li>
                         <li>
                             Adresse :
@@ -122,7 +101,7 @@
                     </ul>
                     <p>Nous essayons de répondre dans les 2 jours ouvrés.</p>
 
-                    <h2 class="h2 mt-3 mt-lg-5">Voie de recours</h2>
+                    <h3 class="mt-3 mt-lg-5">Voie de recours</h3>
                     <p>
                         Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d'accessibilité qui vous empêche d'accéder à un contenu ou à un des services du portail et vous n'avez pas obtenu de réponse satisfaisante.
                     </p>

--- a/tests/www/test_static_views.py
+++ b/tests/www/test_static_views.py
@@ -6,7 +6,7 @@ from pytest_django.asserts import assertContains
 @pytest.mark.parametrize(
     "view_name,expected_title",
     [
-        ("accessibility", "<h1>Déclaration d'accessibilité</h1>"),
+        ("accessibility", "<h1>Accessibilité</h1>"),
         ("legal-notice", "<h1>Mentions légales</h1>"),
         ("legal-privacy", "<h1>Politique de confidentialité</h1>"),
         ("legal-terms", '<h1 id="conditions-générales-dutilisation">Conditions Générales d&#39;Utilisation</h1>'),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour actualiser certaines infos

## :cake: Comment ? 
Suppression de la partie “Contenus non accessibles” car elle détaillait des points défaillants qui ne le sont plus ou qui ne sont plus les mêmes. De plus, cette partie n'est pas présente dans le "modèle" beta.gouv que nous utilisons sur le pilotage, la commu et le site de la pdi

Mise à jour de la section contact par remplacement du lien de contact par un lien vers le formulaire de contact de l'aide