### PR TITLE
Settings : définir `IMMERSION_FACILE_SITE_URL` par une variable d'environnement

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -769,6 +769,9 @@ GPS_CONTACT_EMAIL = "contact.gps@inclusion.gouv.fr"
 # ------------------------------------------------------------------------------
 MON_RECAP_BANNER_DEPARTMENTS = ["59", "69", "93"]
 
+# Immersion facile
+# ------------------------------------------------------------------------------
+IMMERSION_FACILE_SITE_URL = os.getenv("IMMERSION_FACILE_SITE_URL", "https://staging.immersion-facile.beta.gouv.fr")
 
 # Datadog
 # ------------------------------------------------------------------------------

--- a/itou/utils/constants.py
+++ b/itou/utils/constants.py
@@ -6,7 +6,6 @@ ITOU_HELP_CENTER_URL = "https://aide.emplois.inclusion.beta.gouv.fr/hc/fr"
 PILOTAGE_HELP_CENTER_URL = "https://aide.pilotage.inclusion.beta.gouv.fr/hc/fr"
 PILOTAGE_SITE_URL = "https://pilotage.inclusion.beta.gouv.fr"
 EMPLOIS_SITE_URL = "https://emplois.inclusion.beta.gouv.fr"
-IMMERSION_FACILE_SITE_URL = "https://immersion-facile.beta.gouv.fr"
 POLE_EMPLOI_EMAIL_SUFFIX = "@pole-emploi.fr"
 FRANCE_TRAVAIL_EMAIL_SUFFIX = "@francetravail.fr"
 

--- a/itou/utils/immersion_facile.py
+++ b/itou/utils/immersion_facile.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote, urlencode
 
-from itou.utils.constants import IMMERSION_FACILE_SITE_URL
+from django.conf import settings
 
 
 def immersion_search_url(user):
@@ -26,4 +26,4 @@ def immersion_search_url(user):
         if all(address_parts):
             params["place"] = ", ".join(address_parts)
 
-    return f"{IMMERSION_FACILE_SITE_URL}/recherche?{urlencode(params, quote_via=quote)}"
+    return f"{settings.IMMERSION_FACILE_SITE_URL}/recherche?{urlencode(params, quote_via=quote)}"

--- a/tests/utils/test_immersion_facile.py
+++ b/tests/utils/test_immersion_facile.py
@@ -1,4 +1,5 @@
-from itou.utils.constants import IMMERSION_FACILE_SITE_URL
+from django.conf import settings
+
 from itou.utils.immersion_facile import immersion_search_url
 from tests.users.factories import JobSeekerFactory
 
@@ -10,7 +11,7 @@ def test_immersion_search_url():
         with_geoloc=True,
     )
     expected_url = (
-        f"{IMMERSION_FACILE_SITE_URL}/recherche?"
+        f"{settings.IMMERSION_FACILE_SITE_URL}/recherche?"
         f"mtm_campaign=les-emplois-recherche-immersion"
         f"&mtm_kwd=les-emplois-recherche-immersion"
         f"&distanceKm=20"
@@ -22,7 +23,7 @@ def test_immersion_search_url():
 
     user = JobSeekerFactory(without_geoloc=True)
     expected_url = (
-        f"{IMMERSION_FACILE_SITE_URL}/recherche?"
+        f"{settings.IMMERSION_FACILE_SITE_URL}/recherche?"
         f"mtm_campaign=les-emplois-recherche-immersion"
         f"&mtm_kwd=les-emplois-recherche-immersion"
     )

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1560,7 +1560,7 @@
               </strong>
               vous aide à lui trouver une immersion professionnelle sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
               Rechercher une immersion
           </a>
       </div>
@@ -1583,7 +1583,7 @@
               </strong>
               vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
               Rechercher une immersion
           </a>
       </div>
@@ -1608,7 +1608,7 @@
               </strong>
               vous aide à lui trouver une immersion professionnelle sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
               Rechercher une immersion
           </a>
       </div>
@@ -1631,7 +1631,7 @@
               </strong>
               vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
               Rechercher une immersion
           </a>
       </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans nos environnements de recette, on ne veut pas par accident faire une action sur la prod d'Immersion Facile (par exemple #6334).


## :cake: Comment ? <!-- optionnel -->
On définit cette constante par une variable d'environnement.
Si celle-ci n'est pas définie, on pointe par défaut vers le staging de IF.

