### PR TITLE
Retrait d’un test en double dans tests/www/siae_evaluations_views/test_institutions_views.py

### DIFF
--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -35,7 +35,7 @@ from tests.siae_evaluations.factories import (
 )
 from tests.users.factories import JobSeekerFactory
 from tests.utils.test import assertSnapshotQueries, parse_response_to_soup
-from tests.www.siae_evaluations_views.test_siaes_views import TestSiaeEvaluatedJobApplicationView
+from tests.www.siae_evaluations_views.test_siaes_views import DDETS_refusal_comment_txt
 
 
 # fixme vincentporte : convert this method into factory
@@ -3424,7 +3424,7 @@ class TestInstitutionEvaluatedJobApplicationView:
             + f"#{evaluated_job_application.pk}"
         )
         assertContains(response, self.save_text, count=1)
-        assertNotContains(response, TestSiaeEvaluatedJobApplicationView.refusal_comment_txt)
+        assertNotContains(response, DDETS_refusal_comment_txt)
 
     def test_get_before_new_criteria_submitted(self, client):
         now = timezone.now()

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -26,6 +26,9 @@ from tests.users.factories import JobSeekerFactory
 from tests.utils.test import assertSnapshotQueries
 
 
+DDETS_refusal_comment_txt = "Commentaire de la DDETS"
+
+
 # fixme vincentporte : convert this method into factory
 def create_evaluated_siae_with_consistent_datas(siae, user, level_1=True, level_2=False, institution=None):
     job_seeker = JobSeekerFactory()
@@ -1146,8 +1149,6 @@ class TestSiaeEvaluatedSiaeDetailView:
 
 
 class TestSiaeEvaluatedJobApplicationView:
-    refusal_comment_txt = "Commentaire de la DDETS"
-
     def test_access(self, client):
         membership = CompanyMembershipFactory()
         user = membership.user
@@ -1169,7 +1170,7 @@ class TestSiaeEvaluatedJobApplicationView:
         evaluation_campaign.ended_at = timezone.now()
         evaluation_campaign.save(update_fields=["ended_at"])
         response = client.get(url)
-        assertNotContains(response, self.refusal_comment_txt)
+        assertNotContains(response, DDETS_refusal_comment_txt)
 
         # Refusal comment is only displayed when state is refused
         EvaluatedAdministrativeCriteriaFactory(
@@ -1180,4 +1181,4 @@ class TestSiaeEvaluatedJobApplicationView:
         evaluated_siae.reviewed_at = timezone.now()
         evaluated_siae.save(update_fields=["reviewed_at"])
         response = client.get(url)
-        assertContains(response, self.refusal_comment_txt)
+        assertContains(response, DDETS_refusal_comment_txt)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de gaspiller du temps de test, clarifier. Voir le message de commit pour les détails.
