### PR TITLE
Éligibilité : Ne pas réessayer de certifier un diag supprimé

### DIFF
--- a/itou/eligibility/tasks.py
+++ b/itou/eligibility/tasks.py
@@ -114,9 +114,17 @@ def certify_criteria(eligibility_diagnosis):
 
 def _async_certify_criteria(model_name, eligibility_diagnosis_pk):
     model = apps.get_model("eligibility", model_name)
-    eligibility_diagnosis = model.objects.select_related("job_seeker__jobseeker_profile").get(
-        pk=eligibility_diagnosis_pk
-    )
+    try:
+        eligibility_diagnosis = model.objects.select_related("job_seeker__jobseeker_profile").get(
+            pk=eligibility_diagnosis_pk
+        )
+    except model.DoesNotExist:
+        logger.info(
+            "%s with pk %d does not exist, it cannot be certified.",
+            model_name,
+            eligibility_diagnosis_pk,
+        )
+        return
     try:
         with transaction.atomic():
             certify_criteria(eligibility_diagnosis)

--- a/tests/eligibility/test_tasks.py
+++ b/tests/eligibility/test_tasks.py
@@ -149,3 +149,9 @@ class TestCertifyCriteria:
         jobseeker_profile = JobSeekerProfile.objects.get(pk=eligibility_diagnosis.job_seeker.jobseeker_profile)
 
         assertQuerySetEqual(jobseeker_profile.identity_certifications.all(), [])
+
+    def test_no_retries_when_diag_does_not_exist(self, caplog, factory):
+        eligibility_diagnosis_model = factory._meta.model
+        modelname = eligibility_diagnosis_model._meta.model_name
+        async_certify_criteria.call_local(modelname, 0)
+        assert caplog.messages == [f"{modelname} with pk 0 does not exist, it cannot be certified."]


### PR DESCRIPTION
## :thinking: Pourquoi ?

On réessaye 144 fois de rechercher le diagnostic dans la base de données, et obtenons 144 échecs. S’il a été supprimé, rien de sert de réessayer.
