### PR TITLE
Décorer toutes les tâches asynchrones avec on_commit_task

### DIFF
--- a/itou/archive/management/commands/notify_archive_users.py
+++ b/itou/archive/management/commands/notify_archive_users.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-from functools import partial
 
 from django.conf import settings
 from django.db import transaction
@@ -249,7 +248,7 @@ class Command(BaseCommand):
         FollowUpGroup.objects.filter(beneficiary__in=users).delete()
         User.objects.filter(id__in=[user.id for user in users]).delete()
         for user in users:
-            transaction.on_commit(partial(async_delete_contact, user.email))
+            async_delete_contact(user.email)
 
     def _delete_jobapplications_with_related_objects(self, jobapplications):
         File.objects.filter(deleted_at__isnull=True, jobapplication__in=jobapplications).update(

--- a/itou/archive/tasks.py
+++ b/itou/archive/tasks.py
@@ -1,6 +1,6 @@
 import logging
 
-from huey.contrib.djhuey import task
+from huey.contrib.djhuey import on_commit_task
 
 from itou.utils.brevo import BrevoClient
 
@@ -8,7 +8,7 @@ from itou.utils.brevo import BrevoClient
 logger = logging.getLogger(__name__)
 
 
-@task(retries=24 * 6 * 90, retry_delay=10 * 60, context=True)  # Retry every 10 minutes during 90 days.
+@on_commit_task(retries=24 * 6 * 90, retry_delay=10 * 60, context=True)  # Retry every 10 minutes during 90 days.
 def async_delete_contact(email, *, task=None):
     with BrevoClient() as brevo_client:
         if task.retries % 100 == 0:

--- a/itou/gps/grist.py
+++ b/itou/gps/grist.py
@@ -2,13 +2,13 @@ import httpx
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
-from huey.contrib.djhuey import task
+from huey.contrib.djhuey import on_commit_task
 
 from itou.users.enums import UserKind
 from itou.utils.urls import get_absolute_url
 
 
-@task(retries=3, retry_delay=10)
+@on_commit_task(retries=3, retry_delay=10)
 def add_records(doc_id, table_id, records):
     if settings.GRIST_API_KEY is None:
         return


### PR DESCRIPTION
## :thinking: Pourquoi ?

S’assurer que les tâches ne soient exécutées que si la transaction est _commitée_, et seulement après le `COMMIT`.
