### PR TITLE
Limiter le nombre d’actions par minute pour les utilisateurs authentifiés

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -159,6 +159,7 @@ MIDDLEWARE = [
     # Itou specific
     "itou.utils.perms.middleware.ItouCurrentOrganizationMiddleware",
     "itou.www.middleware.never_cache",
+    "itou.www.middleware.RateLimitMiddleware",
     "itou.openid_connect.pro_connect.middleware.ProConnectLoginMiddleware",
     # Final logger
     "django_datadog_logger.middleware.request_log.RequestLoggingMiddleware",

--- a/itou/templates/429.html
+++ b/itou/templates/429.html
@@ -16,7 +16,7 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
-                    <p>Vous avez effectué trop de requêtes. Réessayez dans quelques minutes.</p>
+                    <p>Vous avez effectué trop de requêtes. Réessayez dans {{ retry_after|default:"quelques minutes" }}.</p>
                 </div>
             </div>
         </div>

--- a/itou/utils/throttling.py
+++ b/itou/utils/throttling.py
@@ -1,0 +1,11 @@
+from django.core.cache import caches
+from rest_framework import throttling
+
+
+class FailSafeUserRateThrottle(throttling.UserRateThrottle):
+    rate = "60/minute"
+
+    @property
+    def cache(self):
+        # The property allows swapping cache configuration in tests.
+        return caches["failsafe"]

--- a/tests/www/test_throttling.py
+++ b/tests/www/test_throttling.py
@@ -1,0 +1,39 @@
+import pytest
+from django.urls import reverse
+from pytest_django.asserts import assertContains
+
+from tests.users.factories import PrescriberFactory
+
+
+@pytest.fixture
+def one_request_per_minute(mocker):
+    mocker.patch("itou.utils.throttling.FailSafeUserRateThrottle.rate", "1/minute")
+
+
+def test_throttling(client, one_request_per_minute):
+    client.force_login(PrescriberFactory())
+    response = client.get(reverse("dashboard:index"))
+    assert response.status_code == 200
+    response = client.get(reverse("dashboard:index"))
+    assertContains(
+        response,
+        "<p>Vous avez effectué trop de requêtes. Réessayez dans 60 secondes.</p>",
+        status_code=429,
+    )
+
+
+def test_throttling_ignores_public_views(client, one_request_per_minute):
+    client.force_login(PrescriberFactory())
+    response = client.get(reverse("search:employers_home"))
+    assert response.status_code == 200
+    response = client.get(reverse("search:employers_home"))
+    # Middleware let the request through.
+    assert response.status_code == 200
+
+
+def test_throttling_ignores_anonymous_user(client, one_request_per_minute):
+    response = client.get(reverse("search:employers_home"))
+    assert response.status_code == 200
+    response = client.get(reverse("search:employers_home"))
+    # Middleware let the request through.
+    assert response.status_code == 200


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sécurité : mieux identifier et bloquer les énumérations.

## :cake: Comment ? <!-- optionnel -->

Afin de pouvoir effectuer un rendu complet de la page de 429, il faut que le middleware soit placé après `ItouCurrentOrganizationMiddleware`.

## :desert_island: Comment tester ?

- Se connecter
- Beaucoup appuyer sur la touche <kbd><F5></kbd>

Le testeur malin changera la limite à une requête par minute.

## :computer: Captures d'écran <!-- optionnel -->
![image](https://github.com/user-attachments/assets/1162c26c-2b9c-45c2-9757-ae9576b38c89)
