### PR TITLE
Éligibilité : Correction de la durée de validité de la certification des critères

### DIFF
--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -162,13 +162,6 @@ class GEIQEligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
     def author_structure(self):
         return self.author_geiq or self.author_prescriber_organization
 
-    def get_criteria_display_qs(self, hiring_start_at=None):
-        return (
-            super()
-            .get_criteria_display_qs(hiring_start_at)
-            .exclude(administrative_criteria__annex=AdministrativeCriteriaAnnex.NO_ANNEX)
-        )
-
     @classmethod
     def _expiration_date(cls, author=None):
         return timezone.localdate() + relativedelta(months=cls.EXPIRATION_DELAY_MONTHS)

--- a/itou/eligibility/utils.py
+++ b/itou/eligibility/utils.py
@@ -1,4 +1,3 @@
-import datetime
 from collections import Counter
 
 from itou.eligibility.enums import (
@@ -6,7 +5,6 @@ from itou.eligibility.enums import (
     AdministrativeCriteriaAnnex,
     AdministrativeCriteriaLevel,
 )
-from itou.utils.types import InclusiveDateRange
 
 
 def iae_has_required_criteria(criteria, company_kind):
@@ -18,19 +16,11 @@ def iae_has_required_criteria(criteria, company_kind):
     return level_2_count >= ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[company_kind]
 
 
-def _inclusive_overlap(date_range1: InclusiveDateRange, date_range2: InclusiveDateRange):
-    return date_range1.lower <= date_range2.upper and date_range2.lower <= date_range1.upper
-
-
 def _criteria_for_display(selected_criteria, hiring_start_at):
     for criterion in selected_criteria:
         criterion.is_considered_certified = False
         if hiring_start_at and criterion.certified:
-            validity_period = InclusiveDateRange(
-                hiring_start_at - datetime.timedelta(days=criterion.CERTIFICATION_GRACE_PERIOD_DAYS),
-                hiring_start_at,
-            )
-            criterion.is_considered_certified = _inclusive_overlap(validity_period, criterion.certification_period)
+            criterion.is_considered_certified = hiring_start_at in criterion.certification_period
     return selected_criteria
 
 

--- a/itou/eligibility/utils.py
+++ b/itou/eligibility/utils.py
@@ -1,6 +1,12 @@
+import datetime
 from collections import Counter
 
-from itou.eligibility.enums import ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND, AdministrativeCriteriaLevel
+from itou.eligibility.enums import (
+    ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND,
+    AdministrativeCriteriaAnnex,
+    AdministrativeCriteriaLevel,
+)
+from itou.utils.types import InclusiveDateRange
 
 
 def iae_has_required_criteria(criteria, company_kind):
@@ -10,6 +16,35 @@ def iae_has_required_criteria(criteria, company_kind):
             return True
         level_2_count += 1
     return level_2_count >= ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[company_kind]
+
+
+def _inclusive_overlap(date_range1: InclusiveDateRange, date_range2: InclusiveDateRange):
+    return date_range1.lower <= date_range2.upper and date_range2.lower <= date_range1.upper
+
+
+def _criteria_for_display(selected_criteria, hiring_start_at):
+    for criterion in selected_criteria:
+        criterion.is_considered_certified = False
+        if hiring_start_at and criterion.certified:
+            validity_period = InclusiveDateRange(
+                hiring_start_at - datetime.timedelta(days=criterion.CERTIFICATION_GRACE_PERIOD_DAYS),
+                hiring_start_at,
+            )
+            criterion.is_considered_certified = _inclusive_overlap(validity_period, criterion.certification_period)
+    return selected_criteria
+
+
+def iae_criteria_for_display(eligibility_diagnosis, hiring_start_at=None):
+    return _criteria_for_display(eligibility_diagnosis.selected_administrative_criteria.all(), hiring_start_at)
+
+
+def geiq_criteria_for_display(eligibility_diagnosis, hiring_start_at=None):
+    return _criteria_for_display(
+        eligibility_diagnosis.selected_administrative_criteria.exclude(
+            administrative_criteria__annex=AdministrativeCriteriaAnnex.NO_ANNEX
+        ),
+        hiring_start_at,
+    )
 
 
 def geiq_allowance_amount(is_authorized_prescriber, administrative_criteria) -> int:

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -23,6 +23,7 @@ from itou.companies.enums import CompanyKind, ContractType
 from itou.companies.models import Company
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
+from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
 from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow, PriorAction
 from itou.rdv_insertion.api import get_api_credentials, get_invitation_status
@@ -135,13 +136,15 @@ def details_for_jobseeker(request, job_application_id, template_name="apply/proc
         and _get_geiq_eligibility_diagnosis(job_application, only_prescriber=False)
     )
     if geiq_eligibility_diagnosis:
-        geiq_eligibility_diagnosis.criteria_display = geiq_eligibility_diagnosis.get_criteria_display_qs(
-            hiring_start_at=job_application.hiring_start_at
+        geiq_eligibility_diagnosis.criteria_display = geiq_criteria_for_display(
+            geiq_eligibility_diagnosis,
+            hiring_start_at=job_application.hiring_start_at,
         )
     eligibility_diagnosis = job_application.get_eligibility_diagnosis()
     if eligibility_diagnosis:
-        eligibility_diagnosis.criteria_display = eligibility_diagnosis.get_criteria_display_qs(
-            hiring_start_at=job_application.hiring_start_at
+        eligibility_diagnosis.criteria_display = iae_criteria_for_display(
+            eligibility_diagnosis,
+            hiring_start_at=job_application.hiring_start_at,
         )
 
     context = {
@@ -230,14 +233,16 @@ def details_for_company(request, job_application_id, template_name="apply/proces
         and _get_geiq_eligibility_diagnosis(job_application, only_prescriber=False)
     )
     if geiq_eligibility_diagnosis:
-        geiq_eligibility_diagnosis.criteria_display = geiq_eligibility_diagnosis.get_criteria_display_qs(
-            hiring_start_at=job_application.hiring_start_at
+        geiq_eligibility_diagnosis.criteria_display = geiq_criteria_for_display(
+            geiq_eligibility_diagnosis,
+            hiring_start_at=job_application.hiring_start_at,
         )
 
     eligibility_diagnosis = job_application.get_eligibility_diagnosis()
     if eligibility_diagnosis:
-        eligibility_diagnosis.criteria_display = eligibility_diagnosis.get_criteria_display_qs(
-            hiring_start_at=job_application.hiring_start_at
+        eligibility_diagnosis.criteria_display = iae_criteria_for_display(
+            eligibility_diagnosis,
+            hiring_start_at=job_application.hiring_start_at,
         )
 
     can_be_cancelled = job_application.state.is_accepted and job_application.can_be_cancelled
@@ -318,14 +323,16 @@ def details_for_prescriber(request, job_application_id, template_name="apply/pro
         and _get_geiq_eligibility_diagnosis(job_application, only_prescriber=True)
     )
     if geiq_eligibility_diagnosis:
-        geiq_eligibility_diagnosis.criteria_display = geiq_eligibility_diagnosis.get_criteria_display_qs(
-            hiring_start_at=job_application.hiring_start_at
+        geiq_eligibility_diagnosis.criteria_display = geiq_criteria_for_display(
+            geiq_eligibility_diagnosis,
+            hiring_start_at=job_application.hiring_start_at,
         )
 
     eligibility_diagnosis = job_application.get_eligibility_diagnosis()
     if eligibility_diagnosis:
-        eligibility_diagnosis.criteria_display = eligibility_diagnosis.get_criteria_display_qs(
-            hiring_start_at=job_application.hiring_start_at
+        eligibility_diagnosis.criteria_display = iae_criteria_for_display(
+            eligibility_diagnosis,
+            hiring_start_at=job_application.hiring_start_at,
         )
 
     # Refused applications information is providen to prescribers

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -17,6 +17,7 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company, JobDescription
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
+from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
 from itou.files.models import File
 from itou.gps.models import FollowUpGroup
 from itou.job_applications.models import JobApplication
@@ -839,13 +840,13 @@ class HireConfirmationView(ApplicationBaseView, common_views.BaseAcceptView):
         context = super().get_context_data(**kwargs)
 
         if self.geiq_eligibility_diagnosis:
-            self.geiq_eligibility_diagnosis.criteria_display = (
-                self.geiq_eligibility_diagnosis.get_criteria_display_qs()
+            self.geiq_eligibility_diagnosis.criteria_display = geiq_criteria_for_display(
+                self.geiq_eligibility_diagnosis
             )
         if self.eligibility_diagnosis:
             # The job_seeker object already contains a lot of information: no need to re-retrieve it
             self.eligibility_diagnosis.job_seeker = self.job_seeker
-            self.eligibility_diagnosis.criteria_display = self.eligibility_diagnosis.get_criteria_display_qs()
+            self.eligibility_diagnosis.criteria_display = iae_criteria_for_display(self.eligibility_diagnosis)
 
         context["can_edit_personal_information"] = can_edit_personal_information(self.request, self.job_seeker)
         context["is_subject_to_eligibility_rules"] = self.company.is_subject_to_eligibility_rules

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -10,6 +10,7 @@ from itou.approvals.models import (
     Approval,
     ProlongationRequest,
 )
+from itou.eligibility.utils import iae_criteria_for_display
 from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
@@ -106,8 +107,9 @@ class EmployeeDetailView(DetailView):
         eligibility_diagnosis = job_application and job_application.get_eligibility_diagnosis()
         if eligibility_diagnosis:
             hiring_start_at = job_application.hiring_start_at if job_application else None
-            eligibility_diagnosis.criteria_display = eligibility_diagnosis.get_criteria_display_qs(
-                hiring_start_at=hiring_start_at
+            eligibility_diagnosis.criteria_display = iae_criteria_for_display(
+                eligibility_diagnosis,
+                hiring_start_at=hiring_start_at,
             )
 
         context["can_view_personal_information"] = True  # SIAE members have access to personal info

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -21,6 +21,7 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
 from itou.eligibility.models.iae import EligibilityDiagnosis
+from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
 from itou.gps.models import FollowUpGroup
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
@@ -89,10 +90,10 @@ class JobSeekerDetailView(UserPassesTestMixin, DetailView):
             can_edit_iae_eligibility = True
 
         if geiq_eligibility_diagnosis:
-            geiq_eligibility_diagnosis.criteria_display = geiq_eligibility_diagnosis.get_criteria_display_qs()
+            geiq_eligibility_diagnosis.criteria_display = geiq_criteria_for_display(geiq_eligibility_diagnosis)
 
         if iae_eligibility_diagnosis:
-            iae_eligibility_diagnosis.criteria_display = iae_eligibility_diagnosis.get_criteria_display_qs()
+            iae_eligibility_diagnosis.criteria_display = iae_criteria_for_display(iae_eligibility_diagnosis)
 
         return super().get_context_data(**kwargs) | {
             "geiq_eligibility_diagnosis": geiq_eligibility_diagnosis,

--- a/tests/eligibility/test_utils.py
+++ b/tests/eligibility/test_utils.py
@@ -51,7 +51,4 @@ def test_criteria_for_display(factory, method):
     assert_considered_certified(diagnosis, hiring_start_at=start)
     assert_considered_certified(diagnosis, hiring_start_at=today)
     assert_considered_certified(diagnosis, hiring_start_at=end)
-    assert_considered_certified(diagnosis, hiring_start_at=end + datetime.timedelta(days=1))
-    end_limit = end + datetime.timedelta(days=selected_criterion.CERTIFICATION_GRACE_PERIOD_DAYS)
-    assert_considered_certified(diagnosis, hiring_start_at=end_limit)
-    assert_not_considered_certified(diagnosis, hiring_start_at=end_limit + datetime.timedelta(days=1))
+    assert_not_considered_certified(diagnosis, hiring_start_at=end + datetime.timedelta(days=1))

--- a/tests/eligibility/test_utils.py
+++ b/tests/eligibility/test_utils.py
@@ -1,0 +1,57 @@
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, AdministrativeCriteriaAnnex
+from itou.eligibility.models import GEIQAdministrativeCriteria, GEIQSelectedAdministrativeCriteria
+from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
+from itou.utils.types import InclusiveDateRange
+from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
+
+
+@pytest.mark.parametrize(
+    "factory,method",
+    [
+        pytest.param(GEIQEligibilityDiagnosisFactory, geiq_criteria_for_display, id="geiq"),
+        pytest.param(IAEEligibilityDiagnosisFactory, iae_criteria_for_display, id="iae"),
+    ],
+)
+def test_criteria_for_display(factory, method):
+    def _assert_considered_certified(diagnosis, expected, hiring_start_at):
+        [criterion] = method(diagnosis, hiring_start_at=hiring_start_at)
+        assert criterion.is_considered_certified is expected
+
+    def assert_considered_certified(diagnosis, hiring_start_at=None):
+        _assert_considered_certified(diagnosis, True, hiring_start_at=hiring_start_at)
+
+    def assert_not_considered_certified(diagnosis, hiring_start_at=None):
+        _assert_considered_certified(diagnosis, False, hiring_start_at=hiring_start_at)
+
+    diagnosis = factory(
+        certifiable=True,
+        criteria_kinds=list(CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS)[:1],
+    )
+    if factory is GEIQEligibilityDiagnosisFactory:
+        # Ignored because they are not displayed.
+        ignored_crit = (
+            GEIQAdministrativeCriteria.objects.filter(annex=AdministrativeCriteriaAnnex.NO_ANNEX).order_by("?").first()
+        )
+        GEIQSelectedAdministrativeCriteria(administrative_criteria=ignored_crit, eligibility_diagnosis=diagnosis)
+
+    [selected_criterion] = diagnosis.selected_administrative_criteria.all()
+    selected_criterion.certified = True
+    today = timezone.localdate()
+    start = today - datetime.timedelta(days=10)
+    end = today + datetime.timedelta(days=10)
+    selected_criterion.certification_period = InclusiveDateRange(start, end)
+    selected_criterion.save(update_fields=["certification_period", "certified"])
+    assert_not_considered_certified(diagnosis)
+    assert_not_considered_certified(diagnosis, hiring_start_at=start - datetime.timedelta(days=1))
+    assert_considered_certified(diagnosis, hiring_start_at=start)
+    assert_considered_certified(diagnosis, hiring_start_at=today)
+    assert_considered_certified(diagnosis, hiring_start_at=end)
+    assert_considered_certified(diagnosis, hiring_start_at=end + datetime.timedelta(days=1))
+    end_limit = end + datetime.timedelta(days=selected_criterion.CERTIFICATION_GRACE_PERIOD_DAYS)
+    assert_considered_certified(diagnosis, hiring_start_at=end_limit)
+    assert_not_considered_certified(diagnosis, hiring_start_at=end_limit + datetime.timedelta(days=1))

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1018,7 +1018,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_approval[job application detail for company]
   dict({
-    'num_queries': 22,
+    'num_queries': 21,
     'queries': list([
       dict({
         'origin': list([
@@ -1916,37 +1916,6 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-          '_check_user_view_wrapper[utils/auth.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -2208,7 +2177,7 @@
 # ---
 # name: TestProcessViews.test_details_for_company_from_list[job application detail for company]
   dict({
-    'num_queries': 22,
+    'num_queries': 21,
     'queries': list([
       dict({
         'origin': list([
@@ -3106,37 +3075,6 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details_company.html]',
-          'IfNode[apply/process_details_company.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details_company.html]',
-          'details_for_company[www/apply/views/process_views.py]',
-          '_check_user_view_wrapper[utils/auth.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -3454,7 +3392,7 @@
 # ---
 # name: TestProcessViews.test_details_for_job_seeker
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
       dict({
         'origin': list([
@@ -4197,36 +4135,6 @@
           WHERE ("rdv_insertion_participation"."job_seeker_id" = %s
                  AND "rdv_insertion_appointment"."company_id" = %s)
           ORDER BY "rdv_insertion_appointment"."start_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/process_details.html]',
-          'IfNode[apply/process_details.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/process_base.html]',
-          'ExtendsNode[apply/process_details.html]',
-          'details_for_jobseeker[www/apply/views/process_views.py]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -1343,6 +1343,29 @@
       }),
       dict({
         'origin': list([
+          '_criteria_for_display[eligibility/utils.py]',
+          'iae_criteria_for_display[eligibility/utils.py]',
+          'HireConfirmationView.get_context_data[www/apply/views/submit_views.py]',
+          'HireConfirmationView.dispatch[www/apply/views/submit_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
+          FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
         ]),
         'sql': 'RELEASE SAVEPOINT "<snapshot>"',
@@ -1373,34 +1396,6 @@
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
           LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[apply/submit/hire_confirmation.html]',
-          'BlockNode[apply/submit_base.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[apply/submit_base.html]',
-          'ExtendsNode[apply/submit/hire_confirmation.html]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 %s AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -334,8 +334,13 @@ class TestProcessViews:
         response = client.get(url)
         assertNotContains(response, CERTIFIED_BADGE_HTML, html=True)
 
-        eligibility_diagnosis.expires_at = today + datetime.timedelta(days=1)
+        tomorrow = today + datetime.timedelta(days=1)
+        eligibility_diagnosis.expires_at = tomorrow
         eligibility_diagnosis.save()
+        selected_criteria.certification_period = InclusiveDateRange(
+            selected_criteria.certification_period.lower, tomorrow
+        )
+        selected_criteria.save()
         response = client.get(url)
         assertContains(response, CERTIFIED_BADGE_HTML, html=True)
 

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -14,6 +14,7 @@ from itou.eligibility.enums import (
     AdministrativeCriteriaLevel,
 )
 from itou.eligibility.tasks import certify_criteria
+from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
 from itou.job_applications.enums import Origin
 from itou.jobs.models import Appellation
 from itou.utils.context_processors import expose_enums
@@ -213,7 +214,9 @@ class TestCertifiedBadgeIae:
             job_application.to_company = diagnosis.author_siae
             job_application.save()
         # This is the way it's set in views.
-        diagnosis.criteria_display = diagnosis.get_criteria_display_qs(hiring_start_at=job_application.hiring_start_at)
+        diagnosis.criteria_display = iae_criteria_for_display(
+            diagnosis, hiring_start_at=job_application.hiring_start_at
+        )
         return {
             "eligibility_diagnosis": diagnosis,
             "request": RequestFactory(),
@@ -368,7 +371,9 @@ class TestCertifiedBadgeGEIQ:
         return load_template("apply/includes/geiq/geiq_diagnosis_details.html")
 
     def default_params_geiq(self, diagnosis, job_application):
-        diagnosis.criteria_display = diagnosis.get_criteria_display_qs(hiring_start_at=job_application.hiring_start_at)
+        diagnosis.criteria_display = geiq_criteria_for_display(
+            diagnosis, hiring_start_at=job_application.hiring_start_at
+        )
         return {
             "request": RequestFactory(),
             "diagnosis": diagnosis,

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestEmployeeDetailView.test_detail_view[employee detail view]
   dict({
-    'num_queries': 25,
+    'num_queries': 24,
     'queries': list([
       dict({
         'origin': list([
@@ -965,34 +965,6 @@
           FROM "users_user"
           WHERE "users_user"."id" = %s
           LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IfNode[apply/includes/eligibility_diagnosis.html]',
-          'IncludeNode[employees/detail.html]',
-          'IfNode[employees/detail.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[employees/detail.html]',
-        ]),
-        'sql': '''
-          SELECT "eligibility_selectedadministrativecriteria"."id",
-                 "eligibility_selectedadministrativecriteria"."certified",
-                 "eligibility_selectedadministrativecriteria"."certified_at",
-                 "eligibility_selectedadministrativecriteria"."certification_period",
-                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
-                 "eligibility_selectedadministrativecriteria"."created_at",
-                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
-                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
-                 ("eligibility_selectedadministrativecriteria"."certification_period" && %s
-                  AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
-          FROM "eligibility_selectedadministrativecriteria"
-          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
-          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY "eligibility_administrativecriteria"."level" ASC,
-                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

Au départ, l’API particulier donnait une période d’éligibilité pour la certification des critères. Il s’est avéré que la réponse de l’API correspond à la question « est-ce que cette personne est bénéficiaire aujourd’hui ? », et que la date de début correspond à l’ouverture des droits actuels. La date de fin s’est révélée fausse et a été changée pour ne jamais être spécifiée par l’API (voir 9d44cd13f602550e2aae38afc6a3487897abc704).

Nous avons décidé de fixer la date de fin à 92 jours, qui correspond à la fin d’acceptabilité d’un justificatif daté (justificatif de moins de trois mois). La période de certification inclut donc maintenant le délai de trois mois (`is_considered_valid`), mais nous ne sommes pas revenus sur `with_is_considered_valid`, qui octroie également ce délai. Ainsi, le délai de 92 jours est octroyé deux fois, soit un total de 184 jours au lieu des 92 jours attendus.

## :cake: Comment ? <!-- optionnel -->

Retrait de l’annotation en base de données qui empêchait de profiter des données préchargées (`prefetch_related`).

## :desert_island: Comment tester ?

1. Créer un `SelectedAdministrativeCriteria(certified=True, …)` avec une période de certification se terminant il y a 150 jours (~5 mois).
2. Vérifier que le critère n’apparaît plus comme certifié, par exemple lors du parcours d’embauche.
