### PR TITLE
Tech: éviter de logger les 409 de l'API Particulier

### DIFF
--- a/tests/eligibility/test_tasks.py
+++ b/tests/eligibility/test_tasks.py
@@ -112,6 +112,7 @@ class TestCertifyCriteria:
         "status_code,json_data,headers,retry_task_exception",
         [
             (400, {}, None, None),
+            (409, {}, None, True),
             (429, {}, None, False),
             (429, {}, {"Retry-After": "123"}, True),
             (503, {}, None, False),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter que des données personnelles ne finissent dans nos logs.

## :cake: Comment ? <!-- optionnel -->

Au vu du message présent dans la réponse, cela ressemble à une erreur temporaire: on patiente quelques secondes et on recommence.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
