### PR TITLE
Contrôle a posteriori : Correction d’une régression dans la validation du formulaire de sélection des critères administratifs [GEN-2457]

### DIFF
--- a/itou/www/siae_evaluations_views/forms.py
+++ b/itou/www/siae_evaluations_views/forms.py
@@ -38,9 +38,14 @@ class SetChosenPercentForm(forms.ModelForm):
 
 
 class AdministrativeCriteriaEvaluationForm(AdministrativeCriteriaForm):
-    def __init__(self, user, siae, job_app_selected_administrative_criteria, **kwargs):
+    def __init__(self, siae, job_app_selected_administrative_criteria, **kwargs):
         administrative_criteria = [e.administrative_criteria for e in job_app_selected_administrative_criteria]
-        super().__init__(user, siae, administrative_criteria, **kwargs)
+        super().__init__(
+            is_authorized_prescriber=False,
+            siae=siae,
+            administrative_criteria=administrative_criteria,
+            **kwargs,
+        )
         self.num_level2_admin_criteria = ADMINISTRATIVE_CRITERIA_LEVEL_2_REQUIRED_FOR_SIAE_KIND[siae.kind]
 
 

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -571,7 +571,6 @@ def siae_select_criteria(
     }
 
     form_administrative_criteria = AdministrativeCriteriaEvaluationForm(
-        request.user,
         siae=siae,
         job_app_selected_administrative_criteria=job_application_administrative_criteria,
         data=request.POST or None,

--- a/tests/www/eligibility_views/test_forms.py
+++ b/tests/www/eligibility_views/test_forms.py
@@ -198,7 +198,6 @@ class TestAdministrativeCriteriaEvaluationForm:
         )
 
         form = AdministrativeCriteriaEvaluationForm(
-            user,
             company,
             job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
                 "administrative_criteria"

--- a/tests/www/siae_evaluations_views/test_forms.py
+++ b/tests/www/siae_evaluations_views/test_forms.py
@@ -48,7 +48,6 @@ class TestAdministrativeCriteriaEvaluationForm:
         )
 
         form = AdministrativeCriteriaEvaluationForm(
-            user,
             company,
             job_application.eligibility_diagnosis.selected_administrative_criteria.select_related(
                 "administrative_criteria"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le formulaire autorisait la saisie d’un seul critère de niveau 2 pour justifier une auto-prescription, alors que deux ou trois critères sont requis (selon le type de SIAE).

## :cake: Comment ? <!-- optionnel -->

Bisecté à 9acbe5f32d0bf4d808a5798f6a86746a8fa7fd5e.
Voir le message de commit pour l’explication et pourquoi le code s’exécutait sans erreur.

## :desert_island: Comment tester ?

1. `make resetdb`
1. Se connecter en tant que l’ETTI
2. Depuis le tableau de bord, naviguer vers la campagne de contrôle contrôle a posteriori en cours
3. Sélectionner les critères pour une auto-prescription (uniquement un critère de niveau 2)
5. Soumettre le formulaire

Attendu : une erreur, il faut trois critères de niveau 2 pour une ETTI.
Constaté : le formulaire est accepté, l’employeur peut justifier uniquement un critère

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/ae8a65a4-a6cb-40c6-8bb0-ff95a5d60b2d)
