### PR TITLE
Admin: Tri par défaut selon nom-prénom dans le tableau des membres d'une organisation [GEN-2493]

### DIFF
--- a/itou/common_apps/organizations/admin.py
+++ b/itou/common_apps/organizations/admin.py
@@ -55,6 +55,7 @@ class MembersInline(ItouTabularInline):
     extra = 0
     raw_id_fields = ("user",)
     readonly_fields = ("created_at", "updated_at", "updated_by", "joined_at")
+    ordering = ("user__last_name", "user__first_name", "joined_at")
     formset = MembersInlineFormSet
 
     def has_delete_permission(self, *args, **kwargs):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour simplifier l'identification des membres lorsque la liste est longue

## :cake: Comment ? <!-- optionnel -->

En rajoutant un `ordering` sur l'inline.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

- Se rendre sur la page d'admin d'une entreprise / organisation / institution qui a plusieurs membres
- Constater que les membres sont triés par nom-prénom
