### PR TITLE
Éligibilité : Correction de durées de certification de critères administratifs incorrects

### DIFF
--- a/itou/eligibility/migrations/0014_selectedadministrativecriteria_empty_certification_period.py
+++ b/itou/eligibility/migrations/0014_selectedadministrativecriteria_empty_certification_period.py
@@ -1,0 +1,34 @@
+import datetime
+
+from django.db import migrations
+
+from itou.utils.types import InclusiveDateRange
+
+
+def forwards(apps, schema_editor):
+    SelectedAdministrativeCriteria = apps.get_model("eligibility", "SelectedAdministrativeCriteria")
+    GEIQSelectedAdministrativeCriteria = apps.get_model("eligibility", "GEIQSelectedAdministrativeCriteria")
+    iae = []
+    for crit in SelectedAdministrativeCriteria.objects.filter(certified=True, certification_period=None):
+        crit.certification_period = InclusiveDateRange(
+            crit.certified_at, crit.certified_at + datetime.timedelta(days=92)
+        )
+        iae.append(crit)
+    SelectedAdministrativeCriteria.objects.bulk_update(iae, fields=["certification_period"])
+    geiq = []
+    for crit in GEIQSelectedAdministrativeCriteria.objects.filter(certified=True, certification_period=None):
+        crit.certification_period = InclusiveDateRange(
+            crit.certified_at, crit.certified_at + datetime.timedelta(days=92)
+        )
+        geiq.append(crit)
+    GEIQSelectedAdministrativeCriteria.objects.bulk_update(iae, fields=["certification_period"])
+    print()
+    print(f"Fixed IAE={len(iae)} GEIQ={len(geiq)} selected administrative criteria certification periods.")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("eligibility", "0013_remove_administrative_criteria_created_by_database_operation"),
+    ]
+
+    operations = [migrations.RunPython(forwards, elidable=True)]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il y a des données invalides dans la base de données.

```sql
SELECT certified_at
FROM eligibility_selectedadministrativecriteria
WHERE certified AND certification_period IS NULL
ORDER BY 1 DESC;
```

donne 1048 resultats, le plus récent date du 9 janvier 2025.

https://inclusion.sentry.io/issues/42627599/?project=4508410589020240&referrer=github-pr-bot