### PR TITLE
[API Particulier] Ne plus logger les appels à l'API Particulier faits par HTTPX

### DIFF
--- a/itou/utils/logging.py
+++ b/itou/utils/logging.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 
 from django_datadog_logger.formatters import datadog
@@ -9,6 +10,24 @@ logger = logging.getLogger(__name__)
 
 
 NO_RECURSIVE_LOG_FLAG = "_no_recursive_log_flag"
+
+
+@contextlib.contextmanager
+def suppress_logs(logger: logging.Logger):
+    """Context manager to temporarily disable logs.
+    # Inspired by https://gist.github.com/iansan5653/28ce8ec2c50d507f0543b0b17cdc2637
+    # Arguments
+        logger (logging.Logger): #logging.Logger object to disable.
+
+    # Usage
+        ```python
+           with suppress_logs(some_logger):
+               pass
+        ```
+    """
+    logger.disabled = True
+    yield
+    logger.disabled = False
 
 
 class ItouDataDogJSONFormatter(datadog.DataDogJSONFormatter):

--- a/tests/utils/apis/test_api_particulier.py
+++ b/tests/utils/apis/test_api_particulier.py
@@ -73,7 +73,7 @@ def test_not_found(respx_mock, caplog):
     assert crit.certified is None
     assert crit.certification_period is None
     assert "Dossier allocataire inexistant. Le document ne peut être édité." in caplog.text
-    assert f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active" in caplog.text
+    assert f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active" not in caplog.text
 
 
 def test_service_unavailable(respx_mock, caplog):
@@ -89,4 +89,4 @@ def test_service_unavailable(respx_mock, caplog):
     assert (
         "La réponse retournée par le fournisseur de données est invalide et inconnue de notre service." in caplog.text
     )
-    assert f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active" in caplog.text
+    assert f"{settings.API_PARTICULIER_BASE_URL}v2/revenu-solidarite-active" not in caplog.text


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les appels à l'API Particulier contiennent les données pivot permettant à l'API d'identifier les individus. Elles sont transmises en paramètre de la requête GET, or [HTTPX crée un _log_ avec l'URL lorsqu'il émet une requête](https://github.com/encode/httpx/blob/master/httpx/_client.py#L1025-L1032). Il s'agit d'une fuite de données qu'il faut corriger.

## :cake: Comment ? <!-- optionnel -->

Ce serait probablement mieux de filtrer les paramètres pour ne garder que la première partie de l'URL dans les logs mais, pour le moment, le plus important est de corriger la fuite.
S'il s'avérait qu'il est important de consulter ces logs, nous pourrions mettre en place ce mécanisme à ce moment-là. Pour le moment, ce n'est pas la priorité.
 
## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
