### PR TITLE
Suppression d'une condition inutile dans un gabarit

### DIFF
--- a/itou/templates/companies/includes/_company_info.html
+++ b/itou/templates/companies/includes/_company_info.html
@@ -24,9 +24,7 @@
                 <address class="m-0">{{ company.address_on_one_line }}</address>
                 {% include 'includes/copy_to_clipboard.html' with content=company.address_on_one_line css_classes="btn-link fw-medium ms-1" only_icon=True %}
             </li>
-            {% if company.email or company.phone or company.website %}
-                {% include "companies/includes/_company_details.html" with company=company only %}
-            {% endif %}
+            {% include "companies/includes/_company_details.html" with company=company only %}
         </ul>
         {% if show_cta %}
             {% if job_app_to_transfer|default:False %}

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -4799,7 +4799,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -4828,7 +4827,6 @@
   
   
   
-              
           </ul>
           
               
@@ -4905,7 +4903,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -4934,7 +4931,6 @@
   
   
   
-              
           </ul>
           
               

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -172,7 +172,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -201,7 +200,6 @@
   
   
   
-              
           </ul>
           
               
@@ -604,7 +602,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -633,7 +630,6 @@
   
   
   
-              
           </ul>
           
               

--- a/tests/www/apply/__snapshots__/test_submit_from_job_seekers_list.ambr
+++ b/tests/www/apply/__snapshots__/test_submit_from_job_seekers_list.ambr
@@ -119,7 +119,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -148,7 +147,6 @@
   
   
   
-              
           </ul>
           
               

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -1733,7 +1733,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -1762,7 +1761,6 @@
   
   
   
-              
           </ul>
           
               
@@ -1997,7 +1995,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -2026,7 +2023,6 @@
   
   
   
-              
           </ul>
           
               
@@ -2284,7 +2280,6 @@
   
               </li>
               
-                  
       <li>
       <i aria-hidden="true" class="ri-mail-line fw-normal me-2"></i>
       <a aria-label="Contact par mail" class="text-break" href="mailto:contact@acmeinc.com">contact@acmeinc.com</a>
@@ -2313,7 +2308,6 @@
   
   
   
-              
           </ul>
           
               


### PR DESCRIPTION
## :thinking: Pourquoi ?

La condition est déjà présente dans le fragment inclus.

(cf https://github.com/gip-inclusion/les-emplois/pull/6140#discussion_r2095243731)

