### PR TITLE
Vie privée : anonymisation des candidatures sans emetteur

### DIFF
--- a/itou/archive/management/commands/anonymize_users.py
+++ b/itou/archive/management/commands/anonymize_users.py
@@ -63,7 +63,7 @@ def anonymized_jobapplication(obj):
             obj.job_seeker.jobseeker_profile.birthdate.year if obj.job_seeker.jobseeker_profile.birthdate else None
         ),
         job_seeker_department_same_as_company_department=obj.job_seeker.department == obj.to_company.department,
-        sender_kind=obj.sender.kind,
+        sender_kind=obj.sender_kind,
         sender_company_kind=obj.sender_company.kind if obj.sender_company else None,
         sender_prescriber_organization_kind=(
             obj.sender_prescriber_organization.kind if obj.sender_prescriber_organization else None

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -259,6 +259,37 @@
     }),
   ])
 # ---
+# name: TestArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[sent_by_jobseeker_without_sender][archived_application]
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '76',
+      'company_has_convention': True,
+      'company_kind': 'EI',
+      'company_naf': '7820Z',
+      'had_resume': True,
+      'has_been_transferred': False,
+      'has_diagoriente_invitation': False,
+      'hiring_contract_nature': None,
+      'hiring_contract_type': None,
+      'hiring_rome': None,
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'hiring_without_approval': False,
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': True,
+      'last_transition_at': datetime.date(2025, 3, 1),
+      'number_of_jobs_applied_for': 3,
+      'origin': 'default',
+      'processed_at': None,
+      'refusal_reason': '',
+      'sender_company_kind': None,
+      'sender_kind': 'job_seeker',
+      'sender_prescriber_organization_authorization_status': None,
+      'sender_prescriber_organization_kind': None,
+      'state': 'new',
+    }),
+  ])
+# ---
 # name: TestArchiveUsersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[transferred_application_with_diagoriente_invitation][archived_application]
   list([
     dict({

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -642,6 +642,12 @@ class TestArchiveUsersManagementCommand:
                 0,
                 id="transferred_application_with_diagoriente_invitation",
             ),
+            pytest.param(
+                {"sent_by_job_seeker": True, "sender": None, "to_company__department": 76, "to_company__naf": "7820Z"},
+                True,
+                3,
+                id="sent_by_jobseeker_without_sender",
+            ),
         ],
     )
     def test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period(


### PR DESCRIPTION
## :thinking: Pourquoi ?

2730 candidatures ont un émetteur vide. La méthode `anonymized_jobapplication` échoue dans ce cas.

## :cake: Comment ? <!-- optionnel -->

Utiliser `sender_kind` au lieu de `sender.kind`

+ fiabilsation de tests en utilisant les traits de `JobApplicationFactory`