### PR TITLE
GEIQ: ajout des DDETS/DREETS en copie de l'email de notification de contrôle définitif [GEN-2522]

### DIFF
--- a/itou/geiq_assessments/notifications.py
+++ b/itou/geiq_assessments/notifications.py
@@ -1,5 +1,9 @@
 from itou.communications import NotificationCategory, registry as notifications_registry
 from itou.communications.dispatch import EmailNotification
+from itou.geiq_assessments.models import (
+    AssessmentInstitutionLink,
+)
+from itou.institutions.models import InstitutionMembership
 from itou.utils.urls import get_absolute_url
 
 
@@ -50,3 +54,19 @@ class AssessmentReviewedForGeiqNotification(EmailNotification):
         assessment = context["assessment"]
         context["abs_balance_amount"] = abs(assessment.granted_amount - assessment.advance_amount)
         return context
+
+    def build(self):
+        email_message = super().build()
+        assessment = self.context["assessment"]
+        cc_users = {
+            membership.user
+            for membership in InstitutionMembership.objects.active()
+            .filter(
+                institution__in=AssessmentInstitutionLink.objects.filter(
+                    assessment=assessment, with_convention=True
+                ).values_list("institution", flat=True),
+            )
+            .select_related("user")
+        }
+        email_message.cc = sorted(cc_user.email for cc_user in cc_users)
+        return email_message

--- a/tests/www/geiq_assessments_views/test_views_for_institution.py
+++ b/tests/www/geiq_assessments_views/test_views_for_institution.py
@@ -282,6 +282,18 @@ class TestAssessmentDetailsForInstitutionView:
             user__first_name="Julia",
             user__last_name="Martin",
         )
+        other_ddets_membership = InstitutionMembershipFactory(
+            institution=ddets_membership.institution,
+        )
+        # Inactive memberships
+        InstitutionMembershipFactory(
+            institution=ddets_membership.institution,
+            is_active=False,
+        )
+        InstitutionMembershipFactory(
+            institution=ddets_membership.institution,
+            user__is_active=False,
+        )
         dreets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DREETS_GEIQ)
         geiq_membership = CompanyMembershipFactory(
             company__kind=CompanyKind.GEIQ,
@@ -362,6 +374,7 @@ class TestAssessmentDetailsForInstitutionView:
             )
             assert email.to[0] == geiq_membership.user.email
             assert email.body == snapshot(name="body of mail sent to GEIQ members")
+            assert email.cc == sorted([ddets_membership.user.email, other_ddets_membership.user.email])
 
     def test_ddets_review_dreets_fix_and_dreets_review(self, client, snapshot):
         ddets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_GEIQ)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car elles veullent être en copie de l'email.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
