### PR TITLE
Pilotage : Ajouter l’absence/présence de CV dans la table candidatures de Metabase [GEN-2272]

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -369,6 +369,7 @@ class Command(BaseCommand):
                 "approval_id",
                 "approval_delivery_mode",
                 "contract_type",
+                "resume_link",
             )
             .exclude(origin=Origin.PE_APPROVAL)
             .filter(to_company_id__in=get_active_companies_pks())

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -292,5 +292,11 @@ TABLE.add_columns(
             "comment": "Type de contrat",
             "fn": lambda o: o.contract_type if o.contract_type else "",
         },
+        {
+            "name": "présence_de_cv",
+            "type": "boolean",
+            "comment": "Présence d''un CV",
+            "fn": lambda o: bool(o.resume_link),
+        },
     ]
 )

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -486,6 +486,7 @@ def test_populate_job_applications():
         with_geiq_eligibility_diagnosis=True,
         contract_type=ContractType.APPRENTICESHIP,
         state=JobApplicationState.ACCEPTED,
+        resume_link="https://www.mikescerealshack.co/resume.pdf",
     )
     ja.selected_jobs.add(job)
 
@@ -538,6 +539,7 @@ def test_populate_job_applications():
                 0,
                 "",
                 ja.contract_type,
+                True,
                 datetime.date(2023, 2, 1),
             ),
         ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour permettre à Pilotage de sortir des stats sur ce champ utile, par exemple "dans quelle mesure la présence d'un CV impacte les chances de réussite d'une candidature ?"

## :rotating_light: Revue

- @tonial car potentiel conflit avec https://github.com/gip-inclusion/les-emplois/pull/6102
- @YannickPassa pour le joke (il y a un easter egg pour toi dans cette PR)
- @rsebille pour avoir un dev Pilotage