### PR TITLE
Contrôle a posteriori : Empêcher les sanctions sur une SIAE dont le contrôle est accepté

### DIFF
--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -231,6 +231,12 @@ class InstitutionEvaluatedSiaeNotifyMixin(SingleObjectMixin):
             )
         )
 
+    def get_object(self, queryset=None):
+        obj = super().get_object(queryset=queryset)
+        if obj.state != evaluation_enums.EvaluatedSiaeState.REFUSED:
+            raise Http404
+        return obj
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update(evaluation_campaign_data_context(self.object))

--- a/tests/www/siae_evaluations_views/__snapshots__/test_institutions_views.ambr
+++ b/tests/www/siae_evaluations_views/__snapshots__/test_institutions_views.ambr
@@ -1572,6 +1572,7 @@
       dict({
         'origin': list([
           'InstitutionEvaluatedSiaeNotifyStep1View.get_object[<site-packages>/django/views/generic/detail.py]',
+          'InstitutionEvaluatedSiaeNotifyStep1View.get_object[www/siae_evaluations_views/views.py]',
         ]),
         'sql': '''
           SELECT "siae_evaluations_evaluatedsiae"."id",
@@ -1654,6 +1655,7 @@
       dict({
         'origin': list([
           'InstitutionEvaluatedSiaeNotifyStep1View.get_object[<site-packages>/django/views/generic/detail.py]',
+          'InstitutionEvaluatedSiaeNotifyStep1View.get_object[www/siae_evaluations_views/views.py]',
         ]),
         'sql': '''
           SELECT "siae_evaluations_evaluatedjobapplication"."id",
@@ -1908,6 +1910,7 @@
       dict({
         'origin': list([
           'InstitutionEvaluatedSiaeNotifyStep2View.get_object[<site-packages>/django/views/generic/detail.py]',
+          'InstitutionEvaluatedSiaeNotifyStep2View.get_object[www/siae_evaluations_views/views.py]',
           'InstitutionEvaluatedSiaeNotifyStep2View.get[www/siae_evaluations_views/views.py]',
         ]),
         'sql': '''
@@ -1991,6 +1994,7 @@
       dict({
         'origin': list([
           'InstitutionEvaluatedSiaeNotifyStep2View.get_object[<site-packages>/django/views/generic/detail.py]',
+          'InstitutionEvaluatedSiaeNotifyStep2View.get_object[www/siae_evaluations_views/views.py]',
           'InstitutionEvaluatedSiaeNotifyStep2View.get[www/siae_evaluations_views/views.py]',
         ]),
         'sql': '''
@@ -2246,6 +2250,7 @@
       dict({
         'origin': list([
           'InstitutionEvaluatedSiaeNotifyStep3View.get_object[<site-packages>/django/views/generic/detail.py]',
+          'InstitutionEvaluatedSiaeNotifyStep3View.get_object[www/siae_evaluations_views/views.py]',
           'InstitutionEvaluatedSiaeNotifyStep3View.get[www/siae_evaluations_views/views.py]',
         ]),
         'sql': '''
@@ -2329,6 +2334,7 @@
       dict({
         'origin': list([
           'InstitutionEvaluatedSiaeNotifyStep3View.get_object[<site-packages>/django/views/generic/detail.py]',
+          'InstitutionEvaluatedSiaeNotifyStep3View.get_object[www/siae_evaluations_views/views.py]',
           'InstitutionEvaluatedSiaeNotifyStep3View.get[www/siae_evaluations_views/views.py]',
         ]),
         'sql': '''

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -1812,6 +1812,21 @@ class InstitutionEvaluatedSiaeNotifyViewAccessTestMixin:
         )
         assert response.status_code == 404
 
+    def test_access_accepted_siae(self, client):
+        evaluated_siae = EvaluatedSiaeFactory(
+            evaluation_campaign__institution=self.institution,
+            complete=True,
+            job_app__criteria__review_state=evaluation_enums.EvaluatedJobApplicationsState.ACCEPTED,
+        )
+        self.login(client, evaluated_siae)
+        response = client.get(
+            reverse(
+                self.urlname,
+                kwargs={"evaluated_siae_pk": evaluated_siae.pk},
+            )
+        )
+        assert response.status_code == 404
+
     @freeze_time("2023-01-24 11:11:00")
     def test_data_card_statistics(self, client):
         company = CompanyFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Auparavant, un employé de DDETS malveillant aurait pu sanctionner une SIAE dont le contrôle était positif.
