### PR TITLE
Admin: Correction de la libération d'adresse email utilisée par un SSO

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -405,6 +405,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, UserAdmin)
             messages.error(request, "Ce compte a déjà été libéré")
             return
 
+        user.emailaddress_set.filter(email=user.email).delete()
         user.email = f"{user.email}_old"
         user.username = f"old_{user.username}"
         user.is_active = False

--- a/tests/users/test_admin_views.py
+++ b/tests/users/test_admin_views.py
@@ -274,7 +274,7 @@ def test_free_sso_email_errors(admin_client):
     employer.refresh_from_db()
     assert employer.is_active is True
 
-    # only IC accounts
+    # only SSO accounts
     response = admin_client.post(
         reverse("admin:users_user_changelist"),
         {
@@ -295,6 +295,7 @@ def test_free_sso_email_ic(admin_client):
         email="ic_user@email.com",
         identity_provider=IdentityProvider.INCLUSION_CONNECT,
     )
+    employer.emailaddress_set.create(email=employer.email, verified=True, primary=True)
 
     response = admin_client.post(
         reverse("admin:users_user_changelist"),
@@ -310,6 +311,7 @@ def test_free_sso_email_ic(admin_client):
     assert employer.companymembership_set.get().is_active is False
     assert employer.username == "old_ic_uuid_username"
     assert employer.email == "ic_user@email.com_old"
+    assert not employer.emailaddress_set.exists()
 
     # It won't work twice on the same user
     response = admin_client.post(
@@ -334,6 +336,7 @@ def test_free_sso_email_proconnect(admin_client):
         email="ic_user@email.com",
         identity_provider=IdentityProvider.PRO_CONNECT,
     )
+    assert not employer.emailaddress_set.exists()
 
     response = admin_client.post(
         reverse("admin:users_user_changelist"),
@@ -349,6 +352,7 @@ def test_free_sso_email_proconnect(admin_client):
     assert employer.companymembership_set.get().is_active is False
     assert employer.username == "old_ic_uuid_username"
     assert employer.email == "ic_user@email.com_old"
+    assert not employer.emailaddress_set.exists()
 
     # It won't work twice on the same user
     response = admin_client.post(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il faut supprimer l'objet `EmailAddress` si on souhaite que l'utilisateur puisse le ré-utiliser.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
