### PR TITLE
Interface : suppression d'une espace avant un point final

### DIFF
--- a/itou/templates/apply/includes/eligibility_diagnosis.html
+++ b/itou/templates/apply/includes/eligibility_diagnosis.html
@@ -6,11 +6,10 @@
             {{ is_sent_by_authorized_prescriber|yesno:"Confirmée,Validés" }}
             le <span class="fw-bold">{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</span> par
             <strong>{{ eligibility_diagnosis.author.get_full_name }}</strong>
-            {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}){% endif %}
+            {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}).{% endif %}
             {% if eligibility_diagnosis.author_prescriber_organization %}
-                ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
+                ({{ eligibility_diagnosis.author_prescriber_organization.display_name }}).
             {% endif %}
-            .
         </p>
         <p class="fs-sm">
             <i>Ces critères reflètent la situation du candidat lors de l’établissement du diagnostic ayant permis la délivrance d’un PASS IAE, elle a peut-être changé depuis cette date.</i>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le formattage du fichier HTML fait que le point final arrive sur une nouvelle ligne, et donc soit précédé d'une espace une fois rendu dans le navigateur.

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
