### PR TITLE
Fiches Salarié : Suppression du bouton "Valider cette adresse" pour l'étape "Domiciliation du salarié" [GEN-763]

### DIFF
--- a/itou/templates/employee_record/includes/create_step_2.html
+++ b/itou/templates/employee_record/includes/create_step_2.html
@@ -65,23 +65,15 @@
                     {% bootstrap_field form.hexa_additional_address %}
                     {% bootstrap_field form.hexa_post_code wrapper_class="form-group form-group-input-w-lg-33" %}
                     {% bootstrap_field form.hexa_commune %}
-
-                    <button class="btn btn-outline-primary mb-3">Valider cette adresse</button>
                 </fieldset>
 
-                {% url "employee_record_views:create_step_3" job_application.id as primary_url %}
                 {% url "employee_record_views:create" job_application.id as secondary_url %}
                 {% url "employee_record_views:list" as reset_url %}
                 {% if request.GET.status %}
-                    {% url_add_query primary_url status=request.GET.status as primary_url %}
                     {% url_add_query secondary_url status=request.GET.status as secondary_url %}
                     {% url_add_query reset_url status=request.GET.status as reset_url %}
                 {% endif %}
-                {% if profile.hexa_address_filled %}
-                    {% itou_buttons_form primary_label="Suivant" primary_url=primary_url secondary_url=secondary_url reset_url=reset_url %}
-                {% else %}
-                    {% itou_buttons_form primary_label="Suivant" primary_disabled=True secondary_url=secondary_url reset_url=reset_url %}
-                {% endif %}
+                {% itou_buttons_form primary_label="Suivant" secondary_url=secondary_url reset_url=reset_url %}
 
             </form>
         </div>

--- a/itou/www/employee_record_views/views.py
+++ b/itou/www/employee_record_views/views.py
@@ -352,7 +352,7 @@ def create_step_2(request, job_application_id, template_name="employee_record/cr
             form.save()
             return HttpResponseRedirect(
                 reverse(
-                    "employee_record_views:create_step_2",
+                    "employee_record_views:create_step_3",
                     args=(job_application.id,),
                 )
                 + query_param

--- a/tests/www/employee_record_views/__snapshots__/test_create.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_create.ambr
@@ -400,9 +400,6 @@
                   </option>
               </select>
           </div>
-          <button class="btn btn-outline-primary mb-3">
-              Valider cette adresse
-          </button>
       </fieldset>
       <div class="row">
           <div class="col-12">
@@ -428,11 +425,11 @@
                       </a>
                   </div>
                   <div class="form-group col col-lg-auto order-2 order-lg-3">
-                      <a aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" href="/employee_record/create_step_3/[PK of JobApplication]">
+                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" type="submit">
                           <span>
                               Suivant
                           </span>
-                      </a>
+                      </button>
                   </div>
               </div>
           </div>

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -337,6 +337,9 @@ class TestCreateEmployeeRecordStep1(CreateEmployeeRecordTestMixin):
 class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
     NO_ADDRESS_FILLED_IN = "Aucune adresse n'a été saisie sur les emplois de l'inclusion !"
     ADDRESS_COULD_NOT_BE_AUTO_CHECKED = "L'adresse du salarié n'a pu être vérifiée automatiquement."
+    ERRONEOUS_ADDRESS_COULD_LEAD_TO_ERROR = (
+        "Une saisie incorrecte de l'adresse peut mener à une erreur de traitement de la fiche salarié."
+    )
 
     URL_NAME = "employee_record_views:create_step_2"
 
@@ -345,15 +348,26 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
         self.pass_step_1(client)
 
     def test_job_seeker_without_address(self, client):
-        # Job seeker has no address filled (which should not happen without admin operation)
+        # Job seeker has no address filled (which should not happen without an admin operation)
         job_application = JobApplicationWithApprovalNotCancellableFactory(to_company=self.company)
 
-        response = client.get(self.url)
-        url = reverse("employee_record_views:create_step_2", args=(job_application.pk,))
-        response = client.get(url)
+        response = client.get(reverse(self.URL_NAME, args=(job_application.pk,)))
 
         assertContains(response, self.NO_ADDRESS_FILLED_IN)
         assertContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
+        assertNotContains(response, self.ERRONEOUS_ADDRESS_COULD_LEAD_TO_ERROR)
+
+    def test_job_seeker_with_hexa_address(self, client):
+        # Job seeker has already an address filled
+        job_application = JobApplicationWithApprovalNotCancellableFactory(
+            to_company=self.company,
+            job_seeker__jobseeker_profile__with_hexa_address=True,
+        )
+
+        response = client.get(reverse(self.URL_NAME, args=(job_application.pk,)))
+        assertContains(response, self.NO_ADDRESS_FILLED_IN)
+        assertNotContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
+        assertContains(response, self.ERRONEOUS_ADDRESS_COULD_LEAD_TO_ERROR)
 
     def test_job_seeker_address_geolocated(self, client, snapshot):
         job_seeker = JobSeekerFactory(
@@ -364,9 +378,10 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
             to_company=self.company,
             job_seeker=job_seeker,
         )
+        url = reverse(self.URL_NAME, args=(job_application.pk,))
 
-        # Accept geolocated address provided by mock and pass to step 3
-        response = client.get(reverse("employee_record_views:create_step_2", args=(job_application.pk,)))
+        # Accept the geolocated address provided by mock and pass to step 3
+        response = client.get(url)
         form_soup = parse_response_to_soup(
             response,
             selector=".s-section form",
@@ -390,9 +405,21 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
         )
         assert pretty_indented(form_soup) == snapshot
 
-        response = client.get(reverse("employee_record_views:create_step_3", args=(job_application.pk,)))
-        assertNotContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
-        assertNotContains(response, self.NO_ADDRESS_FILLED_IN)
+        job_seeker.jobseeker_profile.refresh_from_db()  # HEXA address should now have been filled by the GET
+        response = client.post(
+            url,
+            data={
+                "hexa_lane_number": job_seeker.jobseeker_profile.hexa_lane_number,
+                "hexa_std_extension": job_seeker.jobseeker_profile.hexa_std_extension,
+                "hexa_lane_type": job_seeker.jobseeker_profile.hexa_lane_type,
+                "hexa_lane_name": job_seeker.jobseeker_profile.hexa_lane_name,
+                "hexa_additional_address": job_seeker.jobseeker_profile.hexa_additional_address,
+                "hexa_post_code": job_seeker.jobseeker_profile.hexa_post_code,
+                "hexa_commune": job_seeker.jobseeker_profile.hexa_commune.pk,
+            },
+        )
+        assertRedirects(response, reverse("employee_record_views:create_step_3", args=(job_application.pk,)))
+        assertRedirects(response, reverse("employee_record_views:create_step_3", args=(job_application.pk,)))
 
     def test_job_seeker_address_not_geolocated(self, client):
         # Job seeker has an address filled but can't be geolocated
@@ -404,9 +431,10 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
         # Changed job application: new URL
         response = client.get(reverse(self.URL_NAME, args=(job_application.pk,)))
 
-        # Check that when lookup fails, user is properly notified
-        # to input employee address manually
+        # Check that when lookup fails, the user is properly notified
+        # to input the employee address manually
         assertContains(response, self.ADDRESS_COULD_NOT_BE_AUTO_CHECKED)
+        assertNotContains(response, self.ERRONEOUS_ADDRESS_COULD_LEAD_TO_ERROR)
         assertNotContains(response, self.NO_ADDRESS_FILLED_IN)
 
         # Force the way without a profile should raise a PermissionDenied
@@ -415,8 +443,8 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
         assert response.status_code == 403
 
     def test_update_form_with_bad_job_seeker_address(self, client):
-        # If HEXA address is valid, user can still change it
-        # but it must be a valid one, otherwise the previous address is discarded
+        # If the HEXA address is valid, the user can still change it,
+        # but it must be valid; otherwise the previous address is discarded
         response = client.get(self.url)
         assert response.status_code == 200
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

SI on met à jour un des champs et qu’on ne clique pas sur “Valider cette adresse” mais sur "Suivant" alors les modifications apportées sont perdues.

