### PR TITLE
Vie privée : refactor en préparation de la notification et de l'archivage des professionnels

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -3,7 +3,7 @@
   "*/5 * * * * $ROOT/clevercloud/run_management_command.sh scan_s3_files",
   "*/5 0-22 * * * $ROOT/clevercloud/send_approvals_to_pe.sh",
   "*/5 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh reject_job_applications_after_delay",
-  "*/5 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_archive_jobseekers --wet-run",
+  "*/5 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_archive_users --wet-run",
 
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_pec_offers --wet-run",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh update_companies_job_app_score",

--- a/itou/archive/management/commands/notify_archive_jobseekers.py
+++ b/itou/archive/management/commands/notify_archive_jobseekers.py
@@ -15,7 +15,7 @@ from itou.gps.models import FollowUpGroup
 from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication, JobApplicationTransitionLog
 from itou.users.models import User, UserKind
-from itou.users.notifications import ArchiveJobSeeker, InactiveJobSeeker
+from itou.users.notifications import ArchiveUser, InactiveUser
 from itou.utils.command import BaseCommand
 from itou.utils.constants import GRACE_PERIOD, INACTIVITY_PERIOD
 
@@ -148,7 +148,7 @@ class Command(BaseCommand):
 
         if self.wet_run:
             for user in users:
-                InactiveJobSeeker(
+                InactiveUser(
                     user,
                     end_of_grace_period=now + GRACE_PERIOD,
                 ).send()
@@ -229,7 +229,7 @@ class Command(BaseCommand):
 
         if self.wet_run:
             for user in users_to_archive:
-                ArchiveJobSeeker(
+                ArchiveUser(
                     user,
                 ).send()
 

--- a/itou/archive/management/commands/notify_archive_jobseekers.py
+++ b/itou/archive/management/commands/notify_archive_jobseekers.py
@@ -17,12 +17,10 @@ from itou.job_applications.models import JobApplication, JobApplicationTransitio
 from itou.users.models import User, UserKind
 from itou.users.notifications import ArchiveJobSeeker, InactiveJobSeeker
 from itou.utils.command import BaseCommand
+from itou.utils.constants import GRACE_PERIOD, INACTIVITY_PERIOD
 
 
 logger = logging.getLogger(__name__)
-
-GRACE_PERIOD = datetime.timedelta(days=30)
-INACTIVITY_PERIOD = datetime.timedelta(days=365) * 2 - GRACE_PERIOD
 
 BATCH_SIZE = 100
 

--- a/itou/archive/management/commands/notify_archive_users.py
+++ b/itou/archive/management/commands/notify_archive_users.py
@@ -126,7 +126,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--wet-run",
             action="store_true",
-            help="Perform the actual archiving of jobseekers",
+            help="Perform the actual archiving of users",
         )
 
         parser.add_argument(
@@ -134,7 +134,7 @@ class Command(BaseCommand):
             action="store",
             type=int,
             default=BATCH_SIZE,
-            help="Number of jobseekers to process in a batch",
+            help="Number of users to process in a batch",
         )
 
     @transaction.atomic
@@ -246,7 +246,7 @@ class Command(BaseCommand):
         User.objects.filter(id__in=[user.id for user in users]).delete()
 
     @monitor(
-        monitor_slug="notify_archive_jobseekers",
+        monitor_slug="notify_archive_users",
         monitor_config={
             "schedule": {"type": "crontab", "value": "*/5 7-20 * * MON-FRI"},
             "checkin_margin": 5,
@@ -259,7 +259,7 @@ class Command(BaseCommand):
     def handle(self, *args, wet_run, batch_size, **options):
         self.wet_run = wet_run
         self.batch_size = batch_size
-        self.logger.info("Start notifying and archiving jobseekers in %s mode", "wet_run" if wet_run else "dry_run")
+        self.logger.info("Start notifying and archiving users in %s mode", "wet_run" if wet_run else "dry_run")
 
         self.reset_notified_jobseekers_with_recent_activity()
         self.notify_inactive_jobseekers()

--- a/itou/archive/management/commands/notify_archive_users.py
+++ b/itou/archive/management/commands/notify_archive_users.py
@@ -235,12 +235,12 @@ class Command(BaseCommand):
 
             ArchivedJobSeeker.objects.bulk_create(archived_jobseekers)
             ArchivedApplication.objects.bulk_create(archived_jobapplications)
-            self._delete_with_related_objects(users_to_archive)
+            self._delete_jobseekers_with_related_objects(users_to_archive)
 
         self.logger.info("Archived jobseekers after grace period, count: %d", len(archived_jobseekers))
         self.logger.info("Archived job applications after grace period, count: %d", len(archived_jobapplications))
 
-    def _delete_with_related_objects(self, users):
+    def _delete_jobseekers_with_related_objects(self, users):
         FollowUpGroup.objects.filter(beneficiary__in=users).delete()
         JobApplication.objects.filter(job_seeker__in=users).delete()
         User.objects.filter(id__in=[user.id for user in users]).delete()

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -446,9 +446,7 @@ class Command(BaseCommand):
         populate_table(evaluated_criteria.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_users(self):
-        queryset = User.objects.filter(
-            kind__in=[UserKind.EMPLOYER, UserKind.PRESCRIBER, UserKind.LABOR_INSPECTOR], is_active=True
-        )
+        queryset = User.objects.filter(kind__in=UserKind.professionals(), is_active=True)
         populate_table(users.TABLE, batch_size=1000, querysets=[queryset])
 
     def populate_memberships(self):

--- a/itou/templates/account/email/email_inactive_user_body.txt
+++ b/itou/templates/account/email/email_inactive_user_body.txt
@@ -8,7 +8,7 @@
 
 {% block body %}
 Bonjour {{ user.get_full_name }},
-Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le {{ user.last_activity|date:"d/m/Y" }}.
+Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le {% if user.last_activity %}{{ user.last_activity|date:"d/m/Y" }}{% else %}{{ user.last_login|date:"d/m/Y" }}{% endif %}.
 Sans connexion de votre part avant le {{ end_of_grace_period|date:"d/m/Y" }}, votre compte sera supprimé ainsi que toutes les données associées.
 Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
 {% endblock body %}

--- a/itou/users/enums.py
+++ b/itou/users/enums.py
@@ -31,6 +31,14 @@ class UserKind(models.TextChoices):
         }
         return reverse(url_lookup[user_kind]) if user_kind in url_lookup else reverse(default)
 
+    @classmethod
+    def professionals(cls):
+        return [
+            cls.PRESCRIBER,
+            cls.EMPLOYER,
+            cls.LABOR_INSPECTOR,
+        ]
+
 
 MATOMO_ACCOUNT_TYPE = {
     UserKind.PRESCRIBER: "prescripteur",

--- a/itou/users/notifications.py
+++ b/itou/users/notifications.py
@@ -23,8 +23,8 @@ class JobSeekerCreatedByProxyNotification(EmailNotification):
 
 
 @notifications_registry.register
-class InactiveJobSeeker(EmailNotification):
-    name = "Information avant suppression d'un compte candidat inactif"
+class InactiveUser(EmailNotification):
+    name = "Information avant suppression d'un compte utilisateur inactif"
     category = NotificationCategory.DELETION
     subject_template = "account/email/email_inactive_user_subject.txt"
     body_template = "account/email/email_inactive_user_body.txt"
@@ -32,8 +32,8 @@ class InactiveJobSeeker(EmailNotification):
 
 
 @notifications_registry.register
-class ArchiveJobSeeker(EmailNotification):
-    name = "Suppression d'un compte candidat"
+class ArchiveUser(EmailNotification):
+    name = "Suppression d'un compte utilisateur"
     category = NotificationCategory.DELETION
     subject_template = "account/email/email_archive_user_subject.txt"
     body_template = "account/email/email_archive_user_body.txt"

--- a/itou/utils/constants.py
+++ b/itou/utils/constants.py
@@ -1,3 +1,6 @@
+import datetime
+
+
 DDETS_HELP_CENTER_URL = "https://plateforme-inclusion-ddets-dreets.zendesk.com/hc/fr"
 ITOU_HELP_CENTER_URL = "https://aide.emplois.inclusion.beta.gouv.fr/hc/fr"
 PILOTAGE_HELP_CENTER_URL = "https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr"
@@ -20,3 +23,10 @@ MATOMO_SITE_PILOTAGE_ID = "146"
 MB = 1024 * 1024
 
 SUPPORTED_IMAGE_FILE_TYPES = {"image/png": "png", "image/jpeg": "jpeg", "image/jpg": "jpg", "image/gif": "gif"}
+
+# NOTIFY - ARCHIVE USERS
+# ------------------------------------------------------------------------------
+DAYS_OF_GRACE = 30
+GRACE_PERIOD = datetime.timedelta(days=DAYS_OF_GRACE)
+DAYS_OF_INACTIVITY = 365 * 2 - DAYS_OF_GRACE
+INACTIVITY_PERIOD = datetime.timedelta(DAYS_OF_INACTIVITY)

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_not_is_active][archived_jobseeker]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_not_is_active][archived_jobseeker]
   list([
     dict({
       'birth_year': 1964,
@@ -21,7 +21,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker]
   list([
     dict({
       'birth_year': 1990,
@@ -43,7 +43,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_body]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_body]
   '''
   Bonjour Johan ANDERSON,
   Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
@@ -56,10 +56,10 @@
   http://localhost:8000
   '''
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_subject]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_subject]
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker]
   list([
     dict({
       'birth_year': 1985,
@@ -81,7 +81,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_body]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_body]
   '''
   Bonjour Johanna ANDREWS,
   Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
@@ -94,10 +94,10 @@
   http://localhost:8000
   '''
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_subject]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_subject]
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker]
   list([
     dict({
       'birth_year': None,
@@ -119,7 +119,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker_email_body]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker_email_body]
   '''
   Bonjour Martin JACOBSON,
   Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
@@ -132,10 +132,10 @@
   http://localhost:8000
   '''
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker_email_subject]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker_email_subject]
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_authorized_prescriber][archived_application]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_authorized_prescriber][archived_application]
   list([
     dict({
       'applied_at': datetime.date(2025, 2, 1),
@@ -166,7 +166,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_company][archived_application]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_company][archived_application]
   list([
     dict({
       'applied_at': datetime.date(2025, 2, 1),
@@ -197,7 +197,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[hired_jobseeker_with_3_jobs][archived_application]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[hired_jobseeker_with_3_jobs][archived_application]
   list([
     dict({
       'applied_at': datetime.date(2025, 2, 1),
@@ -228,7 +228,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[refused_application_with_1_jobs][archived_application]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[refused_application_with_1_jobs][archived_application]
   list([
     dict({
       'applied_at': datetime.date(2025, 2, 1),
@@ -259,7 +259,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[transferred_application_with_diagoriente_invitation][archived_application]
+# name: TestNotifyArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[transferred_application_with_diagoriente_invitation][archived_application]
   list([
     dict({
       'applied_at': datetime.date(2025, 2, 1),
@@ -290,7 +290,7 @@
     }),
   ])
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_activity][inactive_jobseeker_email_body]
+# name: TestNotifyArchiveUsersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
@@ -303,10 +303,10 @@
   http://localhost:8000
   '''
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_activity][inactive_jobseeker_email_subject]
+# name: TestNotifyArchiveUsersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_activity][inactive_jobseeker_email_subject]
   '[DEV] Information avant suppression de votre compte sur les Emplois de l’inclusion'
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_body]
+# name: TestNotifyArchiveUsersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
@@ -319,10 +319,10 @@
   http://localhost:8000
   '''
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_subject]
+# name: TestNotifyArchiveUsersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_subject]
   '[DEV] Information avant suppression de votre compte sur les Emplois de l’inclusion'
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_body]
+# name: TestNotifyArchiveUsersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
@@ -335,6 +335,6 @@
   http://localhost:8000
   '''
 # ---
-# name: TestNotifyArchiveJobSeekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_subject]
+# name: TestNotifyArchiveUsersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_subject]
   '[DEV] Information avant suppression de votre compte sur les Emplois de l’inclusion'
 # ---

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -66,30 +66,38 @@ class TestNotifyArchiveUsersManagementCommand:
         assert not ArchivedApplication.objects.exists()
 
     @pytest.mark.parametrize(
-        "kwargs, model",
+        "factory,kwargs",
         [
             pytest.param(
+                JobSeekerFactory,
                 {"joined_days_ago": DAYS_OF_INACTIVITY},
-                "user",
                 id="jobseeker_to_notify",
             ),
+        ],
+    )
+    def test_notify_batch_size(self, factory, kwargs):
+        factory.create_batch(3, **kwargs)
+        call_command("notify_archive_users", batch_size=2, wet_run=True)
+
+        assert User.objects.filter(upcoming_deletion_notified_at__isnull=True).count() == 1
+        assert User.objects.exclude(upcoming_deletion_notified_at__isnull=True).count() == 2
+
+    @pytest.mark.parametrize(
+        "factory,kwargs",
+        [
             pytest.param(
+                JobSeekerFactory,
                 {"joined_days_ago": DAYS_OF_INACTIVITY, "notified_days_ago": 30},
-                "archived_jobseeker",
                 id="jobseeker_to_archive",
             ),
         ],
     )
-    def test_batch_size(self, kwargs, model):
-        JobSeekerFactory.create_batch(3, **kwargs)
+    def test_archive_batch_size(self, factory, kwargs):
+        factory.create_batch(3, **kwargs)
         call_command("notify_archive_users", batch_size=2, wet_run=True)
 
-        if model == "user":
-            assert User.objects.filter(upcoming_deletion_notified_at__isnull=True).count() == 1
-            assert User.objects.exclude(upcoming_deletion_notified_at__isnull=True).count() == 2
-        else:
-            assert ArchivedJobSeeker.objects.count() == 2
-            assert User.objects.count() == 1
+        assert ArchivedJobSeeker.objects.count() == 2
+        assert User.objects.count() == 1
 
     @pytest.mark.parametrize(
         "factory, related_object_factory, updated_notification_date",

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -15,6 +15,7 @@ from itou.job_applications.models import JobApplication, JobApplicationTransitio
 from itou.jobs.models import Appellation, Rome
 from itou.users.enums import UserKind
 from itou.users.models import User
+from itou.utils.constants import DAYS_OF_INACTIVITY, GRACE_PERIOD, INACTIVITY_PERIOD
 from tests.approvals.factories import ApprovalFactory
 from tests.companies.factories import JobDescriptionFactory
 from tests.eligibility.factories import (
@@ -30,9 +31,6 @@ from tests.users.factories import (
     LaborInspectorFactory,
     PrescriberFactory,
 )
-
-
-DAYS_OF_INACTIVITY = 730 - 30
 
 
 class TestNotifyArchiveJobSeekersManagementCommand:

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -221,7 +221,7 @@ class TestFranceConnect:
     def test_create_or_update_user_raise_invalid_kind_exception(self):
         fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
 
-        for kind in [UserKind.PRESCRIBER, UserKind.EMPLOYER, UserKind.LABOR_INSPECTOR]:
+        for kind in UserKind.professionals():
             user = UserFactory(username=fc_user_data.username, email=fc_user_data.email, kind=kind)
 
             with pytest.raises(InvalidKindException):
@@ -285,7 +285,7 @@ class TestFranceConnect:
     def test_callback_redirect_on_invalid_kind_exception(self, client):
         fc_user_data = FranceConnectUserData.from_user_info(FC_USERINFO)
 
-        for kind in [UserKind.PRESCRIBER, UserKind.EMPLOYER, UserKind.LABOR_INSPECTOR]:
+        for kind in UserKind.professionals():
             user = UserFactory(username=fc_user_data.username, email=fc_user_data.email, kind=kind)
             mock_oauth_dance(client, expected_route=f"login:{kind}")
             user.delete()

--- a/tests/openid_connect/pe_connect/tests.py
+++ b/tests/openid_connect/pe_connect/tests.py
@@ -185,7 +185,7 @@ class TestPoleEmploiConnect:
     def test_create_or_update_user_raise_invalid_kind_exception(self):
         peamu_user_data = PoleEmploiConnectUserData.from_user_info(PEAMU_USERINFO)
 
-        for kind in [UserKind.PRESCRIBER, UserKind.EMPLOYER, UserKind.LABOR_INSPECTOR]:
+        for kind in UserKind.professionals():
             user = UserFactory(username=peamu_user_data.username, email=peamu_user_data.email, kind=kind)
 
             with pytest.raises(InvalidKindException):
@@ -306,7 +306,7 @@ class TestPoleEmploiConnect:
     def test_callback_redirect_on_invalid_kind_exception(self, client):
         peamu_user_data = PoleEmploiConnectUserData.from_user_info(PEAMU_USERINFO)
 
-        for kind in [UserKind.PRESCRIBER, UserKind.EMPLOYER, UserKind.LABOR_INSPECTOR]:
+        for kind in UserKind.professionals():
             user = UserFactory(username=peamu_user_data.username, email=peamu_user_data.email, kind=kind)
             mock_oauth_dance(client, expected_route=f"login:{kind}")
             user.delete()

--- a/tests/users/factories.py
+++ b/tests/users/factories.py
@@ -93,6 +93,13 @@ class UserFactory(factory.django.DjangoModelFactory):
             if create:
                 obj.save(update_fields=["upcoming_deletion_notified_at"])
 
+    @factory.post_generation
+    def last_login_days_ago(obj, create, extracted, **kwargs):
+        if extracted:
+            obj.last_login = timezone.now() - datetime.timedelta(days=extracted)
+            if create:
+                obj.save(update_fields=["last_login"])
+
 
 class ItouStaffFactory(UserFactory):
     kind = UserKind.ITOU_STAFF


### PR DESCRIPTION
## :thinking: Pourquoi ?

prequis de #6074 

adapter le code existant, spécialisé sur les profils de candidats, compatibles avec les profils d'employeurs, d'inspecteurs du travail et de prescripteurs

## :rotating_light: À vérifier

NON Mettre à jour le CHANGELOG_breaking_changes.md ?
NON Ajouter l'étiquette « Bug » ?

