### PR TITLE
Éligibilité : utiliser le PASS IAE associé au diagnostic pour en calculer la validité

### DIFF
--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -177,7 +177,8 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
 
     @property
     def is_considered_valid(self):
-        return self.is_valid or self.job_seeker.has_valid_approval
+        valid_approvals = self.approval_set.filter(end_at__gt=timezone.localdate())
+        return self.is_valid or valid_approvals.exists()
 
     @property
     def considered_to_expire_at(self):

--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -169,7 +169,9 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
 
     # A diagnosis is considered valid for the whole duration of an approval.
     # Methods below (whose name contain `considered`) take into account
-    # the existence of an ongoing approval.
+    # the existence of an ongoing approval associated to the diagnosis.
+    # There should be 0 or 1 associated approval, but for a handful of diagnoses
+    # there are 2, so we pick the last one.
     # They must not be used "as-is" in admin's `list_display` because checking
     # the latest approvals would trigger additional SQL queries for each row.
 
@@ -179,8 +181,9 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
 
     @property
     def considered_to_expire_at(self):
-        if self.job_seeker.has_valid_approval:
-            return self.job_seeker.latest_approval.end_at
+        latest_approval = self.approval_set.last()
+        if latest_approval and latest_approval.is_valid():
+            return latest_approval.end_at
         return self.expires_at
 
     @classmethod

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -404,9 +404,14 @@ class TestEligibilityDiagnosisModel:
         diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, expired=True)
         assert not diagnosis.is_considered_valid
 
-        # Expired diagnosis but ongoing PASS IAE.
+        # Expired diagnosis but ongoing PASS IAE, not associated to the diagnosis.
         diagnosis = IAEEligibilityDiagnosisFactory(from_prescriber=True, expired=True)
-        ApprovalFactory(user=diagnosis.job_seeker)
+        approval = ApprovalFactory(user=diagnosis.job_seeker)
+        assert diagnosis.is_considered_valid is False
+
+        # Expired diagnosis but ongoing PASS IAE, associated to the diagnosis.
+        approval.eligibility_diagnosis = diagnosis
+        approval.save()
         assert diagnosis.is_considered_valid
 
 

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -1999,8 +1999,6 @@
       }),
       dict({
         'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
           'VariableNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
@@ -2035,8 +2033,9 @@
                  "approvals_approval"."origin_prescriber_organization_kind",
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
+          WHERE "approvals_approval"."eligibility_diagnosis_id" = %s
+          ORDER BY "approvals_approval"."created_at" ASC
+          LIMIT 1
         ''',
       }),
       dict({
@@ -3205,8 +3204,6 @@
       }),
       dict({
         'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
           'VariableNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
@@ -3241,8 +3238,9 @@
                  "approvals_approval"."origin_prescriber_organization_kind",
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
+          WHERE "approvals_approval"."eligibility_diagnosis_id" = %s
+          ORDER BY "approvals_approval"."created_at" ASC
+          LIMIT 1
         ''',
       }),
       dict({
@@ -4273,8 +4271,6 @@
       }),
       dict({
         'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
           'VariableNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
@@ -4308,8 +4304,9 @@
                  "approvals_approval"."origin_prescriber_organization_kind",
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
+          WHERE "approvals_approval"."eligibility_diagnosis_id" = %s
+          ORDER BY "approvals_approval"."created_at" ASC
+          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -465,7 +465,7 @@
 # ---
 # name: TestHireConfirmation.test_as_company[view queries]
   dict({
-    'num_queries': 28,
+    'num_queries': 29,
     'queries': list([
       dict({
         'origin': list([
@@ -1416,6 +1416,45 @@
                  AND "eligibility_administrativecriteria"."kind" IN (%s,
                                                                      %s,
                                                                      %s))
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
+          'VariableNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IfNode[apply/includes/eligibility_diagnosis.html]',
+          'IncludeNode[apply/submit/hire_confirmation.html]',
+          'BlockNode[apply/submit_base.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/submit_base.html]',
+          'ExtendsNode[apply/submit/hire_confirmation.html]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."eligibility_diagnosis_id" = %s
+          ORDER BY "approvals_approval"."created_at" ASC
           LIMIT 1
         ''',
       }),

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1029,8 +1029,6 @@
       }),
       dict({
         'origin': list([
-          'User.latest_approval[users/models.py]',
-          'User.has_valid_approval[users/models.py]',
           'EligibilityDiagnosis.considered_to_expire_at[eligibility/models/iae.py]',
           'VariableNode[apply/includes/eligibility_diagnosis.html]',
           'IfNode[apply/includes/eligibility_diagnosis.html]',
@@ -1062,8 +1060,9 @@
                  "approvals_approval"."origin_prescriber_organization_kind",
                  "approvals_approval"."public_id"
           FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" = %s
-          ORDER BY "approvals_approval"."created_at" DESC
+          WHERE "approvals_approval"."eligibility_diagnosis_id" = %s
+          ORDER BY "approvals_approval"."created_at" ASC
+          LIMIT 1
         ''',
       }),
       dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avant, à partir du moment où un candidat a un PASS en cours de validité, tous ses diagnostics étaient considérés valides.
Ça paraît plus logique de restreindre `is_considered_valid` et `considered_to_expire_at` au PASS associé au diagnostic.

cf https://github.com/gip-inclusion/les-emplois/pull/6084#discussion_r2152116765

