### PR TITLE
Tech: suppression des infos personnelles des logs d'impersonnification

### DIFF
--- a/itou/utils/perms/user.py
+++ b/itou/utils/perms/user.py
@@ -26,11 +26,11 @@ def has_hijack_perm(*, hijacker, hijacked):
 
 
 def hijack_started_signal(sender, hijacker, hijacked, request, **kwargs):
-    logger.info("admin=%s has started impersonation of user=%s", hijacker, hijacked)
+    logger.info("admin=%s has started impersonation of user=%s", hijacker.pk, hijacked.pk)
 
 
 def hijack_ended_signal(sender, hijacker, hijacked, request, **kwargs):
-    logger.info("admin=%s has ended impersonation of user=%s", hijacker, hijacked)
+    logger.info("admin=%s has ended impersonation of user=%s", hijacker.pk, hijacked.pk)
 
 
 signals.hijack_started.connect(hijack_started_signal)

--- a/tests/utils/test_hijack.py
+++ b/tests/utils/test_hijack.py
@@ -27,12 +27,12 @@ class TestUserHijack:
 
         response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
         assertRedirects(response, "/foo/", fetch_redirect_response=False)
-        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
+        assert caplog.records[0].message == f"admin={hijacker.pk} has started impersonation of user={hijacked.pk}"
         caplog.clear()
 
         response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
         assertRedirects(response, "/bar/", fetch_redirect_response=False)
-        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
+        assert caplog.records[0].message == f"admin={hijacker.pk} has ended impersonation of user={hijacked.pk}"
 
     def test_disallowed_hijackers(self, client):
         hijacked = PrescriberFactory()
@@ -64,12 +64,12 @@ class TestUserHijack:
 
         response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
         assertRedirects(response, "/foo/", fetch_redirect_response=False)
-        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
+        assert caplog.records[0].message == f"admin={hijacker.pk} has started impersonation of user={hijacked.pk}"
         caplog.clear()
 
         response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
         assertRedirects(response, "/bar/", fetch_redirect_response=False)
-        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
+        assert caplog.records[0].message == f"admin={hijacker.pk} has ended impersonation of user={hijacked.pk}"
 
     def test_allowed_django_prescriber(self, client, caplog, settings):
         hijacked = PrescriberFactory(identity_provider=IdentityProvider.DJANGO)
@@ -78,12 +78,12 @@ class TestUserHijack:
 
         response = client.post(reverse("hijack:acquire"), {"user_pk": hijacked.pk, "next": "/foo/"})
         assertRedirects(response, "/foo/", fetch_redirect_response=False)
-        assert caplog.records[0].message == f"admin={hijacker} has started impersonation of user={hijacked}"
+        assert caplog.records[0].message == f"admin={hijacker.pk} has started impersonation of user={hijacked.pk}"
         caplog.clear()
 
         response = client.post(reverse("hijack:release"), {"user_pk": hijacked.pk, "next": "/bar/"})
         assertRedirects(response, "/bar/", fetch_redirect_response=False)
-        assert caplog.records[0].message == f"admin={hijacker} has ended impersonation of user={hijacked}"
+        assert caplog.records[0].message == f"admin={hijacker.pk} has ended impersonation of user={hijacked.pk}"
 
     def test_release_redirects_to_admin(self, client):
         hijacked = JobSeekerFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Moins d'infos personnelles dans les logs.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
