### PR TITLE
Prescripteur : dans la page d'édition de l'organisation, n'afficher l'alerte sur la visibilité des informations qu'aux prescripteurs habilités

### DIFF
--- a/itou/templates/prescribers/edit_organization.html
+++ b/itou/templates/prescribers/edit_organization.html
@@ -19,16 +19,18 @@
 
 {% block title_messages %}
     {{ block.super }}
-    <div class="alert alert-info" role="status">
-        <p class="mb-0">
-            {% if organization.kind == PrescriberOrganizationKind.FT %}
-                Affichage des informations en lecture seule. Si vous souhaitez modifier ces informations, merci de
-                <a href="{{ ITOU_HELP_CENTER_URL }}" class="has-external-link" target="_blank">contacter notre support technique</a>.
-            {% else %}
-                Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
-            {% endif %}
-        </p>
-    </div>
+    {% if organization.is_authorized %}
+        <div class="alert alert-info" role="status">
+            <p class="mb-0">
+                {% if organization.kind == PrescriberOrganizationKind.FT %}
+                    Affichage des informations en lecture seule. Si vous souhaitez modifier ces informations, merci de
+                    <a href="{{ ITOU_HELP_CENTER_URL }}" class="has-external-link" target="_blank">contacter notre support technique</a>.
+                {% else %}
+                    Les coordonnées de contact de votre organisation sont visibles par tous les utilisateurs connectés.
+                {% endif %}
+            </p>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/tests/www/prescribers_views/test_edit.py
+++ b/tests/www/prescribers_views/test_edit.py
@@ -249,6 +249,26 @@ class TestEditOrganization:
         assertion(response, '<label class="form-label" for="id_description">Description</label>', html=True)
 
     @pytest.mark.parametrize(
+        "factory,assertion",
+        [
+            (partial(PrescriberOrganizationWithMembershipFactory, authorized=True), assertContains),
+            (partial(PrescriberOrganizationWithMembershipFactory, authorized=False), assertNotContains),
+        ],
+    )
+    def test_display_banner(self, client, factory, assertion):
+        organization = factory(
+            kind=FuzzyChoice(set(PrescriberOrganizationKind.values) - {PrescriberOrganizationKind.FT})
+        )
+        client.force_login(organization.members.first())
+        response = client.get(reverse("prescribers_views:edit_organization"))
+        assertion(
+            response,
+            """<p class="mb-0">Les coordonnées de contact de votre organisation sont visibles
+                par tous les utilisateurs connectés.</p>""",
+            html=True,
+        )
+
+    @pytest.mark.parametrize(
         "back_url,expected_redirect",
         [
             (reverse("dashboard:index"), reverse("dashboard:index")),


### PR DESCRIPTION

## :thinking: Pourquoi ?
La bannière dit que les informations entrées sont visibles par tous les utilisateurs connectés, ce qui n'est vrai que pour les prescripteurs habilités.

