### PR TITLE
Typos : Correctif de typos variées dans le code et les commentaires du code

### DIFF
--- a/itou/geiq/sync.py
+++ b/itou/geiq/sync.py
@@ -214,8 +214,8 @@ def _compute_eligibility_fields(api_codes, code_to_criteria, support_days_nb):
                 raise ValueError(f"Unknown code: {unknown_code}")
 
     annex1_nb = annex2_level1_nb = annex2_level2_nb = 0
-    administrative_criterias = [code_to_criteria[code] for code in emplois_codes]
-    for criteria in administrative_criterias:
+    administrative_criteria = [code_to_criteria[code] for code in emplois_codes]
+    for criteria in administrative_criteria:
         if criteria.annex in (AdministrativeCriteriaAnnex.ANNEX_1, AdministrativeCriteriaAnnex.BOTH_ANNEXES):
             annex1_nb += 1
         if criteria.annex in (AdministrativeCriteriaAnnex.ANNEX_2, AdministrativeCriteriaAnnex.BOTH_ANNEXES):
@@ -228,7 +228,7 @@ def _compute_eligibility_fields(api_codes, code_to_criteria, support_days_nb):
         allowance_amount = 0
     else:
         allowance_amount = geiq_allowance_amount(
-            is_authorized_prescriber=authorized_prescriber, administrative_criteria=administrative_criterias
+            is_authorized_prescriber=authorized_prescriber, administrative_criteria=administrative_criteria
         )
 
     return {

--- a/itou/siae_evaluations/models.py
+++ b/itou/siae_evaluations/models.py
@@ -378,12 +378,12 @@ class EvaluationCampaign(models.Model):
             emails = []
             for evaluated_siae in evaluated_siaes:
                 if evaluated_siae.final_reviewed_at is None:
-                    criterias = [
+                    criteria = [
                         crit
                         for jobapp in evaluated_siae.evaluated_job_applications.all()
                         for crit in jobapp.evaluated_administrative_criteria.all()
                     ]
-                    if len(criterias) == 0 or any(crit.submitted_at is None for crit in criterias):
+                    if len(criteria) == 0 or any(crit.submitted_at is None for crit in criteria):
                         siae_without_proofs.append(evaluated_siae)
                         has_siae_to_notify = True
 

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -636,21 +636,21 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, UserAdmin)
                 fields_choices=sorted(fields_choices, key=lambda field: field[1]), data=request.POST or None
             )
             if request.POST and form.is_valid():
-                items_transfered = []
+                transferred_items = []
                 for field_name in form.cleaned_data["fields_to_transfer"]:
                     field = transfer_fields[field_name]
                     for item in transfer_data[field_name]["from"]:
                         setattr(item, field.remote_field.name, to_user)
                         item.save()
-                        items_transfered.append((transfer_data[field_name]["title"], item))
-                if items_transfered:
+                        transferred_items.append((transfer_data[field_name]["title"], item))
+                if transferred_items:
                     summary_text = "\n".join(
                         [
                             "-" * 20,
                             f"Transfert du {timezone.now():%Y-%m-%d %H:%M:%S} effectué par {request.user} ",
                             f"de l'utilisateur {from_user.pk} vers {to_user.pk}:",
                         ]
-                        + [f"- {item_title} {item} transféré " for item_title, item in items_transfered]
+                        + [f"- {item_title} {item} transféré " for item_title, item in transferred_items]
                         + ["-" * 20]
                     )
                     add_support_remark_to_obj(from_user, summary_text)

--- a/itou/www/apply/views/batch_views.py
+++ b/itou/www/apply/views/batch_views.py
@@ -390,11 +390,11 @@ def transfer(request):
         pk=request.POST.get("target_company_id"),
     )
     applications = _get_and_lock_received_applications(request, request.POST.getlist("application_ids"))
-    transfered_ids = []
+    transferred_ids = []
     for job_application in applications:
         try:
             job_application.transfer(user=request.user, target_company=target_company)
-            transfered_ids.append(job_application.pk)
+            transferred_ids.append(job_application.pk)
         except (ValidationError, xwf_models.InvalidTransitionError):
             error_msg = f"La candidature de {job_application.job_seeker.get_full_name()} n’a pas pu être transférée"
             if not job_application.transfer.is_available():
@@ -403,15 +403,15 @@ def transfer(request):
                 error_msg += "."
             messages.error(request, error_msg, extra_tags="toast")
 
-    transfered_nb = len(transfered_ids)
-    if transfered_nb > 1:
-        messages.success(request, f"{transfered_nb} candidatures ont bien été transférées.", extra_tags="toast")
-    elif transfered_nb == 1:
+    transferred_nb = len(transferred_ids)
+    if transferred_nb > 1:
+        messages.success(request, f"{transferred_nb} candidatures ont bien été transférées.", extra_tags="toast")
+    elif transferred_nb == 1:
         messages.success(request, "1 candidature a bien été transférée.", extra_tags="toast")
     logger.info(
-        "user=%s batch transfered %s applications: %s",
+        "user=%s batch transferred %s applications: %s",
         request.user.pk,
-        transfered_nb,
-        ",".join(str(app_uid) for app_uid in transfered_ids),
+        transferred_nb,
+        ",".join(str(app_uid) for app_uid in transferred_ids),
     )
     return HttpResponseRedirect(next_url)

--- a/scripts/clever-deploy
+++ b/scripts/clever-deploy
@@ -61,10 +61,10 @@ esac
             break
         time.sleep(1)
     else:
-        sys.exit("No new deployment despite successfull push")
+        sys.exit("No new deployment despite successful push")
 
     if len(new_deployments) != 1:
-        print(f"Multiple new deployements - all bets are off: {new_deployments}")
+        print(f"Multiple new deployments - all bets are off: {new_deployments}")
 
     deployment_uid = new_deployments[0]["uuid"]
     print(f"Following deployment {deployment_uid}")

--- a/tests/api/employee_record_api/test_serializers.py
+++ b/tests/api/employee_record_api/test_serializers.py
@@ -128,8 +128,8 @@ def test_notification_serializer():
     assert data.get("mesure") == employee_record.asp_siae_type
     assert data.get("typeMouvement") == EmployeeRecordUpdateNotification.ASP_MOVEMENT_TYPE
 
-    personnal_data = data.get("personnePhysique")
-    assert personnal_data is not None
-    assert personnal_data.get("passIae") == employee_record.approval_number
-    assert personnal_data.get("passDateDeb") == start_at.strftime("%d/%m/%Y")
-    assert personnal_data.get("passDateFin") == end_at.strftime("%d/%m/%Y")
+    personal_data = data.get("personnePhysique")
+    assert personal_data is not None
+    assert personal_data.get("passIae") == employee_record.approval_number
+    assert personal_data.get("passDateDeb") == start_at.strftime("%d/%m/%Y")
+    assert personal_data.get("passDateFin") == end_at.strftime("%d/%m/%Y")

--- a/tests/approvals/test_prolongation_requests.py
+++ b/tests/approvals/test_prolongation_requests.py
@@ -156,7 +156,7 @@ def test_chores_send_reminder_to_prescriber_organization_other_members_copy_limi
         with django_capture_on_commit_callbacks(execute=True):
             command.handle(command="email_reminder", wet_run=True)
 
-    assert len(mailoutbox) == 11  # prolongation_request.validated_by and 10 collegues
+    assert len(mailoutbox) == 11  # prolongation_request.validated_by and 10 coworkers
 
     assert set(email.to[0] for email in mailoutbox) == {prolongation_request.validated_by.email} | {
         member.email for member in admin_prescribers

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -132,12 +132,12 @@ class TestEmployeeRecordUpdateNotificationSerializer:
         assert data.get("mesure") == employee_record.asp_siae_type
         assert data.get("typeMouvement") == EmployeeRecordUpdateNotification.ASP_MOVEMENT_TYPE
 
-        personnal_data = data.get("personnePhysique")
+        personal_data = data.get("personnePhysique")
 
-        assert personnal_data is not None
-        assert personnal_data.get("passIae") == employee_record.approval_number
-        assert personnal_data.get("passDateDeb") == start_at.strftime("%d/%m/%Y")
-        assert personnal_data.get("passDateFin") == end_at.strftime("%d/%m/%Y")
+        assert personal_data is not None
+        assert personal_data.get("passIae") == employee_record.approval_number
+        assert personal_data.get("passDateDeb") == start_at.strftime("%d/%m/%Y")
+        assert personal_data.get("passDateFin") == end_at.strftime("%d/%m/%Y")
 
     def test_batch_serializer(self, subtests):
         # This is the same serializer used for employee record batches.

--- a/tests/external_data/tests.py
+++ b/tests/external_data/tests.py
@@ -184,7 +184,7 @@ class TestJobSeekerExternalData:
         assert 7 + 1 == len(report.get("fields_updated"))  # fields + history
         assert 12 == len(report.get("fields_fetched"))
 
-        # Just checking birthdate is not overriden
+        # Just checking birthdate is not overridden
         user = JobSeekerFactory()
         birthdate = user.jobseeker_profile.birthdate
 

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -88,7 +88,7 @@ def test_transfer():
         state=JobApplicationState.ACCEPTED,
     )
 
-    # Conditions hould be covered by previous test, but does not hurt (and tests raise)
+    # Conditions should be covered by previous test, but does not hurt (and tests raise)
     with pytest.raises(xworkflows.InvalidTransitionError):
         job_application.transfer(user=lambda_user, target_company=target_company)
     with pytest.raises(xworkflows.InvalidTransitionError):

--- a/tests/job_applications/test_transfer.py
+++ b/tests/job_applications/test_transfer.py
@@ -20,7 +20,7 @@ from tests.utils.test import assertSnapshotQueries
 
 def test_transferable_states(subtests):
     # If job application is in ACCEPTED state
-    # it can't be transfered
+    # it can't be transferred
     evil_states = [JobApplicationState.ACCEPTED]
     good_states = [
         JobApplicationState.NEW,

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -588,7 +588,7 @@ class TestJobApplicationQuerySet:
             job_app_with_future_hiring_start_at,
         }
 
-        # Test all disabling criterias
+        # Test all disabling criteria
         # ----------------------------
         def assert_job_app_not_in_queryset(ja):
             assert ja not in JobApplication.objects.eligible_as_employee_record(ja.to_company)

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -232,9 +232,9 @@ def test_populate_job_seekers():
     num_queries += 1  # COMMIT Queryset counts (autocommit mode)
     num_queries += 1  # COMMIT Create table
     num_queries += 1  # Select all elements ids (chunked_queryset)
-    num_queries += 1  # Select last pk for current chunck
-    num_queries += 1  # Select job seekers chunck (with annotations)
-    num_queries += 1  # Prefetch EligibilityDiagnosis with anotations, author_prescriber_organization and author_siae
+    num_queries += 1  # Select last pk for current chunk
+    num_queries += 1  # Select job seekers chunk (with annotations)
+    num_queries += 1  # Prefetch EligibilityDiagnosis with annotations, author_prescriber_organization and author_siae
     num_queries += 1  # Prefetch EligibilityDiagnosis's selected administrative criteria
     num_queries += 1  # Prefetch JobApplications with Siaes
     num_queries += 1  # Get QPV users
@@ -1238,7 +1238,7 @@ def test_populate_companies():
         coords="POINT (5.43567 12.123876)",
     )
     # Add an inactive membership, and a active membership on an inactive user
-    # both should be ignored in total_members agregation
+    # both should be ignored in total_members aggregation
     CompanyMembershipFactory(company=company, is_active=False)
     CompanyMembershipFactory(company=company, user__is_active=False)
 
@@ -1250,9 +1250,9 @@ def test_populate_companies():
     num_queries += 1  # Select siaes with annotations and columns
     num_queries += 1  # Select other siaes with the same convention
     num_queries += 1  # Prefetch siae job descriptions
-    num_queries += 1  # Prefecth siae active memberships (for total_membres)
-    num_queries += 1  # Prefecth siae memberships (for first_membership_join_date)
-    num_queries += 1  # Prefecth siae members (for members last_login)
+    num_queries += 1  # Prefetch siae active memberships (for total_membres)
+    num_queries += 1  # Prefetch siae memberships (for first_membership_join_date)
+    num_queries += 1  # Prefetch siae members (for members last_login)
     num_queries += 1  # Prefetch cities
     num_queries += 1  # COMMIT (inject_chunk)
     num_queries += 1  # COMMIT (rename_table_atomically DROP TABLE)
@@ -1429,7 +1429,7 @@ def test_populate_organizations():
         post_code="63020",
     )
     # Add an inactive membership, and a active membership on an inactive user
-    # both should be ignored in total_members agregation
+    # both should be ignored in total_members aggregation
     PrescriberMembershipFactory(organization=first_organisation, is_active=False)
     PrescriberMembershipFactory(organization=first_organisation, user__is_active=False)
 

--- a/tests/users/test_admin.py
+++ b/tests/users/test_admin.py
@@ -200,7 +200,7 @@ def test_get_fields_to_transfer_for_job_seekers():
     # Check that all fields have been accounted for
     # If this test fails:
     # - either a new relation has been added
-    #   (and the dev must decide if it needs to be transfered or ignored in the transfer)
+    #   (and the dev must decide if it needs to be transferred or ignored in the transfer)
     # - either an existing relation has been dropped (and the relation can be removed from the relevant list)
     assert not fields_to_transfer & fields_to_ignore, fields_to_transfer & fields_to_ignore
     assert {f.name for f in relation_fields} == fields_to_transfer | fields_to_ignore

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -1513,7 +1513,7 @@ class TestSendCheckAuthorizedMembersEmailManagementCommand:
         self.labor_inspector_1.institution.created_at -= relativedelta(months=3)
         self.labor_inspector_1.institution.save(update_fields=["created_at", "updated_at"])
 
-        # Create other insitution the user was once a member of
+        # Create other institution the user was once a member of
         DT_3_MONTHS_AGO = timezone.now() - relativedelta(months=3)
         institution_2 = InstitutionFactory(name="Institution 2", created_at=DT_3_MONTHS_AGO)
         InstitutionMembershipFactory(

--- a/tests/www/apply/test_batch_views.py
+++ b/tests/www/apply/test_batch_views.py
@@ -972,7 +972,7 @@ class TestBatchRefuse:
         response = client.get(prescriber_answer_url)
         assertRedirects(response, job_seeker_answer_url, fetch_redirect_response=False)
 
-    def test_single_app_transfered_concurrently(self, client):
+    def test_single_app_transferred_concurrently(self, client):
         company = CompanyFactory(with_membership=True)
         employer = company.members.first()
         next_url = add_url_params(reverse("apply:list_for_siae"), {"state": "PROCESSING"})
@@ -1077,7 +1077,7 @@ class TestBatchRefuse:
         response = client.get(refusal_reason_url)
         assertContains(response, "<strong>Étape 1</strong>/3 : Choix du motif de refus", html=True)
 
-        # One of the application is removed (or transfered)
+        # One of the application is removed (or transferred)
         refusable_apps[0].delete()
 
         post_data = {
@@ -1300,7 +1300,7 @@ class TestBatchTransfer:
             ],
         )
 
-    def test_already_transfered(self, client):
+    def test_already_transferred(self, client):
         company = CompanyFactory(with_membership=True)
         employer = company.members.first()
         other_company = CompanyMembershipFactory(user=employer).company
@@ -1358,7 +1358,7 @@ class TestBatchTransfer:
                 to_company=company,
                 state=JobApplicationState.ACCEPTED,
             ),
-            # 1 already transfered application:
+            # 1 already transferred application:
             JobApplicationFactory(
                 job_seeker__first_name="Jean",
                 job_seeker__last_name="Bond",
@@ -1378,7 +1378,7 @@ class TestBatchTransfer:
             },
         )
         assertRedirects(response, next_url)
-        # 2 transferable apps have been successfully transfered despite all the error messages
+        # 2 transferable apps have been successfully transferred despite all the error messages
         apps[0].refresh_from_db()
         assert apps[0].to_company == other_company
         apps[1].refresh_from_db()

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -1065,7 +1065,7 @@ def test_list_for_siae_actions_forced_refresh(client):
     assert not response.headers.get("HX-Refresh")
     response = client.get(reverse("apply:list_for_siae_actions"), {"selected-application": [job_application.pk]})
     assert not response.headers.get("HX-Refresh")
-    # If the user checks an application, that either doesn't exist anymore or was transfered to another company
+    # If the user checks an application, that either doesn't exist anymore or was transferred to another company
     # a forced refresh should occur
     response = client.get(reverse("apply:list_for_siae_actions"), {"selected-application": [str(uuid.uuid4())]})
     assert response.headers.get("HX-Refresh") == "true"

--- a/tests/www/apply/test_list_rdv_insertion.py
+++ b/tests/www/apply/test_list_rdv_insertion.py
@@ -193,7 +193,7 @@ class TestRdvInsertionDisplay:
         profile_login(profile, self.job_application)
 
         # Force job application transition logs creation
-        # This leads to duplicates on agregated results due to the join with transition logs
+        # This leads to duplicates on aggregated results due to the join with transition logs
         # Hence a subquery is required while last_change isn't persisted in a job application column
         self.job_application.process()
         self.job_application.accept(user=self.job_application.to_company.members.first())

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -499,7 +499,7 @@ class TestProcessViews:
         assert response.status_code == 200
 
     def test_details_for_unauthorized_prescriber(self, client):
-        """As an unauthorized prescriber I cannot access personnal information of arbitrary job seekers"""
+        """As an unauthorized prescriber I cannot access personal information of arbitrary job seekers"""
         prescriber = PrescriberFactory()
         job_application = JobApplicationFactory(
             job_seeker__first_name="Supersecretname",
@@ -1260,7 +1260,7 @@ class TestProcessViews:
             "apply:batch_refuse_steps", kwargs={"session_uuid": refuse_session_name, "step": "job-seeker-answer"}
         )
         response = client.get(job_seeker_answer_url)
-        # Trying to acess step 2 without providing data for step 1 redirects to step 1
+        # Trying to access step 2 without providing data for step 1 redirects to step 1
         assertRedirects(response, refusal_reason_url)
 
     def test_postpone_from_prescriber(self, client, snapshot, mailoutbox, subtests):

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -35,7 +35,7 @@ class TestApprovalProlongation:
             yield
 
     def _setup_with_company_kind(self, siae_kind: CompanyKind):
-        # freeze_time does not wotk inside factories
+        # freeze_time does not work inside factories
         today = timezone.localdate()
         self.job_application = JobApplicationFactory(
             with_approval=True,

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -415,7 +415,7 @@ class TestDashboardView:
             siae=membership.company,
             evaluation_campaign__evaluations_asked_at=timezone.now(),
         )
-        # Add jb applications and criterias to check for 1+N
+        # Add jb applications and criteria to check for 1+N
         evaluated_job_app_1 = EvaluatedJobApplicationFactory(evaluated_siae=evaluated_siae)
         EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=evaluated_job_app_1)
         EvaluatedAdministrativeCriteriaFactory(evaluated_job_application=evaluated_job_app_1)

--- a/tests/www/dashboard/test_edit_user_info.py
+++ b/tests/www/dashboard/test_edit_user_info.py
@@ -645,7 +645,7 @@ class TestEditUserInfoView:
         assert user.phone == post_data["phone"]
         self._test_address_autocomplete(user=user, post_data=post_data)
 
-        # Ensure that the job seeker cannot update data retreived from the SSO here.
+        # Ensure that the job seeker cannot update data retrieved from the SSO here.
         assert user.first_name != post_data["first_name"]
         assert user.last_name != post_data["last_name"]
         assert user.jobseeker_profile.birthdate != birthdate

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -61,7 +61,7 @@ class TestListEmployeeRecords:
 
     def test_new_employee_records_list(self, client):
         """
-        Check if previous_step and back_url parmaeters are where we need them
+        Check if previous_step and back_url parameters are where we need them
         """
         record = employee_record_factories.EmployeeRecordWithProfileFactory(
             job_application__to_company=self.company,

--- a/tests/www/employees_views/test_detail.py
+++ b/tests/www/employees_views/test_detail.py
@@ -44,7 +44,7 @@ class TestEmployeeDetailView:
             from_employer=True, job_seeker=approval.user, author_siae=job_application.to_company
         )
 
-        # Another job applcation on the same SIAE, by a non authorized prescriber
+        # Another job application on the same SIAE, by a non authorized prescriber
         same_siae_job_application = JobApplicationSentByPrescriberOrganizationFactory(
             job_seeker=job_application.job_seeker,
             to_company=job_application.to_company,

--- a/tests/www/geiq_eligibility_views/test_forms.py
+++ b/tests/www/geiq_eligibility_views/test_forms.py
@@ -65,7 +65,7 @@ def test_init_geiq_administrative_criteria_form_fields_with_parent(new_geiq, cri
         assert form.is_valid()
         assert [criterion.parent.key, criterion.key] == list(map(lambda x: x.key, form.cleaned_data))
 
-    # Check akward case of "pole_emploi_related" field: result of foldable radio set
+    # Check awkward case of "pole_emploi_related" field: result of foldable radio set
     for criterion in criteria_in_radio:
         form = GEIQAdministrativeCriteriaForm(
             new_geiq, (), form_url=_FAKER.url(), data={"pole_emploi_related": criterion.pk}

--- a/tests/www/itou_staff_views/tests.py
+++ b/tests/www/itou_staff_views/tests.py
@@ -391,7 +391,7 @@ class TestMergeUsers:
         assert not User.objects.filter(pk=prescriber_2.pk).exists()
 
     @freeze_time("2024-11-19")
-    def test_merge_personnal_data(self, client, caplog):
+    def test_merge_personal_data(self, client, caplog):
         prescriber_1 = PrescriberFactory()
         prescriber_2 = PrescriberFactory()
 

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -43,10 +43,10 @@ class TestJobSeekerSignup:
         response = client.get(situation_url)
         signup_url = reverse("signup:job_seeker")
         assertContains(response, signup_url)
-        criterias_url = reverse("signup:job_seeker_criteria")
-        assertContains(response, criterias_url)
+        criteria_url = reverse("signup:job_seeker_criteria")
+        assertContains(response, criteria_url)
 
-        response = client.get(criterias_url)
+        response = client.get(criteria_url)
         assert response.status_code == 200
 
     def _test_job_seeker_signup_forms(self, client, nir, **extra_signup_kwargs):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour mettre ça derrière moi avant de partir en congé.

Seconde passe après https://github.com/gip-inclusion/les-emplois/pull/6030

## :cake: Comment ?

- `personal` avec un N 
- `aggregation` avec deux G
- `transferred` avec deux R
- `criteria` ne prend pas de S car est déjà le pluriel de `criterion`
- `preferred` avec deux R
- `overridden` avec deux D
- et d'autres

Je me suis pas mal aidé de https://github.com/codespell-project/codespell

## Notes pour la prochaine passe
- champ `agregation_kind` 💩 
