### PR TITLE
Vie privée : rendre la tâche de suppression des emails visible de Huey

### DIFF
--- a/itou/archive/management/commands/notify_archive_users.py
+++ b/itou/archive/management/commands/notify_archive_users.py
@@ -10,6 +10,7 @@ from sentry_sdk.crons import monitor
 
 from itou.approvals.models import Approval
 from itou.archive.models import AnonymizedApplication, AnonymizedJobSeeker
+from itou.archive.tasks import async_delete_contact
 from itou.companies.enums import CompanyKind
 from itou.companies.models import JobDescription
 from itou.eligibility.models import EligibilityDiagnosis, GEIQEligibilityDiagnosis
@@ -19,7 +20,6 @@ from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication, JobApplicationTransitionLog
 from itou.users.models import User, UserKind
 from itou.users.notifications import ArchiveUser, InactiveUser
-from itou.utils.brevo import async_delete_contact
 from itou.utils.command import BaseCommand
 from itou.utils.constants import GRACE_PERIOD, INACTIVITY_PERIOD
 

--- a/itou/archive/tasks.py
+++ b/itou/archive/tasks.py
@@ -1,0 +1,16 @@
+import logging
+
+from huey.contrib.djhuey import task
+
+from itou.utils.brevo import BrevoClient
+
+
+logger = logging.getLogger(__name__)
+
+
+@task(retries=24 * 6 * 90, retry_delay=10 * 60, context=True)  # Retry every 10 minutes during 90 days.
+def async_delete_contact(email, *, task=None):
+    with BrevoClient() as brevo_client:
+        if task.retries % 100 == 0:
+            logger.warning("Attempting to delete email %s, remaining %d retries", email, task.retries)
+        brevo_client.delete_contact(email)

--- a/itou/utils/brevo.py
+++ b/itou/utils/brevo.py
@@ -4,7 +4,6 @@ from itertools import batched
 
 import httpx
 from django.conf import settings
-from huey.contrib.djhuey import task
 
 
 logger = logging.getLogger(__name__)
@@ -88,11 +87,3 @@ class BrevoClient:
         except httpx.HTTPStatusError as e:
             logger.error(f"Brevo API: HTTP error occurred: {str(e)}")
             raise
-
-
-@task(retries=24 * 6 * 90, retry_delay=10 * 60, context=True)  # Retry every 10 minutes during 90 days.
-def async_delete_contact(email, *, task=None):
-    with BrevoClient() as brevo_client:
-        if task.retries % 100 == 0:
-            logger.warning("Attempting to delete email %s, remaining %d retries", email, task.retries)
-        brevo_client.delete_contact(email)

--- a/tests/archive/__snapshots__/tests_tasks.ambr
+++ b/tests/archive/__snapshots__/tests_tasks.ambr
@@ -1,0 +1,7 @@
+# serializer version: 1
+# name: test_async_delete_contact_retries_warning[100][attempting-to-delete-email-100-retries]
+  'Attempting to delete email somebody@email.com, remaining 100 retries'
+# ---
+# name: test_async_delete_contact_retries_warning[200][attempting-to-delete-email-200-retries]
+  'Attempting to delete email somebody@email.com, remaining 200 retries'
+# ---

--- a/tests/archive/tests_tasks.py
+++ b/tests/archive/tests_tasks.py
@@ -1,0 +1,38 @@
+import httpx
+import pytest
+
+from itou.archive.tasks import async_delete_contact
+from itou.utils.brevo import BREVO_API_URL
+from tests.utils.test_brevo import brevo_client_fixture  # noqa: F401
+
+
+@pytest.mark.parametrize("status_code", [204, 404])
+def test_delete_contact(respx_mock, django_capture_on_commit_callbacks, status_code, caplog, brevo_client):
+    email = "somebody@mail.com"
+    respx_mock.delete(f"{BREVO_API_URL}/contacts/{email}?identifierType=email_id").mock(
+        return_value=httpx.Response(status_code=status_code)
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        async_delete_contact(email)
+
+    assert [record.levelname for record in caplog.records] == ["INFO"]
+
+
+@pytest.mark.parametrize("retries", [1, 100, 200])
+def test_async_delete_contact_retries_warning(
+    respx_mock, django_capture_on_commit_callbacks, retries, caplog, snapshot, brevo_client
+):
+    email = "somebody@email.com"
+    respx_mock.delete(f"{BREVO_API_URL}/contacts/{email}?identifierType=email_id").mock(
+        return_value=httpx.Response(status_code=503)
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        async_delete_contact(email, retries=retries)
+
+    assert respx_mock.calls.called
+
+    if retries % 100 == 0:
+        warning_record = next(record for record in caplog.records if record.levelname == "WARNING")
+        assert warning_record.message == snapshot(name=f"attempting-to-delete-email-{retries}-retries")

--- a/tests/utils/__snapshots__/test_brevo.ambr
+++ b/tests/utils/__snapshots__/test_brevo.ambr
@@ -1,10 +1,4 @@
 # serializer version: 1
-# name: test_async_delete_contact_retries_warning[100][attempting-to-delete-email-100-retries]
-  'Attempting to delete email somebody@email.com, remaining 100 retries'
-# ---
-# name: test_async_delete_contact_retries_warning[200][attempting-to-delete-email-200-retries]
-  'Attempting to delete email somebody@email.com, remaining 200 retries'
-# ---
 # name: test_delete_contact_on_http_status_error[brevo-api-http-error-500]
   '''
   Brevo API: HTTP error occurred: Server error '500 Internal Server Error' for url 'https://api.brevo.com/v3/contacts/somebody@mail.com?identifierType=email_id'

--- a/tests/utils/test_brevo.py
+++ b/tests/utils/test_brevo.py
@@ -1,7 +1,7 @@
 import httpx
 import pytest
 
-from itou.utils.brevo import BREVO_API_URL, BrevoClient, async_delete_contact
+from itou.utils.brevo import BREVO_API_URL, BrevoClient
 from tests.users.factories import JobSeekerFactory
 
 
@@ -74,19 +74,6 @@ def test_import_contacts_request_error(mocker, caplog, brevo_client):
     assert error_record.message == "Brevo API: Request failed: Connection timed out"
 
 
-@pytest.mark.parametrize("status_code", [204, 404])
-def test_delete_contact(respx_mock, django_capture_on_commit_callbacks, status_code, caplog, brevo_client):
-    email = "somebody@mail.com"
-    respx_mock.delete(f"{BREVO_API_URL}/contacts/{email}?identifierType=email_id").mock(
-        return_value=httpx.Response(status_code=status_code)
-    )
-
-    with django_capture_on_commit_callbacks(execute=True):
-        async_delete_contact(email)
-
-    assert [record.levelname for record in caplog.records] == ["INFO"]
-
-
 def test_delete_contact_request_error(mocker, caplog, snapshot, brevo_client):
     mocker.patch("itou.utils.brevo.httpx.Client.delete", side_effect=httpx.RequestError("Connection timed out"))
 
@@ -112,22 +99,3 @@ def test_delete_contact_on_http_status_error(respx_mock, caplog, snapshot, brevo
 
     error_record = next(record for record in caplog.records if record.levelname == "ERROR")
     assert error_record.message == snapshot(name="brevo-api-http-error-500")
-
-
-@pytest.mark.parametrize("retries", [1, 100, 200])
-def test_async_delete_contact_retries_warning(
-    respx_mock, django_capture_on_commit_callbacks, retries, caplog, snapshot, brevo_client
-):
-    email = "somebody@email.com"
-    respx_mock.delete(f"{BREVO_API_URL}/contacts/{email}?identifierType=email_id").mock(
-        return_value=httpx.Response(status_code=503)
-    )
-
-    with django_capture_on_commit_callbacks(execute=True):
-        async_delete_contact(email, retries=retries)
-
-    assert respx_mock.calls.called
-
-    if retries % 100 == 0:
-        warning_record = next(record for record in caplog.records if record.levelname == "WARNING")
-        assert warning_record.message == snapshot(name=f"attempting-to-delete-email-{retries}-retries")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les méthodes décorées par `@task` doivent être déclarées dans un fichier nommé `tasks.py` pour être visible de `Huey`

## :cake: Comment ? <!-- optionnel -->

déplacer de `async_delete_contact` dans un fichier `tasks.py` dans l'app `Archive`

