### PR TITLE
 Tests: Remettre <genexpr> des origins dans les snapshots de requêtes

### DIFF
--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -174,6 +174,7 @@
       }),
       dict({
         'origin': list([
+          'EvaluationCampaign.<genexpr>[siae_evaluations/models.py]',
           'EvaluationCampaign.populate[siae_evaluations/models.py]',
         ]),
         'sql': '''

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -366,9 +366,6 @@ def _detect_origin(debug=False):
                 function = f"{class_name}.{frame_info.function}"
             else:
                 function = frame_info.function
-            if "<genexpr>" in function:
-                # These are not consistant between devs, even with the same env setup ¯\_(ツ)_/¯
-                continue
             parts.append(f"{function}[{normalized_filename}]")
             if debug:
                 parts.append(

--- a/tests/www/itou_staff_views/__snapshots__/tests.ambr
+++ b/tests/www/itou_staff_views/__snapshots__/tests.ambr
@@ -77,6 +77,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "companies_companymembership"."id",
@@ -171,6 +172,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "prescribers_prescribermembership"."id",
@@ -344,6 +346,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "job_applications_jobapplication"."id",
@@ -980,6 +983,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "job_applications_jobapplication"."id",
@@ -1616,6 +1620,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "job_applications_jobapplication"."id",
@@ -2168,6 +2173,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
@@ -2207,6 +2213,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT ("eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id") AS "_prefetch_related_val_eligibility_diagnosis_id",
@@ -2230,6 +2237,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "prescribers_prescriberorganization"."id",
@@ -2269,6 +2277,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "approvals_prolongation"."id",
@@ -2298,6 +2307,7 @@
       dict({
         'origin': list([
           'content[www/itou_staff_views/views.py]',
+          '<genexpr>[www/itou_staff_views/views.py]',
         ]),
         'sql': '''
           SELECT "approvals_suspension"."id",

--- a/tests/www/siae_evaluations_views/__snapshots__/test_institutions_views.ambr
+++ b/tests/www/siae_evaluations_views/__snapshots__/test_institutions_views.ambr
@@ -346,6 +346,7 @@
         'origin': list([
           'EvaluatedJobApplication.compute_state[siae_evaluations/models.py]',
           'state_from[siae_evaluations/models.py]',
+          '<genexpr>[siae_evaluations/models.py]',
           'EvaluatedSiae.state_from_applications[siae_evaluations/models.py]',
           'EvaluatedSiae.state[siae_evaluations/models.py]',
           'IfNode[siae_evaluations/includes/criterion_validation.html]',

--- a/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
+++ b/tests/www/siae_evaluations_views/__snapshots__/test_siaes_views.ambr
@@ -944,6 +944,7 @@
         'origin': list([
           'EvaluatedJobApplication.compute_state[siae_evaluations/models.py]',
           'state_from[siae_evaluations/models.py]',
+          '<genexpr>[siae_evaluations/models.py]',
           'EvaluatedSiae.state_from_applications[siae_evaluations/models.py]',
           'EvaluatedSiae.state[siae_evaluations/models.py]',
           'EvaluatedSiae.can_submit[siae_evaluations/models.py]',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Rollback de #6297 
cpython 3.13.5 a rollback le commit problématique. 

On verra ce qui se passera en 3.14 :shrug:

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
