### PR TITLE
Admin : permettre la modification de la date de début des suspensions si la nouvelle date est avant la date de création

### DIFF
--- a/itou/www/approvals_views/forms.py
+++ b/itou/www/approvals_views/forms.py
@@ -490,7 +490,7 @@ class SuspensionForm(forms.ModelForm):
             self.instance.approval = self.approval
             self.fields["reason"].initial = None  # Uncheck radio buttons.
 
-        min_start_at = Suspension.next_min_start_at(self.approval, suspension_pk, referent_date, True)
+        min_start_at = Suspension.next_min_start_at(self.approval, suspension_pk, referent_date)
         # A suspension is backdatable but cannot start in the future.
         self.fields["start_at"].widget = DuetDatePickerWidget({"min": min_start_at, "max": today})
         self.fields["end_at"].widget = DuetDatePickerWidget(
@@ -507,7 +507,7 @@ class SuspensionForm(forms.ModelForm):
             suspension_pk = self.instance.pk
             referent_date = self.instance.created_at.date()
 
-        next_min_start_at = Suspension.next_min_start_at(self.approval, suspension_pk, referent_date, True)
+        next_min_start_at = Suspension.next_min_start_at(self.approval, suspension_pk, referent_date)
         if start_at < next_min_start_at:
             raise ValidationError(
                 f"Vous ne pouvez pas saisir une date de début de suspension "

--- a/tests/approvals/tests.py
+++ b/tests/approvals/tests.py
@@ -1178,11 +1178,6 @@ class TestSuspensionModel:
         )
         job_application_4 = JobApplicationFactory(with_approval=True, hiring_start_at=None, origin=Origin.PE_APPROVAL)
 
-        # TODO: must be checked with PO
-        # - empty hiring start date
-        # - `with_retroactivity_limitation` set to `False`
-        # What should be the expected suspension mimimum start date ?
-
         min_start_at = Suspension.next_min_start_at(job_application_1.approval)
         assert min_start_at == today
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le support est bloqué car des utilisateurs demandent à changer la date de début des suspensions. Actuellement, la limite est fixée à la date de création de la suspension pour le support seulement. Les utilisateurs finaux peuvent faire commencer la suspension jusqu'à 365 jours avant sa date de création (`Suspension.MAX_RETROACTIVITY_DURATION_DAYS`). 
Ce comportement a été introduit [dans cette PR](https://github.com/gip-inclusion/les-emplois/pull/1038).
Aujourd'hui, le support a oublié que c'était une demande métier et se retrouve simplement coincé. Il crée des tickets Supportix. Sandrine et Zohra pensent que le plus simple et que tout le monde suive la même règle.  

Cette PR est liée à la PR #6243 . Le support a mis à jour manuellement la date de fin des PASS IAE mais ne peut pas répercuter les modifications sur les suspensions. Passer par un script n'est pas non plus la solution car il y a plusieurs cas d'exception. Leur laisser la main est le plus efficace.

## :cake: Comment ?

Suppression de la règle et ajout d'un test.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Modifier une suspension selon les cas suivants :
- la nouvelle date de début de la suspension est **avant** sa date de création : OK.
- la nouvelle date de début de la suspension est **après** sa date de création : OK.
- la nouvelle date de début de la suspension est **avant** la date de **début** du PASS : KO.
- la nouvelle date de début de la suspension est **après** la date de **fin** du PASS : KO.
- autres cas tordus selon votre créativité :sunglasses: 
