### PR TITLE
Fiches salarié : correction d'un test bagottant

### DIFF
--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -295,7 +295,7 @@ class TestListEmployeeRecords:
         Any status except PROCESSED
         """
         client.force_login(self.user)
-        status = random.choice(list(set(Status) - {Status.PROCESSED}))
+        status = random.choice(list(set(Status) - {Status.PROCESSED, Status.ARCHIVED}))
 
         self.employee_record.status = status
         self.company.siret = "10000000000001"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un test bagottant dû à la sélection aléatoire du statut de fiche salarié.
Les fiches archivées ne sont pas affichables.


## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
