### PR TITLE
GPS: Ajout d'un filtre dans l'admin

### DIFF
--- a/itou/gps/admin.py
+++ b/itou/gps/admin.py
@@ -23,6 +23,25 @@ class MemberInline(ReadonlyMixin, admin.TabularInline):
     show_change_link = True
 
 
+class ReasonStatusFilter(admin.SimpleListFilter):
+    title = "motif de suivi"
+    parameter_name = "has_reason"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("yes", "Renseigné"),
+            ("no", "Non renseigné"),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "yes":
+            return queryset.exclude(reason="")
+        if value == "no":
+            return queryset.filter(reason="")
+        return queryset
+
+
 @admin.register(models.FollowUpGroupMembership)
 class FollowUpGroupMembershipAdmin(ItouModelAdmin):
     list_display = (
@@ -38,6 +57,7 @@ class FollowUpGroupMembershipAdmin(ItouModelAdmin):
         "is_referent_certified",
         "is_referent",
         "created_in_bulk",
+        ReasonStatusFilter,
     )
     raw_id_fields = ("follow_up_group", "member")
     fields = (

--- a/tests/gps/test_admin.py
+++ b/tests/gps/test_admin.py
@@ -75,3 +75,25 @@ def test_create_follow_up_membership(admin_client):
     assertContains(
         response, "Un objet Relation avec ces champs Groupe de suivi et Membre du groupe de suivi existe déjà."
     )
+
+
+def test_reason_status_filter(admin_client):
+    group = FollowUpGroupFactory()
+    membership_with_reason = FollowUpGroupMembershipFactory(
+        follow_up_group=group,
+        reason="This is a reason",
+    )
+    membership_without_reason = FollowUpGroupMembershipFactory(
+        follow_up_group=group,
+        reason="",
+    )
+
+    membership_admin_url = reverse("admin:gps_followupgroupmembership_changelist")
+
+    response = admin_client.get(membership_admin_url + "?has_reason=yes")
+    assertContains(response, str(membership_with_reason.pk))
+    assert str(membership_without_reason.pk) not in response.content.decode()
+
+    response = admin_client.get(membership_admin_url + "?has_reason=no")
+    assertContains(response, str(membership_without_reason.pk))
+    assert str(membership_with_reason.pk) not in response.content.decode()

--- a/tests/gps/test_admin.py
+++ b/tests/gps/test_admin.py
@@ -91,9 +91,9 @@ def test_reason_status_filter(admin_client):
     membership_admin_url = reverse("admin:gps_followupgroupmembership_changelist")
 
     response = admin_client.get(membership_admin_url + "?has_reason=yes")
-    assertContains(response, str(membership_with_reason.pk))
-    assert str(membership_without_reason.pk) not in response.content.decode()
+    assertContains(response, str(membership_with_reason.member.email))
+    assert str(membership_without_reason.member.email) not in response.content.decode()
 
     response = admin_client.get(membership_admin_url + "?has_reason=no")
-    assertContains(response, str(membership_without_reason.pk))
-    assert str(membership_with_reason.pk) not in response.content.decode()
+    assertContains(response, str(membership_without_reason.member.email))
+    assert str(membership_with_reason.member.email) not in response.content.decode()

--- a/tests/gps/test_admin.py
+++ b/tests/gps/test_admin.py
@@ -91,9 +91,9 @@ def test_reason_status_filter(admin_client):
     membership_admin_url = reverse("admin:gps_followupgroupmembership_changelist")
 
     response = admin_client.get(membership_admin_url + "?has_reason=yes")
-    assertContains(response, str(membership_with_reason.member.email))
-    assertNotContains(response, str(membership_without_reason.member.email))
+    assertContains(response, membership_with_reason.member.email)
+    assertNotContains(response, membership_without_reason.member.email)
 
     response = admin_client.get(membership_admin_url + "?has_reason=no")
-    assertContains(response, str(membership_without_reason.member.email))
-    assertNotContains(response, str(membership_with_reason.member.email))
+    assertContains(response, membership_without_reason.member.email)
+    assertNotContains(response, membership_with_reason.member.email)

--- a/tests/gps/test_admin.py
+++ b/tests/gps/test_admin.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 from django.contrib.auth import get_user
 from django.urls import reverse
-from pytest_django.asserts import assertContains
+from pytest_django.asserts import assertContains, assertNotContains
 
 from itou.utils.urls import add_url_params
 from tests.gps.factories import FollowUpGroupFactory, FollowUpGroupMembershipFactory
@@ -92,8 +92,8 @@ def test_reason_status_filter(admin_client):
 
     response = admin_client.get(membership_admin_url + "?has_reason=yes")
     assertContains(response, str(membership_with_reason.member.email))
-    assert str(membership_without_reason.member.email) not in response.content.decode()
+    assertNotContains(response, str(membership_without_reason.member.email))
 
     response = admin_client.get(membership_admin_url + "?has_reason=no")
     assertContains(response, str(membership_without_reason.member.email))
-    assert str(membership_with_reason.member.email) not in response.content.decode()
+    assertNotContains(response, str(membership_with_reason.member.email))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour contrôler, mesurer et comprendre les usages de la fonction "Motif d'accompagnement".

## :desert_island: Comment tester ?

Dans l'admin, via `/admin/gps/followupgroupmembership/?has_reason=yes`.

## :computer: Captures d'écran <!-- optionnel -->
<img width="151" alt="image" src="https://github.com/user-attachments/assets/d546131a-e499-4299-bfb7-c420a3a4538b" />