### PR TITLE
[Pilotage] Suppression du TB 357 pour les DREETS/DDETS

### DIFF
--- a/itou/templates/dashboard/includes/stats.html
+++ b/itou/templates/dashboard/includes/stats.html
@@ -30,12 +30,6 @@
                             </a>
 
                         </li>
-                        <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_ddets_iae_follow_prolongation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
-                                <span>Suivi des demandes de prolongation de mon département</span>
-                            </a>
-                        </li>
                         <!-- Stats temporarily suspended until we stabilize them
                             <li class="d-flex justify-content-between align-items-center mb-3">
                                 <a href="{% url 'stats:stats_ddets_iae_iae' %}" class="btn-link btn-ico">
@@ -85,12 +79,6 @@
                                 <span>Suivi des prescriptions des prescripteurs habilités de ma région</span>
                             </a>
 
-                        </li>
-                        <li class="d-flex justify-content-between align-items-center mb-3">
-                            <a href="{% url 'stats:stats_dreets_iae_follow_prolongation' %}" class="btn-link btn-ico">
-                                <i class="ri-bar-chart-line ri-lg fw-normal align-self-start" aria-hidden="true"></i>
-                                <span>Suivi des demandes de prolongation de ma région</span>
-                            </a>
                         </li>
                         <!-- Stats temporarily suspended until we stabilize them
                             <li class="d-flex justify-content-between align-items-center mb-3">

--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -133,11 +133,6 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "wbWKEo",
         "tally_embed_form_id": "wvPEvQ",
     },
-    "stats_ddets_iae_follow_prolongation": {
-        "dashboard_id": 357,
-        "tally_popup_form_id": "nG0lDp",
-        "tally_embed_form_id": "mO0GY7",
-    },
     "stats_ddets_iae_iae": {
         "dashboard_id": 117,
     },
@@ -179,11 +174,6 @@ METABASE_DASHBOARDS = {
         "dashboard_id": 289,
         "tally_popup_form_id": "wbWKEo",
         "tally_embed_form_id": "wvPEvQ",
-    },
-    "stats_dreets_iae_follow_prolongation": {
-        "dashboard_id": 357,
-        "tally_popup_form_id": "nG0lDp",
-        "tally_embed_form_id": "mO0GY7",
     },
     "stats_dreets_iae_iae": {
         "dashboard_id": 117,

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -44,11 +44,6 @@ urlpatterns = [
         views.stats_ddets_iae_ph_prescription,
         name="stats_ddets_iae_ph_prescription",
     ),
-    path(
-        "ddets/follow_prolongation",
-        views.stats_ddets_iae_follow_prolongation,
-        name="stats_ddets_iae_follow_prolongation",
-    ),
     path("ddets/iae", views.stats_ddets_iae_iae, name="stats_ddets_iae_iae"),
     path("ddets/siae_evaluation", views.stats_ddets_iae_siae_evaluation, name="stats_ddets_iae_siae_evaluation"),
     path("ddets/hiring", views.stats_ddets_iae_hiring, name="stats_ddets_iae_hiring"),
@@ -66,11 +61,6 @@ urlpatterns = [
         "dreets/ph_prescription",
         views.stats_dreets_iae_ph_prescription,
         name="stats_dreets_iae_ph_prescription",
-    ),
-    path(
-        "dreets/follow_prolongation",
-        views.stats_dreets_iae_follow_prolongation,
-        name="stats_dreets_iae_follow_prolongation",
     ),
     path("dreets/iae", views.stats_dreets_iae_iae, name="stats_dreets_iae_iae"),
     path("dreets/hiring", views.stats_dreets_iae_hiring, name="stats_dreets_iae_hiring"),

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -522,10 +522,6 @@ def stats_ddets_iae_ph_prescription(request):
     return render_stats_ddets_iae(request=request, page_title="Suivi des prescriptions des prescripteurs habilités")
 
 
-def stats_ddets_iae_follow_prolongation(request):
-    return render_stats_ddets_iae(request=request, page_title="Suivi des demandes de prolongation")
-
-
 def stats_ddets_iae_iae(request):
     return render_stats_ddets_iae(request=request, page_title="Données IAE de mon département")
 
@@ -607,10 +603,6 @@ def stats_dreets_iae_ph_prescription(request):
     return render_stats_dreets_iae(request=request, page_title="Suivi des prescriptions des prescripteurs habilités")
 
 
-def stats_dreets_iae_follow_prolongation(request):
-    return render_stats_dreets_iae(request=request, page_title="Suivi des demandes de prolongation")
-
-
 def stats_dreets_iae_iae(request):
     return render_stats_dreets_iae(
         request=request,
@@ -663,10 +655,6 @@ def stats_dgefp_iae_auto_prescription(request):
 
 def stats_dgefp_iae_follow_siae_evaluation(request):
     return render_stats_dgefp_iae(request=request, page_title="Suivi du contrôle à posteriori")
-
-
-def stats_dgefp_iae_follow_prolongation(request):
-    return render_stats_dgefp_iae(request=request, page_title="Suivi des demandes de prolongation")
 
 
 def stats_dgefp_iae_hiring(request):


### PR DESCRIPTION
## :thinking: Pourquoi ?

A la demande du métier,  suppression du TB 357.

@rsebille je pense que j'ai tout fait sauf le snapshot qui marche plus en local chez moi (je dois réparer les emplois). Est ce que tu pourrais le faire ?

Aussi, tu peux me confirmer que le 298 a bien été supprimé pour les SIAE ? Je le vois plus nulle part.

Merci ! 
