### PR TITLE
Vie privée : anonymiser les professionnels non actifs depuis plus de deux ans

### DIFF
--- a/itou/archive/management/commands/anonymize_jobseekers.py
+++ b/itou/archive/management/commands/anonymize_jobseekers.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.conf import settings
 from django.db import transaction
 from django.db.models import Count, F, Max, OuterRef, Q, Subquery
@@ -8,6 +6,7 @@ from sentry_sdk.crons import monitor
 
 from itou.archive.models import AnonymizedApplication, AnonymizedJobSeeker
 from itou.archive.tasks import async_delete_contact
+from itou.archive.utils import get_year_month_or_none
 from itou.companies.enums import CompanyKind
 from itou.companies.models import JobDescription
 from itou.files.models import File
@@ -21,16 +20,6 @@ from itou.utils.constants import GRACE_PERIOD
 
 
 BATCH_SIZE = 100
-
-
-def get_year_month_or_none(date=None):
-    if not date:
-        return None
-
-    if isinstance(date, datetime.datetime):
-        return timezone.localdate(date).replace(day=1)
-
-    return date.replace(day=1)
 
 
 def anonymized_jobseeker(user):

--- a/itou/archive/management/commands/anonymize_professionals.py
+++ b/itou/archive/management/commands/anonymize_professionals.py
@@ -1,9 +1,21 @@
 from django.conf import settings
-from django.db.models import F
+from django.contrib.auth.hashers import make_password
+from django.db import transaction
+from django.db.models import Exists, F, OuterRef, Q
+from django.utils import timezone
 from sentry_sdk.crons import monitor
 
+from itou.archive.models import AnonymizedProfessional
+from itou.archive.tasks import async_delete_contact
+from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check, get_year_month_or_none
+from itou.companies.models import CompanyMembership
+from itou.institutions.models import InstitutionMembership
+from itou.prescribers.enums import PrescriberAuthorizationStatus
+from itou.prescribers.models import PrescriberMembership
 from itou.users.models import User, UserKind
+from itou.users.notifications import ArchiveUser
 from itou.utils.command import BaseCommand
+from itou.utils.constants import GRACE_PERIOD
 
 
 BATCH_SIZE = 100
@@ -41,6 +53,114 @@ class Command(BaseCommand):
             reset_nb = users_to_reset_qs.count()
         self.logger.info("Reset notified professionals with recent activity: %s", reset_nb)
 
+    @transaction.atomic
+    def anonymize_professionals_after_grace_period(self):
+        now = timezone.now()
+        grace_period_since = now - GRACE_PERIOD
+        self.logger.info("Archiving professionals after grace period, notified before: %s", grace_period_since)
+
+        users = self.get_users(grace_period_since)
+
+        # split users to anonymize into those that can be deleted and those that can only be anonymized
+        users_to_delete = self.get_users_to_anonymize_and_delete(users)
+
+        # users that can be anonymized but not deleted. Users without email are already anonymized
+        users_to_anonymize = [user for user in users if user not in users_to_delete and user.email is not None]
+
+        # users to anonymize or delete that have an email set
+        users_to_remove_from_contact = [user for user in users if user.email]
+
+        if self.wet_run:
+            for user in users:
+                ArchiveUser(user).send()
+
+            self.anonymize_and_delete_professionals(users_to_delete)
+            self.anonymize_professionals_without_deletion(users_to_anonymize)
+            self.remove_from_contact(users_to_remove_from_contact)
+
+        self.logger.info("Anonymized professionals after grace period, count: %d", len(users))
+        self.logger.info(
+            "Included in this count: %d to delete, %d to remove from contact",
+            len(users_to_delete),
+            len(users_to_remove_from_contact),
+        )
+
+    def get_users(self, grace_period_since):
+        return list(
+            User.objects.filter(
+                kind__in=UserKind.professionals(), upcoming_deletion_notified_at__lte=grace_period_since
+            )
+            .annotate(is_deactivated=Q(email__isnull=True))
+            .order_by("is_deactivated", "upcoming_deletion_notified_at")
+            .select_for_update(of=("self",), skip_locked=True)[: self.batch_size]
+        )
+
+    def get_users_to_anonymize_and_delete(self, users):
+        related_objects_to_check = get_filter_kwargs_on_user_for_related_objects_to_check()
+        has_membership_in_authorized_organization_sqs = PrescriberMembership.objects.filter(
+            user_id=OuterRef("id"), organization__authorization_status=PrescriberAuthorizationStatus.VALIDATED
+        )
+        return list(
+            User.objects.filter(id__in=[user.id for user in users])
+            .filter(**related_objects_to_check)
+            .annotate(has_membership_in_authorized_organization=Exists(has_membership_in_authorized_organization_sqs))
+            .prefetch_related(
+                "companymembership_set",
+                "institutionmembership_set",
+                "prescribermembership_set",
+            )
+        )
+
+    # def get_users_to_anonymize_without_deletion(self, users):
+    #    # we do not want to anonymize users that have no email set, as they are already anonymized
+    #    return list(User.objects.filter(id__in=[user.id for user in users], email__isnull=False))
+
+    def make_anonymized_professional(self, user):
+        memberships = [
+            *user.companymembership_set.all(),
+            *user.institutionmembership_set.all(),
+            *user.prescribermembership_set.all(),
+        ]
+        return AnonymizedProfessional(
+            date_joined=get_year_month_or_none(user.date_joined),
+            first_login=get_year_month_or_none(user.first_login),
+            last_login=get_year_month_or_none(user.last_login),
+            department=user.department,
+            title=user.title,
+            kind=user.kind,
+            number_of_memberships=len(memberships),
+            number_of_active_memberships=sum(m.is_active for m in memberships),
+            number_of_memberships_as_administrator=sum(m.is_admin for m in memberships),
+            had_memberships_in_authorized_organization=user.has_membership_in_authorized_organization,
+            identity_provider=user.identity_provider,
+        )
+
+    def anonymize_and_delete_professionals(self, users):
+        AnonymizedProfessional.objects.bulk_create([self.make_anonymized_professional(user) for user in users])
+        User.objects.filter(id__in=[user.id for user in users]).delete()
+
+    def anonymize_professionals_without_deletion(self, users):
+        user_ids = [user.id for user in users]
+        for model in [CompanyMembership, InstitutionMembership, PrescriberMembership]:
+            model.objects.filter(user_id__in=user_ids).update(is_active=False)
+
+        User.objects.filter(id__in=user_ids).update(
+            is_active=False,
+            password=make_password(None),
+            email=None,
+            phone="",
+            address_line_1="",
+            address_line_2="",
+            post_code="",
+            city="",
+            coords=None,
+            insee_city=None,
+        )
+
+    def remove_from_contact(self, users):
+        for user in users:
+            async_delete_contact(user.email)
+
     @monitor(
         monitor_slug="anonymize_professionals",
         monitor_config={
@@ -61,3 +181,4 @@ class Command(BaseCommand):
         self.logger.info("Start anonymizing professionals in %s mode", "wet_run" if wet_run else "dry_run")
 
         self.reset_notified_professionals_with_recent_activity()
+        self.anonymize_professionals_after_grace_period()

--- a/itou/archive/utils.py
+++ b/itou/archive/utils.py
@@ -1,0 +1,15 @@
+from django.db import models
+
+from itou.users.models import User
+
+
+def get_filter_kwargs_on_user_for_related_objects_to_check():
+    """
+    Returns a dictionary of filter parameters to check for objects related
+    to the User model that are not cascade deleted.
+    """
+    return {
+        f"{obj.name}__isnull": True
+        for obj in User._meta.related_objects
+        if getattr(obj, "on_delete", None) and obj.on_delete != models.CASCADE
+    }

--- a/itou/archive/utils.py
+++ b/itou/archive/utils.py
@@ -1,4 +1,7 @@
+import datetime
+
 from django.db import models
+from django.utils import timezone
 
 from itou.users.models import User
 
@@ -13,3 +16,13 @@ def get_filter_kwargs_on_user_for_related_objects_to_check():
         for obj in User._meta.related_objects
         if getattr(obj, "on_delete", None) and obj.on_delete != models.CASCADE
     }
+
+
+def get_year_month_or_none(date=None):
+    if not date:
+        return None
+
+    if isinstance(date, datetime.datetime):
+        return timezone.localdate(date).replace(day=1)
+
+    return date.replace(day=1)

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -333,6 +333,2084 @@
 # name: TestAnonymizeJobseekersManagementCommand.test_suspend_command_setting[True-True][suspend_anonymize_jobseekers_command_log]
   'Anonymizing job seekers is suspended, exiting command'
 # ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_after_grace_period[has_related_objects_and_not_anonymized][user_values_after_anonymization]
+  <UserQuerySet [{'is_active': False, 'password': 'pbkdf2_sha256$test$hash', 'phone': '', 'address_line_1': '', 'address_line_2': '', 'post_code': '', 'city': '', 'coords': None, 'insee_city': None, 'upcoming_deletion_notified_at': FakeDatetime(2025, 1, 15, 0, 0, tzinfo=datetime.timezone.utc), 'first_name': 'Pierre', 'last_name': 'Dupont'}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_after_grace_period[no_related_objects_and_is_anonymized][anonymized_professional]
+  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'department': '44', 'title': '', 'kind': 'labor_inspector', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'DJANGO'}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_after_grace_period[no_related_objects_and_not_anonymized][anonymized_professional]
+  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'department': '44', 'title': '', 'kind': 'employer', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_body]
+  '''
+  Bonjour Micheline DUBOIS,
+  Le 15/01/2025, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
+  A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
+  En cas de besoin, vous pouvez toujours vous réinscrire sur https://emplois.inclusion.beta.gouv.fr/
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_subject]
+  '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[authorized_prescriber_admin_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': True}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[company_admin_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[company_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 0, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_company_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 0, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_institution_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 0, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_prescriber_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 0, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[institution_admin_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[institution_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 0, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[prescriber_membership][anonymized_professionals_with_annotations]
+  <QuerySet [{'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 0, 'had_memberships_in_authorized_organization': False}]>
+# ---
+# name: TestAnonymizeProfessionalManagementCommand.test_num_queries[anonymize_professionals_queries]
+  dict({
+    'num_queries': 78,
+    'queries': list([
+      dict({
+        'origin': list([
+          'Command.reset_notified_professionals_with_recent_activity[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          UPDATE "users_user"
+          SET "upcoming_deletion_notified_at" = NULL
+          WHERE ("users_user"."kind" IN (%s,
+                                         %s,
+                                         %s)
+                 AND "users_user"."last_login" >= ("users_user"."upcoming_deletion_notified_at")
+                 AND "users_user"."upcoming_deletion_notified_at" IS NOT NULL)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'Command.get_users[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 "users_user"."email"::text IS NULL AS "is_deactivated"
+          FROM "users_user"
+          WHERE ("users_user"."kind" IN (%s,
+                                         %s,
+                                         %s)
+                 AND "users_user"."upcoming_deletion_notified_at" <= %s)
+          ORDER BY 36 ASC,
+                   "users_user"."upcoming_deletion_notified_at" ASC
+          LIMIT 100
+          FOR
+          UPDATE OF "users_user" SKIP LOCKED
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.get_users_to_anonymize_and_delete[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "prescribers_prescribermembership" U0
+             INNER JOIN "prescribers_prescriberorganization" U1 ON (U0."organization_id" = U1."id")
+             WHERE (U1."authorization_status" = %s
+                    AND U0."user_id" = ("users_user"."id"))
+             LIMIT 1) AS "has_membership_in_authorized_organization"
+          FROM "users_user"
+          LEFT OUTER JOIN "approvals_approval" ON ("users_user"."id" = "approvals_approval"."created_by_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."approval_manually_delivered_by_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" T4 ON ("users_user"."id" = T4."approval_manually_refused_by_id")
+          LEFT OUTER JOIN "approvals_approval" T5 ON ("users_user"."id" = T5."user_id")
+          LEFT OUTER JOIN "approvals_suspension" ON ("users_user"."id" = "approvals_suspension"."created_by_id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_user"."id" = "prescribers_prescriberorganization"."authorization_updated_by_id")
+          LEFT OUTER JOIN "geiq_assessments_assessment" ON ("users_user"."id" = "geiq_assessments_assessment"."created_by_id")
+          LEFT OUTER JOIN "companies_company" ON ("users_user"."id" = "companies_company"."created_by_id")
+          LEFT OUTER JOIN "gps_followupgroupmembership" ON ("users_user"."id" = "gps_followupgroupmembership"."creator_id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" T11 ON ("users_user"."id" = T11."created_by_id")
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("users_user"."id" = "eligibility_eligibilitydiagnosis"."author_id")
+          LEFT OUTER JOIN "geiq_assessments_assessment" T13 ON ("users_user"."id" = T13."final_reviewed_by_id")
+          LEFT OUTER JOIN "eligibility_geiqeligibilitydiagnosis" ON ("users_user"."id" = "eligibility_geiqeligibilitydiagnosis"."author_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" T15 ON ("users_user"."id" = T15."job_seeker_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" T16 ON ("users_user"."id" = T16."sender_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" T17 ON ("users_user"."id" = T17."transferred_by_id")
+          LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("users_user"."id" = "job_applications_jobapplicationtransitionlog"."user_id")
+          LEFT OUTER JOIN "approvals_prolongationrequest" ON ("users_user"."id" = "approvals_prolongationrequest"."processed_by_id")
+          LEFT OUTER JOIN "approvals_prolongationrequest" T20 ON ("users_user"."id" = T20."created_by_id")
+          LEFT OUTER JOIN "approvals_prolongationrequest" T21 ON ("users_user"."id" = T21."declared_by_id")
+          LEFT OUTER JOIN "approvals_prolongationrequest" T22 ON ("users_user"."id" = T22."updated_by_id")
+          LEFT OUTER JOIN "approvals_prolongationrequest" T23 ON ("users_user"."id" = T23."validated_by_id")
+          LEFT OUTER JOIN "approvals_prolongation" ON ("users_user"."id" = "approvals_prolongation"."created_by_id")
+          LEFT OUTER JOIN "approvals_prolongation" T25 ON ("users_user"."id" = T25."declared_by_id")
+          LEFT OUTER JOIN "approvals_prolongation" T26 ON ("users_user"."id" = T26."updated_by_id")
+          LEFT OUTER JOIN "approvals_prolongation" T27 ON ("users_user"."id" = T27."validated_by_id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("users_user"."id" = "companies_siaeconvention"."reactivated_by_id")
+          LEFT OUTER JOIN "geiq_assessments_assessment" T29 ON ("users_user"."id" = T29."reviewed_by_id")
+          LEFT OUTER JOIN "geiq_assessments_assessment" T30 ON ("users_user"."id" = T30."submitted_by_id")
+          LEFT OUTER JOIN "approvals_suspension" T31 ON ("users_user"."id" = T31."updated_by_id")
+          LEFT OUTER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."updated_by_id")
+          LEFT OUTER JOIN "institutions_institutionmembership" ON ("users_user"."id" = "institutions_institutionmembership"."updated_by_id")
+          LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."updated_by_id")
+          LEFT OUTER JOIN "users_user" T35 ON ("users_user"."id" = T35."created_by_id")
+          WHERE ("users_user"."id" IN (%s,
+                                       %s,
+                                       %s,
+                                       %s,
+                                       %s,
+                                       %s,
+                                       %s,
+                                       %s,
+                                       %s)
+                 AND "approvals_approval"."id" IS NULL
+                 AND "job_applications_jobapplication"."id" IS NULL
+                 AND T4."id" IS NULL
+                 AND T5."id" IS NULL
+                 AND "approvals_suspension"."id" IS NULL
+                 AND "prescribers_prescriberorganization"."id" IS NULL
+                 AND "geiq_assessments_assessment"."id" IS NULL
+                 AND "companies_company"."id" IS NULL
+                 AND "gps_followupgroupmembership"."id" IS NULL
+                 AND T11."id" IS NULL
+                 AND "eligibility_eligibilitydiagnosis"."id" IS NULL
+                 AND T13."id" IS NULL
+                 AND "eligibility_geiqeligibilitydiagnosis"."id" IS NULL
+                 AND T15."id" IS NULL
+                 AND T16."id" IS NULL
+                 AND T17."id" IS NULL
+                 AND "job_applications_jobapplicationtransitionlog"."id" IS NULL
+                 AND "approvals_prolongationrequest"."id" IS NULL
+                 AND T20."id" IS NULL
+                 AND T21."id" IS NULL
+                 AND T22."id" IS NULL
+                 AND T23."id" IS NULL
+                 AND "approvals_prolongation"."id" IS NULL
+                 AND T25."id" IS NULL
+                 AND T26."id" IS NULL
+                 AND T27."id" IS NULL
+                 AND "companies_siaeconvention"."id" IS NULL
+                 AND T29."id" IS NULL
+                 AND T30."id" IS NULL
+                 AND T31."id" IS NULL
+                 AND "companies_companymembership"."id" IS NULL
+                 AND "institutions_institutionmembership"."id" IS NULL
+                 AND "prescribers_prescribermembership"."id" IS NULL
+                 AND T35."id" IS NULL)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.get_users_to_anonymize_and_delete[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE "companies_companymembership"."user_id" IN (%s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.get_users_to_anonymize_and_delete[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id"
+          FROM "institutions_institutionmembership"
+          WHERE "institutions_institutionmembership"."user_id" IN (%s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.get_users_to_anonymize_and_delete[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id"
+          FROM "prescribers_prescribermembership"
+          WHERE "prescribers_prescribermembership"."user_id" IN (%s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Email.save[<site-packages>/django/db/models/base.py]',
+          'AsyncEmailBackend.send_messages[emails/tasks.py]',
+          'ArchiveUser.send[communications/dispatch/email.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "emails_email" ("to",
+                                      "cc",
+                                      "bcc",
+                                      "subject",
+                                      "body_text",
+                                      "from_email",
+                                      "reply_to",
+                                      "created_at",
+                                      "esp_response")
+          VALUES (%s::citext[], %s::citext[], %s::citext[], %s, %s, %s, %s::citext[], %s, %s) RETURNING "emails_email"."id"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          INSERT INTO "archive_anonymizedprofessional" ("id",
+                                                        "date_joined",
+                                                        "first_login",
+                                                        "last_login",
+                                                        "anonymized_at",
+                                                        "department",
+                                                        "title",
+                                                        "kind",
+                                                        "number_of_memberships",
+                                                        "number_of_active_memberships",
+                                                        "number_of_memberships_as_administrator",
+                                                        "had_memberships_in_authorized_organization",
+                                                        "identity_provider")
+          SELECT *
+          FROM UNNEST((%s)::UUID[], (%s)::date[], (%s)::date[], (%s)::date[], (%s)::timestamp WITH TIME ZONE[], (%s)::varchar(3)[], (%s)::varchar(3)[], (%s)::varchar(50)[], (%s)::integer[], (%s)::integer[], (%s)::integer[], (%s)::boolean[], (%s)::varchar(20)[])
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" IN (%s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "account_emailaddress"."id"
+          FROM "account_emailaddress"
+          WHERE "account_emailaddress"."user_id" IN (%s,
+                                                     %s,
+                                                     %s,
+                                                     %s,
+                                                     %s,
+                                                     %s,
+                                                     %s,
+                                                     %s,
+                                                     %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id"
+          FROM "companies_company"
+          WHERE "companies_company"."created_by_id" IN (%s,
+                                                        %s,
+                                                        %s,
+                                                        %s,
+                                                        %s,
+                                                        %s,
+                                                        %s,
+                                                        %s,
+                                                        %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE "companies_companymembership"."updated_by_id" IN (%s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_siaeconvention"."id"
+          FROM "companies_siaeconvention"
+          WHERE "companies_siaeconvention"."reactivated_by_id" IN (%s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id"
+          FROM "users_user"
+          WHERE "users_user"."created_by_id" IN (%s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerprofile"."user_id"
+          FROM "users_jobseekerprofile"
+          WHERE "users_jobseekerprofile"."user_id" IN (%s,
+                                                       %s,
+                                                       %s,
+                                                       %s,
+                                                       %s,
+                                                       %s,
+                                                       %s,
+                                                       %s,
+                                                       %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id"
+          FROM "prescribers_prescriberorganization"
+          WHERE "prescribers_prescriberorganization"."created_by_id" IN (%s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id"
+          FROM "prescribers_prescriberorganization"
+          WHERE "prescribers_prescriberorganization"."authorization_updated_by_id" IN (%s,
+                                                                                       %s,
+                                                                                       %s,
+                                                                                       %s,
+                                                                                       %s,
+                                                                                       %s,
+                                                                                       %s,
+                                                                                       %s,
+                                                                                       %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id"
+          FROM "prescribers_prescribermembership"
+          WHERE "prescribers_prescribermembership"."updated_by_id" IN (%s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id"
+          FROM "institutions_institutionmembership"
+          WHERE "institutions_institutionmembership"."updated_by_id" IN (%s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."job_seeker_id" IN (%s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."sender_id" IN (%s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."archived_by_id" IN (%s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."approval_manually_delivered_by_id" IN (%s,
+                                                                                          %s,
+                                                                                          %s,
+                                                                                          %s,
+                                                                                          %s,
+                                                                                          %s,
+                                                                                          %s,
+                                                                                          %s,
+                                                                                          %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."approval_manually_refused_by_id" IN (%s,
+                                                                                        %s,
+                                                                                        %s,
+                                                                                        %s,
+                                                                                        %s,
+                                                                                        %s,
+                                                                                        %s,
+                                                                                        %s,
+                                                                                        %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."transferred_by_id" IN (%s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplicationtransitionlog"."id",
+                 "job_applications_jobapplicationtransitionlog"."transition",
+                 "job_applications_jobapplicationtransitionlog"."from_state",
+                 "job_applications_jobapplicationtransitionlog"."to_state",
+                 "job_applications_jobapplicationtransitionlog"."timestamp",
+                 "job_applications_jobapplicationtransitionlog"."job_application_id",
+                 "job_applications_jobapplicationtransitionlog"."user_id",
+                 "job_applications_jobapplicationtransitionlog"."target_company_id"
+          FROM "job_applications_jobapplicationtransitionlog"
+          WHERE "job_applications_jobapplicationtransitionlog"."user_id" IN (%s,
+                                                                             %s,
+                                                                             %s,
+                                                                             %s,
+                                                                             %s,
+                                                                             %s,
+                                                                             %s,
+                                                                             %s,
+                                                                             %s)
+          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" IN (%s,
+                                                   %s,
+                                                   %s,
+                                                   %s,
+                                                   %s,
+                                                   %s,
+                                                   %s,
+                                                   %s,
+                                                   %s)
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."created_by_id" IN (%s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s)
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."created_by_id" IN (%s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."updated_by_id" IN (%s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s,
+                                                           %s)
+          ORDER BY "approvals_suspension"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id"
+          FROM "approvals_prolongationrequest"
+          WHERE "approvals_prolongationrequest"."declared_by_id" IN (%s,
+                                                                     %s,
+                                                                     %s,
+                                                                     %s,
+                                                                     %s,
+                                                                     %s,
+                                                                     %s,
+                                                                     %s,
+                                                                     %s)
+          ORDER BY "approvals_prolongationrequest"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id"
+          FROM "approvals_prolongationrequest"
+          WHERE "approvals_prolongationrequest"."validated_by_id" IN (%s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s)
+          ORDER BY "approvals_prolongationrequest"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id"
+          FROM "approvals_prolongationrequest"
+          WHERE "approvals_prolongationrequest"."created_by_id" IN (%s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s)
+          ORDER BY "approvals_prolongationrequest"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id"
+          FROM "approvals_prolongationrequest"
+          WHERE "approvals_prolongationrequest"."updated_by_id" IN (%s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s)
+          ORDER BY "approvals_prolongationrequest"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id"
+          FROM "approvals_prolongationrequest"
+          WHERE "approvals_prolongationrequest"."processed_by_id" IN (%s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s)
+          ORDER BY "approvals_prolongationrequest"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id",
+                 "approvals_prolongation"."approval_id",
+                 "approvals_prolongation"."start_at",
+                 "approvals_prolongation"."end_at",
+                 "approvals_prolongation"."reason",
+                 "approvals_prolongation"."reason_explanation",
+                 "approvals_prolongation"."declared_by_id",
+                 "approvals_prolongation"."declared_by_siae_id",
+                 "approvals_prolongation"."validated_by_id",
+                 "approvals_prolongation"."prescriber_organization_id",
+                 "approvals_prolongation"."created_at",
+                 "approvals_prolongation"."created_by_id",
+                 "approvals_prolongation"."updated_at",
+                 "approvals_prolongation"."updated_by_id",
+                 "approvals_prolongation"."report_file_id",
+                 "approvals_prolongation"."require_phone_interview",
+                 "approvals_prolongation"."contact_email",
+                 "approvals_prolongation"."contact_phone",
+                 "approvals_prolongation"."request_id"
+          FROM "approvals_prolongation"
+          WHERE "approvals_prolongation"."declared_by_id" IN (%s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s)
+          ORDER BY "approvals_prolongation"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id",
+                 "approvals_prolongation"."approval_id",
+                 "approvals_prolongation"."start_at",
+                 "approvals_prolongation"."end_at",
+                 "approvals_prolongation"."reason",
+                 "approvals_prolongation"."reason_explanation",
+                 "approvals_prolongation"."declared_by_id",
+                 "approvals_prolongation"."declared_by_siae_id",
+                 "approvals_prolongation"."validated_by_id",
+                 "approvals_prolongation"."prescriber_organization_id",
+                 "approvals_prolongation"."created_at",
+                 "approvals_prolongation"."created_by_id",
+                 "approvals_prolongation"."updated_at",
+                 "approvals_prolongation"."updated_by_id",
+                 "approvals_prolongation"."report_file_id",
+                 "approvals_prolongation"."require_phone_interview",
+                 "approvals_prolongation"."contact_email",
+                 "approvals_prolongation"."contact_phone",
+                 "approvals_prolongation"."request_id"
+          FROM "approvals_prolongation"
+          WHERE "approvals_prolongation"."validated_by_id" IN (%s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s)
+          ORDER BY "approvals_prolongation"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id",
+                 "approvals_prolongation"."approval_id",
+                 "approvals_prolongation"."start_at",
+                 "approvals_prolongation"."end_at",
+                 "approvals_prolongation"."reason",
+                 "approvals_prolongation"."reason_explanation",
+                 "approvals_prolongation"."declared_by_id",
+                 "approvals_prolongation"."declared_by_siae_id",
+                 "approvals_prolongation"."validated_by_id",
+                 "approvals_prolongation"."prescriber_organization_id",
+                 "approvals_prolongation"."created_at",
+                 "approvals_prolongation"."created_by_id",
+                 "approvals_prolongation"."updated_at",
+                 "approvals_prolongation"."updated_by_id",
+                 "approvals_prolongation"."report_file_id",
+                 "approvals_prolongation"."require_phone_interview",
+                 "approvals_prolongation"."contact_email",
+                 "approvals_prolongation"."contact_phone",
+                 "approvals_prolongation"."request_id"
+          FROM "approvals_prolongation"
+          WHERE "approvals_prolongation"."created_by_id" IN (%s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s)
+          ORDER BY "approvals_prolongation"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id",
+                 "approvals_prolongation"."approval_id",
+                 "approvals_prolongation"."start_at",
+                 "approvals_prolongation"."end_at",
+                 "approvals_prolongation"."reason",
+                 "approvals_prolongation"."reason_explanation",
+                 "approvals_prolongation"."declared_by_id",
+                 "approvals_prolongation"."declared_by_siae_id",
+                 "approvals_prolongation"."validated_by_id",
+                 "approvals_prolongation"."prescriber_organization_id",
+                 "approvals_prolongation"."created_at",
+                 "approvals_prolongation"."created_by_id",
+                 "approvals_prolongation"."updated_at",
+                 "approvals_prolongation"."updated_by_id",
+                 "approvals_prolongation"."report_file_id",
+                 "approvals_prolongation"."require_phone_interview",
+                 "approvals_prolongation"."contact_email",
+                 "approvals_prolongation"."contact_phone",
+                 "approvals_prolongation"."request_id"
+          FROM "approvals_prolongation"
+          WHERE "approvals_prolongation"."updated_by_id" IN (%s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s)
+          ORDER BY "approvals_prolongation"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_geiqeligibilitydiagnosis"."id"
+          FROM "eligibility_geiqeligibilitydiagnosis"
+          WHERE "eligibility_geiqeligibilitydiagnosis"."author_id" IN (%s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_geiqeligibilitydiagnosis"."id"
+          FROM "eligibility_geiqeligibilitydiagnosis"
+          WHERE "eligibility_geiqeligibilitydiagnosis"."job_seeker_id" IN (%s,
+                                                                           %s,
+                                                                           %s,
+                                                                           %s,
+                                                                           %s,
+                                                                           %s,
+                                                                           %s,
+                                                                           %s,
+                                                                           %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_eligibilitydiagnosis"."id"
+          FROM "eligibility_eligibilitydiagnosis"
+          WHERE "eligibility_eligibilitydiagnosis"."author_id" IN (%s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s)
+          ORDER BY "eligibility_eligibilitydiagnosis"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_eligibilitydiagnosis"."id"
+          FROM "eligibility_eligibilitydiagnosis"
+          WHERE "eligibility_eligibilitydiagnosis"."job_seeker_id" IN (%s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s)
+          ORDER BY "eligibility_eligibilitydiagnosis"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "external_data_externaldataimport"."id"
+          FROM "external_data_externaldataimport"
+          WHERE "external_data_externaldataimport"."user_id" IN (%s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "employee_record_employeerecordtransitionlog"."id",
+                 "employee_record_employeerecordtransitionlog"."transition",
+                 "employee_record_employeerecordtransitionlog"."from_state",
+                 "employee_record_employeerecordtransitionlog"."to_state",
+                 "employee_record_employeerecordtransitionlog"."timestamp",
+                 "employee_record_employeerecordtransitionlog"."asp_processing_code",
+                 "employee_record_employeerecordtransitionlog"."asp_processing_label",
+                 "employee_record_employeerecordtransitionlog"."asp_batch_file",
+                 "employee_record_employeerecordtransitionlog"."asp_batch_line_number",
+                 "employee_record_employeerecordtransitionlog"."archived_json",
+                 "employee_record_employeerecordtransitionlog"."employee_record_id",
+                 "employee_record_employeerecordtransitionlog"."user_id",
+                 "employee_record_employeerecordtransitionlog"."recovered"
+          FROM "employee_record_employeerecordtransitionlog"
+          WHERE "employee_record_employeerecordtransitionlog"."user_id" IN (%s,
+                                                                            %s,
+                                                                            %s,
+                                                                            %s,
+                                                                            %s,
+                                                                            %s,
+                                                                            %s,
+                                                                            %s,
+                                                                            %s)
+          ORDER BY "employee_record_employeerecordtransitionlog"."timestamp" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id"
+          FROM "geiq_assessments_assessment"
+          WHERE "geiq_assessments_assessment"."created_by_id" IN (%s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id"
+          FROM "geiq_assessments_assessment"
+          WHERE "geiq_assessments_assessment"."submitted_by_id" IN (%s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id"
+          FROM "geiq_assessments_assessment"
+          WHERE "geiq_assessments_assessment"."reviewed_by_id" IN (%s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_assessment"."id"
+          FROM "geiq_assessments_assessment"
+          WHERE "geiq_assessments_assessment"."final_reviewed_by_id" IN (%s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s,
+                                                                         %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "communications_notificationsettings"."id"
+          FROM "communications_notificationsettings"
+          WHERE "communications_notificationsettings"."user_id" IN (%s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroup"."id"
+          FROM "gps_followupgroup"
+          WHERE "gps_followupgroup"."beneficiary_id" IN (%s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s,
+                                                         %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroupmembership"."id",
+                 "gps_followupgroupmembership"."is_referent_certified",
+                 "gps_followupgroupmembership"."is_active",
+                 "gps_followupgroupmembership"."created_at",
+                 "gps_followupgroupmembership"."created_in_bulk",
+                 "gps_followupgroupmembership"."last_contact_at",
+                 "gps_followupgroupmembership"."started_at",
+                 "gps_followupgroupmembership"."ended_at",
+                 "gps_followupgroupmembership"."updated_at",
+                 "gps_followupgroupmembership"."can_view_personal_information",
+                 "gps_followupgroupmembership"."follow_up_group_id",
+                 "gps_followupgroupmembership"."member_id",
+                 "gps_followupgroupmembership"."creator_id",
+                 "gps_followupgroupmembership"."reason",
+                 "gps_followupgroupmembership"."end_reason"
+          FROM "gps_followupgroupmembership"
+          WHERE "gps_followupgroupmembership"."creator_id" IN (%s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s,
+                                                               %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "rdv_insertion_invitationrequest"."id"
+          FROM "rdv_insertion_invitationrequest"
+          WHERE "rdv_insertion_invitationrequest"."job_seeker_id" IN (%s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s,
+                                                                      %s)
+          ORDER BY "rdv_insertion_invitationrequest"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "django_admin_log"
+          WHERE "django_admin_log"."user_id" IN (%s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s,
+                                                 %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "authtoken_token"
+          WHERE "authtoken_token"."user_id" IN (%s,
+                                                %s,
+                                                %s,
+                                                %s,
+                                                %s,
+                                                %s,
+                                                %s,
+                                                %s,
+                                                %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "otp_totp_totpdevice"
+          WHERE "otp_totp_totpdevice"."user_id" IN (%s,
+                                                    %s,
+                                                    %s,
+                                                    %s,
+                                                    %s,
+                                                    %s,
+                                                    %s,
+                                                    %s,
+                                                    %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "companies_companymembership"
+          WHERE "companies_companymembership"."user_id" IN (%s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "users_user_groups"
+          WHERE "users_user_groups"."user_id" IN (%s,
+                                                  %s,
+                                                  %s,
+                                                  %s,
+                                                  %s,
+                                                  %s,
+                                                  %s,
+                                                  %s,
+                                                  %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "users_user_user_permissions"
+          WHERE "users_user_user_permissions"."user_id" IN (%s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s,
+                                                            %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "prescribers_prescribermembership"
+          WHERE "prescribers_prescribermembership"."user_id" IN (%s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "institutions_institutionmembership"
+          WHERE "institutions_institutionmembership"."user_id" IN (%s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s,
+                                                                   %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "invitations_prescriberwithorginvitation"
+          WHERE "invitations_prescriberwithorginvitation"."sender_id" IN (%s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s,
+                                                                          %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "invitations_employerinvitation"
+          WHERE "invitations_employerinvitation"."sender_id" IN (%s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s,
+                                                                 %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "invitations_laborinspectorinvitation"
+          WHERE "invitations_laborinspectorinvitation"."sender_id" IN (%s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s,
+                                                                       %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "external_data_jobseekerexternaldata"
+          WHERE "external_data_jobseekerexternaldata"."user_id" IN (%s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "gps_followupgroupmembership"
+          WHERE "gps_followupgroupmembership"."member_id" IN (%s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s,
+                                                              %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "rdv_insertion_participation"
+          WHERE "rdv_insertion_participation"."job_seeker_id" IN (%s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s,
+                                                                  %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          DELETE
+          FROM "users_user"
+          WHERE "users_user"."id" IN (%s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_activity][inactive_jobseeker_email_body]
   '''
   Bonjour Jane DOE,

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -1,10 +1,4 @@
 # serializer version: 1
-# name: TestAnonymizeProfessionalManagementCommand.test_suspend_command_setting[False][suspend_anonymize_professionals_command_log]
-  'Start anonymizing professionals in wet_run mode'
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_suspend_command_setting[True][suspend_anonymize_professionals_command_log]
-  'Anonymizing professionals is suspended, exiting command'
-# ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_not_is_active][archived_jobseeker]
   list([
     dict({

--- a/tests/archive/__snapshots__/tests_utils.ambr
+++ b/tests/archive/__snapshots__/tests_utils.ambr
@@ -1,0 +1,103 @@
+# serializer version: 1
+# name: TestRelatedObjectsConsistency.test_get_filter_kwargs_on_user_for_related_objects_to_check[filter_kwargs_on_user_for_related_objects_to_check]
+  dict({
+    'approval__isnull': True,
+    'approval_manually_delivered__isnull': True,
+    'approval_manually_refused__isnull': True,
+    'approvals__isnull': True,
+    'approvals_suspended_set__isnull': True,
+    'authorization_status_set__isnull': True,
+    'created_assessments__isnull': True,
+    'created_company_set__isnull': True,
+    'created_follow_up_groups__isnull': True,
+    'created_prescriber_organization_set__isnull': True,
+    'eligibilitydiagnosis__isnull': True,
+    'final_reviewed_assessments__isnull': True,
+    'geiqeligibilitydiagnosis__isnull': True,
+    'job_applications__isnull': True,
+    'job_applications_sent__isnull': True,
+    'jobapplication__isnull': True,
+    'jobapplicationtransitionlog__isnull': True,
+    'prolongationrequest_processed__isnull': True,
+    'prolongationrequests_created__isnull': True,
+    'prolongationrequests_declared__isnull': True,
+    'prolongationrequests_updated__isnull': True,
+    'prolongationrequests_validated__isnull': True,
+    'prolongations_created__isnull': True,
+    'prolongations_declared__isnull': True,
+    'prolongations_updated__isnull': True,
+    'prolongations_validated__isnull': True,
+    'reactivated_siae_convention_set__isnull': True,
+    'reviewed_assessments__isnull': True,
+    'submitted_assessments__isnull': True,
+    'suspension__isnull': True,
+    'updated_companymembership_set__isnull': True,
+    'updated_institutionmembership_set__isnull': True,
+    'updated_prescribermembership_set__isnull': True,
+    'user__isnull': True,
+  })
+# ---
+# name: TestRelatedObjectsConsistency.test_user_related_objects_deleted_on_cascade[user_related_objects_deleted_on_cascade]
+  list([
+    dict({
+      'logentry': <class 'django.contrib.admin.models.LogEntry'>,
+    }),
+    dict({
+      'auth_token': <class 'rest_framework.authtoken.models.Token'>,
+    }),
+    dict({
+      'totpdevice': <class 'django_otp.plugins.otp_totp.models.TOTPDevice'>,
+    }),
+    dict({
+      'emailaddress': <class 'allauth.account.models.EmailAddress'>,
+    }),
+    dict({
+      'companymembership': <class 'itou.companies.models.CompanyMembership'>,
+    }),
+    dict({
+      'jobseeker_profile': <class 'itou.users.models.JobSeekerProfile'>,
+    }),
+    dict({
+      'prescribermembership': <class 'itou.prescribers.models.PrescriberMembership'>,
+    }),
+    dict({
+      'institutionmembership': <class 'itou.institutions.models.InstitutionMembership'>,
+    }),
+    dict({
+      'geiq_eligibility_diagnoses': <class 'itou.eligibility.models.geiq.GEIQEligibilityDiagnosis'>,
+    }),
+    dict({
+      'eligibility_diagnoses': <class 'itou.eligibility.models.iae.EligibilityDiagnosis'>,
+    }),
+    dict({
+      'prescriber_org_invitations': <class 'itou.invitations.models.PrescriberWithOrgInvitation'>,
+    }),
+    dict({
+      'company_invitations': <class 'itou.invitations.models.EmployerInvitation'>,
+    }),
+    dict({
+      'institution_invitations': <class 'itou.invitations.models.LaborInspectorInvitation'>,
+    }),
+    dict({
+      'externaldataimport': <class 'itou.external_data.models.ExternalDataImport'>,
+    }),
+    dict({
+      'jobseekerexternaldata': <class 'itou.external_data.models.JobSeekerExternalData'>,
+    }),
+    dict({
+      'notification_settings': <class 'itou.communications.models.NotificationSettings'>,
+    }),
+    dict({
+      'follow_up_group': <class 'itou.gps.models.FollowUpGroup'>,
+    }),
+    dict({
+      'follow_up_groups': <class 'itou.gps.models.FollowUpGroupMembership'>,
+    }),
+    dict({
+      'rdvi_invitation_requests': <class 'itou.rdv_insertion.models.InvitationRequest'>,
+    }),
+    dict({
+      'rdvi_participations': <class 'itou.rdv_insertion.models.Participation'>,
+    }),
+  ])
+# ---

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -779,11 +779,17 @@ class TestAnonymizeJobseekersManagementCommand:
 
 
 class TestAnonymizeProfessionalManagementCommand:
-    @pytest.mark.parametrize("suspended", [True, False])
-    def test_suspend_command_setting(self, settings, suspended, caplog, snapshot):
+    @pytest.mark.parametrize(
+        "suspended,expected_message",
+        [
+            (True, "Anonymizing professionals is suspended, exiting command"),
+            (False, "Start anonymizing professionals in wet_run mode"),
+        ],
+    )
+    def test_suspend_command_setting(self, settings, suspended, expected_message, caplog):
         settings.SUSPEND_ANONYMIZE_PROFESSIONALS = suspended
         call_command("anonymize_professionals", wet_run=True)
-        assert caplog.messages[0] == snapshot(name="suspend_anonymize_professionals_command_log")
+        assert expected_message in caplog.messages
 
     @pytest.mark.parametrize("factory", [EmployerFactory, PrescriberFactory, LaborInspectorFactory])
     def test_reset_notified_professional_dry_run(self, factory):

--- a/tests/archive/tests_utils.py
+++ b/tests/archive/tests_utils.py
@@ -1,0 +1,21 @@
+from django.db import models
+
+from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check
+from itou.users.models import User
+
+
+class TestRelatedObjectsConsistency:
+    # Theses tests aims to prevent any add or update FK relationship on User model
+    # that would not be handled by the management command `notify_archive_users`.
+    # If one of these tests fails, consider looking at this command and updating it
+    def test_get_filter_kwargs_on_user_for_related_objects_to_check(self, snapshot):
+        filter_kwargs = get_filter_kwargs_on_user_for_related_objects_to_check()
+        assert filter_kwargs == snapshot(name="filter_kwargs_on_user_for_related_objects_to_check")
+
+    def test_user_related_objects_deleted_on_cascade(self, snapshot):
+        user_related_objects = [
+            {obj.name: obj.related_model}
+            for obj in User._meta.related_objects
+            if getattr(obj, "on_delete", None) and obj.on_delete == models.CASCADE
+        ]
+        assert user_related_objects == snapshot(name="user_related_objects_deleted_on_cascade")

--- a/tests/archive/tests_utils.py
+++ b/tests/archive/tests_utils.py
@@ -1,6 +1,11 @@
-from django.db import models
+import datetime
 
-from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check
+import pytest
+import pytz
+from django.db import models
+from django.utils import timezone
+
+from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check, get_year_month_or_none
 from itou.users.models import User
 
 
@@ -19,3 +24,16 @@ class TestRelatedObjectsConsistency:
             if getattr(obj, "on_delete", None) and obj.on_delete == models.CASCADE
         ]
         assert user_related_objects == snapshot(name="user_related_objects_deleted_on_cascade")
+
+
+@pytest.mark.parametrize(
+    "date_input, expected_output",
+    [
+        (timezone.make_aware(datetime.datetime(2023, 10, 15)), datetime.date(2023, 10, 1)),
+        (timezone.make_aware(datetime.datetime(2024, 8, 31, 23, 0, 0), pytz.utc), datetime.date(2024, 9, 1)),
+        (datetime.date(2023, 10, 15), datetime.date(2023, 10, 1)),
+        (None, None),
+    ],
+)
+def test_get_year_month_or_none(date_input, expected_output):
+    assert get_year_month_or_none(date_input) == expected_output


### PR DESCRIPTION
reprise de #6074 suite au split de la management commande dans #6332 

prerequis #6370 (ajout & modification des modèles) et #6371 (déclaration de la management command)

## :thinking: Pourquoi ?

Anonymiser les comptes de prescripteurs, d'employeurs et d'inspecteurs du travail, inactifs depuis 24 mois

Si le compte n'est lié à aucun objet protégé ou restreint, l'utilisater est supprimé, un `AnonymizedProfessionnal` est enregistré à la place.

Si le compte est lié à des objets protégés ou restreints, l'utilisateur est conservé, les données personnelles sont effacées sauf le nom et le prénom. L'utilisateur et ses `memberships `sont passés à l'état `is_active=False`. Son password est rendu inutilisable

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._


## 🎲  A noter
Les tests de la classe `TestRelatedObjectsConsistency` permettent de s'assurer que la liste des relations avec le modèle `User` n'évolue pas sans rappeler le besoin de mettre à jour, éventuellement, les commandes de notification et d'archivage