### PR TITLE
Renommer `switch{User,Structure}Dropdown`

### DIFF
--- a/itou/templates/layout/_structure_switcher_nav.html
+++ b/itou/templates/layout/_structure_switcher_nav.html
@@ -1,10 +1,10 @@
 {% if organizations|length > 1 %}
     <li class="d-none d-lg-inline-block dropdown dropdown-structure">
-        <button type="button" class="btn btn-outline-primary btn-ico bg-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdown" aria-expanded="false">
+        <button type="button" class="btn btn-outline-primary btn-ico bg-white dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="switchStructureDropdown" aria-expanded="false">
             <i class="{{ icon }}" aria-hidden="true"></i>
             <span>{{ current_organization.kind }} - {{ current_organization.display_name }}</span>
         </button>
-        <div class="dropdown-menu w-100" id="switchUserDropdown">
+        <div class="dropdown-menu w-100" id="switchStructureDropdown">
             {% include "layout/_structure_switcher_dropdown_menu.html" %}
         </div>
     </li>

--- a/itou/templates/layout/_structure_switcher_offcanvas.html
+++ b/itou/templates/layout/_structure_switcher_offcanvas.html
@@ -11,12 +11,12 @@
         <strong>{{ current_organization.display_name }}</strong>
     </div>
 {% else %}
-    <button type="button" class="dropdown-toggle dropdown-toggle__summary" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="switchUserDropdownMobile" aria-expanded="false">
+    <button type="button" class="dropdown-toggle dropdown-toggle__summary" data-bs-toggle="dropdown" aria-haspopup="true" aria-controls="switchStructureDropdownMobile" aria-expanded="false">
         <i class="{{ icon }}" aria-hidden="true"></i>
         <span>{{ current_organization.kind }}</span>
         <strong>{{ current_organization.display_name }}</strong>
     </button>
-    <div class="dropdown-menu" id="switchUserDropdownMobile">
+    <div class="dropdown-menu" id="switchStructureDropdownMobile">
         {% include "layout/_structure_switcher_dropdown_menu.html" %}
     </div>
 {% endif %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

On change de structure, et non d’utilisateur.
