### PR TITLE
Fiches Salarié : Ne plus proposer l'option "Renvoyer" si des informations sont manquantes ou erronées

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -488,6 +488,28 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
         )
         return self.siret != siret_from_asp_source
 
+    def has_valid_data_filled(self):
+        # In `JobSeekerProfile.clean_model()` some fields are only checked if present, but we need them to be filled
+        try:
+            has_extra_required_fields = all(
+                [
+                    self.job_application.job_seeker.jobseeker_profile.birth_country,
+                    self.job_application.job_seeker.jobseeker_profile.hexa_commune,  # Any of the hexa fields will do
+                ]
+            )
+        except AttributeError:
+            return False
+        else:
+            if not has_extra_required_fields:
+                return False
+
+        # Now we can use the common validation methods
+        try:
+            self.clean()
+        except Exception:
+            return False
+        return True
+
     @classmethod
     def from_job_application(cls, job_application, clean=True):
         """

--- a/itou/templates/employee_record/includes/send_back_dropdown.html
+++ b/itou/templates/employee_record/includes/send_back_dropdown.html
@@ -2,9 +2,20 @@
     Renvoyer cette fiche salarié
 </button>
 <div class="dropdown-menu" id="sendBackRecordDropDown-{{ employee_record.pk }}">
-    <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.pk %}" class="js-prevent-multiple-submit">
-        {% csrf_token %}
-        <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
-    </form>
+    {% if not employee_record.has_valid_data_filled %}
+        <div class="dropdown-item">
+            <span class="disabled" aria-label="Le bouton « Renvoyer » est désactivé car certaines informations obligatoires sont manquantes ou erronées. Utilisez le bouton « Modifier et renvoyer ».">Renvoyer</span>
+            <i class="ri-information-line ri-xl text-info ms-1"
+               data-bs-toggle="tooltip"
+               data-bs-placement="top"
+               data-bs-title="Le bouton « Renvoyer » est désactivé car certaines informations obligatoires sont manquantes ou erronées. Utilisez le bouton « Modifier et renvoyer »."
+               aria-hidden="true"></i>
+        </div>
+    {% else %}
+        <form method="post" action="{% url "employee_record_views:create_step_5" employee_record.job_application.pk %}" class="js-prevent-multiple-submit">
+            {% csrf_token %}
+            <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
+        </form>
+    {% endif %}
     <a class="dropdown-item" href="{% url "employee_record_views:create" employee_record.job_application.pk %}">Modifier et renvoyer</a>
 </div>

--- a/tests/www/employee_record_views/__snapshots__/test_template.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_template.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_send_back_dropdown[with_complete_profile]
+  '''
+  <button class="btn  dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" aria-controls="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      Renvoyer cette fiche salarié
+  </button>
+  <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      
+          <form method="post" action="/employee_record/create_step_5/[Pk of JobApplication]" class="js-prevent-multiple-submit">
+              
+              <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
+          </form>
+      
+      <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
+  </div>
+  
+  '''
+# ---
+# name: test_send_back_dropdown[without_birth_country]
+  '''
+  <button class="btn  dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" aria-controls="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      Renvoyer cette fiche salarié
+  </button>
+  <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      
+          <div class="dropdown-item">
+              <span class="disabled" aria-label="Le bouton « Renvoyer » est désactivé car certaines informations obligatoires sont manquantes ou erronées. Utilisez le bouton « Modifier et renvoyer ».">Renvoyer</span>
+              <i class="ri-information-line ri-xl text-info ms-1"
+                 data-bs-toggle="tooltip"
+                 data-bs-placement="top"
+                 data-bs-title="Le bouton « Renvoyer » est désactivé car certaines informations obligatoires sont manquantes ou erronées. Utilisez le bouton « Modifier et renvoyer »."
+                 aria-hidden="true"></i>
+          </div>
+      
+      <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
+  </div>
+  
+  '''
+# ---
+# name: test_send_back_dropdown[without_hexa_address]
+  '''
+  <button class="btn  dropdown-toggle" type="button" aria-haspopup="true" aria-expanded="false" data-bs-toggle="dropdown" aria-controls="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      Renvoyer cette fiche salarié
+  </button>
+  <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
+      
+          <div class="dropdown-item">
+              <span class="disabled" aria-label="Le bouton « Renvoyer » est désactivé car certaines informations obligatoires sont manquantes ou erronées. Utilisez le bouton « Modifier et renvoyer ».">Renvoyer</span>
+              <i class="ri-information-line ri-xl text-info ms-1"
+                 data-bs-toggle="tooltip"
+                 data-bs-placement="top"
+                 data-bs-title="Le bouton « Renvoyer » est désactivé car certaines informations obligatoires sont manquantes ou erronées. Utilisez le bouton « Modifier et renvoyer »."
+                 aria-hidden="true"></i>
+          </div>
+      
+      <a class="dropdown-item" href="/employee_record/create/[Pk of JobApplication]">Modifier et renvoyer</a>
+  </div>
+  
+  '''
+# ---

--- a/tests/www/employee_record_views/test_template.py
+++ b/tests/www/employee_record_views/test_template.py
@@ -1,0 +1,34 @@
+import pytest
+from django.template import Context
+
+from tests.employee_record.factories import EmployeeRecordWithProfileFactory
+from tests.utils.test import load_template
+
+
+@pytest.mark.parametrize(
+    "factory_kwargs",
+    [
+        pytest.param({}, id="with_complete_profile"),
+        pytest.param({"birth_country": None}, id="without_birth_country"),
+        pytest.param({"with_hexa_address": None}, id="without_hexa_address"),
+    ],
+)
+def test_send_back_dropdown(snapshot, factory_kwargs):
+    template = load_template("employee_record/includes/send_back_dropdown.html")
+    employee_record = EmployeeRecordWithProfileFactory(
+        **{f"job_application__job_seeker__jobseeker_profile__{k}": v for k, v in factory_kwargs.items()}
+    )
+
+    html = template.render(Context({"employee_record": employee_record}))
+    normalized_html = (
+        html.replace(
+            f"/employee_record/create/{employee_record.job_application_id}",
+            "/employee_record/create/[Pk of JobApplication]",
+        )
+        .replace(
+            f"/employee_record/create_step_5/{employee_record.job_application_id}",
+            "/employee_record/create_step_5/[Pk of JobApplication]",
+        )
+        .replace(f"sendBackRecordDropDown-{employee_record.pk}", "sendBackRecordDropDown-[Pk of EmployeeRecord]")
+    )
+    assert normalized_html == snapshot


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans certain cas, le pays (et ville) de naissance sont supprimées après la première intégration, donc lorsque que l'employeur fait "Renvoyer" (sans modification) ça explose dans `transfer_employee_record` à cause du champ manquant.
On vérifie donc désormais que toutes les données sont bien renseignées avant de proposer l'option "Renvoyer", si ce n'est pas le cas on laisse seulement "Modifier et renvoyer".

## :desert_island: Comment tester ?

- Modifier le SIRET d'une des structure ayant 1 FS Intégrée
- Supprimer le pays de naissance du candidat lié à 1 FS Intégrée de la structure avec le SIRET modifié

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/9c8789b3-c0d3-4a04-a90c-73183d0c77f0)

