### PR TITLE
Réusinage de siae_select_criteria pour les critères certifiés

### DIFF
--- a/itou/eligibility/migrations/0001_initial.py
+++ b/itou/eligibility/migrations/0001_initial.py
@@ -156,6 +156,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
+                "ordering": ["administrative_criteria"],
                 "verbose_name": "critère administratif IAE sélectionné",
                 "verbose_name_plural": "critères administratifs IAE sélectionnés",
                 "unique_together": {("eligibility_diagnosis", "administrative_criteria")},
@@ -339,6 +340,7 @@ class Migration(migrations.Migration):
                 ),
             ],
             options={
+                "ordering": ["administrative_criteria"],
                 "verbose_name": "critère administratif GEIQ sélectionné",
                 "verbose_name_plural": "critères administratifs GEIQ sélectionnés",
                 "unique_together": {("eligibility_diagnosis", "administrative_criteria")},

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -115,9 +115,6 @@ class AdministrativeCriteriaQuerySet(models.QuerySet):
     def level2(self):
         return self.filter(level=AdministrativeCriteriaLevel.LEVEL_2)
 
-    def for_job_application(self, job_application):
-        return self.filter(eligibilitydiagnosis__jobapplication=job_application)
-
     @property
     def certifiable_lookup(self):
         return models.Q(kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS)

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -312,6 +312,7 @@ class GEIQSelectedAdministrativeCriteria(AbstractSelectedAdministrativeCriteria)
     )
 
     class Meta:
+        ordering = ["administrative_criteria"]
         verbose_name = "critère administratif GEIQ sélectionné"
         verbose_name_plural = "critères administratifs GEIQ sélectionnés"
         unique_together = ("eligibility_diagnosis", "administrative_criteria")

--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -284,6 +284,7 @@ class SelectedAdministrativeCriteria(AbstractSelectedAdministrativeCriteria):
     )
 
     class Meta:
+        ordering = ["administrative_criteria"]
         verbose_name = "critère administratif IAE sélectionné"
         verbose_name_plural = "critères administratifs IAE sélectionnés"
         unique_together = ("eligibility_diagnosis", "administrative_criteria")

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -31,16 +31,16 @@ class AdministrativeCriteriaForm(forms.Form):
         f"Vous ne pouvez pas sélectionner en même temps les critères {NAME_DETLD_24} et {NAME_DELD_12}."
     )
 
-    def get_administrative_criteria(self):
-        return AdministrativeCriteria.objects.all()
-
-    def __init__(self, is_authorized_prescriber, siae, **kwargs):
+    def __init__(self, is_authorized_prescriber, siae, administrative_criteria=None, **kwargs):
         self.is_authorized_prescriber = is_authorized_prescriber
         self.siae = siae
         super().__init__(**kwargs)
 
         initial_administrative_criteria = self.initial.get("administrative_criteria", [])
-        for criterion in self.get_administrative_criteria():
+
+        if administrative_criteria is None:
+            administrative_criteria = AdministrativeCriteria.objects.all()
+        for criterion in administrative_criteria:
             key = criterion.key
             self.fields[key] = forms.BooleanField(required=False, label=criterion.name, help_text=criterion.desc)
             self.fields[key].widget.attrs["class"] = "form-check-input"  # Bootstrap CSS class.

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -75,7 +75,12 @@ class AdministrativeCriteriaForm(forms.Form):
 
 class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
     def get_administrative_criteria(self):
-        return AdministrativeCriteria.objects.for_job_application(self.job_application)
+        return [
+            e.administrative_criteria
+            for e in self.job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
+                "administrative_criteria"
+            )
+        ]
 
     def __init__(self, user, siae, job_application, **kwargs):
         self.job_application = job_application

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -84,7 +84,7 @@ class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
 
     def __init__(self, user, siae, job_application, **kwargs):
         self.job_application = job_application
+        super().__init__(user, siae, **kwargs)
         self.num_level2_admin_criteria = eligibilty_enums.ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[
             siae.kind
         ]
-        super().__init__(user, siae, **kwargs)

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -71,20 +71,3 @@ class AdministrativeCriteriaForm(forms.Form):
             raise forms.ValidationError(message)
 
         return selected_objects
-
-
-class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
-    def get_administrative_criteria(self):
-        return [
-            e.administrative_criteria
-            for e in self.job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
-                "administrative_criteria"
-            )
-        ]
-
-    def __init__(self, user, siae, job_application, **kwargs):
-        self.job_application = job_application
-        super().__init__(user, siae, **kwargs)
-        self.num_level2_admin_criteria = eligibilty_enums.ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[
-            siae.kind
-        ]

--- a/itou/www/eligibility_views/forms.py
+++ b/itou/www/eligibility_views/forms.py
@@ -84,8 +84,6 @@ class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
 
     def __init__(self, user, siae, job_application, **kwargs):
         self.job_application = job_application
-
-        self.siae = siae
         self.num_level2_admin_criteria = eligibilty_enums.ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[
             siae.kind
         ]

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -38,17 +38,9 @@ class SetChosenPercentForm(forms.ModelForm):
 
 
 class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
-    def get_administrative_criteria(self):
-        return [
-            e.administrative_criteria
-            for e in self.job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
-                "administrative_criteria"
-            )
-        ]
-
-    def __init__(self, user, siae, job_application, **kwargs):
-        self.job_application = job_application
-        super().__init__(user, siae, **kwargs)
+    def __init__(self, user, siae, job_app_selected_administrative_criteria, **kwargs):
+        administrative_criteria = [e.administrative_criteria for e in job_app_selected_administrative_criteria]
+        super().__init__(user, siae, administrative_criteria, **kwargs)
         self.num_level2_admin_criteria = ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[siae.kind]
 
 

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
+from itou.eligibility.enums import ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND
 from itou.files.forms import ItouFileField
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.models import (
@@ -15,6 +16,7 @@ from itou.utils.constants import MB
 from itou.utils.types import InclusiveDateRange
 from itou.utils.validators import MinDateValidator
 from itou.utils.widgets import DuetDatePickerWidget
+from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
 
 
 class SetChosenPercentForm(forms.ModelForm):
@@ -33,6 +35,21 @@ class SetChosenPercentForm(forms.ModelForm):
                 }
             )
         }
+
+
+class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
+    def get_administrative_criteria(self):
+        return [
+            e.administrative_criteria
+            for e in self.job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
+                "administrative_criteria"
+            )
+        ]
+
+    def __init__(self, user, siae, job_application, **kwargs):
+        self.job_application = job_application
+        super().__init__(user, siae, **kwargs)
+        self.num_level2_admin_criteria = ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[siae.kind]
 
 
 class SubmitEvaluatedAdministrativeCriteriaProofForm(forms.Form):

--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -37,7 +37,7 @@ class SetChosenPercentForm(forms.ModelForm):
         }
 
 
-class AdministrativeCriteriaOfJobApplicationForm(AdministrativeCriteriaForm):
+class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
     def get_administrative_criteria(self):
         return [
             e.administrative_criteria

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -26,8 +26,8 @@ from itou.utils.emails import send_email_messages
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.urls import get_safe_url
-from itou.www.eligibility_views.forms import AdministrativeCriteriaOfJobApplicationForm
 from itou.www.siae_evaluations_views.forms import (
+    AdministrativeCriteriaOfJobApplicationForm,
     InstitutionEvaluatedSiaeNotifyStep1Form,
     InstitutionEvaluatedSiaeNotifyStep2Form,
     InstitutionEvaluatedSiaeNotifyStep3Form,

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -27,7 +27,7 @@ from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.perms.institution import get_current_institution_or_404
 from itou.utils.urls import get_safe_url
 from itou.www.siae_evaluations_views.forms import (
-    AdministrativeCriteriaOfJobApplicationForm,
+    AdministrativeCriteriaEvaluationForm,
     InstitutionEvaluatedSiaeNotifyStep1Form,
     InstitutionEvaluatedSiaeNotifyStep2Form,
     InstitutionEvaluatedSiaeNotifyStep3Form,
@@ -565,7 +565,7 @@ def siae_select_criteria(
         for eval_criterion in evaluated_job_application.evaluated_administrative_criteria.all()
     }
 
-    form_administrative_criteria = AdministrativeCriteriaOfJobApplicationForm(
+    form_administrative_criteria = AdministrativeCriteriaEvaluationForm(
         request.user,
         siae=siae,
         job_application=evaluated_job_application.job_application,
@@ -595,12 +595,12 @@ def siae_select_criteria(
     level_1_fields = [
         field
         for field in form_administrative_criteria
-        if AdministrativeCriteriaOfJobApplicationForm.LEVEL_1_PREFIX in field.name
+        if AdministrativeCriteriaEvaluationForm.LEVEL_1_PREFIX in field.name
     ]
     level_2_fields = [
         field
         for field in form_administrative_criteria
-        if AdministrativeCriteriaOfJobApplicationForm.LEVEL_2_PREFIX in field.name
+        if AdministrativeCriteriaEvaluationForm.LEVEL_2_PREFIX in field.name
     ]
 
     back_url = get_safe_url(request, "back_url", fallback_url=url)

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -17,7 +17,6 @@ from itou.eligibility.enums import (
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.eligibility.models.common import (
     AbstractSelectedAdministrativeCriteria,
-    AdministrativeCriteriaQuerySet,
 )
 from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
 from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
@@ -34,7 +33,6 @@ from tests.eligibility.factories import (
     GEIQEligibilityDiagnosisFactory,
     IAEEligibilityDiagnosisFactory,
 )
-from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberOrganizationWithMembershipFactory
 from tests.users.factories import JobSeekerFactory
 
@@ -495,42 +493,6 @@ class TestAdministrativeCriteriaModel:
         qs = AdministrativeCriteria.objects.level2()
         assert level2_criterion in qs
         assert level1_criterion not in qs
-
-    def test_for_job_application(self):
-        company = CompanyFactory(department="14", with_membership=True)
-
-        job_seeker = JobSeekerFactory()
-        user = company.members.first()
-
-        criteria1 = AdministrativeCriteria.objects.get(
-            level=AdministrativeCriteriaLevel.LEVEL_1, kind=AdministrativeCriteriaKind.RSA
-        )
-        eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
-            job_seeker, author=user, author_organization=company, administrative_criteria=[criteria1]
-        )
-
-        job_application1 = JobApplicationFactory(
-            with_approval=True,
-            to_company=company,
-            sender_company=company,
-            eligibility_diagnosis=eligibility_diagnosis,
-            hiring_start_at=timezone.localdate() - relativedelta(months=2),
-        )
-
-        job_application2 = JobApplicationFactory(
-            with_approval=True,
-            to_company=company,
-            sender_company=company,
-            hiring_start_at=timezone.localdate() - relativedelta(months=2),
-        )
-
-        assert isinstance(
-            AdministrativeCriteria.objects.for_job_application(job_application1), AdministrativeCriteriaQuerySet
-        )
-
-        assert 1 == AdministrativeCriteria.objects.for_job_application(job_application1).count()
-        assert criteria1 == AdministrativeCriteria.objects.for_job_application(job_application1).first()
-        assert 0 == AdministrativeCriteria.objects.for_job_application(job_application2).count()
 
     def test_key_property(self):
         criterion_level_1 = AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first()

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1791,8 +1791,10 @@
                  "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
                  "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -1930,8 +1932,10 @@
                  ("eligibility_selectedadministrativecriteria"."certification_period" && %s
                   AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -2970,8 +2974,10 @@
                  "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
                  "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -3109,8 +3115,10 @@
                  ("eligibility_selectedadministrativecriteria"."certification_period" && %s
                   AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -3949,8 +3957,10 @@
                  "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
                  "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -4188,8 +4198,10 @@
                  ("eligibility_selectedadministrativecriteria"."certification_period" && %s
                   AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -1393,8 +1393,10 @@
                  "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
                  %s AS "is_considered_certified"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/eligibility_views/test_forms.py
+++ b/tests/www/eligibility_views/test_forms.py
@@ -9,7 +9,8 @@ from itou.eligibility.enums import (
     AdministrativeCriteriaLevel,
 )
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
-from itou.www.eligibility_views.forms import AdministrativeCriteriaForm, AdministrativeCriteriaOfJobApplicationForm
+from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
+from itou.www.siae_evaluations_views.forms import AdministrativeCriteriaOfJobApplicationForm
 from tests.companies.factories import CompanyFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import JobSeekerFactory

--- a/tests/www/eligibility_views/test_forms.py
+++ b/tests/www/eligibility_views/test_forms.py
@@ -10,7 +10,7 @@ from itou.eligibility.enums import (
 )
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
-from itou.www.siae_evaluations_views.forms import AdministrativeCriteriaOfJobApplicationForm
+from itou.www.siae_evaluations_views.forms import AdministrativeCriteriaEvaluationForm
 from tests.companies.factories import CompanyFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import JobSeekerFactory
@@ -174,7 +174,7 @@ class TestAdministrativeCriteriaForm:
         assert AdministrativeCriteriaForm(is_authorized_prescriber=False, siae=None, data={}).is_valid()
 
 
-class TestAdministrativeCriteriaOfJobApplicationForm:
+class TestAdministrativeCriteriaEvaluationForm:
     def test_job_application(self):
         company = CompanyFactory(with_membership=True)
         user = company.members.first()
@@ -199,7 +199,7 @@ class TestAdministrativeCriteriaOfJobApplicationForm:
             hiring_start_at=timezone.localdate() - relativedelta(months=2),
         )
 
-        form = AdministrativeCriteriaOfJobApplicationForm(user, company, job_application=job_application)
+        form = AdministrativeCriteriaEvaluationForm(user, company, job_application=job_application)
 
         assert 2 == len(form.fields)
         assert (
@@ -222,5 +222,5 @@ class TestAdministrativeCriteriaOfJobApplicationForm:
             sender_company=company,
             hiring_start_at=timezone.localdate() - relativedelta(months=2),
         )
-        form = AdministrativeCriteriaOfJobApplicationForm(user, company, job_application=job_application)
+        form = AdministrativeCriteriaEvaluationForm(user, company, job_application=job_application)
         assert ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[kind] == form.num_level2_admin_criteria

--- a/tests/www/eligibility_views/test_forms.py
+++ b/tests/www/eligibility_views/test_forms.py
@@ -1,19 +1,10 @@
-import pytest
-from dateutil.relativedelta import relativedelta
-from django.utils import timezone
-
 from itou.companies.enums import CompanyKind
 from itou.eligibility.enums import (
-    ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND,
     AdministrativeCriteriaKind,
-    AdministrativeCriteriaLevel,
 )
-from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
+from itou.eligibility.models import AdministrativeCriteria
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
-from itou.www.siae_evaluations_views.forms import AdministrativeCriteriaEvaluationForm
 from tests.companies.factories import CompanyFactory
-from tests.job_applications.factories import JobApplicationFactory
-from tests.users.factories import JobSeekerFactory
 
 
 class TestAdministrativeCriteriaForm:
@@ -172,55 +163,3 @@ class TestAdministrativeCriteriaForm:
 
         assert not AdministrativeCriteriaForm(is_authorized_prescriber=False, siae=company, data={}).is_valid()
         assert AdministrativeCriteriaForm(is_authorized_prescriber=False, siae=None, data={}).is_valid()
-
-
-class TestAdministrativeCriteriaEvaluationForm:
-    def test_job_application(self):
-        company = CompanyFactory(with_membership=True)
-        user = company.members.first()
-
-        job_seeker = JobSeekerFactory()
-
-        eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
-            job_seeker,
-            author=user,
-            author_organization=company,
-            administrative_criteria=[
-                AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first()
-            ]
-            + [AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_2).first()],
-        )
-
-        job_application = JobApplicationFactory(
-            with_approval=True,
-            to_company=company,
-            sender_company=company,
-            eligibility_diagnosis=eligibility_diagnosis,
-            hiring_start_at=timezone.localdate() - relativedelta(months=2),
-        )
-
-        form = AdministrativeCriteriaEvaluationForm(user, company, job_application=job_application)
-
-        assert 2 == len(form.fields)
-        assert (
-            AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first().key
-            in form.fields.keys()
-        )
-        assert (
-            AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_2).first().key
-            in form.fields.keys()
-        )
-
-    @pytest.mark.parametrize("kind", CompanyKind.siae_kinds())
-    def test_num_level2_admin_criteria(self, kind):
-        company = CompanyFactory(kind=kind, with_membership=True)
-        user = company.members.first()
-
-        job_application = JobApplicationFactory(
-            with_approval=True,
-            to_company=company,
-            sender_company=company,
-            hiring_start_at=timezone.localdate() - relativedelta(months=2),
-        )
-        form = AdministrativeCriteriaEvaluationForm(user, company, job_application=job_application)
-        assert ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[kind] == form.num_level2_admin_criteria

--- a/tests/www/eligibility_views/test_forms.py
+++ b/tests/www/eligibility_views/test_forms.py
@@ -1,10 +1,17 @@
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+
 from itou.companies.enums import CompanyKind
 from itou.eligibility.enums import (
     AdministrativeCriteriaKind,
+    AdministrativeCriteriaLevel,
 )
-from itou.eligibility.models import AdministrativeCriteria
+from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.www.eligibility_views.forms import AdministrativeCriteriaForm
+from itou.www.siae_evaluations_views.forms import AdministrativeCriteriaEvaluationForm
 from tests.companies.factories import CompanyFactory
+from tests.job_applications.factories import JobApplicationFactory
+from tests.users.factories import JobSeekerFactory
 
 
 class TestAdministrativeCriteriaForm:
@@ -163,3 +170,47 @@ class TestAdministrativeCriteriaForm:
 
         assert not AdministrativeCriteriaForm(is_authorized_prescriber=False, siae=company, data={}).is_valid()
         assert AdministrativeCriteriaForm(is_authorized_prescriber=False, siae=None, data={}).is_valid()
+
+
+class TestAdministrativeCriteriaEvaluationForm:
+    def test_job_application(self):
+        company = CompanyFactory(with_membership=True)
+        user = company.members.first()
+
+        job_seeker = JobSeekerFactory()
+
+        eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
+            job_seeker,
+            author=user,
+            author_organization=company,
+            administrative_criteria=[
+                AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first()
+            ]
+            + [AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_2).first()],
+        )
+
+        job_application = JobApplicationFactory(
+            with_approval=True,
+            to_company=company,
+            sender_company=company,
+            eligibility_diagnosis=eligibility_diagnosis,
+            hiring_start_at=timezone.localdate() - relativedelta(months=2),
+        )
+
+        form = AdministrativeCriteriaEvaluationForm(
+            user,
+            company,
+            job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
+                "administrative_criteria"
+            ),
+        )
+
+        assert 2 == len(form.fields)
+        assert (
+            AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first().key
+            in form.fields.keys()
+        )
+        assert (
+            AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_2).first().key
+            in form.fields.keys()
+        )

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -604,8 +604,10 @@
                  "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
                  "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({
@@ -978,8 +980,10 @@
                  ("eligibility_selectedadministrativecriteria"."certification_period" && %s
                   AND "eligibility_selectedadministrativecriteria"."certified") AS "is_considered_certified"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" = %s
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -1653,8 +1653,10 @@
                  "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
                  "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
           FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
           WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
-          ORDER BY RANDOM() ASC
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
         ''',
       }),
       dict({

--- a/tests/www/siae_evaluations_views/test_forms.py
+++ b/tests/www/siae_evaluations_views/test_forms.py
@@ -1,7 +1,15 @@
+from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
-from itou.www.siae_evaluations_views.forms import LaborExplanationForm
+from itou.eligibility.enums import (
+    AdministrativeCriteriaLevel,
+)
+from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
+from itou.www.siae_evaluations_views.forms import AdministrativeCriteriaEvaluationForm, LaborExplanationForm
+from tests.companies.factories import CompanyFactory
+from tests.job_applications.factories import JobApplicationFactory
 from tests.siae_evaluations.factories import EvaluatedJobApplicationFactory
+from tests.users.factories import JobSeekerFactory
 
 
 class TestLaborExplanationForm:
@@ -12,3 +20,47 @@ class TestLaborExplanationForm:
         form = LaborExplanationForm(instance=evaluated_job_application)
 
         assert form.fields["labor_inspector_explanation"].disabled
+
+
+class TestAdministrativeCriteriaEvaluationForm:
+    def test_job_application(self):
+        company = CompanyFactory(with_membership=True)
+        user = company.members.first()
+
+        job_seeker = JobSeekerFactory()
+
+        eligibility_diagnosis = EligibilityDiagnosis.create_diagnosis(
+            job_seeker,
+            author=user,
+            author_organization=company,
+            administrative_criteria=[
+                AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first()
+            ]
+            + [AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_2).first()],
+        )
+
+        job_application = JobApplicationFactory(
+            with_approval=True,
+            to_company=company,
+            sender_company=company,
+            eligibility_diagnosis=eligibility_diagnosis,
+            hiring_start_at=timezone.localdate() - relativedelta(months=2),
+        )
+
+        form = AdministrativeCriteriaEvaluationForm(
+            user,
+            company,
+            job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
+                "administrative_criteria"
+            ),
+        )
+
+        assert 2 == len(form.fields)
+        assert (
+            AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_1).first().key
+            in form.fields.keys()
+        )
+        assert (
+            AdministrativeCriteria.objects.filter(level=AdministrativeCriteriaLevel.LEVEL_2).first().key
+            in form.fields.keys()
+        )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Découpage pour mieux gérer la sélection de critères en présence de critères certifiés (qui seront cochés et `disabled` par défaut).

## :cake: Comment ? <!-- optionnel -->

Déplacer la logique de récupération des critères dans la vue.
