### PR TITLE
Interface: Correction de bugs à l'impression des fiches candidatures

### DIFF
--- a/itou/templates/apply/includes/certification_info_box.html
+++ b/itou/templates/apply/includes/certification_info_box.html
@@ -1,60 +1,46 @@
 {% if request.user.is_employer or request.from_authorized_prescriber %}
     {% if diagnosis.criteria_can_be_certified %}
-        <div class="c-box bg-info-lightest my-4 p-0">
-            <button class="has-collapse-caret w-100 text-start d-block d-flex justify-content-between fw-bold text-left p-3 align-items-center"
-                    type="button"
-                    data-bs-target="#collapse-certif-help-text"
-                    data-bs-toggle="collapse"
-                    aria-expanded="false"
-                    aria-controls="collapse-certif-help-text">
-                <div>
-                    <i class="ri-lightbulb-line fw-medium pe-2" aria-hidden="true"></i>
-                    <span>Pourquoi certains critères peuvent-ils être certifiés ?</span>
-                </div>
+        <div class="c-info my-4">
+            <button class="c-info__summary" data-bs-toggle="collapse" data-bs-target="#collapse-certif-help-text" aria-expanded="true" aria-controls="collapse-certif-help-text">
+                <span>Pourquoi certains critères peuvent-ils être certifiés ?</span>
             </button>
-            <div id="collapse-certif-help-text" class="collapse justify-content-between pb-4 ps-5 pe-3">
-                <span>
+            <div class="c-info__detail collapse" id="collapse-certif-help-text">
+                <p>
                     Nous développons progressivement nos connexions avec les
                     différents services de l’État qui fournissent les justificatifs
                     correspondant aux critères administratifs. Après interrogation
                     du système d’information de l’État, deux types de badges
                     peuvent être affichés :
-                    <dl>
-                        <div class="my-3 ms-3">
-                            <dt class="d-inline">Certifié</dt>
-                            <dd class="d-inline">
-                                Aucune action n’est nécessaire.
-                            </dd>
-                        </div>
-
-                        <div class="my-3 ms-3">
-                            <dt class="d-inline">Non certifié</dt>
-                            <dd class="d-inline">
-                                Nous n’avons pas trouvé d’information permettant de
-                                valider ce critère administratif.
-                            </dd>
-                        </div>
-                    </dl>
-
-                    <p>
-                        <strong>
-                            Lorsqu’un critère n’est pas certifié dans le cadre d’une
-                            auto-prescription, nous recommandons à l’employeur de
-                            récupérer et conserver une copie du justificatif
-                            administratif.
-                        </strong>
-                        Pour rappel, les critères déclarés par les prescripteurs habilités ne nécessitent aucun justificatif.
-                    </p>
-                    <p>
-                        L’absence de badge signifie que nous ne sommes pas encore en
-                        mesure d’interroger le système d’information de l’État pour ce
-                        critère.
-                    </p>
-                    <p class="mb-0">
-                        Retrouvez le détail des conditions dans
-                        <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" class="has-external-link" target="_blank" rel="noreferrer">notre documentation</a>.
-                    </p>
-                </span>
+                </p>
+                <dl class="my-3 ms-3">
+                    <dt>Certifié</dt>
+                    <dd>
+                        Aucune action n’est nécessaire.
+                    </dd>
+                    <dt>Non certifié</dt>
+                    <dd>
+                        Nous n’avons pas trouvé d’information permettant de
+                        valider ce critère administratif.
+                    </dd>
+                </dl>
+                <p>
+                    <strong>
+                        Lorsqu’un critère n’est pas certifié dans le cadre d’une
+                        auto-prescription, nous recommandons à l’employeur de
+                        récupérer et conserver une copie du justificatif
+                        administratif.
+                    </strong>
+                    Pour rappel, les critères déclarés par les prescripteurs habilités ne nécessitent aucun justificatif.
+                </p>
+                <p>
+                    L’absence de badge signifie que nous ne sommes pas encore en
+                    mesure d’interroger le système d’information de l’État pour ce
+                    critère.
+                </p>
+                <p class="mb-0">
+                    Retrouvez le détail des conditions dans
+                    <a href="{{ itou_help_center_url }}/articles/14733921254161--Les-crit%C3%A8res-d-%C3%A9ligibilit%C3%A9-IAE#h_01J28K61VYBEBMK0CRVSHWRKRG" class="has-external-link" target="_blank" rel="noreferrer">notre documentation</a>.
+                </p>
             </div>
         </div>
     {% endif %}

--- a/itou/templates/apply/includes/job_application_diagoriente_invite.html
+++ b/itou/templates/apply/includes/job_application_diagoriente_invite.html
@@ -1,7 +1,7 @@
 {% load django_bootstrap5 %}
 
 {% if not job_application.diagoriente_invite_sent_at %}
-    <div class="c-info d-flex flex-column flex-md-row justify-content-between align-items-center mb-3 p-3 fs-sm">
+    <div class="c-info d-flex flex-column flex-md-row justify-content-between align-items-center mb-3 p-3 fs-sm d-print-none">
         <div class="w-100 w-md-50 text-center text-md-start">
             <p class="fw-bold mb-2">Ce candidat n’a pas de CV ?</p>
             <p class="m-0">

--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -219,11 +219,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.9.2.zip",
-            "sha256": "93e7cdc4fbc994b02bccb8aedd996c7e9c6aadafed48cfda45a67b294a0c1189",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.9.3.zip",
+            "sha256": "aa1d9e039b9ce7379a78307ad09660827ce8d5943ef53415303f7b2298d447ff",
         },
         "extract": {
-            "origin": "itou-theme-2.9.2/dist",
+            "origin": "itou-theme-2.9.3/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le contenu des "nouvelles" `.list-data` n'étaient pas correctement affichées à l'impression des fiches candidature

## :cake: Comment ? <!-- optionnel -->
Ne pas appliquer les `container-type` si `@media print` car mal supportés
En passant quelques ajustements html et css (masquage de certains éléments à l'impression)
