### PR TITLE
Candidature : permettre l'édition de la commune de naissance lors de l'acceptation d'une candidature, même si le candidat a des critères certifiés

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1482,6 +1482,11 @@ class JobSeekerProfile(models.Model):
                 case IdentityCertificationAuthorities.API_PARTICULIER:
                     blocked_fields.update(api_particulier.USER_REQUIRED_FIELDS)
                     blocked_fields.update(api_particulier.JOBSEEKER_PROFILE_REQUIRED_FIELDS)
+
+                    # The birth_place field can be empty even after the certification, generating an error
+                    # when the form is validated. Hence we allow the edition of this field.
+                    if self.birth_place is None:
+                        blocked_fields.discard("birth_place")
         return blocked_fields
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?
Les champs nécessaires à la certification des critères sont non modifiables, notamment lors de l'acceptation d'une candidature.
Or, parfois, le champ "Commune de naissance" est vide. Et donc le formulaire ne peut être validé.

## :cake: Comment ? <!-- optionnel -->

On ne met ce champ en lecture seule que s'il n'est pas vide.

