### PR TITLE
Clarifier User.can_create_siae_antenna

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -721,9 +721,9 @@ class User(AbstractUser, AddressMixin):
         """
         return (
             self.is_employer
-            and parent_siae.has_admin(self)
             and parent_siae.kind in [CompanyKind.GEIQ, *CompanyKind.siae_kinds()]
             and parent_siae.is_active
+            and parent_siae.has_admin(self)
         )
 
     def update_external_data_source_history_field(self, provider, field, value) -> bool:

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -721,12 +721,9 @@ class User(AbstractUser, AddressMixin):
         """
         return (
             self.is_employer
-            and parent_siae.is_active
             and parent_siae.has_admin(self)
-            and (
-                parent_siae.kind == CompanyKind.GEIQ
-                or (parent_siae.should_have_convention and parent_siae.convention is not None)
-            )
+            and parent_siae.kind in [CompanyKind.GEIQ, *CompanyKind.siae_kinds()]
+            and parent_siae.is_active
         )
 
     def update_external_data_source_history_field(self, provider, field, value) -> bool:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Faciliter la lecture des règles associées à la création d’antennes.
