### PR TITLE
Employeur : prescrire une PMSMP depuis les Emplois [GEN-2269]

### DIFF
--- a/itou/templates/apply/includes/pmsmp_box.html
+++ b/itou/templates/apply/includes/pmsmp_box.html
@@ -1,0 +1,16 @@
+{% if immersion_facile_pmsmp_url %}
+    <div class="c-box p-0 mb-4" id="immersion-facile-pmsmp">
+        <div class="c-box__header--immersion-facile p-3 p-lg-4">
+            <span class="h4 m-0">Immersion facilitée</span>
+        </div>
+        <div class="p-3 p-lg-4">
+            <p>
+                La <strong><abbr title="Période de mise en situation en milieu professionnel">PMSMP</abbr></strong> permet à un candidat de découvrir un métier ou valider un projet dans votre structure, sans obligation d’embauche.
+                En cliquant sur « <strong>Proposer une PMSMP</strong> », vous accédez à un formulaire sur <i>Immersion Facilitée</i>.
+            </p>
+            <a href="{{ immersion_facile_pmsmp_url }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Proposer une PMSMP (ouverture dans un nouvel onglet)">
+                Proposer une PMSMP
+            </a>
+        </div>
+    </div>
+{% endif %}

--- a/itou/templates/apply/process_base.html
+++ b/itou/templates/apply/process_base.html
@@ -96,6 +96,7 @@
                                         {% endif %}
                                     {% endif %}
                                 {% endwith %}
+                                {% include "apply/includes/pmsmp_box.html" with immersion_facile_pmsmp_url=immersion_facile_pmsmp_url|default:None %}
                             {% elif request.user.is_prescriber %}
                                 {# Approval status. #}
                                 {% if job_application.approval %}

--- a/itou/utils/immersion_facile.py
+++ b/itou/utils/immersion_facile.py
@@ -2,6 +2,8 @@ from urllib.parse import quote, urlencode
 
 from django.conf import settings
 
+from itou.prescribers.enums import PrescriberOrganizationKind
+
 
 def immersion_search_url(user):
     """
@@ -27,3 +29,27 @@ def immersion_search_url(user):
             params["place"] = ", ".join(address_parts)
 
     return f"{settings.IMMERSION_FACILE_SITE_URL}/recherche?{urlencode(params, quote_via=quote)}"
+
+
+def get_pmsmp_url(prescriber_organization, to_company):
+    """
+    Return an URL to a pre-filled form to send a job seeker to a PMSMP
+    (période de mise en situation en milieu professionnel).
+    """
+
+    agency_kind = {
+        PrescriberOrganizationKind.FT: "pole-emploi",
+        PrescriberOrganizationKind.ML: "mission-locale",
+        PrescriberOrganizationKind.CAP_EMPLOI: "cap-emploi",
+    }.get(prescriber_organization.kind, "autre")
+
+    params = {
+        "agencyDepartment": prescriber_organization.department,
+        "agencyKind": agency_kind,
+        "siret": to_company.siret,
+        "skipIntro": "true",
+        "acquisitionCampaign": "emplois",
+        "mtm_kwd": "candidature",
+    }
+
+    return f"{settings.IMMERSION_FACILE_SITE_URL}/demande-immersion?{urlencode(params, quote_via=quote)}"

--- a/itou/www/apply/views/process_views.py
+++ b/itou/www/apply/views/process_views.py
@@ -31,6 +31,7 @@ from itou.rdv_insertion.models import Invitation, InvitationRequest
 from itou.users.enums import Title, UserKind
 from itou.users.models import User
 from itou.utils.auth import check_user
+from itou.utils.immersion_facile import get_pmsmp_url
 from itou.utils.perms.utils import can_edit_personal_information, can_view_personal_information
 from itou.utils.urls import get_safe_url
 from itou.www.apply.forms import (
@@ -249,6 +250,15 @@ def details_for_company(request, job_application_id, template_name="apply/proces
 
     can_be_cancelled = job_application.state.is_accepted and job_application.can_be_cancelled
 
+    immersion_facile_pmsmp_url = None
+    if job_application.is_sent_by_authorized_prescriber and job_application.to_company.kind in (
+        [CompanyKind.AI, CompanyKind.ACI, CompanyKind.EI]
+    ):
+        immersion_facile_pmsmp_url = get_pmsmp_url(
+            prescriber_organization=job_application.sender_prescriber_organization,
+            to_company=job_application.to_company,
+        )
+
     context = {
         "can_be_cancelled": can_be_cancelled,
         "can_view_personal_information": True,  # SIAE members have access to personal info
@@ -268,6 +278,7 @@ def details_for_company(request, job_application_id, template_name="apply/proces
         ),
         "matomo_custom_title": "Candidature",
         "job_application_sender_left_org": job_application_sender_left_org(job_application),
+        "immersion_facile_pmsmp_url": immersion_facile_pmsmp_url,
     }
 
     return render(request, template_name, context)

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -39,7 +39,7 @@ from itou.job_applications import enums as job_applications_enums
 from itou.job_applications.enums import JobApplicationState, QualificationLevel, QualificationType, SenderKind
 from itou.job_applications.models import JobApplication, JobApplicationWorkflow
 from itou.jobs.models import Appellation
-from itou.prescribers.enums import PrescriberAuthorizationStatus
+from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.siae_evaluations.models import Sanctions
 from itou.users.enums import LackOfNIRReason, LackOfPoleEmploiId, Title, UserKind
 from itou.users.models import User
@@ -850,6 +850,56 @@ class TestProcessViews:
         assertNotContains(response, self.REFUSAL_REASON_JOB_SEEKER_MENTION, html=True)
         assertContains(response, self.REFUSAL_REASON_SHARED_MENTION, html=True)
         assertNotContains(response, self.REFUSAL_REASON_NOT_SHARED_MENTION, html=True)
+
+    @pytest.mark.parametrize(
+        "from_authorized_prescriber,company_in_target,assertion",
+        [
+            (True, True, assertContains),
+            (True, False, assertNotContains),
+            (False, True, assertNotContains),
+            (False, False, assertNotContains),
+        ],
+    )
+    def test_details_for_company_display_pmsmp_box(
+        self, client, from_authorized_prescriber, company_in_target, assertion
+    ):
+        TARGET_COMPANIES = [CompanyKind.AI, CompanyKind.ACI, CompanyKind.EI]
+        OTHER_COMPANIES = set(CompanyKind) - set(TARGET_COMPANIES)
+        TARGET_ORGANIZATIONS = [
+            PrescriberOrganizationKind.FT,
+            PrescriberOrganizationKind.CAP_EMPLOI,
+            PrescriberOrganizationKind.ML,
+        ]
+        OTHER_ORGANIZATIONS = set(PrescriberOrganizationKind) - set(TARGET_ORGANIZATIONS)
+        company_kind = (
+            random.choice(list(TARGET_COMPANIES)) if company_in_target else random.choice(list(OTHER_COMPANIES))
+        )
+        organization_kind = (
+            random.choice(list(TARGET_ORGANIZATIONS))
+            if from_authorized_prescriber
+            else random.choice(list(OTHER_ORGANIZATIONS))
+        )
+        job_application = JobApplicationFactory(
+            sent_by_authorized_prescriber_organisation=from_authorized_prescriber,
+            to_company__kind=company_kind,
+            sender_prescriber_organization__kind=organization_kind,
+        )
+
+        client.force_login(job_application.to_company.members.first())
+        url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+        response = client.get(url)
+        assertion(
+            response,
+            """
+            <p>
+                La <strong><abbr title="Période de mise en situation en milieu professionnel">PMSMP</abbr></strong>
+                permet à un candidat de découvrir un métier ou valider un projet dans votre structure, sans
+                obligation d’embauche. En cliquant sur « <strong>Proposer une PMSMP</strong> », vous accédez à un
+                formulaire sur <i>Immersion Facilitée</i>.
+            </p>
+            """,
+            html=True,
+        )
 
     def test_company_information_displayed_for_prescriber_when_refused(self, client, subtests):
         """


### PR DESCRIPTION
## :thinking: Pourquoi ?
Intégrer un encart pour informer l’employeur qu’il peut proposer une PMSMP au candidat.

Dans la page de détail d’une candidature ; ne concerne que les candidatures adressées par un prescripteur habilité

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
