### PR TITLE
Tableau de bord : afficher au candidat le statut de son PASS IAE, même quand il n'en a pas

### DIFF
--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -186,9 +186,7 @@
 
                                 {% if user.is_job_seeker %}
                                     {% include "dashboard/includes/job_seeker_job_applications_card.html" %}
-                                    {% if user.latest_common_approval %}
-                                        {% include "dashboard/includes/job_seeker_approval_card.html" %}
-                                    {% endif %}
+                                    {% include "dashboard/includes/job_seeker_approval_card.html" with user=user itou_help_center_url=ITOU_HELP_CENTER_URL only %}
                                 {% endif %}
                                 {# end of if user.is_job_seeker #}
 

--- a/itou/templates/dashboard/includes/job_seeker_approval_card.html
+++ b/itou/templates/dashboard/includes/job_seeker_approval_card.html
@@ -1,3 +1,26 @@
 <div class="col mb-3 mb-md-5">
-    {% include "approvals/includes/box.html" with approval=user.latest_common_approval link_from_current_url=request.get_full_path job_seeker_dashboard_version=True extra_class="h-100" only %}
+    {% if not user.latest_common_approval %}
+        <div class="col mb-3 mb-md-5">
+            <div class="c-box bg-warning-lightest border-warning h-100 d-flex flex-column">
+                <div class="mb-3 mb-md-4">
+                    <span class="badge badge-base rounded-pill bg-warning text-white">
+                        <i class="ri-pass-expired-line" aria-hidden="true"></i>
+                        PASS IAE inexistant
+                    </span>
+                </div>
+                <div class="flex-grow-1">
+                    <p class="mb-0">
+                        Pour obtenir un PASS IAE, vous devez avoir un diagnostic d’éligibilité à l’IAE valide et avoir une candidature acceptée dans une SIAE (Structure d’insertion par l’activité économique).
+                    </p>
+                </div>
+                <a href="{{ itou_help_center_url }}/articles/16923064254353--Mon-PASS-IAE-Candidat" rel="noopener" target="_blank" class="btn btn-outline-primary btn-block btn-ico bg-white mt-3 has-external-link">
+                    <i class="ri-question-line font-weight-medium" aria-hidden="true"></i>
+                    <span>En savoir plus sur le PASS IAE</span>
+                </a>
+            </div>
+        </div>
+
+    {% else %}
+        {% include "approvals/includes/box.html" with approval=user.latest_common_approval link_from_current_url=request.get_full_path job_seeker_dashboard_version=True extra_class="h-100" only %}
+    {% endif %}
 </div>

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -742,7 +742,7 @@ class TestDashboardView:
         assertContains(response, self.SUSPEND_TEXT)
 
     @freeze_time("2022-09-15")
-    def test_dashboard_access_by_a_jobseeker(self, client):
+    def test_jobseeker_approval_card(self, client):
         WAITING_PERIOD_WITH_VALID_DIAGNOSIS = (
             "Votre PASS IAE a expiré depuis moins de 2 ans mais un prescripteur habilité a réalisé un nouveau "
             "diagnostic d’éligibilité IAE."
@@ -752,11 +752,22 @@ class TestDashboardView:
             "doit réaliser un nouveau diagnostic d’éligibilité IAE : France Travail, Mission Locale, Cap emploi par "
             "exemple."
         )
+        HOW_TO_GET_PASS = (
+            "Pour obtenir un PASS IAE, vous devez avoir un diagnostic d’éligibilité à l’IAE valide et avoir une "
+            "candidature acceptée dans une SIAE (Structure d’insertion par l’activité économique)."
+        )
 
         user = JobSeekerFactory(with_address=True)
-        approval = ApprovalFactory(user=user, start_at=date(2022, 6, 21), end_at=date(2022, 12, 6))
         client.force_login(user)
         url = reverse("dashboard:index")
+        response = client.get(url)
+        assertContains(response, "PASS IAE inexistant")
+        assertContains(response, HOW_TO_GET_PASS, html=True)
+        assertNotContains(response, "Numéro de PASS IAE")
+        assertNotContains(response, WAITING_PERIOD_WITHOUT_DIAGNOSIS, html=True)
+        assertNotContains(response, WAITING_PERIOD_WITH_VALID_DIAGNOSIS, html=True)
+
+        approval = ApprovalFactory(user=user, start_at=date(2022, 6, 21), end_at=date(2022, 12, 6))
         response = client.get(url)
         assertContains(response, "Numéro de PASS IAE")
         assertContains(response, format_approval_number(approval))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Jusqu'à présent on n'affiche sur le tableau de bord des candidats les informations relatives à son PASS IAE uniquement s'il a un PASS.
Il serait également utile d'afficher une information lorsqu'il n'a pas de PASS, et lui suggérer de se rapprocher d'un prescripteur habilité.


