### PR TITLE
Vie privée : ajout de champs dans l'admin

### DIFF
--- a/itou/archive/admin.py
+++ b/itou/archive/admin.py
@@ -13,6 +13,11 @@ class AnonymizedProfessionalAdmin(ItouModelAdmin):
         "anonymized_at",
         "department",
         "title",
+        "kind",
+        "number_of_memberships",
+        "number_of_active_memberships",
+        "number_of_memberships_as_administrator",
+        "had_memberships_in_authorized_organization",
         "identity_provider",
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Certains champs de `AnonymizedProfessional` sont manquant dans l'admin

