### PR TITLE
Éligibilité : Corriger les périodes de certifications de critères GEIQ

### DIFF
--- a/itou/eligibility/migrations/0015_geiqselectedadministrativecriteria_empty_certification_period.py
+++ b/itou/eligibility/migrations/0015_geiqselectedadministrativecriteria_empty_certification_period.py
@@ -1,0 +1,29 @@
+import datetime
+
+from django.db import migrations
+
+from itou.utils.types import InclusiveDateRange
+
+
+def forwards(apps, schema_editor):
+    GEIQSelectedAdministrativeCriteria = apps.get_model("eligibility", "GEIQSelectedAdministrativeCriteria")
+    geiq = []
+    for crit in GEIQSelectedAdministrativeCriteria.objects.filter(certified=True, certification_period=None):
+        crit.certification_period = InclusiveDateRange(
+            crit.certified_at, crit.certified_at + datetime.timedelta(days=92)
+        )
+        geiq.append(crit)
+    # Previous migration used the `iae` variable here instead of `geiq`.
+    # Thankfully, no rows were touched in production.
+    # https://github.com/gip-inclusion/les-emplois/pull/6173#discussion_r2099704697
+    GEIQSelectedAdministrativeCriteria.objects.bulk_update(geiq, fields=["certification_period"])
+    print()
+    print(f"Fixed GEIQ={len(geiq)} selected administrative criteria certification periods.")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("eligibility", "0014_selectedadministrativecriteria_empty_certification_period"),
+    ]
+
+    operations = [migrations.RunPython(forwards, elidable=True)]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une typo s’est glissée dans fa9035bc7f33afd882dc620b7e9a78781213ec96, et les critères certifiés GEIQ n’ont pas été corrigés. Heureusement, la typo n’a pas causé de dégâts, parce que la requête suivante ne retourne pas de résultats.
```
SELECT *
FROM eligibility_geiqselectedadministrativecriteria
WHERE id in (
     SELECT id
     FROM eligibility_selectedadministrativecriteria
     WHERE certified AND certification_period IS NULL
);
```
