### PR TITLE
Candidature : correction du nom du paramètre permettant de postuler pour un candidat

### DIFF
--- a/itou/templates/search/includes/siaes_search_top.html
+++ b/itou/templates/search/includes/siaes_search_top.html
@@ -43,7 +43,7 @@
                             {% bootstrap_field form.company wrapper_class="w-lg-400px" show_label=False %}
                             <input type="hidden" name="city" value="{{ form.city.value }}">
                             <input type="hidden" name="distance" value="{{ form.distance.value }}">
-                            {% if job_seeker %}<input type="hidden" name="job_seeker" value="{{ job_seeker.public_id }}">{% endif %}
+                            {% if job_seeker %}<input type="hidden" name="job_seeker_public_id" value="{{ job_seeker.public_id }}">{% endif %}
                         </form>
                     {% endif %}
                 {% endif %}

--- a/itou/templates/search/siaes_search_results.html
+++ b/itou/templates/search/siaes_search_results.html
@@ -26,7 +26,7 @@
 {% block title_extra %}
     <form class="mt-md-4">
         {% include "search/includes/siaes_search_form.html" with form=form is_home=False only %}
-        {% if job_seeker %}<input type="hidden" name="job_seeker" value="{{ job_seeker.public_id }}">{% endif %}
+        {% if job_seeker %}<input type="hidden" name="job_seeker_public_id" value="{{ job_seeker.public_id }}">{% endif %}
     </form>
     {% include "search/includes/siaes_search_tabs.html" %}
 {% endblock %}

--- a/tests/www/apply/test_submit_from_job_seekers_list.py
+++ b/tests/www/apply/test_submit_from_job_seekers_list.py
@@ -17,6 +17,8 @@ from tests.utils.test import parse_response_to_soup
 
 
 class TestApplyAsPrescriber:
+    JOB_SEEKER_INPUT_MARKUP = '<input type="hidden" name="job_seeker_public_id" value="%s">'
+
     @freeze_time("2025-04-03 10:03")
     def test_apply_as_prescriber(self, client, snapshot):
         guerande = create_city_guerande()
@@ -102,6 +104,8 @@ class TestApplyAsPrescriber:
             response,
             company_url_with_job_seeker_id,
         )
+        # Two hidden inputs: next to city input and next to structure select
+        assertContains(response, self.JOB_SEEKER_INPUT_MARKUP % job_seeker.public_id, html=True, count=2)
 
         # Step apply to company
         # ----------------------------------------------------------------------
@@ -274,6 +278,8 @@ class TestApplyAsPrescriber:
             response,
             company_url_with_job_seeker_id,
         )
+        # Two hidden inputs: next to city input and next to structure select
+        assertContains(response, self.JOB_SEEKER_INPUT_MARKUP % job_seeker.public_id, html=True, count=2)
 
         # Step apply to company
         # ----------------------------------------------------------------------


### PR DESCRIPTION

## :thinking: Pourquoi ?

Avec 1b913d8c4267355251978878acaf02165db77256, on a changé le paramètre GET `job_seeker` en `job_seeker_public_id`.

Et donc, avant ce correctif, si l'on postule pour un candidat et qu'on veut sélectionner une autre ville ou une structure, on fait une requête GET avec le mauvais paramètre (`job_seeker` au lieu de `job_seeker_public_id`).

Un test a été ajouté pour s'assurer que l'input caché est bien présent avec le bon nom de paramètre.

