### PR TITLE
Éligibilité : Vérifier que le badge certifié n’était pas affiché aux employeurs après l’expiration du diag

### DIFF
--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -31,6 +31,7 @@ from tests.job_applications.factories import (
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import EmployerFactory, JobSeekerFactory
 from tests.utils.test import load_template
+from tests.www.eligibility_views.utils import CERTIFIED_BADGE_HTML, NOT_CERTIFIED_BADGE_HTML
 
 
 def get_request(path="/"):
@@ -193,16 +194,6 @@ def test_known_criteria_template_with_partial_zrr_criterion():
     assert "est classée en ZRR" not in rendered
     assert "est partiellement classée en ZRR" in rendered
     assert escape(job_seeker.city) in rendered
-
-
-CERTIFIED_BADGE_HTML = """\
-<span class="badge badge-xs rounded-pill bg-info-lighter text-info ms-3">
-    <i class="ri-verified-badge-fill" aria-hidden="true"></i>
-    Certifié</span>"""
-NOT_CERTIFIED_BADGE_HTML = """\
-<span class="badge badge-xs rounded-pill bg-warning-lighter text-warning ms-3">
-    <i class="ri-error-warning-fill" aria-hidden="true"></i>
-    Non certifié</span>"""
 
 
 class TestCertifiedBadgeIae:

--- a/tests/www/eligibility_views/utils.py
+++ b/tests/www/eligibility_views/utils.py
@@ -1,0 +1,8 @@
+CERTIFIED_BADGE_HTML = """\
+<span class="badge badge-xs rounded-pill bg-info-lighter text-info ms-3">
+    <i class="ri-verified-badge-fill" aria-hidden="true"></i>
+    Certifié</span>"""
+NOT_CERTIFIED_BADGE_HTML = """\
+<span class="badge badge-xs rounded-pill bg-warning-lighter text-warning ms-3">
+    <i class="ri-error-warning-fill" aria-hidden="true"></i>
+    Non certifié</span>"""


### PR DESCRIPTION
## :thinking: Pourquoi ?

La durée de validité d’une certification était calculée de manière incorrecte, un critère restait certifié plus longtemps qu’attendu (184 jours au lieu de 92 jours attendus). Les employeurs n’ont pas rencontré ce bug, parce que le diagnostic d’élígibilité expire au bout des 92 jours comme prévu, masquant le fait que le calcul de l’éligibilité était incorrect.

Voir https://github.com/gip-inclusion/les-emplois/pull/6126

Ce test permet de vérifier que le critère certifié n’apparaîssait pas grâce a l’expiration du diagnostic. Je ne pense pas l’intégrer, mais il permet de jouer avec le système et de bien comprendre son comportement.