### PR TITLE
Tech: Suppression de django-extensions

### DIFF
--- a/CHANGELOG_breaking_changes.md
+++ b/CHANGELOG_breaking_changes.md
@@ -1,5 +1,10 @@
 # Journal des changements techniques majeurs
 
+## 2025-06-10
+
+- Suppression de django-extensions et de sa commande `shell_plus` maintenant
+  que `shell` importe les modèles.
+
 ## 2025-04-07
 
 - Mise à jour vers Postgres 17: si vous utilisez docker il faudra supprimer

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -28,7 +28,6 @@ AUTH_PASSWORD_VALIDATORS = []
 
 INSTALLED_APPS.extend(  # noqa: F405
     [
-        "django_extensions",
         "debug_toolbar",
     ]
 )

--- a/itou/utils/management/commands/shell.py
+++ b/itou/utils/management/commands/shell.py
@@ -1,0 +1,10 @@
+from django.core.management.commands import shell
+
+
+class Command(shell.Command):
+    def get_auto_imports(self):
+        return super().get_auto_imports() + [
+            "django.conf.settings",
+            "django.utils.timezone",
+            "datetime",
+        ]

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,4 +11,3 @@ pre-commit  # https://github.com/pre-commit/pre-commit
 # Django
 # ------------------------------------------------------------------------------
 django-debug-toolbar  # https://github.com/jazzband/django-debug-toolbar
-django-extensions  # https://github.com/django-extensions/django-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -378,7 +378,6 @@ django==5.2.2 \
     #   django-csp
     #   django-datadog-logger
     #   django-debug-toolbar
-    #   django-extensions
     #   django-filter
     #   django-formtools
     #   django-hijack
@@ -425,10 +424,6 @@ django-datadog-logger==0.7.3 \
 django-debug-toolbar==5.2.0 \
     --hash=sha256:15627f4c2836a9099d795e271e38e8cf5204ccd79d5dbcd748f8a6c284dcd195 \
     --hash=sha256:9e7f0145e1a1b7d78fcc3b53798686170a5b472d9cf085d88121ff823e900821
-    # via -r requirements/dev.in
-django-extensions==4.1 \
-    --hash=sha256:0699a7af28f2523bf8db309a80278519362cd4b6e1fd0a8cd4bf063e1e023336 \
-    --hash=sha256:7b70a4d28e9b840f44694e3f7feb54f55d495f8b3fa6c5c0e5e12bcb2aa3cdeb
     # via -r requirements/dev.in
 django-filter==25.1 \
     --hash=sha256:1ec9eef48fa8da1c0ac9b411744b16c3f4c31176c867886e4c48da369c407153 \


### PR DESCRIPTION
## :thinking: Pourquoi ?

La commande `shell` de django importe à présent les modèles, et on peut ajouter `datetime` comme on le faisait avec `django-extensions`

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
