### PR TITLE
Tech: ajout de l'info d'impersonnification dans les logs

### DIFF
--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -22,22 +22,24 @@ class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):
                 del log_entry_dict[log_key]
         wsgi_request = self.get_wsgi_request()
         if wsgi_request is not None:
+            try:
+                user = datadog.get_wsgi_request_user(wsgi_request)
+            except Exception:  # NOQA: we cannot crash the log formatter under any circumstances
+                user = None
             if current_org := getattr(wsgi_request, "current_organization", None):
                 log_entry_dict["usr.organization_id"] = current_org.pk
             if token := getattr(wsgi_request, "auth", None):
                 if hasattr(token, "datadog_info"):
                     log_entry_dict["token"] = token.datadog_info()
                 else:
-                    try:
-                        user_pk = wsgi_request.user.pk
-                    except AttributeError:
-                        user_pk = None
-                    if user_pk is None and not getattr(wsgi_request, NO_RECURSIVE_LOG_FLAG, False):
+                    if getattr(user, "pk", None) is None and not getattr(wsgi_request, NO_RECURSIVE_LOG_FLAG, False):
                         # Avoid coming right back here with the following logger.warning
                         setattr(wsgi_request, NO_RECURSIVE_LOG_FLAG, True)
                         logger.warning(
                             "Request using token (%r) without datadog_info() method: please define one", token
                         )
+            if getattr(user, "is_hijacked", False):
+                log_entry_dict["usr.is_hijacked"] = True
         if (command_info := get_current_command_info()) is not None:
             log_entry_dict["command.run_uid"] = command_info.run_uid
             log_entry_dict["command.name"] = command_info.name

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -1759,6 +1759,38 @@ def test_log_current_command(client):
     assert uuid.UUID(log["command.run_uid"])
 
 
+def test_log_hijack_infos(client):
+    dashboard_url = reverse("dashboard:index")
+    membership = CompanyMembershipFactory()
+    client.force_login(membership.user)
+    root_logger = logging.getLogger()
+    stream_handler = root_logger.handlers[0]
+    captured = io.StringIO()
+    assert isinstance(stream_handler, logging.StreamHandler)
+    # caplog cannot be used since the organization_id is written by the log formatter
+    # capsys/capfd did not want to work because https://github.com/pytest-dev/pytest/issues/5997
+    with patch.object(stream_handler, "stream", captured):
+        response = client.get(dashboard_url)
+    assert response.status_code == 200
+    # Check that the hijack info is not there
+    assert f'"usr.id": {membership.user.id}' in captured.getvalue()
+    assert "usr.is_hijacked" not in captured.getvalue()
+
+    hijacker = ItouStaffFactory(is_superuser=True)
+    client.force_login(hijacker)
+    response = client.post(reverse("hijack:acquire"), {"user_pk": membership.user.pk, "next": dashboard_url})
+    assertRedirects(response, dashboard_url, fetch_redirect_response=False)
+    captured = io.StringIO()
+    # caplog cannot be used since the organization_id is written by the log formatter
+    # capsys/capfd did not want to work because https://github.com/pytest-dev/pytest/issues/5997
+    with patch.object(stream_handler, "stream", captured):
+        response = client.get(dashboard_url)
+    assert response.status_code == 200
+    # Check that the hijack info is there there
+    assert f'"usr.id": {membership.user.id}' in captured.getvalue()
+    assert '"usr.is_hijacked": true' in captured.getvalue()
+
+
 def test_create_fake_postcode():
     with mock.patch.dict(DEPARTMENTS, {"2A": "2A - Corse-du-Sud"}):
         postcode = create_fake_postcode()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour rapidement voir si un log est concerné par une impersonnification.

J'ai hésité à rajouter l'`hijack_history` mais je me suis dit qu'au besoin on irait fouiller dans les logs.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
