### PR TITLE
Admin : Rendre les champs utilisateurs éditables même lorsque son identité est certifiée

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -454,8 +454,6 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, UserAdmin)
                 readonly_fields.extend(["first_name", "last_name", "email"])
         if obj:
             readonly_fields.append("kind")  # kind is never editable, but still addable
-            if obj.kind == UserKind.JOB_SEEKER:
-                readonly_fields.extend(obj.jobseeker_profile.readonly_pii_fields())
         return readonly_fields
 
     def get_fieldsets(self, request, obj=None):

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -1,17 +1,13 @@
-from datetime import date
-
 import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
-from itou.asp.models import Country
 from itou.users import admin
-from itou.users.enums import IdentityCertificationAuthorities, Title
+from itou.users.enums import IdentityCertificationAuthorities
 from itou.users.models import IdentityCertification, JobSeekerProfile, User
 from itou.utils.models import PkSupportRemark
 from tests.companies.factories import CompanyMembershipFactory
-from tests.eligibility.factories import IAESelectedAdministrativeCriteriaFactory
 from tests.institutions.factories import InstitutionMembershipFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.users.factories import JobSeekerFactory
@@ -78,60 +74,6 @@ def test_filter():
         api_particulier_certified.jobseeker_profile,
         not_certified.jobseeker_profile,
     }
-
-
-def test_readonly_fields_for_certified_job_seekers(admin_client):
-    danemark = Country.objects.get(name="DANEMARK")
-    job_seeker = JobSeekerFactory(
-        title=Title.M,
-        first_name="Arthur",
-        last_name="Dupond",
-        jobseeker_profile__birthdate=date(1978, 1, 1),
-        jobseeker_profile__birth_country=danemark,
-    )
-    IAESelectedAdministrativeCriteriaFactory(certified=True, eligibility_diagnosis__job_seeker=job_seeker)
-    ro_template = """
-    <div class="flex-container">
-        <label>{field} :</label>
-        <div class="readonly">{value}</div>
-    </div>
-    """
-
-    response = admin_client.get(
-        reverse(
-            "admin:users_user_change",
-            kwargs={"object_id": job_seeker.pk},
-        )
-    )
-    for field, value in [
-        ("Prénom", "Arthur"),
-        ("Nom", "Dupond"),
-        ("Civilité", "Monsieur"),
-    ]:
-        assertContains(
-            response,
-            ro_template.format(field=field, value=value),
-            html=True,
-            count=1,
-        )
-
-    response = admin_client.get(
-        reverse(
-            "admin:users_jobseekerprofile_change",
-            kwargs={"object_id": job_seeker.jobseeker_profile.pk},
-        )
-    )
-    danemark_url = reverse("admin:asp_country_change", kwargs={"object_id": danemark.pk})
-    for field, value in [
-        ("Date de naissance", "1 janvier 1978"),
-        ("Pays de naissance", f'<a href="{danemark_url}">DANEMARK</a>'),
-    ]:
-        assertContains(
-            response,
-            ro_template.format(field=field, value=value),
-            html=True,
-            count=1,
-        )
 
 
 def test_get_fields_to_transfer_for_job_seekers():


### PR DESCRIPTION
Several users contacted us to modify job seekers' information
that should be valid, because these job seekers were certified by the
API Particulier, but are not.
Until we find out how job seekers could certified with what
could be wrong information, let's unblock customer support.

![image](https://github.com/user-attachments/assets/0f19aa62-d37b-4b18-a4be-14fd95acbeb9)

