### PR TITLE
Vie privée: correction de la surveillance d'une tâche planifiée

### DIFF
--- a/itou/archive/management/commands/anonymize_users.py
+++ b/itou/archive/management/commands/anonymize_users.py
@@ -214,7 +214,7 @@ class Command(BaseCommand):
     @monitor(
         monitor_slug="anonymize_users",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "* 7-20 * * MON-FRI"},
+            "schedule": {"type": "crontab", "value": "0 7-20 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 2,


### PR DESCRIPTION
## :thinking: Pourquoi ?

ajuster le monitor `sentry` à la planification de `anonymize_users`