### PR TITLE
Resserrer les select_for_update() pour mieux gérer la concurrence

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -86,7 +86,7 @@ class CommonApprovalMixin(models.Model):
     def last_number(cls):
         # Lock the table's first row until the end of the transaction, effectively acting as a
         # poor man's semaphore.
-        cls.objects.order_by("pk").select_for_update().first()
+        cls.objects.order_by("pk").select_for_update(of=("self",), no_key=True).first()
         # Now we can do a whole new SELECT that will take into account eventual new rows.
         number = (
             cls.objects.filter(number__startswith=Approval.ASP_ITOU_PREFIX)

--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -30,7 +30,7 @@ def certify_criteria(eligibility_diagnosis):
             administrative_criteria__kind__in=CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS,
             eligibility_diagnosis=eligibility_diagnosis,
         )
-        .select_for_update(no_key=True)
+        .select_for_update(of=("self",), no_key=True)
         .select_related("administrative_criteria")
     )
     with api_particulier.client() as client:

--- a/itou/emails/tasks.py
+++ b/itou/emails/tasks.py
@@ -69,7 +69,7 @@ _NB_RETRIES = int(
 def _async_send_message(email_id, *, task=None):
     with transaction.atomic():
         try:
-            email = Email.objects.select_for_update(no_key=True).get(pk=email_id)
+            email = Email.objects.select_for_update(of=("self",), no_key=True).get(pk=email_id)
         except Email.DoesNotExist:
             # Email deleted from django admin, stop trying to send it.
             logger.warning("Not sending email_id=%d, it does not exist in the database.", email_id)

--- a/itou/geiq/sync.py
+++ b/itou/geiq/sync.py
@@ -125,7 +125,9 @@ def sync_employee_and_contracts(assessment):
     assessment_antenna_ids = []
     assert not assessment.contracts_synced_at
     # Prevent concurrent sync on the same assessment
-    assessment = geiq_assessments_models.Assessment.objects.select_for_update().get(pk=assessment.pk)
+    assessment = geiq_assessments_models.Assessment.objects.select_for_update(of=("self",), no_key=True).get(
+        pk=assessment.pk
+    )
     if assessment.contracts_synced_at:
         logger.info(
             "Assessment pk=%s: contract already synced at %s - aborting",

--- a/itou/gps/management/commands/import_advisor_information.py
+++ b/itou/gps/management/commands/import_advisor_information.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
                     group.beneficiary_id: group
                     for group in FollowUpGroup.objects.filter(beneficiary_id__in=batch.keys())
                     .prefetch_related("memberships")
-                    .select_for_update()
+                    .select_for_update(of=("self",), no_key=True)
                 }
 
                 prescribers_dict = {

--- a/itou/gps/management/commands/sync_follow_up_groups_and_members.py
+++ b/itou/gps/management/commands/sync_follow_up_groups_and_members.py
@@ -106,7 +106,7 @@ class Command(BaseCommand):
                     group.beneficiary_id: group
                     for group in FollowUpGroup.objects.filter(beneficiary_id__in=beneficiaries_ids)
                     .prefetch_related("memberships")
-                    .select_for_update()
+                    .select_for_update(of=("self",), no_key=True)
                 }
 
                 memberships_to_create = []

--- a/itou/job_applications/management/commands/reject_job_applications_after_delay.py
+++ b/itou/job_applications/management/commands/reject_job_applications_after_delay.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
                 job_seeker_applications = (
                     JobApplication.objects.filter(job_seeker_id=job_seeker["job_seeker"])
                     .automatically_rejectable_applications()
-                    .select_for_update()
+                    .select_for_update(of=("self",), no_key=True, skip_locked=True)
                 )
 
                 for job_seeker_job_application in job_seeker_applications:

--- a/itou/www/apply/views/batch_views.py
+++ b/itou/www/apply/views/batch_views.py
@@ -36,7 +36,7 @@ def _get_and_lock_received_applications(request, application_ids, lock=True):
     company = get_current_company_or_404(request)
     qs = company.job_applications_received.filter(pk__in=application_ids)
     if lock:
-        qs = qs.select_for_update()
+        qs = qs.select_for_update(of=("self",), no_key=True)
     applications = list(qs)
     if mismatch_nb := len(application_ids) - len(applications):
         if mismatch_nb > 1:

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -830,7 +830,7 @@ def send_diagoriente_invite(request, job_application_id):
     As a company member, I can send a Diagoriente invite to the prescriber or the job seeker.
     """
     queryset = JobApplication.objects.is_active_company_member(request.user)
-    job_application = get_object_or_404(queryset.select_for_update(), pk=job_application_id)
+    job_application = get_object_or_404(queryset.select_for_update(of=("self",), no_key=True), pk=job_application_id)
     if not job_application.resume_id and not job_application.diagoriente_invite_sent_at:
         if job_application.is_sent_by_proxy:
             job_application.email_diagoriente_invite_for_prescriber.send()

--- a/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
+++ b/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
@@ -1191,7 +1191,7 @@
           WHERE "emails_email"."id" = %s
           LIMIT 21
           FOR NO KEY
-          UPDATE
+          UPDATE OF "emails_email"
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

Incident en production aujourd’hui, tout le site était très lent.

## :cake: Comment ? <!-- optionnel -->

https://docs.djangoproject.com/en/5.2/ref/models/querysets/

> By default, select_for_update() locks all rows that are selected by the query. For example, rows of related objects specified in select_related() are locked in addition to rows of the queryset’s model. If this isn’t desired, specify the related objects you want to lock in select_for_update(of=(...)) using the same fields syntax as select_related(). Use the value 'self' to refer to the queryset’s model.

```sql
SELECT * FROM pg_stat_activity;
```
a révélé plus de 70 requêtes en attente pour des SelectedAdministrativeCriteria. D’après la description ci-dessus, le critère administratif correspondant était aussi verrouillé, ce qui limitait beaucoup la concurrence et ralentissait tout le site.

Pour éviter ce problème dans le futur, utilisons `of=('self',)`. Aussi, ajouter `FOR NO KEY UPDATE` permet à la base de données de valider les contraintes référentielles sans attendre le relâchement du verrou.
