### PR TITLE
PASS IAE: Correction d'un bug lors de l'acceptation d'un demande de prolongation [GEN-2204]

### DIFF
--- a/itou/templates/approvals/prolongation_requests/show.html
+++ b/itou/templates/approvals/prolongation_requests/show.html
@@ -28,7 +28,7 @@
             <h2 class="visually-hidden">Actions rapides</h2>
             <div class="form-row align-items-center gx-3">
                 <div class="form-group col-12 col-lg-auto">
-                    <form method="post" action="{% url "approvals:prolongation_request_grant" prolongation_request.pk %}">
+                    <form method="post" action="{% url "approvals:prolongation_request_grant" prolongation_request.pk %}" class="js-prevent-multiple-submit">
                         {% csrf_token %}
                         <button class="btn btn-lg btn-white btn-block btn-ico justify-content-center">
                             <i class="ri-check-line" aria-hidden="true"></i>

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -520,6 +520,14 @@ class ProlongationRequestGrantView(ProlongationRequestViewMixin, View):
     http_method_names = ["post"]
 
     def post(self, request, *args, **kwargs):
+        if self.prolongation_request.status == approvals_enums.ProlongationRequestStatus.GRANTED:
+            messages.success(
+                request,
+                f"La prolongation de {self.prolongation_request.approval.user.get_full_name()} a déjà été acceptée.",
+                extra_tags="toast",
+            )
+            return HttpResponseRedirect(reverse("approvals:prolongation_requests_list"))
+
         try:
             self.prolongation_request.grant(request.user)
         except IntegrityError:

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -2100,7 +2100,7 @@
               <h2 class="visually-hidden">Actions rapides</h2>
               <div class="form-row align-items-center gx-3">
                   <div class="form-group col-12 col-lg-auto">
-                      <form action="/approvals/prolongation/request/666/grant" method="post">
+                      <form action="/approvals/prolongation/request/666/grant" class="js-prevent-multiple-submit" method="post">
                           <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                           <button class="btn btn-lg btn-white btn-block btn-ico justify-content-center">
                               <i aria-hidden="true" class="ri-check-line"></i>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Voir sentry : https://inclusion.sentry.io/issues/15013580/events/latest/?referrer=latest-event

Soit lié à un double click (j'ai ajouté la class js pour l'éviter)
Soit parce que la demande a été validée depuis un autre onget (ou par un collègue en parallèle)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
