### PR TITLE
Fiches salarié : Retrait d’une vérification de cohérence de l’adresse

### DIFF
--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -473,8 +473,7 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
             "hexa_commune": Commune.objects.by_insee_code("67482").pk,
         }
 
-        data = test_data
-        response = client.post(self.url, data=data)
+        response = client.post(self.url, data=test_data)
         # This data set should pass
         assert response.status_code == 302
 

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -480,33 +480,50 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
         # Check form validators
 
         # Lane number :
-        data = test_data
+        data = test_data.copy()
 
         # Can't use extension without number
         data["hexa_lane_number"] = ""
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "__all__": ["L'extension doit être saisie avec un numéro de voie"],
+        }
 
         # Can't use anything else than up to 5 digits
         data["hexa_lane_number"] = "a"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "__all__": ["L'extension doit être saisie avec un numéro de voie"],
+            "hexa_lane_number": ["Numéro de voie incorrect"],
+        }
 
         data["hexa_lane_number"] = "123456"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "__all__": ["L'extension doit être saisie avec un numéro de voie"],
+            "hexa_lane_number": ["Numéro de voie incorrect"],
+        }
 
         # Post code :
-        data = test_data
+        data = test_data.copy()
 
         # 5 digits exactly
         data["hexa_post_code"] = "123456"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_post_code": ["Code postal incorrect"],
+        }
 
         data["hexa_post_code"] = "1234"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_post_code": ["Code postal incorrect"],
+        }
 
         data["hexa_lane_number"] = "1234a"
         response = client.post(self.url, data=data)
@@ -516,29 +533,52 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
         data["hexa_lane_number"] = "12345"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_post_code": ["Code postal incorrect"],
+        }
 
         # Lane name and additional address
-        data = test_data
+        data = test_data.copy()
 
         # No special characters
         data["hexa_lane_name"] = "des colons !"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_lane_name": [
+                "Le champ ne doit contenir ni caractères spéciaux, ni accents et ne pas excéder 32 caractères"
+            ],
+        }
 
         # 32 chars max
         data["hexa_lane_name"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_lane_name": [
+                "Le champ ne doit contenir ni caractères spéciaux, ni accents et ne pas excéder 32 caractères"
+            ],
+        }
 
-        data = test_data
+        data = test_data.copy()
         data["hexa_additional_address"] = "Bat a !"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_additional_address": [
+                "Le champ ne doit contenir ni caractères spéciaux, ni accents et ne pas excéder 32 caractères"
+            ],
+        }
 
         # 32 chars max
         data["hexa_additional_address"] = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         response = client.post(self.url, data=data)
         assert response.status_code == 200
+        assert response.context["form"].errors == {
+            "hexa_additional_address": [
+                "Le champ ne doit contenir ni caractères spéciaux, ni accents et ne pas excéder 32 caractères"
+            ],
+        }
 
 
 class TestCreateEmployeeRecordStep3(CreateEmployeeRecordTestMixin):

--- a/tests/www/employee_record_views/test_create.py
+++ b/tests/www/employee_record_views/test_create.py
@@ -525,10 +525,6 @@ class TestCreateEmployeeRecordStep2(CreateEmployeeRecordTestMixin):
             "hexa_post_code": ["Code postal incorrect"],
         }
 
-        data["hexa_lane_number"] = "1234a"
-        response = client.post(self.url, data=data)
-        assert response.status_code == 200
-
         # Coherence with INSEE code
         data["hexa_lane_number"] = "12345"
         response = client.post(self.url, data=data)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un employeur est bloqué par cette vérification pour remplir l’adresse de son salarié dans sa fiche salarié. Le salarié habite à Bastia, dont le code postal est 20600, et le code INSEE 2B033.

https://fr.wikipedia.org/wiki/Liste_des_communes_de_France_dont_le_code_postal_ne_correspond_pas_au_d%C3%A9partement

## :cake: Comment ? <!-- optionnel -->

Remplacé par une vérification que le code postal correspond à une ville.
