### PR TITLE
admin : Permettre les recherches de NIR contenant un A ou un B

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -13,6 +13,7 @@ from itou.employee_record import enums as employee_record_enums
 from itou.employee_record.constants import get_availability_date_for_kind
 from itou.employee_record.models import EmployeeRecord
 from itou.job_applications.models import JobApplication
+from itou.users.utils import NIR_RE
 from itou.utils.admin import (
     CreatedOrUpdatedByMixin,
     InconsistencyCheckMixin,
@@ -292,13 +293,8 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
                 # Handle partial numbers not starting with the prefix (migrated PEApproval)
                 search_fields.append("number__contains")
 
-        if search_term.isdecimal() and 13 <= len(search_term) <= 15:
-            # Searching by NIR is much more expensive than by number
-            # so only do so for long numbers
-            if len(search_term) == 15:  # Complete NIR
-                search_fields.append("user__jobseeker_profile__nir__exact")
-            else:
-                search_fields.append("user__jobseeker_profile__nir__contains")
+        if NIR_RE.match(search_term):
+            search_fields.append("user__jobseeker_profile__nir__exact")
 
         if not search_fields:
             search_fields.append("user__email")

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -33,6 +33,7 @@ from itou.users.admin_forms import (
     UserAdminForm,
 )
 from itou.users.enums import IdentityCertificationAuthorities, IdentityProvider, UserKind
+from itou.users.utils import NIR_RE
 from itou.utils.admin import (
     ChooseFieldsToTransfer,
     CreatedOrUpdatedByMixin,
@@ -533,9 +534,10 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, UserAdmin)
             search_fields.append("public_id__exact")
         except ValueError:
             pass
+        if NIR_RE.match(search_term):
+            search_fields.append("jobseeker_profile__nir__exact")
         if search_term.isdecimal():
             search_fields.append("pk__exact")
-            search_fields.append("jobseeker_profile__nir__exact")
         else:
             search_fields.append("email")
             if "@" not in search_term:
@@ -909,9 +911,10 @@ class JobSeekerProfileAdmin(DisabledNotificationsMixin, InconsistencyCheckMixin,
                 pass
             else:
                 search_fields.append("asp_uid__exact")
+        if NIR_RE.match(search_term):
+            search_fields.append("nir__exact")
         if search_term.isdecimal():
             search_fields.append("pk__exact")
-            search_fields.append("nir__exact")
         else:
             search_fields.append("user__email")
             if "@" not in search_term:

--- a/itou/users/utils.py
+++ b/itou/users/utils.py
@@ -1,0 +1,18 @@
+import re
+
+
+# https://fr.wikipedia.org/wiki/Num%C3%A9ro_de_s%C3%A9curit%C3%A9_sociale_en_France#Signification_des_chiffres_du_NIR
+NIR_RE = re.compile(
+    """
+    ^
+    [0-9]      # sexe
+    [0-9]{2}   # année de naissance
+    [0-9]{2}   # mois de naissance
+    [0-9]      # premier chiffre du département
+    [0-9AB]  # deuxième chiffre du département
+    [0-9]{3}   # lieu de naissance
+    [0-9]{3}   # numéro d’ordre de naissance
+    [0-9]{2}   # clé
+    $""",
+    re.IGNORECASE | re.VERBOSE,
+)

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -262,11 +262,6 @@ def test_search_fields(admin_client):
     assertContains(response, url_1)
     assertNotContains(response, url_2)
 
-    # Search by NIR truncated
-    response = admin_client.get(list_url, {"q": approval1.user.jobseeker_profile.nir[:-2]})
-    assertContains(response, url_1)
-    assertNotContains(response, url_2)
-
     # Search on email
     response = admin_client.get(list_url, {"q": "michel@example"})
     assertContains(response, url_1)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le NIR n’est pas uniquement décimal. Cette erreur a amené à une réponse erronée du support, qui ne trouvait pas la personne par son NIR.
