### PR TITLE
Fiches Salarié : Réduction du nombre de requête SQL lors de l'envoi

### DIFF
--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -139,8 +139,10 @@ class Command(EmployeeRecordTransferCommand):
         },
     )
     def upload(self, sftp: paramiko.SFTPClient, dry_run: bool):
-        new_notifications = EmployeeRecordUpdateNotification.objects.filter(status=NotificationStatus.NEW).order_by(
-            "updated_at", "pk"
+        new_notifications = (
+            EmployeeRecordUpdateNotification.objects.full_fetch()
+            .filter(status=NotificationStatus.NEW)
+            .order_by("updated_at", "pk")
         )
 
         if len(new_notifications) > 0:

--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -144,6 +144,7 @@ class EmployeeRecordQuerySet(models.QuerySet):
             "job_application",
             "job_application__approval",
             "job_application__to_company",
+            "job_application__to_company__convention",
             "job_application__job_seeker",
             "job_application__job_seeker__jobseeker_profile__birth_country",
             "job_application__job_seeker__jobseeker_profile__birth_place",
@@ -639,6 +640,20 @@ class EmployeeRecordUpdateNotificationWorkflow(xwf_models.Workflow):
 class EmployeeRecordUpdateNotificationQuerySet(QuerySet):
     def find_by_batch(self, filename, line_number):
         return self.filter(asp_batch_file=filename, asp_batch_line_number=line_number)
+
+    def full_fetch(self):
+        return self.select_related(
+            "employee_record",
+            "employee_record__job_application",
+            "employee_record__job_application__approval",
+            "employee_record__job_application__to_company",
+            "employee_record__job_application__job_seeker",
+            "employee_record__job_application__job_seeker__jobseeker_profile__birth_country",
+            "employee_record__job_application__job_seeker__jobseeker_profile__birth_place",
+            "employee_record__job_application__job_seeker__jobseeker_profile",
+            "employee_record__job_application__job_seeker__jobseeker_profile__hexa_commune",
+            "employee_record__job_application__sender_prescriber_organization",
+        )
 
 
 class EmployeeRecordUpdateNotification(ASPExchangeInformation, xwf_models.WorkflowEnabled):

--- a/tests/api/employee_record_api/__snapshots__/tests.ambr
+++ b/tests/api/employee_record_api/__snapshots__/tests.ambr
@@ -490,6 +490,16 @@
                  "companies_company"."is_searchable",
                  "companies_company"."rdv_solidarites_id",
                  "companies_company"."fields_history",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at",
                  "approvals_approval"."id",
                  "approvals_approval"."start_at",
                  "approvals_approval"."end_at",
@@ -526,6 +536,7 @@
           LEFT OUTER JOIN "asp_country" ON ("users_jobseekerprofile"."birth_country_id" = "asp_country"."id")
           LEFT OUTER JOIN "asp_commune" T8 ON ("users_jobseekerprofile"."hexa_commune_id" = T8."id")
           LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
           LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
           LEFT OUTER JOIN "companies_siaefinancialannex" ON ("employee_record_employeerecord"."financial_annex_id" = "companies_siaefinancialannex"."id")
           WHERE ("employee_record_employeerecord"."status" IN (%s,

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -65,7 +65,7 @@
 # ---
 # name: test_upload_and_download[download]
   dict({
-    'num_queries': 14,
+    'num_queries': 5,
     'queries': list([
       dict({
         'origin': list([
@@ -101,26 +101,8 @@
                  "employee_record_employeerecord"."asp_id",
                  "employee_record_employeerecord"."asp_measure",
                  "employee_record_employeerecord"."siret",
-                 "employee_record_employeerecord"."processed_as_duplicate"
-          FROM "employee_record_employeerecord"
-          WHERE ("employee_record_employeerecord"."asp_batch_file" = %s
-                 AND "employee_record_employeerecord"."asp_batch_line_number" = %s)
-          ORDER BY "employee_record_employeerecord"."created_at" DESC
-          LIMIT 1
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_application[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplication"."id",
+                 "employee_record_employeerecord"."processed_as_duplicate",
+                 "job_applications_jobapplication"."id",
                  "job_applications_jobapplication"."job_seeker_id",
                  "job_applications_jobapplication"."eligibility_diagnosis_id",
                  "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
@@ -165,138 +147,8 @@
                  "job_applications_jobapplication"."qualification_level",
                  "job_applications_jobapplication"."planned_training_hours",
                  "job_applications_jobapplication"."inverted_vae_contract",
-                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
-          FROM "job_applications_jobapplication"
-          WHERE "job_applications_jobapplication"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_application[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."spontaneous_applications_open_since",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 "companies_company"."fields_history"
-          FROM "companies_company"
-          WHERE "companies_company"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_application[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_siaeconvention"."id",
-                 "companies_siaeconvention"."kind",
-                 "companies_siaeconvention"."siret_signature",
-                 "companies_siaeconvention"."is_active",
-                 "companies_siaeconvention"."deactivated_at",
-                 "companies_siaeconvention"."reactivated_by_id",
-                 "companies_siaeconvention"."reactivated_at",
-                 "companies_siaeconvention"."asp_id",
-                 "companies_siaeconvention"."created_at",
-                 "companies_siaeconvention"."updated_at"
-          FROM "companies_siaeconvention"
-          WHERE "companies_siaeconvention"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_application[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 "users_user"."id",
                  "users_user"."password",
                  "users_user"."last_login",
                  "users_user"."is_superuser",
@@ -330,24 +182,8 @@
                  "users_user"."address_filled_at",
                  "users_user"."first_login",
                  "users_user"."upcoming_deletion_notified_at",
-                 "users_user"."allow_next_sso_sub_update"
-          FROM "users_user"
-          WHERE "users_user"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "users_jobseekerprofile"."user_id",
+                 "users_user"."allow_next_sso_sub_update",
+                 "users_jobseekerprofile"."user_id",
                  "users_jobseekerprofile"."birthdate",
                  "users_jobseekerprofile"."birth_place_id",
                  "users_jobseekerprofile"."birth_country_id",
@@ -385,89 +221,150 @@
                  "users_jobseekerprofile"."pe_last_certification_attempt_at",
                  "users_jobseekerprofile"."created_by_prescriber_organization_id",
                  "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."fields_history"
-          FROM "users_jobseekerprofile"
-          WHERE "users_jobseekerprofile"."user_id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'JobSeekerProfile._clean_birth_fields[users/models.py]',
-          'JobSeekerProfile._clean_job_seeker_details[users/models.py]',
-          'JobSeekerProfile.clean_model[users/models.py]',
-          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_country"."id",
+                 "users_jobseekerprofile"."fields_history",
+                 "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore",
+                 "asp_country"."id",
                  "asp_country"."code",
                  "asp_country"."name",
                  "asp_country"."group",
-                 "asp_country"."department"
-          FROM "asp_country"
-          WHERE "asp_country"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'JobSeekerProfile._clean_birth_fields[users/models.py]',
-          'JobSeekerProfile._clean_job_seeker_details[users/models.py]',
-          'JobSeekerProfile.clean_model[users/models.py]',
-          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_commune"."id",
-                 "asp_commune"."start_date",
-                 "asp_commune"."end_date",
-                 "asp_commune"."code",
-                 "asp_commune"."name",
-                 "asp_commune"."normalized_name",
-                 "asp_commune"."created_at",
-                 "asp_commune"."city_id",
-                 "asp_commune"."ignore"
-          FROM "asp_commune"
-          WHERE "asp_commune"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'JobSeekerProfile._clean_job_seeker_hexa_address[users/models.py]',
-          'JobSeekerProfile.clean_model[users/models.py]',
-          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.process[employee_record/models.py]',
-          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.download_json_file[employee_record/common_management.py]',
-          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_commune"."id",
-                 "asp_commune"."start_date",
-                 "asp_commune"."end_date",
-                 "asp_commune"."code",
-                 "asp_commune"."name",
-                 "asp_commune"."normalized_name",
-                 "asp_commune"."created_at",
-                 "asp_commune"."city_id",
-                 "asp_commune"."ignore"
-          FROM "asp_commune"
-          WHERE "asp_commune"."id" = %s
-          LIMIT 21
+                 "asp_country"."department",
+                 T7."id",
+                 T7."start_date",
+                 T7."end_date",
+                 T7."code",
+                 T7."name",
+                 T7."normalized_name",
+                 T7."created_at",
+                 T7."city_id",
+                 T7."ignore",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id",
+                 "companies_siaefinancialannex"."id",
+                 "companies_siaefinancialannex"."number",
+                 "companies_siaefinancialannex"."state",
+                 "companies_siaefinancialannex"."start_at",
+                 "companies_siaefinancialannex"."end_at",
+                 "companies_siaefinancialannex"."created_at",
+                 "companies_siaefinancialannex"."updated_at",
+                 "companies_siaefinancialannex"."convention_id"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "asp_commune" ON ("users_jobseekerprofile"."birth_place_id" = "asp_commune"."id")
+          LEFT OUTER JOIN "asp_country" ON ("users_jobseekerprofile"."birth_country_id" = "asp_country"."id")
+          LEFT OUTER JOIN "asp_commune" T7 ON ("users_jobseekerprofile"."hexa_commune_id" = T7."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
+          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          LEFT OUTER JOIN "companies_siaefinancialannex" ON ("employee_record_employeerecord"."financial_annex_id" = "companies_siaefinancialannex"."id")
+          WHERE ("employee_record_employeerecord"."asp_batch_file" = %s
+                 AND "employee_record_employeerecord"."asp_batch_line_number" = %s)
+          ORDER BY "employee_record_employeerecord"."created_at" DESC
+          LIMIT 1
         ''',
       }),
       dict({
@@ -561,7 +458,7 @@
 # ---
 # name: test_upload_and_download[upload]
   dict({
-    'num_queries': 13,
+    'num_queries': 3,
     'queries': list([
       dict({
         'origin': list([
@@ -586,24 +483,8 @@
                  "employee_record_employeerecord"."asp_id",
                  "employee_record_employeerecord"."asp_measure",
                  "employee_record_employeerecord"."siret",
-                 "employee_record_employeerecord"."processed_as_duplicate"
-          FROM "employee_record_employeerecord"
-          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
-          WHERE ("job_applications_jobapplication"."state" = %s
-                 AND "employee_record_employeerecord"."status" = %s)
-          ORDER BY "employee_record_employeerecord"."updated_at" ASC,
-                   "employee_record_employeerecord"."id" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplication"."id",
+                 "employee_record_employeerecord"."processed_as_duplicate",
+                 "job_applications_jobapplication"."id",
                  "job_applications_jobapplication"."job_seeker_id",
                  "job_applications_jobapplication"."eligibility_diagnosis_id",
                  "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
@@ -648,70 +529,8 @@
                  "job_applications_jobapplication"."qualification_level",
                  "job_applications_jobapplication"."planned_training_hours",
                  "job_applications_jobapplication"."inverted_vae_contract",
-                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
-          FROM "job_applications_jobapplication"
-          WHERE "job_applications_jobapplication"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."spontaneous_applications_open_since",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 "companies_company"."fields_history"
-          FROM "companies_company"
-          WHERE "companies_company"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 "users_user"."id",
                  "users_user"."password",
                  "users_user"."last_login",
                  "users_user"."is_superuser",
@@ -745,20 +564,8 @@
                  "users_user"."address_filled_at",
                  "users_user"."first_login",
                  "users_user"."upcoming_deletion_notified_at",
-                 "users_user"."allow_next_sso_sub_update"
-          FROM "users_user"
-          WHERE "users_user"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "users_jobseekerprofile"."user_id",
+                 "users_user"."allow_next_sso_sub_update",
+                 "users_jobseekerprofile"."user_id",
                  "users_jobseekerprofile"."birthdate",
                  "users_jobseekerprofile"."birth_place_id",
                  "users_jobseekerprofile"."birth_country_id",
@@ -796,21 +603,8 @@
                  "users_jobseekerprofile"."pe_last_certification_attempt_at",
                  "users_jobseekerprofile"."created_by_prescriber_organization_id",
                  "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."fields_history"
-          FROM "users_jobseekerprofile"
-          WHERE "users_jobseekerprofile"."user_id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          '_PersonSerializer.get_codeComInsee[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_commune"."id",
+                 "users_jobseekerprofile"."fields_history",
+                 "asp_commune"."id",
                  "asp_commune"."start_date",
                  "asp_commune"."end_date",
                  "asp_commune"."code",
@@ -818,91 +612,22 @@
                  "asp_commune"."normalized_name",
                  "asp_commune"."created_at",
                  "asp_commune"."city_id",
-                 "asp_commune"."ignore"
-          FROM "asp_commune"
-          WHERE "asp_commune"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_country"."id",
+                 "asp_commune"."ignore",
+                 "asp_country"."id",
                  "asp_country"."code",
                  "asp_country"."name",
                  "asp_country"."group",
-                 "asp_country"."department"
-          FROM "asp_country"
-          WHERE "asp_country"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_commune"."id",
-                 "asp_commune"."start_date",
-                 "asp_commune"."end_date",
-                 "asp_commune"."code",
-                 "asp_commune"."name",
-                 "asp_commune"."normalized_name",
-                 "asp_commune"."created_at",
-                 "asp_commune"."city_id",
-                 "asp_commune"."ignore"
-          FROM "asp_commune"
-          WHERE "asp_commune"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord.asp_prescriber_type[employee_record/models.py]',
-          'EmployeeRecordSerializer.get_situationSalarie[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "prescribers_prescriberorganization"."id",
+                 "asp_country"."department",
+                 T7."id",
+                 T7."start_date",
+                 T7."end_date",
+                 T7."code",
+                 T7."name",
+                 T7."normalized_name",
+                 T7."created_at",
+                 T7."city_id",
+                 T7."ignore",
+                 "prescribers_prescriberorganization"."id",
                  "prescribers_prescriberorganization"."address_line_1",
                  "prescribers_prescriberorganization"."address_line_2",
                  "prescribers_prescriberorganization"."post_code",
@@ -931,23 +656,45 @@
                  "prescribers_prescriberorganization"."authorization_status",
                  "prescribers_prescriberorganization"."authorization_updated_at",
                  "prescribers_prescriberorganization"."authorization_updated_by_id",
-                 "prescribers_prescriberorganization"."is_gps_authorized"
-          FROM "prescribers_prescriberorganization"
-          WHERE "prescribers_prescriberorganization"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord._clean_job_application[employee_record/models.py]',
-          'EmployeeRecord.clean[employee_record/models.py]',
-          'EmployeeRecord.wait_for_asp_response[employee_record/models.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_siaeconvention"."id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history",
+                 "companies_siaeconvention"."id",
                  "companies_siaeconvention"."kind",
                  "companies_siaeconvention"."siret_signature",
                  "companies_siaeconvention"."is_active",
@@ -956,10 +703,50 @@
                  "companies_siaeconvention"."reactivated_at",
                  "companies_siaeconvention"."asp_id",
                  "companies_siaeconvention"."created_at",
-                 "companies_siaeconvention"."updated_at"
-          FROM "companies_siaeconvention"
-          WHERE "companies_siaeconvention"."id" = %s
-          LIMIT 21
+                 "companies_siaeconvention"."updated_at",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id",
+                 "companies_siaefinancialannex"."id",
+                 "companies_siaefinancialannex"."number",
+                 "companies_siaefinancialannex"."state",
+                 "companies_siaefinancialannex"."start_at",
+                 "companies_siaefinancialannex"."end_at",
+                 "companies_siaefinancialannex"."created_at",
+                 "companies_siaefinancialannex"."updated_at",
+                 "companies_siaefinancialannex"."convention_id"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "asp_commune" ON ("users_jobseekerprofile"."birth_place_id" = "asp_commune"."id")
+          LEFT OUTER JOIN "asp_country" ON ("users_jobseekerprofile"."birth_country_id" = "asp_country"."id")
+          LEFT OUTER JOIN "asp_commune" T7 ON ("users_jobseekerprofile"."hexa_commune_id" = T7."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
+          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          LEFT OUTER JOIN "companies_siaefinancialannex" ON ("employee_record_employeerecord"."financial_annex_id" = "companies_siaefinancialannex"."id")
+          WHERE ("job_applications_jobapplication"."state" = %s
+                 AND "employee_record_employeerecord"."status" = %s)
+          ORDER BY "employee_record_employeerecord"."updated_at" ASC,
+                   "employee_record_employeerecord"."id" ASC
         ''',
       }),
       dict({

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records.ambr
@@ -63,7 +63,479 @@
     'No object to check. Exiting preflight.',
   ])
 # ---
-# name: test_upload_and_download
+# name: test_upload_and_download[download]
+  dict({
+    'num_queries': 14,
+    'queries': list([
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecord"."asp_processing_code",
+                 "employee_record_employeerecord"."asp_processing_label",
+                 "employee_record_employeerecord"."asp_batch_file",
+                 "employee_record_employeerecord"."asp_batch_line_number",
+                 "employee_record_employeerecord"."archived_json",
+                 "employee_record_employeerecord"."created_at",
+                 "employee_record_employeerecord"."updated_at",
+                 "employee_record_employeerecord"."processed_at",
+                 "employee_record_employeerecord"."status",
+                 "employee_record_employeerecord"."job_application_id",
+                 "employee_record_employeerecord"."financial_annex_id",
+                 "employee_record_employeerecord"."approval_number",
+                 "employee_record_employeerecord"."asp_id",
+                 "employee_record_employeerecord"."asp_measure",
+                 "employee_record_employeerecord"."siret",
+                 "employee_record_employeerecord"."processed_as_duplicate"
+          FROM "employee_record_employeerecord"
+          WHERE ("employee_record_employeerecord"."asp_batch_file" = %s
+                 AND "employee_record_employeerecord"."asp_batch_line_number" = %s)
+          ORDER BY "employee_record_employeerecord"."created_at" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_application[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_application[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history"
+          FROM "companies_company"
+          WHERE "companies_company"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_application[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_siaeconvention"
+          WHERE "companies_siaeconvention"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_application[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."fields_history"
+          FROM "users_jobseekerprofile"
+          WHERE "users_jobseekerprofile"."user_id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobSeekerProfile._clean_birth_fields[users/models.py]',
+          'JobSeekerProfile._clean_job_seeker_details[users/models.py]',
+          'JobSeekerProfile.clean_model[users/models.py]',
+          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          WHERE "asp_country"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobSeekerProfile._clean_birth_fields[users/models.py]',
+          'JobSeekerProfile._clean_job_seeker_details[users/models.py]',
+          'JobSeekerProfile.clean_model[users/models.py]',
+          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'JobSeekerProfile._clean_job_seeker_hexa_address[users/models.py]',
+          'JobSeekerProfile.clean_model[users/models.py]',
+          'EmployeeRecord._clean_job_seeker[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.process[employee_record/models.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.save[<site-packages>/django/db/models/base.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          UPDATE "employee_record_employeerecord"
+          SET "asp_processing_code" = %s,
+              "asp_processing_label" = %s,
+              "asp_batch_file" = %s,
+              "asp_batch_line_number" = %s,
+              "archived_json" = %s,
+              "created_at" = %s,
+              "updated_at" = %s,
+              "processed_at" = %s,
+              "status" = %s,
+              "job_application_id" = %s,
+              "financial_annex_id" = NULL,
+              "approval_number" = %s,
+              "asp_id" = %s,
+              "asp_measure" = %s,
+              "siret" = %s,
+              "processed_as_duplicate" = %s
+          WHERE "employee_record_employeerecord"."id" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordTransitionLog.save[<site-packages>/django/db/models/base.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "employee_record_employeerecordtransitionlog" ("transition",
+                                                                     "from_state",
+                                                                     "to_state",
+                                                                     "timestamp",
+                                                                     "asp_processing_code",
+                                                                     "asp_processing_label",
+                                                                     "asp_batch_file",
+                                                                     "asp_batch_line_number",
+                                                                     "archived_json",
+                                                                     "employee_record_id",
+                                                                     "user_id",
+                                                                     "recovered")
+          VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "employee_record_employeerecordtransitionlog"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: test_upload_and_download[logs]
   list([
     '[chan 0] Opened sftp connection (server version 3)',
     'Connected to "0.0.0.0" as "django_tests"',
@@ -86,6 +558,463 @@
     '[chan 1] sftp session closed.',
     'Employee records processing done!',
   ])
+# ---
+# name: test_upload_and_download[upload]
+  dict({
+    'num_queries': 13,
+    'queries': list([
+      dict({
+        'origin': list([
+          'chunks[utils/iterators.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecord"."asp_processing_code",
+                 "employee_record_employeerecord"."asp_processing_label",
+                 "employee_record_employeerecord"."asp_batch_file",
+                 "employee_record_employeerecord"."asp_batch_line_number",
+                 "employee_record_employeerecord"."archived_json",
+                 "employee_record_employeerecord"."created_at",
+                 "employee_record_employeerecord"."updated_at",
+                 "employee_record_employeerecord"."processed_at",
+                 "employee_record_employeerecord"."status",
+                 "employee_record_employeerecord"."job_application_id",
+                 "employee_record_employeerecord"."financial_annex_id",
+                 "employee_record_employeerecord"."approval_number",
+                 "employee_record_employeerecord"."asp_id",
+                 "employee_record_employeerecord"."asp_measure",
+                 "employee_record_employeerecord"."siret",
+                 "employee_record_employeerecord"."processed_as_duplicate"
+          FROM "employee_record_employeerecord"
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          WHERE ("job_applications_jobapplication"."state" = %s
+                 AND "employee_record_employeerecord"."status" = %s)
+          ORDER BY "employee_record_employeerecord"."updated_at" ASC,
+                   "employee_record_employeerecord"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history"
+          FROM "companies_company"
+          WHERE "companies_company"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."fields_history"
+          FROM "users_jobseekerprofile"
+          WHERE "users_jobseekerprofile"."user_id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '_PersonSerializer.get_codeComInsee[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          WHERE "asp_country"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.asp_prescriber_type[employee_record/models.py]',
+          'EmployeeRecordSerializer.get_situationSalarie[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescriberorganization"
+          WHERE "prescribers_prescriberorganization"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord._clean_job_application[employee_record/models.py]',
+          'EmployeeRecord.clean[employee_record/models.py]',
+          'EmployeeRecord.wait_for_asp_response[employee_record/models.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_siaeconvention"
+          WHERE "companies_siaeconvention"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.save[<site-packages>/django/db/models/base.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          UPDATE "employee_record_employeerecord"
+          SET "asp_processing_code" = NULL,
+              "asp_processing_label" = NULL,
+              "asp_batch_file" = %s,
+              "asp_batch_line_number" = %s,
+              "archived_json" = %s,
+              "created_at" = %s,
+              "updated_at" = %s,
+              "processed_at" = NULL,
+              "status" = %s,
+              "job_application_id" = %s,
+              "financial_annex_id" = NULL,
+              "approval_number" = %s,
+              "asp_id" = %s,
+              "asp_measure" = %s,
+              "siret" = %s,
+              "processed_as_duplicate" = %s
+          WHERE "employee_record_employeerecord"."id" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordTransitionLog.save[<site-packages>/django/db/models/base.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "employee_record_employeerecordtransitionlog" ("transition",
+                                                                     "from_state",
+                                                                     "to_state",
+                                                                     "timestamp",
+                                                                     "asp_processing_code",
+                                                                     "asp_processing_label",
+                                                                     "asp_batch_file",
+                                                                     "asp_batch_line_number",
+                                                                     "archived_json",
+                                                                     "employee_record_id",
+                                                                     "user_id",
+                                                                     "recovered")
+          VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING "employee_record_employeerecordtransitionlog"."id"
+        ''',
+      }),
+    ]),
+  })
 # ---
 # name: test_upload_file_error
   list([

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
@@ -57,7 +57,80 @@
     'No object to check. Exiting preflight.',
   ])
 # ---
-# name: test_upload_and_download
+# name: test_upload_and_download[download]
+  dict({
+    'num_queries': 4,
+    'queries': list([
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationQuerySet.first[<site-packages>/django/db/models/query.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecordupdatenotification"."id",
+                 "employee_record_employeerecordupdatenotification"."asp_processing_code",
+                 "employee_record_employeerecordupdatenotification"."asp_processing_label",
+                 "employee_record_employeerecordupdatenotification"."asp_batch_file",
+                 "employee_record_employeerecordupdatenotification"."asp_batch_line_number",
+                 "employee_record_employeerecordupdatenotification"."archived_json",
+                 "employee_record_employeerecordupdatenotification"."created_at",
+                 "employee_record_employeerecordupdatenotification"."updated_at",
+                 "employee_record_employeerecordupdatenotification"."status",
+                 "employee_record_employeerecordupdatenotification"."employee_record_id"
+          FROM "employee_record_employeerecordupdatenotification"
+          WHERE ("employee_record_employeerecordupdatenotification"."asp_batch_file" = %s
+                 AND "employee_record_employeerecordupdatenotification"."asp_batch_line_number" = %s)
+          ORDER BY "employee_record_employeerecordupdatenotification"."created_at" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotification.save[<site-packages>/django/db/models/base.py]',
+          'Command._parse_feedback_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          UPDATE "employee_record_employeerecordupdatenotification"
+          SET "asp_processing_code" = %s,
+              "asp_processing_label" = %s,
+              "asp_batch_file" = %s,
+              "asp_batch_line_number" = %s,
+              "archived_json" = %s,
+              "created_at" = %s,
+              "updated_at" = %s,
+              "status" = %s,
+              "employee_record_id" = %s
+          WHERE "employee_record_employeerecordupdatenotification"."id" = %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'Command.download_json_file[employee_record/common_management.py]',
+          'Command.download[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
+# name: test_upload_and_download[logs]
   list([
     '[chan 1] Opened sftp connection (server version 3)',
     'Connected to "0.0.0.0" as "django_tests"',
@@ -71,6 +144,432 @@
     '[chan 1] sftp session closed.',
     'Employee record notifications processing done!',
   ])
+# ---
+# name: test_upload_and_download[upload]
+  dict({
+    'num_queries': 12,
+    'queries': list([
+      dict({
+        'origin': list([
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecordupdatenotification"."id",
+                 "employee_record_employeerecordupdatenotification"."asp_processing_code",
+                 "employee_record_employeerecordupdatenotification"."asp_processing_label",
+                 "employee_record_employeerecordupdatenotification"."asp_batch_file",
+                 "employee_record_employeerecordupdatenotification"."asp_batch_line_number",
+                 "employee_record_employeerecordupdatenotification"."archived_json",
+                 "employee_record_employeerecordupdatenotification"."created_at",
+                 "employee_record_employeerecordupdatenotification"."updated_at",
+                 "employee_record_employeerecordupdatenotification"."status",
+                 "employee_record_employeerecordupdatenotification"."employee_record_id"
+          FROM "employee_record_employeerecordupdatenotification"
+          WHERE "employee_record_employeerecordupdatenotification"."status" = %s
+          ORDER BY "employee_record_employeerecordupdatenotification"."updated_at" ASC,
+                   "employee_record_employeerecordupdatenotification"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecord"."asp_processing_code",
+                 "employee_record_employeerecord"."asp_processing_label",
+                 "employee_record_employeerecord"."asp_batch_file",
+                 "employee_record_employeerecord"."asp_batch_line_number",
+                 "employee_record_employeerecord"."archived_json",
+                 "employee_record_employeerecord"."created_at",
+                 "employee_record_employeerecord"."updated_at",
+                 "employee_record_employeerecord"."processed_at",
+                 "employee_record_employeerecord"."status",
+                 "employee_record_employeerecord"."job_application_id",
+                 "employee_record_employeerecord"."financial_annex_id",
+                 "employee_record_employeerecord"."approval_number",
+                 "employee_record_employeerecord"."asp_id",
+                 "employee_record_employeerecord"."asp_measure",
+                 "employee_record_employeerecord"."siret",
+                 "employee_record_employeerecord"."processed_as_duplicate"
+          FROM "employee_record_employeerecord"
+          WHERE "employee_record_employeerecord"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history"
+          FROM "companies_company"
+          WHERE "companies_company"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."fields_history"
+          FROM "users_jobseekerprofile"
+          WHERE "users_jobseekerprofile"."user_id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_country"."id",
+                 "asp_country"."code",
+                 "asp_country"."name",
+                 "asp_country"."group",
+                 "asp_country"."department"
+          FROM "asp_country"
+          WHERE "asp_country"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotificationSerializer.get_adresse[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "asp_commune"."id",
+                 "asp_commune"."start_date",
+                 "asp_commune"."end_date",
+                 "asp_commune"."code",
+                 "asp_commune"."name",
+                 "asp_commune"."normalized_name",
+                 "asp_commune"."created_at",
+                 "asp_commune"."city_id",
+                 "asp_commune"."ignore"
+          FROM "asp_commune"
+          WHERE "asp_commune"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecord.asp_prescriber_type[employee_record/models.py]',
+          'EmployeeRecordUpdateNotificationSerializer.get_situationSalarie[employee_record/serializers.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescriberorganization"
+          WHERE "prescribers_prescriberorganization"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EmployeeRecordUpdateNotification.save[<site-packages>/django/db/models/base.py]',
+          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
+          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
+        ]),
+        'sql': '''
+          UPDATE "employee_record_employeerecordupdatenotification"
+          SET "asp_processing_code" = NULL,
+              "asp_processing_label" = NULL,
+              "asp_batch_file" = %s,
+              "asp_batch_line_number" = %s,
+              "archived_json" = %s,
+              "created_at" = %s,
+              "updated_at" = %s,
+              "status" = %s,
+              "employee_record_id" = %s
+          WHERE "employee_record_employeerecordupdatenotification"."id" = %s
+        ''',
+      }),
+    ]),
+  })
 # ---
 # name: test_upload_file_error
   list([

--- a/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
+++ b/tests/employee_record/__snapshots__/test_transfer_employee_records_updates.ambr
@@ -147,7 +147,7 @@
 # ---
 # name: test_upload_and_download[upload]
   dict({
-    'num_queries': 12,
+    'num_queries': 2,
     'queries': list([
       dict({
         'origin': list([
@@ -164,21 +164,8 @@
                  "employee_record_employeerecordupdatenotification"."created_at",
                  "employee_record_employeerecordupdatenotification"."updated_at",
                  "employee_record_employeerecordupdatenotification"."status",
-                 "employee_record_employeerecordupdatenotification"."employee_record_id"
-          FROM "employee_record_employeerecordupdatenotification"
-          WHERE "employee_record_employeerecordupdatenotification"."status" = %s
-          ORDER BY "employee_record_employeerecordupdatenotification"."updated_at" ASC,
-                   "employee_record_employeerecordupdatenotification"."id" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "employee_record_employeerecord"."id",
+                 "employee_record_employeerecordupdatenotification"."employee_record_id",
+                 "employee_record_employeerecord"."id",
                  "employee_record_employeerecord"."asp_processing_code",
                  "employee_record_employeerecord"."asp_processing_label",
                  "employee_record_employeerecord"."asp_batch_file",
@@ -194,21 +181,8 @@
                  "employee_record_employeerecord"."asp_id",
                  "employee_record_employeerecord"."asp_measure",
                  "employee_record_employeerecord"."siret",
-                 "employee_record_employeerecord"."processed_as_duplicate"
-          FROM "employee_record_employeerecord"
-          WHERE "employee_record_employeerecord"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "job_applications_jobapplication"."id",
+                 "employee_record_employeerecord"."processed_as_duplicate",
+                 "job_applications_jobapplication"."id",
                  "job_applications_jobapplication"."job_seeker_id",
                  "job_applications_jobapplication"."eligibility_diagnosis_id",
                  "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
@@ -253,71 +227,8 @@
                  "job_applications_jobapplication"."qualification_level",
                  "job_applications_jobapplication"."planned_training_hours",
                  "job_applications_jobapplication"."inverted_vae_contract",
-                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
-          FROM "job_applications_jobapplication"
-          WHERE "job_applications_jobapplication"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord.asp_siae_type[employee_record/models.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "companies_company"."id",
-                 "companies_company"."address_line_1",
-                 "companies_company"."address_line_2",
-                 "companies_company"."post_code",
-                 "companies_company"."city",
-                 "companies_company"."department",
-                 "companies_company"."coords",
-                 "companies_company"."geocoding_score",
-                 "companies_company"."geocoding_updated_at",
-                 "companies_company"."ban_api_resolved_address",
-                 "companies_company"."insee_city_id",
-                 "companies_company"."name",
-                 "companies_company"."created_at",
-                 "companies_company"."updated_at",
-                 "companies_company"."uid",
-                 "companies_company"."active_members_email_reminder_last_sent_at",
-                 "companies_company"."automatic_geocoding_update",
-                 "companies_company"."siret",
-                 "companies_company"."naf",
-                 "companies_company"."kind",
-                 "companies_company"."brand",
-                 "companies_company"."phone",
-                 "companies_company"."email",
-                 "companies_company"."auth_email",
-                 "companies_company"."website",
-                 "companies_company"."description",
-                 "companies_company"."provided_support",
-                 "companies_company"."source",
-                 "companies_company"."created_by_id",
-                 "companies_company"."block_job_applications",
-                 "companies_company"."job_applications_blocked_at",
-                 "companies_company"."spontaneous_applications_open_since",
-                 "companies_company"."convention_id",
-                 "companies_company"."job_app_score",
-                 "companies_company"."is_searchable",
-                 "companies_company"."rdv_solidarites_id",
-                 "companies_company"."fields_history"
-          FROM "companies_company"
-          WHERE "companies_company"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 "users_user"."id",
                  "users_user"."password",
                  "users_user"."last_login",
                  "users_user"."is_superuser",
@@ -351,21 +262,8 @@
                  "users_user"."address_filled_at",
                  "users_user"."first_login",
                  "users_user"."upcoming_deletion_notified_at",
-                 "users_user"."allow_next_sso_sub_update"
-          FROM "users_user"
-          WHERE "users_user"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "users_jobseekerprofile"."user_id",
+                 "users_user"."allow_next_sso_sub_update",
+                 "users_jobseekerprofile"."user_id",
                  "users_jobseekerprofile"."birthdate",
                  "users_jobseekerprofile"."birth_place_id",
                  "users_jobseekerprofile"."birth_country_id",
@@ -403,21 +301,8 @@
                  "users_jobseekerprofile"."pe_last_certification_attempt_at",
                  "users_jobseekerprofile"."created_by_prescriber_organization_id",
                  "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."fields_history"
-          FROM "users_jobseekerprofile"
-          WHERE "users_jobseekerprofile"."user_id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_commune"."id",
+                 "users_jobseekerprofile"."fields_history",
+                 "asp_commune"."id",
                  "asp_commune"."start_date",
                  "asp_commune"."end_date",
                  "asp_commune"."code",
@@ -425,94 +310,22 @@
                  "asp_commune"."normalized_name",
                  "asp_commune"."created_at",
                  "asp_commune"."city_id",
-                 "asp_commune"."ignore"
-          FROM "asp_commune"
-          WHERE "asp_commune"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_country"."id",
+                 "asp_commune"."ignore",
+                 "asp_country"."id",
                  "asp_country"."code",
                  "asp_country"."name",
                  "asp_country"."group",
-                 "asp_country"."department"
-          FROM "asp_country"
-          WHERE "asp_country"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecordUpdateNotificationSerializer.get_personnePhysique[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecordUpdateNotificationSerializer.get_adresse[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "asp_commune"."id",
-                 "asp_commune"."start_date",
-                 "asp_commune"."end_date",
-                 "asp_commune"."code",
-                 "asp_commune"."name",
-                 "asp_commune"."normalized_name",
-                 "asp_commune"."created_at",
-                 "asp_commune"."city_id",
-                 "asp_commune"."ignore"
-          FROM "asp_commune"
-          WHERE "asp_commune"."id" = %s
-          LIMIT 21
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'EmployeeRecord.asp_prescriber_type[employee_record/models.py]',
-          'EmployeeRecordUpdateNotificationSerializer.get_situationSalarie[employee_record/serializers.py]',
-          'Command._upload_batch_file[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.upload[employee_record/management/commands/transfer_employee_records_updates.py]',
-          'Command.handle[employee_record/management/commands/transfer_employee_records_updates.py]',
-        ]),
-        'sql': '''
-          SELECT "prescribers_prescriberorganization"."id",
+                 "asp_country"."department",
+                 T8."id",
+                 T8."start_date",
+                 T8."end_date",
+                 T8."code",
+                 T8."name",
+                 T8."normalized_name",
+                 T8."created_at",
+                 T8."city_id",
+                 T8."ignore",
+                 "prescribers_prescriberorganization"."id",
                  "prescribers_prescriberorganization"."address_line_1",
                  "prescribers_prescriberorganization"."address_line_2",
                  "prescribers_prescriberorganization"."post_code",
@@ -541,10 +354,77 @@
                  "prescribers_prescriberorganization"."authorization_status",
                  "prescribers_prescriberorganization"."authorization_updated_at",
                  "prescribers_prescriberorganization"."authorization_updated_by_id",
-                 "prescribers_prescriberorganization"."is_gps_authorized"
-          FROM "prescribers_prescriberorganization"
-          WHERE "prescribers_prescriberorganization"."id" = %s
-          LIMIT 21
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "employee_record_employeerecordupdatenotification"
+          INNER JOIN "employee_record_employeerecord" ON ("employee_record_employeerecordupdatenotification"."employee_record_id" = "employee_record_employeerecord"."id")
+          INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "asp_commune" ON ("users_jobseekerprofile"."birth_place_id" = "asp_commune"."id")
+          LEFT OUTER JOIN "asp_country" ON ("users_jobseekerprofile"."birth_country_id" = "asp_country"."id")
+          LEFT OUTER JOIN "asp_commune" T8 ON ("users_jobseekerprofile"."hexa_commune_id" = T8."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          WHERE "employee_record_employeerecordupdatenotification"."status" = %s
+          ORDER BY "employee_record_employeerecordupdatenotification"."updated_at" ASC,
+                   "employee_record_employeerecordupdatenotification"."id" ASC
         ''',
       }),
       dict({

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -671,6 +671,16 @@
                  "companies_company"."is_searchable",
                  "companies_company"."rdv_solidarites_id",
                  "companies_company"."fields_history",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at",
                  "approvals_approval"."id",
                  "approvals_approval"."start_at",
                  "approvals_approval"."end_at",
@@ -701,6 +711,7 @@
           FROM "employee_record_employeerecord"
           INNER JOIN "job_applications_jobapplication" ON ("employee_record_employeerecord"."job_application_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
           INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           LEFT OUTER JOIN "asp_commune" ON ("users_jobseekerprofile"."birth_place_id" = "asp_commune"."id")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter une cascade de requête SQL au moment de la sérialisation de l'objet.
