### PR TITLE
Vie privée : suppression du champ created_by dans les modèles AdministrativeCriteria [GEN-2453] (partie 3/2)

### DIFF
--- a/itou/eligibility/migrations/0012_remove_administrativecriteria_created_by_state_operation.py
+++ b/itou/eligibility/migrations/0012_remove_administrativecriteria_created_by_state_operation.py
@@ -9,22 +9,12 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.RemoveField(
-                    model_name="administrativecriteria",
-                    name="created_by",
-                ),
-            ],
-            database_operations=[],
+        migrations.RemoveField(
+            model_name="administrativecriteria",
+            name="created_by",
         ),
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.RemoveField(
-                    model_name="geiqadministrativecriteria",
-                    name="created_by",
-                ),
-            ],
-            database_operations=[],
+        migrations.RemoveField(
+            model_name="geiqadministrativecriteria",
+            name="created_by",
         ),
     ]

--- a/itou/eligibility/migrations/0013_remove_administrative_criteria_created_by_database_operation.py
+++ b/itou/eligibility/migrations/0013_remove_administrative_criteria_created_by_database_operation.py
@@ -6,17 +6,4 @@ class Migration(migrations.Migration):
         ("eligibility", "0012_remove_administrativecriteria_created_by_state_operation"),
     ]
 
-    operations = [
-        migrations.RunSQL(
-            sql="ALTER TABLE eligibility_administrativecriteria DROP COLUMN IF EXISTS created_by_id",
-            reverse_sql=(
-                "ALTER TABLE eligibility_administrativecriteria ADD COLUMN created_by_id timestamp DEFAULT NULL"
-            ),
-        ),
-        migrations.RunSQL(
-            sql="ALTER TABLE eligibility_geiqadministrativecriteria DROP COLUMN IF EXISTS created_by_id",
-            reverse_sql=(
-                "ALTER TABLE eligibility_geiqadministrativecriteria ADD COLUMN created_by_id timestamp DEFAULT NULL"
-            ),
-        ),
-    ]
+    operations = []


### PR DESCRIPTION
## :thinking: Pourquoi ?

conserver un historique de migrations simples

## :cake: Comment ? <!-- optionnel -->

remplacement du couple de migrations pour un `zero_downtime` par une migration simple.

