### PR TITLE
Nouveautés: correction de l'affichage de la modale

### DIFF
--- a/itou/static/js/demo_accounts.js
+++ b/itou/static/js/demo_accounts.js
@@ -1,12 +1,12 @@
-function supports_local_storage() {
-    try {
-        return 'localStorage' in window && window['localStorage'] !== null;
-    } catch(e){
-        return false;
-    }
-}
-
 $(document).ready(function(){
+    function supports_local_storage() {
+        try {
+            return 'localStorage' in window && window['localStorage'] !== null;
+        } catch(e){
+            return false;
+        }
+    }
+
     if (supports_local_storage()) {
         infoKey = localStorage.getItem("testAccountsModal");
         if (!infoKey) {

--- a/itou/static/js/demo_accounts.js
+++ b/itou/static/js/demo_accounts.js
@@ -1,19 +1,9 @@
 $(document).ready(function(){
-    function supports_local_storage() {
-        try {
-            return 'localStorage' in window && window['localStorage'] !== null;
-        } catch(e){
-            return false;
-        }
-    }
-
-    if (supports_local_storage()) {
-        infoKey = localStorage.getItem("testAccountsModal");
-        if (!infoKey) {
-            localStorage.setItem("testAccountsModal", true);
-            const testAccountsModal = new bootstrap.Modal("#testAccountsModal");
-        }
-    }
+      infoKey = localStorage.getItem("testAccountsModal");
+      if (!infoKey) {
+          localStorage.setItem("testAccountsModal", true);
+          const testAccountsModal = new bootstrap.Modal("#testAccountsModal");
+      }
 
     $('.postLogin').on('click', function(){
         const actionUrl = $(this).data('action-url');

--- a/itou/templates/layout/_news_modal.html
+++ b/itou/templates/layout/_news_modal.html
@@ -30,6 +30,14 @@
 
 <script nonce="{{ CSP_NONCE }}">
     $(document).ready(function() {
+        function supports_local_storage() {
+            try {
+                return 'localStorage' in window && window['localStorage'] !== null;
+            } catch (e) {
+                return false;
+            }
+        }
+
         // news modal is rendered if there are recent updates which haven't been viewed on this device
         if (supports_local_storage()) {
             let lastNewsModalViewed = localStorage.getItem("lastNewsModalViewed");

--- a/itou/templates/layout/_news_modal.html
+++ b/itou/templates/layout/_news_modal.html
@@ -30,24 +30,14 @@
 
 <script nonce="{{ CSP_NONCE }}">
     $(document).ready(function() {
-        function supports_local_storage() {
-            try {
-                return 'localStorage' in window && window['localStorage'] !== null;
-            } catch (e) {
-                return false;
-            }
-        }
-
         // news modal is rendered if there are recent updates which haven't been viewed on this device
-        if (supports_local_storage()) {
-            let lastNewsModalViewed = localStorage.getItem("lastNewsModalViewed");
-            let newsModalUpdated = new Date($("#news-modal-start-date").val());
+        let lastNewsModalViewed = localStorage.getItem("lastNewsModalViewed");
+        let newsModalUpdated = new Date($("#news-modal-start-date").val());
 
-            if (!lastNewsModalViewed || new Date(lastNewsModalViewed) < newsModalUpdated) {
-                localStorage.setItem("lastNewsModalViewed", new Date().toISOString());
-                const newsModal = new bootstrap.Modal("#news-modal");
-                newsModal.show();
-            }
+        if (!lastNewsModalViewed || new Date(lastNewsModalViewed) < newsModalUpdated) {
+            localStorage.setItem("lastNewsModalViewed", new Date().toISOString());
+            const newsModal = new bootstrap.Modal("#news-modal");
+            newsModal.show();
         }
     });
 </script>


### PR DESCRIPTION

## :thinking: Pourquoi ?

La fonction `supports_local_storage` n'était dispo que sur la démo & les recettes jetables, pour l'affichage de la modale de connexion des comptes de démo.

La modale de nouveautés n'a donc jamais fonctionné en production :see_no_evil: :smiling_face_with_tear: .

## :cake: Comment ? <!-- optionnel -->

En définissant la fonction uniquement là où elle est utilisée.

Mais je me demande si on ne pourrait pas complètement la supprimer au vu de la compatibilité des navigateurs:
https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#browser_compatibility

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
