### PR TITLE
Interface : Petite amélioration de l’encart justificatif du contrôle a posteriori

### DIFF
--- a/itou/templates/siae_evaluations/includes/criterion_infos.html
+++ b/itou/templates/siae_evaluations/includes/criterion_infos.html
@@ -1,22 +1,27 @@
-{% if review_state == "ACCEPTED" %}
-    <strong class="text-success"><i class="ri-check-line" aria-hidden="true"></i> Validé</strong>
-    <br>
-{% elif review_state == "REFUSED" or review_state == "REFUSED_2" %}
-    <strong class="text-danger"><i class="ri-close-line" aria-hidden="true"></i> Refusé</strong>
-    <br>
-{% endif %}
-<strong class="fs-sm">{{ criteria.name }}</strong>
-<br>
-<ul class="fs-sm">
-    {% if criteria.written_proof %}<li class="m-0">Pièce justificative : {{ criteria.written_proof }}</li>{% endif %}
-    {% if criteria.written_proof_validity %}
-        <li class="m-0">Durée de validité du justificatif : {{ criteria.written_proof_validity }}</li>
+<div class="fs-sm">
+    {% if review_state == "ACCEPTED" %}
+        <p class="mb-1">
+            <strong class="text-success"><i class="ri-check-line" aria-hidden="true"></i> Validé</strong>
+        </p>
+    {% elif review_state == "REFUSED" or review_state == "REFUSED_2" %}
+        <p class="mb-1">
+            <strong class="text-danger"><i class="ri-close-line" aria-hidden="true"></i> Refusé</strong>
+        </p>
     {% endif %}
-    {% if criteria.written_proof_url %}
-        <li class="m-0">
-            <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" class="has-external-link" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
-                {{ criteria.written_proof_url }}
-            </a>
-        </li>
-    {% endif %}
-</ul>
+    <p class="mb-1">
+        <strong>{{ criteria.name }}</strong>
+    </p>
+    <ul>
+        {% if criteria.written_proof %}<li class="m-0">Pièce justificative : {{ criteria.written_proof }}</li>{% endif %}
+        {% if criteria.written_proof_validity %}
+            <li class="m-0">Durée de validité du justificatif : {{ criteria.written_proof_validity }}</li>
+        {% endif %}
+        {% if criteria.written_proof_url %}
+            <li class="m-0">
+                <a href="{{ criteria.written_proof_url }}" rel="noopener" target="_blank" class="has-external-link" aria-label="{{ criteria.written_proof_url }} (ouverture dans un nouvel onglet)">
+                    {{ criteria.written_proof_url }}
+                </a>
+            </li>
+        {% endif %}
+    </ul>
+</div>

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -263,9 +263,12 @@ class TestSiaeJobApplicationListView:
                 "XXXXX2412345",
                 '<span class="badge badge-sm rounded-pill text-nowrap bg-success text-white">Validé</span>',
                 """
-                <strong class="text-success"><i class="ri-check-line" aria-hidden="true"></i> Validé</strong>
-                <br>
-                <strong class="fs-sm">Bénéficiaire du RSA</strong>
+                <p class="mb-1">
+                    <strong class="text-success">
+                        <i class="ri-check-line" aria-hidden="true"></i> Validé
+                    </strong>
+                </p>
+                <p class="mb-1"><strong>Bénéficiaire du RSA</strong></p>
                 """,
             ),
             (
@@ -273,9 +276,12 @@ class TestSiaeJobApplicationListView:
                 "XXXXX2423456",
                 SIAE_JOB_APPLICATION_LIST_REFUSED_HTML,
                 """
-                <strong class="text-danger"><i class="ri-close-line" aria-hidden="true"></i> Refusé</strong>
-                <br>
-                <strong class="fs-sm">Bénéficiaire du RSA</strong>
+                <p class="mb-1">
+                    <strong class="text-danger">
+                        <i class="ri-close-line" aria-hidden="true"></i> Refusé
+                    </strong>
+                </p>
+                <p class="mb-1"><strong>Bénéficiaire du RSA</strong></p>
                 """,
             ),
         ],


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mieux structure l’information, faciliter l’ajout du badge certifié pour https://www.figma.com/design/D03fLXh9KzMgCiKbrGEnQg/%F0%9F%94%B5-Contr%C3%B4le-a-posteriori?node-id=4878-3837&p=f.

## :computer: Captures d'écran <!-- optionnel -->
### Avant
![image](https://github.com/user-attachments/assets/fb4f0383-78f5-4cf9-9453-8e21faab94fe)


### Après
![image](https://github.com/user-attachments/assets/91fb374b-f762-4850-9ce8-59e6eb7f259f)




