### PR TITLE
Fin du bagotage pour prescribers_views.test_edit

### DIFF
--- a/tests/www/prescribers_views/test_edit.py
+++ b/tests/www/prescribers_views/test_edit.py
@@ -47,7 +47,10 @@ class TestCardView:
     def test_card_subtitle(self, client):
         prescriber_org = PrescriberOrganizationFactory(
             authorized=True,
-            kind=FuzzyChoice(set(PrescriberOrganizationKind.values) - {PrescriberOrganizationKind.FT}),
+            kind=FuzzyChoice(
+                set(PrescriberOrganizationKind.values)
+                - {PrescriberOrganizationKind.FT, PrescriberOrganizationKind.OTHER}
+            ),
         )
         url = reverse("prescribers_views:card", kwargs={"org_id": prescriber_org.pk})
         response = client.get(url)
@@ -257,7 +260,10 @@ class TestEditOrganization:
     )
     def test_display_banner(self, client, factory, assertion):
         organization = factory(
-            kind=FuzzyChoice(set(PrescriberOrganizationKind.values) - {PrescriberOrganizationKind.FT})
+            kind=FuzzyChoice(
+                set(PrescriberOrganizationKind.values)
+                - {PrescriberOrganizationKind.FT, PrescriberOrganizationKind.OTHER}
+            )
         )
         client.force_login(organization.members.first())
         response = client.get(reverse("prescribers_views:edit_organization"))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Erreurs intermittentes des tests:

```
=================================== FAILURES ===================================
_______________________ TestCardView.test_card_subtitle ________________________
[gw3] linux -- Python 3.13.3 /home/runner/work/les-emplois/les-emplois/.venv/bin/python3

self = <django.db.backends.utils.CursorWrapper object at 0x7f7dc09d0410>
sql = 'INSERT INTO "prescribers_prescriberorganization" ("address_line_1", "address_line_2", "post_code", "city", "departmen...s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "prescribers_prescriberorganization"."id"'
params = ('', '', '75167', '', '75', None, ...)
ignored_wrapper_args = (False, {'connection': <DatabaseWrapper vendor='postgresql' alias='default'>, 'cursor': <django.db.backends.utils.CursorWrapper object at 0x7f7dc09d0410>})

    def _execute(self, sql, params, *ignored_wrapper_args):
        # Raise a warning during app initialization (stored_app_configs is only
        # ever set during testing).
        if not apps.ready and not apps.stored_app_configs:
            warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                # params default might be backend specific.
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)

.venv/lib/python3.13/site-packages/django/db/backends/utils.py:105:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.postgresql.base.Cursor [closed] [INERROR] (user=postgres database=test_itou_gw3) at 0x7f7dc207de50>
query = 'INSERT INTO "prescribers_prescriberorganization" ("address_line_1", "address_line_2", "post_code", "city", "departmen...s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "prescribers_prescriberorganization"."id"'
params = ('', '', '75167', '', '75', None, ...)

    def execute(
        self,
        query: Query,
        params: Params | None = None,
        *,
        prepare: bool | None = None,
        binary: bool | None = None,
    ) -> Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           psycopg.errors.CheckViolation: new row for relation "prescribers_prescriberorganization" violates check constraint "prevent_validated_authorization_if_other"
E           DETAIL:  Failing row contains (142, , , 75167, , 75, null, null, 12242724616952, Émile Carre, 9012036194, christellebrun@example.net, , , null, 2025-05-19 13:24:53.042431+00, null, Autre, 2025-05-19 13:24:53.042794+00, VALIDATED, null, null, f, f, 523a3db9-ecd5-49a8-8c17-0a921973ab40, null, null, null, null, t).

.venv/lib/python3.13/site-packages/psycopg/cursor.py:97: CheckViolation

The above exception was the direct cause of the following exception:

self = <tests.www.prescribers_views.test_edit.TestCardView object at 0x7f7dc3750050>
client = <tests.utils.test.ItouClient object at 0x7f7dc0a247d0>

    def test_card_subtitle(self, client):
>       prescriber_org = PrescriberOrganizationFactory(
            authorized=True,
            kind=FuzzyChoice(set(PrescriberOrganizationKind.values) - {PrescriberOrganizationKind.FT}),
        )

tests/www/prescribers_views/test_edit.py:48:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.13/site-packages/factory/base.py:43: in __call__
    return cls.create(**kwargs)
.venv/lib/python3.13/site-packages/factory/base.py:539: in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
.venv/lib/python3.13/site-packages/factory/django.py:122: in _generate
    return super()._generate(strategy, params)
.venv/lib/python3.13/site-packages/factory/base.py:468: in _generate
    return step.build()
.venv/lib/python3.13/site-packages/factory/builder.py:274: in build
    instance = self.factory_meta.instantiate(
.venv/lib/python3.13/site-packages/factory/base.py:320: in instantiate
    return self.factory._create(model, *args, **kwargs)
.venv/lib/python3.13/site-packages/factory/django.py:175: in _create
    return manager.create(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/query.py:679: in create
    obj.save(force_insert=True, using=self.db)
itou/prescribers/models.py:231: in save
    return super().save(*args, **kwargs)
tests/conftest.py:702: in strict_save
    return original_save(self, *args, update_fields=update_fields, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/base.py:892: in save
    self.save_base(
.venv/lib/python3.13/site-packages/django/db/models/base.py:998: in save_base
    updated = self._save_table(
.venv/lib/python3.13/site-packages/django/db/models/base.py:1161: in _save_table
    results = self._do_insert(
.venv/lib/python3.13/site-packages/django/db/models/base.py:1202: in _do_insert
    return manager._insert(
.venv/lib/python3.13/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/query.py:1847: in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py:1836: in execute_sql
    cursor.execute(sql, params)
.venv/lib/python3.13/site-packages/sentry_sdk/utils.py:1811: in runner
    return sentry_patched_function(*args, **kwargs)
.venv/lib/python3.13/site-packages/sentry_sdk/integrations/django/__init__.py:651: in execute
    result = real_execute(self, sql, params)
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:79: in execute
    return self._execute_with_wrappers(
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:92: in _execute_with_wrappers
    return executor(sql, params, many, context)
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:100: in _execute
    with self.db.wrap_database_errors:
.venv/lib/python3.13/site-packages/django/db/utils.py:91: in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:105: in _execute
    return self.cursor.execute(sql, params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.postgresql.base.Cursor [closed] [INERROR] (user=postgres database=test_itou_gw3) at 0x7f7dc207de50>
query = 'INSERT INTO "prescribers_prescriberorganization" ("address_line_1", "address_line_2", "post_code", "city", "departmen...s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "prescribers_prescriberorganization"."id"'
params = ('', '', '75167', '', '75', None, ...)

    def execute(
        self,
        query: Query,
        params: Params | None = None,
        *,
        prepare: bool | None = None,
        binary: bool | None = None,
    ) -> Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           django.db.utils.IntegrityError: new row for relation "prescribers_prescriberorganization" violates check constraint "prevent_validated_authorization_if_other"
E           DETAIL:  Failing row contains (142, , , 75167, , 75, null, null, 12242724616952, Émile Carre, 9012036194, christellebrun@example.net, , , null, 2025-05-19 13:24:53.042431+00, null, Autre, 2025-05-19 13:24:53.042794+00, VALIDATED, null, null, f, f, 523a3db9-ecd5-49a8-8c17-0a921973ab40, null, null, null, null, t).

.venv/lib/python3.13/site-packages/psycopg/cursor.py:97: IntegrityError
______ TestEditOrganization.test_display_banner[factory0-assertContains] _______
[gw3] linux -- Python 3.13.3 /home/runner/work/les-emplois/les-emplois/.venv/bin/python3

self = <django.db.backends.utils.CursorWrapper object at 0x7f7dc0d24050>
sql = 'INSERT INTO "prescribers_prescriberorganization" ("address_line_1", "address_line_2", "post_code", "city", "departmen...s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "prescribers_prescriberorganization"."id"'
params = ('', '', '75167', '', '75', None, ...)
ignored_wrapper_args = (False, {'connection': <DatabaseWrapper vendor='postgresql' alias='default'>, 'cursor': <django.db.backends.utils.CursorWrapper object at 0x7f7dc0d24050>})

    def _execute(self, sql, params, *ignored_wrapper_args):
        # Raise a warning during app initialization (stored_app_configs is only
        # ever set during testing).
        if not apps.ready and not apps.stored_app_configs:
            warnings.warn(self.APPS_NOT_READY_WARNING_MSG, category=RuntimeWarning)
        self.db.validate_no_broken_transaction()
        with self.db.wrap_database_errors:
            if params is None:
                # params default might be backend specific.
                return self.cursor.execute(sql)
            else:
>               return self.cursor.execute(sql, params)

.venv/lib/python3.13/site-packages/django/db/backends/utils.py:105:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.postgresql.base.Cursor [closed] [INERROR] (user=postgres database=test_itou_gw3) at 0x7f7dc207cad0>
query = 'INSERT INTO "prescribers_prescriberorganization" ("address_line_1", "address_line_2", "post_code", "city", "departmen...s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "prescribers_prescriberorganization"."id"'
params = ('', '', '75167', '', '75', None, ...)

    def execute(
        self,
        query: Query,
        params: Params | None = None,
        *,
        prepare: bool | None = None,
        binary: bool | None = None,
    ) -> Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           psycopg.errors.CheckViolation: new row for relation "prescribers_prescriberorganization" violates check constraint "prevent_validated_authorization_if_other"
E           DETAIL:  Failing row contains (146, , , 75167, , 75, null, null, 12242724616952, Émile Carre, 9012036194, christellebrun@example.net, , , null, 2025-05-19 13:24:54.07158+00, null, Autre, 2025-05-19 13:24:54.071974+00, VALIDATED, null, null, f, f, 916eea01-b1f2-4743-9172-4e3477a99be4, null, null, null, null, t).

.venv/lib/python3.13/site-packages/psycopg/cursor.py:97: CheckViolation

The above exception was the direct cause of the following exception:

self = <tests.www.prescribers_views.test_edit.TestEditOrganization object at 0x7f7dc36bebe0>
client = <tests.utils.test.ItouClient object at 0x7f7dc0a53ed0>
factory = functools.partial(<class 'tests.prescribers.factories.PrescriberOrganizationWithMembershipFactory'>, authorized=True)
assertion = <function SimpleTestCase.assertContains at 0x7f7dc58c51c0>

    @pytest.mark.parametrize(
        "factory,assertion",
        [
            (partial(PrescriberOrganizationWithMembershipFactory, authorized=True), assertContains),
            (partial(PrescriberOrganizationWithMembershipFactory, authorized=False), assertNotContains),
        ],
    )
    def test_display_banner(self, client, factory, assertion):
>       organization = factory(
            kind=FuzzyChoice(set(PrescriberOrganizationKind.values) - {PrescriberOrganizationKind.FT})
        )

tests/www/prescribers_views/test_edit.py:259:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.venv/lib/python3.13/site-packages/factory/base.py:43: in __call__
    return cls.create(**kwargs)
.venv/lib/python3.13/site-packages/factory/base.py:539: in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
.venv/lib/python3.13/site-packages/factory/django.py:122: in _generate
    return super()._generate(strategy, params)
.venv/lib/python3.13/site-packages/factory/base.py:468: in _generate
    return step.build()
.venv/lib/python3.13/site-packages/factory/builder.py:274: in build
    instance = self.factory_meta.instantiate(
.venv/lib/python3.13/site-packages/factory/base.py:320: in instantiate
    return self.factory._create(model, *args, **kwargs)
.venv/lib/python3.13/site-packages/factory/django.py:175: in _create
    return manager.create(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/query.py:679: in create
    obj.save(force_insert=True, using=self.db)
itou/prescribers/models.py:231: in save
    return super().save(*args, **kwargs)
tests/conftest.py:702: in strict_save
    return original_save(self, *args, update_fields=update_fields, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/base.py:892: in save
    self.save_base(
.venv/lib/python3.13/site-packages/django/db/models/base.py:998: in save_base
    updated = self._save_table(
.venv/lib/python3.13/site-packages/django/db/models/base.py:1161: in _save_table
    results = self._do_insert(
.venv/lib/python3.13/site-packages/django/db/models/base.py:1202: in _do_insert
    return manager._insert(
.venv/lib/python3.13/site-packages/django/db/models/manager.py:87: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
.venv/lib/python3.13/site-packages/django/db/models/query.py:1847: in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py:1836: in execute_sql
    cursor.execute(sql, params)
.venv/lib/python3.13/site-packages/sentry_sdk/utils.py:1811: in runner
    return sentry_patched_function(*args, **kwargs)
.venv/lib/python3.13/site-packages/sentry_sdk/integrations/django/__init__.py:651: in execute
    result = real_execute(self, sql, params)
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:79: in execute
    return self._execute_with_wrappers(
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:92: in _execute_with_wrappers
    return executor(sql, params, many, context)
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:100: in _execute
    with self.db.wrap_database_errors:
.venv/lib/python3.13/site-packages/django/db/utils.py:91: in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
.venv/lib/python3.13/site-packages/django/db/backends/utils.py:105: in _execute
    return self.cursor.execute(sql, params)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <django.db.backends.postgresql.base.Cursor [closed] [INERROR] (user=postgres database=test_itou_gw3) at 0x7f7dc207cad0>
query = 'INSERT INTO "prescribers_prescriberorganization" ("address_line_1", "address_line_2", "post_code", "city", "departmen...s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "prescribers_prescriberorganization"."id"'
params = ('', '', '75167', '', '75', None, ...)

    def execute(
        self,
        query: Query,
        params: Params | None = None,
        *,
        prepare: bool | None = None,
        binary: bool | None = None,
    ) -> Self:
        """
        Execute a query or command to the database.
        """
        try:
            with self._conn.lock:
                self._conn.wait(
                    self._execute_gen(query, params, prepare=prepare, binary=binary)
                )
        except e._NO_TRACEBACK as ex:
>           raise ex.with_traceback(None)
E           django.db.utils.IntegrityError: new row for relation "prescribers_prescriberorganization" violates check constraint "prevent_validated_authorization_if_other"
E           DETAIL:  Failing row contains (146, , , 75167, , 75, null, null, 12242724616952, Émile Carre, 9012036194, christellebrun@example.net, , , null, 2025-05-19 13:24:54.07158+00, null, Autre, 2025-05-19 13:24:54.071974+00, VALIDATED, null, null, f, f, 916eea01-b1f2-4743-9172-4e3477a99be4, null, null, null, null, t).

.venv/lib/python3.13/site-packages/psycopg/cursor.py:97: IntegrityError
=========================== short test summary info ============================
FAILED tests/www/prescribers_views/test_edit.py::TestCardView::test_card_subtitle - django.db.utils.IntegrityError: new row for relation "prescribers_prescriberorganization" violates check constraint "prevent_validated_authorization_if_other"
DETAIL:  Failing row contains (142, , , 75167, , 75, null, null, 12242724616952, Émile Carre, 9012036194, christellebrun@example.net, , , null, 2025-05-19 13:24:53.042431+00, null, Autre, 2025-05-19 13:24:53.042794+00, VALIDATED, null, null, f, f, 523a3db9-ecd5-49a8-8c17-0a921973ab40, null, null, null, null, t).
FAILED tests/www/prescribers_views/test_edit.py::TestEditOrganization::test_display_banner[factory0-assertContains] - django.db.utils.IntegrityError: new row for relation "prescribers_prescriberorganization" violates check constraint "prevent_validated_authorization_if_other"
DETAIL:  Failing row contains (146, , , 75167, , 75, null, null, 12242724616952, Émile Carre, 9012036194, christellebrun@example.net, , , null, 2025-05-19 13:24:54.07158+00, null, Autre, 2025-05-19 13:24:54.071974+00, VALIDATED, null, null, f, f, 916eea01-b1f2-4743-9172-4e3477a99be4, null, null, null, null, t).
== 2 failed, 4133 passed, 1 xpassed, 471 subtests passed in 397.10s (0:06:37) ==
```