### PR TITLE
Fiches salarié : Ordre (vraiment) déterministe pour les objets sélectionnés lors du transfert

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -169,7 +169,7 @@ class Command(EmployeeRecordTransferCommand):
         self.logger.info("Starting UPLOAD of employee records")
         employee_records_to_send = EmployeeRecord.objects.filter(
             status=Status.READY, job_application__state=JobApplicationState.ACCEPTED
-        ).order_by("updated_at")
+        ).order_by("updated_at", "pk")
         for batch in chunks(
             employee_records_to_send, EmployeeRecordBatch.MAX_EMPLOYEE_RECORDS, max_chunk=self.MAX_UPLOADED_FILES
         ):

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -140,7 +140,7 @@ class Command(EmployeeRecordTransferCommand):
     )
     def upload(self, sftp: paramiko.SFTPClient, dry_run: bool):
         new_notifications = EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).order_by(
-            "updated_at"
+            "updated_at", "pk"
         )
 
         if len(new_notifications) > 0:

--- a/tests/employee_record/test_transfer_employee_records.py
+++ b/tests/employee_record/test_transfer_employee_records.py
@@ -126,8 +126,8 @@ def test_upload_file_error(faker, snapshot, sftp_directory, command, caplog):
 @freezegun.freeze_time("2021-09-27")
 def test_upload_only_create_a_limited_number_of_files(mocker, snapshot, sftp_directory, command, caplog):
     mocker.patch.object(EmployeeRecordBatch, "MAX_EMPLOYEE_RECORDS", 1)
-    EmployeeRecordFactory(pk=1234, ready_for_transfer=True)
     EmployeeRecordFactory(pk=4321, ready_for_transfer=True)
+    EmployeeRecordFactory(pk=1234, ready_for_transfer=True)
 
     command.handle(upload=True, download=False, preflight=False, wet_run=True)
     assert len(list(sftp_directory.joinpath(REMOTE_UPLOAD_DIR).iterdir())) == command.MAX_UPLOADED_FILES

--- a/tests/employee_record/test_transfer_employee_records_updates.py
+++ b/tests/employee_record/test_transfer_employee_records_updates.py
@@ -103,8 +103,8 @@ def test_upload_file_error(faker, snapshot, sftp_directory, command, caplog):
 @freezegun.freeze_time("2021-09-27")
 def test_upload_only_create_a_limited_number_of_files(mocker, snapshot, sftp_directory, command, caplog):
     mocker.patch.object(EmployeeRecordBatch, "MAX_EMPLOYEE_RECORDS", 1)
-    EmployeeRecordUpdateNotificationFactory(pk=1234, ready_for_transfer=True)
     EmployeeRecordUpdateNotificationFactory(pk=4321, ready_for_transfer=True)
+    EmployeeRecordUpdateNotificationFactory(pk=1234, ready_for_transfer=True)
 
     command.handle(upload=True, download=False, preflight=False, wet_run=True)
     assert len(list(sftp_directory.joinpath(REMOTE_UPLOAD_DIR).iterdir())) == command.MAX_UPLOADED_FILES


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car la PR précédente (https://github.com/gip-inclusion/les-emplois/pull/6207) ne réglait pas le problème complètement.