### PR TITLE
Stabilité : correctif d'un test incomplet

### DIFF
--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -2755,7 +2755,7 @@
 # ---
 # name: TestProcessListSiae.test_list_for_siae_filters_query[SQL queries filters]
   dict({
-    'num_queries': 20,
+    'num_queries': 25,
     'queries': list([
       dict({
         'origin': list([
@@ -3481,7 +3481,7 @@
                                                                                AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
                                                                         ORDER BY U0."created_at" DESC
                                                                         LIMIT 1))))
-                LIMIT 1) AS "eligibility_diagnosis_criterion_1",
+                LIMIT 1) AS "eligibility_diagnosis_criterion_3",
                     EXISTS
                (SELECT %s AS "a"
                 FROM "approvals_suspension" U0
@@ -3551,6 +3551,518 @@
       }),
       dict({
         'origin': list([
+          '_add_pending_for_weeks[www/apply/views/list_views.py]',
+          'list_for_siae[www/apply/views/list_views.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."hiring_without_approval",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 GREATEST("job_applications_jobapplication"."created_at", MAX("job_applications_jobapplicationtransitionlog"."timestamp")) AS "last_change",
+          
+            (SELECT U0."id" AS "id"
+             FROM "eligibility_eligibilitydiagnosis" U0
+             WHERE (U0."expires_at" > %s
+                    AND (U0."author_kind" = %s
+                         OR U0."author_siae_id" = ("job_applications_jobapplication"."to_company_id"))
+                    AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
+             ORDER BY U0."created_at" DESC
+             LIMIT 1) AS "jobseeker_valid_eligibility_diagnosis",
+                 COALESCE("job_applications_jobapplication"."eligibility_diagnosis_id",
+                            (SELECT U0."id" AS "id"
+                             FROM "eligibility_eligibilitydiagnosis" U0
+                             WHERE (U0."expires_at" > %s
+                                    AND (U0."author_kind" = %s
+                                         OR U0."author_siae_id" = ("job_applications_jobapplication"."to_company_id"))
+                                    AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
+                             ORDER BY U0."created_at" DESC
+                             LIMIT 1)) AS "jobseeker_eligibility_diagnosis",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "eligibility_selectedadministrativecriteria" U0
+             WHERE (U0."administrative_criteria_id" = %s
+                    AND U0."eligibility_diagnosis_id" = (COALESCE("job_applications_jobapplication"."eligibility_diagnosis_id",
+                                                                    (SELECT U0."id" AS "id"
+                                                                     FROM "eligibility_eligibilitydiagnosis" U0
+                                                                     WHERE (U0."expires_at" > %s
+                                                                            AND (U0."author_kind" = %s
+                                                                                 OR U0."author_siae_id" = ("job_applications_jobapplication"."to_company_id"))
+                                                                            AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
+                                                                     ORDER BY U0."created_at" DESC
+                                                                     LIMIT 1))))
+             LIMIT 1) AS "eligibility_diagnosis_criterion_3",
+                 EXISTS
+            (SELECT %s AS "a"
+             FROM "approvals_suspension" U0
+             WHERE (U0."approval_id" = ("job_applications_jobapplication"."approval_id")
+                    AND U0."end_at" >= %s
+                    AND U0."start_at" <= %s)
+             LIMIT 1) AS "has_suspended_approval",
+                 (COALESCE(LOWER("users_user"."first_name"), %s) || COALESCE((COALESCE(%s, %s) || COALESCE(LOWER("users_user"."last_name"), %s)), %s)) AS "job_seeker_full_name",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."fields_history",
+                 T7."id",
+                 T7."password",
+                 T7."last_login",
+                 T7."is_superuser",
+                 T7."username",
+                 T7."first_name",
+                 T7."last_name",
+                 T7."is_staff",
+                 T7."is_active",
+                 T7."date_joined",
+                 T7."address_line_1",
+                 T7."address_line_2",
+                 T7."post_code",
+                 T7."city",
+                 T7."department",
+                 T7."coords",
+                 T7."geocoding_score",
+                 T7."geocoding_updated_at",
+                 T7."ban_api_resolved_address",
+                 T7."insee_city_id",
+                 T7."title",
+                 T7."full_name_search_vector",
+                 T7."email",
+                 T7."phone",
+                 T7."kind",
+                 T7."identity_provider",
+                 T7."has_completed_welcoming_tour",
+                 T7."created_by_id",
+                 T7."external_data_source_history",
+                 T7."last_checked_at",
+                 T7."public_id",
+                 T7."address_filled_at",
+                 T7."first_login",
+                 T7."upcoming_deletion_notified_at",
+                 T7."allow_next_sso_sub_update",
+                 T10."id",
+                 T10."address_line_1",
+                 T10."address_line_2",
+                 T10."post_code",
+                 T10."city",
+                 T10."department",
+                 T10."coords",
+                 T10."geocoding_score",
+                 T10."geocoding_updated_at",
+                 T10."ban_api_resolved_address",
+                 T10."insee_city_id",
+                 T10."name",
+                 T10."created_at",
+                 T10."updated_at",
+                 T10."uid",
+                 T10."active_members_email_reminder_last_sent_at",
+                 T10."automatic_geocoding_update",
+                 T10."siret",
+                 T10."naf",
+                 T10."kind",
+                 T10."brand",
+                 T10."phone",
+                 T10."email",
+                 T10."auth_email",
+                 T10."website",
+                 T10."description",
+                 T10."provided_support",
+                 T10."source",
+                 T10."created_by_id",
+                 T10."block_job_applications",
+                 T10."job_applications_blocked_at",
+                 T10."spontaneous_applications_open_since",
+                 T10."convention_id",
+                 T10."job_app_score",
+                 T10."is_searchable",
+                 T10."rdv_solidarites_id",
+                 T10."fields_history",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at",
+                 "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplicationtransitionlog"."job_application_id")
+          INNER JOIN "users_user" ON ("job_applications_jobapplication"."job_seeker_id" = "users_user"."id")
+          INNER JOIN "approvals_approval" ON ("job_applications_jobapplication"."approval_id" = "approvals_approval"."id")
+          INNER JOIN "users_user" T7 ON ("job_applications_jobapplication"."sender_id" = T7."id")
+          INNER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          LEFT OUTER JOIN "companies_company" T10 ON ("job_applications_jobapplication"."sender_company_id" = T10."id")
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
+          WHERE ("job_applications_jobapplication"."to_company_id" = %s
+                 AND "job_applications_jobapplication"."state" IN (%s)
+                 AND "approvals_approval"."end_at" >= %s
+                 AND NOT EXISTS
+                   (SELECT %s AS "a"
+                    FROM "approvals_suspension" U0
+                    WHERE (U0."approval_id" = ("job_applications_jobapplication"."approval_id")
+                           AND U0."end_at" >= %s
+                           AND U0."start_at" <= %s)
+                    LIMIT 1)
+                 AND "job_applications_jobapplication"."created_at" >= %s
+                 AND "job_applications_jobapplication"."created_at" <= %s
+                 AND "users_user"."department" IN (%s)
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "eligibility_selectedadministrativecriteria" U0
+                    WHERE (U0."administrative_criteria_id" = %s
+                           AND U0."eligibility_diagnosis_id" = (COALESCE("job_applications_jobapplication"."eligibility_diagnosis_id",
+                                                                           (SELECT U0."id" AS "id"
+                                                                            FROM "eligibility_eligibilitydiagnosis" U0
+                                                                            WHERE (U0."expires_at" > %s
+                                                                                   AND (U0."author_kind" = %s
+                                                                                        OR U0."author_siae_id" = ("job_applications_jobapplication"."to_company_id"))
+                                                                                   AND U0."job_seeker_id" = ("job_applications_jobapplication"."job_seeker_id"))
+                                                                            ORDER BY U0."created_at" DESC
+                                                                            LIMIT 1))))
+                    LIMIT 1)
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "users_user" V0
+                    WHERE ((EXISTS
+                              (SELECT %s AS "a"
+                               FROM "approvals_approval" U0
+                               WHERE (U0."user_id" = (V0."id")
+                                      AND U0."end_at" >= %s)
+                               LIMIT 1)
+                            OR EXISTS
+                              (SELECT %s AS "a"
+                               FROM "eligibility_eligibilitydiagnosis" U0
+                               WHERE ((U0."author_kind" = %s
+                                       OR U0."author_siae_id" = ("job_applications_jobapplication"."to_company_id"))
+                                      AND U0."job_seeker_id" = (V0."id")
+                                      AND U0."expires_at" > %s)
+                               LIMIT 1))
+                           AND V0."id" = ("job_applications_jobapplication"."job_seeker_id"))
+                    LIMIT 1)
+                 AND "job_applications_jobapplication"."sender_id" IN (%s)
+                 AND "job_applications_jobapplication"."job_seeker_id" = %s
+                 AND "job_applications_jobapplication"."archived_at" IS NULL
+                 AND "job_applications_jobapplication"."sender_prescriber_organization_id" IN (%s))
+          GROUP BY "job_applications_jobapplication"."id",
+                   49,
+                   52,
+                   "users_user"."id",
+                   "users_jobseekerprofile"."user_id",
+                   T7."id",
+                   T10."id",
+                   "prescribers_prescriberorganization"."id",
+                   "companies_company"."id",
+                   "companies_siaeconvention"."id",
+                   "approvals_approval"."id"
+          ORDER BY "job_applications_jobapplication"."created_at" DESC,
+                   "job_applications_jobapplication"."id" DESC
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '_add_pending_for_weeks[www/apply/views/list_views.py]',
+          'list_for_siae[www/apply/views/list_views.py]',
+        ]),
+        'sql': '''
+          SELECT ("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "_prefetch_related_val_jobapplication_id",
+                 "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."last_employer_update_at",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."contract_nature",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source"
+          FROM "companies_jobdescription"
+          INNER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
+          WHERE "job_applications_jobapplication_selected_jobs"."jobapplication_id" IN (%s)
+          ORDER BY "jobs_appellation"."name" ASC,
+                   "companies_jobdescription"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '_add_pending_for_weeks[www/apply/views/list_views.py]',
+          'list_for_siae[www/apply/views/list_views.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."user_id" IN (%s)
+          ORDER BY "approvals_approval"."start_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '_add_administrative_criteria[www/apply/views/list_views.py]',
+          'list_for_siae[www/apply/views/list_views.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id",
+                 "eligibility_administrativecriteria"."id",
+                 "eligibility_administrativecriteria"."level",
+                 "eligibility_administrativecriteria"."name",
+                 "eligibility_administrativecriteria"."desc",
+                 "eligibility_administrativecriteria"."written_proof",
+                 "eligibility_administrativecriteria"."written_proof_url",
+                 "eligibility_administrativecriteria"."written_proof_validity",
+                 "eligibility_administrativecriteria"."kind",
+                 "eligibility_administrativecriteria"."ui_rank",
+                 "eligibility_administrativecriteria"."created_at"
+          FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s)
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."name" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'Company.has_job_descriptions_not_updated_recently[companies/models.py]',
           'IfNode[layout/base.html]',
           'BlockNode[layout/base.html]',
@@ -3591,6 +4103,38 @@
                            AND U0."is_admin"
                            AND U2."is_active"))
                  AND "users_user"."id" = %s)
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Approval.is_suspended[approvals/models.py]',
+          'Approval.state[approvals/models.py]',
+          'approval_state_badge[utils/templatetags/badges.py]',
+          'SimpleNode[apply/includes/eligibility_badge.html]',
+          'IfNode[apply/includes/eligibility_badge.html]',
+          'IfNode[apply/includes/eligibility_badge.html]',
+          'WithNode[apply/includes/eligibility_badge.html]',
+          'IncludeNode[apply/includes/list_tr.html]',
+          'IfNode[apply/includes/list_tr.html]',
+          'IfNode[apply/includes/list_tr.html]',
+          'IncludeNode[apply/includes/list_table.html]',
+          'ForNode[apply/includes/list_table.html]',
+          'IncludeNode[apply/includes/list_job_applications.html]',
+          'IfNode[apply/includes/list_job_applications.html]',
+          'IfNode[apply/includes/list_job_applications.html]',
+          'IfNode[apply/includes/list_job_applications.html]',
+          'IncludeNode[apply/list_for_siae.html]',
+          'BlockNode[layout/base.html]',
+          'ExtendsNode[apply/list_for_siae.html]',
+          'list_for_siae[www/apply/views/list_views.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "approvals_suspension"
+          WHERE ("approvals_suspension"."approval_id" = %s
+                 AND "approvals_suspension"."end_at" >= %s
+                 AND "approvals_suspension"."start_at" <= %s)
           LIMIT 1
         ''',
       }),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce que ce test problématique a causé bien de la confusion dans https://github.com/gip-inclusion/les-emplois/pull/6376

Le test construit une job_app et fait une recherche en laissant penser au lecteur que le résultat est cette unique job_app. En fait le résultat n'était pas testé et était vide, ce qui faisait que certaines requêtes SQL habituellement effectuées n'avaient pas lieu.

## :cake: Comment ?

En corrigeant le test pour que la recherche retourne bien un résultat non vide. Du coup les requêtes SQL manquantes font surface.
