### PR TITLE
Tech: Ajout d'un mode de maintenance

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -138,6 +138,9 @@ MIDDLEWARE = [
     # Django stack
     "django.middleware.gzip.GZipMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    # Maintenance: if enabled we will skip all the remaning middlewares
+    "itou.www.middleware.maintenance",
+    # Django stack again
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -828,3 +831,9 @@ REQUIRE_OTP_FOR_STAFF = os.getenv("REQUIRE_OTP_FOR_STAFF", "True") == "True"
 # Notify_archive_users
 # ------------------------------------------------------------------------------
 SUSPEND_NOTIFY_ARCHIVE_USERS = os.getenv("SUSPEND_NOTIFY_ARCHIVE_USERS", "False") == "True"
+
+
+# Mainenance mode
+# ------------------------------------------------------------------------------
+MAINTENANCE_MODE = os.getenv("MAINTENANCE_MODE", "False") == "True"
+MAINTENANCE_DESCRIPTION = os.getenv("MAINTENANCE_DESCRIPTION", None)

--- a/itou/templates/static/maintenance.html
+++ b/itou/templates/static/maintenance.html
@@ -1,0 +1,30 @@
+{% extends "layout/base.html" %}
+{% load components %}
+
+{% block title %}Maintenance {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Maintenance</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="row">
+                <div class="col-12">
+                    <p>
+                        {% if description %}
+                            {{ description }}
+                        {% else %}
+                            Le service est actuellement en maintenance, revenez dans quelques minutes.
+                        {% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}

--- a/itou/www/middleware.py
+++ b/itou/www/middleware.py
@@ -1,8 +1,12 @@
 import sentry_sdk
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
 from django.core.files.storage import default_storage
 from django.db import connection
+from django.http import JsonResponse
 from django.http.response import HttpResponse, HttpResponseServerError
+from django.shortcuts import render
 from django.utils.cache import add_never_cache_headers
 
 
@@ -25,24 +29,42 @@ def public_health_check(get_response):
         a 400 BadRequest because the request Host header is not in the ALLOWED_HOSTS.
         """
         if request.path == "/check-health":
+            body = b"Healthy\n"
+            ok_response = HttpResponse(
+                body,
+                content_type="text/plain",
+                charset="utf-8",
+                # CommonMiddleware is later in the middleware chain, and it checks ALLOWED_HOSTS.
+                headers={
+                    "Content-Length": str(len(body)),
+                },
+            )
+            if settings.MAINTENANCE_MODE is True:
+                return ok_response
+
             try:
                 with connection.cursor() as c:
                     c.execute("SELECT 'check-database-connection'")
                 cache.get("check-cache-connection")
                 default_storage.exists("check-s3-file-access.txt")
-                body = b"Healthy\n"
-                return HttpResponse(
-                    body,
-                    content_type="text/plain",
-                    charset="utf-8",
-                    # CommonMiddleware is later in the middleware chain, and it checks ALLOWED_HOSTS.
-                    headers={
-                        "Content-Length": str(len(body)),
-                    },
-                )
+                return ok_response
             except Exception as e:
                 sentry_sdk.capture_exception(e)
                 return HttpResponseServerError()
+        return get_response(request)
+
+    return middleware
+
+
+def maintenance(get_response):
+    def middleware(request):
+        if settings.MAINTENANCE_MODE is True:
+            if request.content_type == "application/json":
+                return JsonResponse({"error": settings.MAINTENANCE_DESCRIPTION or "maintenance en cours"}, status=503)
+            request.user = AnonymousUser()  # for itou.utils.context_processors.matomo
+            return render(
+                request, "static/maintenance.html", context={"description": settings.MAINTENANCE_DESCRIPTION}
+            )
         return get_response(request)
 
     return middleware

--- a/tests/www/__snapshots__/test_maintenance.ambr
+++ b/tests/www/__snapshots__/test_maintenance.ambr
@@ -1,0 +1,71 @@
+# serializer version: 1
+# name: test_maintenance[no_description]
+  '''
+  <main class="s-main" id="main" role="main">
+      <div aria-atomic="true" aria-live="polite" class="toast-container">
+      </div>
+      <section class="s-title-02">
+          <div class="s-title-02__container container">
+              <div class="s-title-02__row row">
+                  <div class="s-title-02__col col-12">
+                      <div class="c-title">
+                          <div class="c-title__main">
+                              <h1>
+                                  Maintenance
+                              </h1>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12">
+                      <p>
+                          Le service est actuellement en maintenance, revenez dans quelques minutes.
+                      </p>
+                  </div>
+              </div>
+          </div>
+      </section>
+  </main>
+  
+  '''
+# ---
+# name: test_maintenance[with_description]
+  '''
+  <main class="s-main" id="main" role="main">
+      <div aria-atomic="true" aria-live="polite" class="toast-container">
+      </div>
+      <section class="s-title-02">
+          <div class="s-title-02__container container">
+              <div class="s-title-02__row row">
+                  <div class="s-title-02__col col-12">
+                      <div class="c-title">
+                          <div class="c-title__main">
+                              <h1>
+                                  Maintenance
+                              </h1>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+      </section>
+      <section class="s-section">
+          <div class="s-section__container container">
+              <div class="row">
+                  <div class="col-12">
+                      <p>
+                          Oups
+                      </p>
+                  </div>
+              </div>
+          </div>
+      </section>
+  </main>
+  
+  '''
+# ---

--- a/tests/www/test_maintenance.py
+++ b/tests/www/test_maintenance.py
@@ -1,0 +1,35 @@
+from django.urls import reverse
+from pytest_django.asserts import assertNumQueries
+
+from tests.users.factories import JobSeekerFactory
+from tests.utils.test import parse_response_to_soup, pretty_indented
+
+
+def test_maintenance(client, settings, snapshot):
+    # Maintenance mode
+    settings.MAINTENANCE_MODE = True
+    with assertNumQueries(0):
+        response = client.get(reverse("dashboard:index"))
+    assert pretty_indented(parse_response_to_soup(response, "main")) == snapshot(name="no_description")
+
+    with assertNumQueries(0):
+        response = client.get(reverse("dashboard:index"), headers={"Content-Type": "application/json"})
+    assert response.json() == {"error": "maintenance en cours"}
+    assert response.status_code == 503
+
+    # With description
+    settings.MAINTENANCE_DESCRIPTION = "Oups"
+    with assertNumQueries(0):
+        response = client.get(reverse("dashboard:index"))
+    assert pretty_indented(parse_response_to_soup(response, "main")) == snapshot(name="with_description")
+
+    with assertNumQueries(0):
+        response = client.get(reverse("dashboard:index"), headers={"Content-Type": "application/json"})
+    assert response.json() == {"error": "Oups"}
+    assert response.status_code == 503
+
+    # Still no queries if the user was logged in
+    user = JobSeekerFactory()
+    client.force_login(user)
+    with assertNumQueries(0):
+        response = client.get(reverse("dashboard:index"))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour permettre de facilement faire des petites coupures de service pour certains déploiements

- [x] Finir de nettoyer le template (retirer les boutons de login/signup, recherche, etc)
![image](https://github.com/user-attachments/assets/0f164d2c-28fa-499d-901f-e32eef2b9067)
- [x] Ajouter les tests
- [x] Peut être permettre l'affichage d'un message personnalisé (utile dans le cadre d'une maintenance plus longue et programmée) ?

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
