### PR TITLE
Supprimer les emails de la base de données plus tôt

### DIFF
--- a/itou/emails/management/commands/delete_old_emails.py
+++ b/itou/emails/management/commands/delete_old_emails.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *, wet_run, **options):
-        qs = Email.objects.filter(created_at__lt=timezone.now() - timedelta(days=365))
+        qs = Email.objects.filter(created_at__lt=timezone.now() - timedelta(days=182))
         if wet_run:
             prefix = "Deleted"
             count, _details = qs.delete()

--- a/tests/emails/test_commands.py
+++ b/tests/emails/test_commands.py
@@ -11,9 +11,9 @@ from itou.emails.models import Email
 class TestExpireOldEmails:
     def test_dry_run(self, caplog):
         now = timezone.now()
-        with freeze_time(now - timedelta(days=365)):
+        with freeze_time(now - timedelta(days=182)):
             old = Email.objects.create(to=["old@test.local"], subject="Old stuff", body_text="Old")
-        with freeze_time(now - timedelta(days=364)):
+        with freeze_time(now - timedelta(days=181)):
             after_cutoff = Email.objects.create(to=["recent@test.local"], subject="Recent stuff", body_text="Recent")
         call_command("delete_old_emails")
         assert caplog.messages[0] == "Would delete 1 email"
@@ -21,9 +21,9 @@ class TestExpireOldEmails:
 
     def test_wet_run(self, caplog):
         now = timezone.now()
-        with freeze_time(now - timedelta(days=365)):
+        with freeze_time(now - timedelta(days=182)):
             Email.objects.create(to=["old@test.local"], subject="Old stuff", body_text="Old")
-        with freeze_time(now - timedelta(days=364)):
+        with freeze_time(now - timedelta(days=181)):
             after_cutoff = Email.objects.create(to=["recent@test.local"], subject="Recent stuff", body_text="Recent")
         call_command("delete_old_emails", wet_run=True)
         assert caplog.messages[0] == "Deleted 1 email"


### PR DESCRIPTION
## :thinking: Pourquoi ?

On envoie environ 400K emails par mois, ce qui prend environ 1.2 GB dans les sauvegardes compressées, et 8 GB sur le disque une fois la base de données restaurée. Nos investigations remontent rarement à 1 an, même la nouvelle limit de 6 mois reste très prudente.
