### PR TITLE
Tech : Correction d'un argument ayant changé de nom en Django 5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ quality: $(VIRTUAL_ENV)
 	find * -type f -name '*.sh' -exec shellcheck --external-sources {} +
 	python manage.py makemigrations --check --dry-run --noinput || (echo "⚠ Missing migration ⚠"; exit 1)
 	python manage.py collectstatic --no-input
+	python manage.py findstatic favicon.ico vendor/theme-inclusion/stylesheets/app.css vendor/jquery/jquery.min.js
 	# Make sure pytest help is still accessible.
 	pytest --help >/dev/null
 

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -363,5 +363,5 @@ class DownloadAndVendorStaticFilesFinder(BaseFinder):
         update_all()
         return []
 
-    def find(self, path, all=False):
+    def find(self, path, find_all=False):
         return []


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à la [MAJ de Django en 5.2](https://github.com/gip-inclusion/les-emplois/pull/6287) mon `runserver` échoue avec une erreur `TypeError: DownloadAndVendorStaticFilesFinder.find() got an unexpected keyword argument 'find_all'`.
Et je reproduis l'erreur avec `findstatic` donc j'en ai profité pour l'ajouter à la recette du Makefile.

