### PR TITLE
Contrôle a posteriori : Fusionner le statut « Nouveaux justificatifs à traiter » dans « À traiter » [GEN-2458]

### DIFF
--- a/itou/siae_evaluations/templatetags/siae_evaluations_tags.py
+++ b/itou/siae_evaluations/templatetags/siae_evaluations_tags.py
@@ -43,7 +43,6 @@ def action_required_badge(content):
 
 
 ACCEPTED_BADGE = success_badge("Validé")
-PENDING_AFTER_REVIEW_BADGE = action_required_badge("Nouveaux justificatifs à traiter")
 REFUSED_BADGE = danger_badge("Problème constaté")
 TODO_BADGE = action_required_badge("À traiter")
 UPLOADED_BADGE = action_required_badge("Justificatifs téléversés")
@@ -59,7 +58,7 @@ def get_employer_badges(adversarial_stage):
             EvaluatedJobApplicationsState.REFUSED: REFUSED_BADGE,
             EvaluatedJobApplicationsState.REFUSED_2: REFUSED_BADGE,
             EvaluatedJobApplicationsState.PROCESSING: TODO_BADGE,
-            EvaluatedJobApplicationsState.PENDING: PENDING_AFTER_REVIEW_BADGE,
+            EvaluatedJobApplicationsState.PENDING: TODO_BADGE,
         }
     return {
         EvaluatedJobApplicationsState.PENDING: TODO_BADGE,
@@ -107,7 +106,7 @@ def get_labor_inspector_badges(adversarial_stage, submission_freezed, evaluation
 
     NOT_SUBMITTED = danger_badge("Justificatifs non transmis")
     if submission_freezed:
-        submission_freezed_badges = {
+        return {
             EvaluatedJobApplicationsState.PENDING: NOT_SUBMITTED,
             EvaluatedJobApplicationsState.PROCESSING: NOT_SUBMITTED,
             EvaluatedJobApplicationsState.UPLOADED: NOT_SUBMITTED,
@@ -116,11 +115,6 @@ def get_labor_inspector_badges(adversarial_stage, submission_freezed, evaluation
             EvaluatedJobApplicationsState.ACCEPTED: ACCEPTED_BADGE,
             EvaluatedJobApplicationsState.REFUSED_2: REFUSED_BADGE,
         }
-        if adversarial_stage:
-            # TODO: Use the TODO_BADGE and drop if adversarial_stage above.
-            submission_freezed_badges[EvaluatedJobApplicationsState.SUBMITTED] = PENDING_AFTER_REVIEW_BADGE
-            return submission_freezed_badges
-        return submission_freezed_badges
 
     PENDING_BADGE = info_badge("En attente")
     if adversarial_stage:
@@ -128,8 +122,7 @@ def get_labor_inspector_badges(adversarial_stage, submission_freezed, evaluation
             EvaluatedJobApplicationsState.PENDING: PENDING_BADGE,
             EvaluatedJobApplicationsState.PROCESSING: PENDING_BADGE,
             EvaluatedJobApplicationsState.UPLOADED: UPLOADED_BADGE,
-            # TODO: Use the TODO_BADGE.
-            EvaluatedJobApplicationsState.SUBMITTED: PENDING_AFTER_REVIEW_BADGE,
+            EvaluatedJobApplicationsState.SUBMITTED: TODO_BADGE,
             # Show “Problème constaté” until the review is submitted, which starts
             # the “phase contradictoire” (tracked by the reviewed_at field).
             EvaluatedJobApplicationsState.REFUSED: info_badge("Phase contradictoire - En attente"),

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -1028,27 +1028,20 @@ class TestInstitutionEvaluatedSiaeDetailView:
         assertContains(response, self.control_text)
 
         # EvaluatedAdministrativeCriteria submitted
-        submitted_status = "À traiter"
-        adversarial_submitted_status = "Nouveaux justificatifs à traiter"
+        submitted_badge = """
+            <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">
+             À traiter
+            </span>
+            """
         evaluated_administrative_criteria.submitted_at = timezone.now()
         evaluated_administrative_criteria.save(update_fields=["submitted_at"])
         response = client.get(url)
         assertContains(response, evaluated_job_application_url)
         assertNotContains(response, uploaded_status)
         assertNotContains(response, pending_status)
-        assertNotContains(response, adversarial_submitted_status)
         assertContains(response, validation_button_disabled, html=True, count=1)
         assertContains(response, self.control_text)
-        assertContains(
-            response,
-            f"""
-            <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">
-             {submitted_status}
-            </span>
-            """,
-            html=True,
-            count=1,
-        )
+        assertContains(response, submitted_badge, html=True, count=1)
 
         # EvaluatedAdministrativeCriteria Accepted
         evaluated_administrative_criteria.review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.ACCEPTED
@@ -1156,7 +1149,7 @@ class TestInstitutionEvaluatedSiaeDetailView:
         assertNotContains(response, uploaded_status)
         assertNotContains(response, pending_status)
         assertNotContains(response, refused_status)
-        assertContains(response, adversarial_submitted_status)
+        assertContains(response, submitted_badge, html=True, count=1)
         assertContains(response, validation_button_disabled, html=True, count=1)
         assertContains(response, self.control_text)
 
@@ -1316,26 +1309,19 @@ class TestInstitutionEvaluatedSiaeDetailView:
         assertContains(response, self.control_text)
 
         # EvaluatedAdministrativeCriteria submitted
-        submitted_status = "À traiter"
-        adversarial_submitted_status = "Nouveaux justificatifs à traiter"
+        submitted_badge = """
+        <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">
+            À traiter
+        </span>
+        """
         evaluated_administrative_criteria.submitted_at = timezone.now()
         evaluated_administrative_criteria.save(update_fields=["submitted_at"])
         response = client.get(url)
         assertContains(response, evaluated_job_application_url)
         assertNotContains(response, not_transmitted_status)
-        assertNotContains(response, adversarial_submitted_status)
         assertContains(response, validation_button_disabled, html=True, count=1)
         assertContains(response, self.control_text)
-        assertContains(
-            response,
-            f"""
-            <span class="badge badge-sm rounded-pill text-nowrap bg-accent-03 text-primary">
-             {submitted_status}
-            </span>
-            """,
-            html=True,
-            count=1,
-        )
+        assertContains(response, submitted_badge, html=True, count=1)
 
         # Adversarial phase (but still frozen)
         evaluated_siae.reviewed_at = timezone.now()
@@ -1359,7 +1345,7 @@ class TestInstitutionEvaluatedSiaeDetailView:
         response = client.get(url)
         assertContains(response, evaluated_job_application_url)
         assertNotContains(response, not_transmitted_status)
-        assertContains(response, adversarial_submitted_status)
+        assertContains(response, submitted_badge, html=True, count=1)
         assertContains(response, validation_button_disabled, html=True, count=1)
         assertContains(response, self.control_text)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Simplifier le code et l’interface. La distinction qui a conduit à la création d’un statut particulier pour « Nouveaux justificatifs à traiter » n’est plus valide.
