### PR TITLE
Considérer les fixtures `.json` comme du texte et non comme des fichiers binaires

### DIFF
--- a/itou/fixtures/django/.gitattributes
+++ b/itou/fixtures/django/.gitattributes
@@ -1,1 +1,0 @@
-*.json binary


### PR DESCRIPTION
## :thinking: Pourquoi ?

C'est assez laborieux de travailler avec des fichiers binaires, et ça ne servait, a priori, qu'à nettoyer la sortie de `git grep`.

Les utilisateurs de `git grep` seront heureux de savoir qu'un comportement similaire peut être retrouvé avec `git grep "Jacques" -- ':(exclude)*.json'`.

