### PR TITLE
Prescripteur : mieux afficher le nom et type d'organisation dans la fiche public dans le cas de France Travail"

### DIFF
--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -14,7 +14,10 @@
     {% component_title c_title__main=c_title__main %}
         {% fragment as c_title__main %}
             <h1>Prescripteur habilité</h1>
-            <p>{{ prescriber_org.get_kind_display }} - {{ prescriber_org.name }}</p>
+            <p>
+                {% if prescriber_org.kind != "FT" %}{{ prescriber_org.get_kind_display }} -{% endif %}
+                {{ prescriber_org.name }}
+            </p>
         {% endfragment %}
     {% endcomponent_title %}
 {% endblock %}

--- a/itou/templates/prescribers/card.html
+++ b/itou/templates/prescribers/card.html
@@ -11,12 +11,10 @@
 {% endblock %}
 
 {% block title_content %}
-    {% component_title c_title__main=c_title__main c_title__secondary=c_title__secondary %}
+    {% component_title c_title__main=c_title__main %}
         {% fragment as c_title__main %}
             <h1>Prescripteur habilité</h1>
-        {% endfragment %}
-        {% fragment as c_title__secondary %}
-            <h2>{{ prescriber_org.get_kind_display }} - {{ prescriber_org.name }}</h2>
+            <p>{{ prescriber_org.get_kind_display }} - {{ prescriber_org.name }}</p>
         {% endfragment %}
     {% endcomponent_title %}
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il y avait un peu de redite.

## :cake: Comment ? <!-- optionnel -->

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
