### PR TITLE
Vie privée : suppression du champ created_by dans les modèles AdministrativeCriteria [GEN-2453] (partie 2/2)

### DIFF
--- a/itou/eligibility/migrations/0013_remove_administrative_criteria_created_by_database_operation.py
+++ b/itou/eligibility/migrations/0013_remove_administrative_criteria_created_by_database_operation.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("eligibility", "0012_remove_administrativecriteria_created_by_state_operation"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="ALTER TABLE eligibility_administrativecriteria DROP COLUMN IF EXISTS created_by_id",
+            reverse_sql=(
+                "ALTER TABLE eligibility_administrativecriteria ADD COLUMN created_by_id timestamp DEFAULT NULL"
+            ),
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE eligibility_geiqadministrativecriteria DROP COLUMN IF EXISTS created_by_id",
+            reverse_sql=(
+                "ALTER TABLE eligibility_geiqadministrativecriteria ADD COLUMN created_by_id timestamp DEFAULT NULL"
+            ),
+        ),
+    ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

prequis #6133 

Le champ `created_by` n'est pas utilisé dans les modèles `AdministrativeCriteria` et `GEIQAdministrativeCriteria`.
Il crée une ambiguïté vis-à-vis des traitements d'archivage. 

## :cake: Comment ? 

Suppression du champ pour SQL (partie 2)

## :rotating_light: À vérifier

NON Mettre à jour le CHANGELOG_breaking_changes.md ?
NON Ajouter l'étiquette « Bug » ?