### PR TITLE
Fiches Salarié : Ne plus tronquer l'identifiant France Travail lors de l'envoi à l'Extranet IAE

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -165,7 +165,7 @@ class _SituationSerializer(serializers.Serializer):
     )  # Required if registered with France Travail
     numeroIDE = NullIfEmptyCharField(
         source="job_application.job_seeker.jobseeker_profile.pole_emploi_id",
-        truncate=8,
+        truncate=11,
     )  # Required if registered with France Travail
 
     salarieRQTH = serializers.BooleanField(

--- a/tests/employee_record/__snapshots__/test_serializers.ambr
+++ b/tests/employee_record/__snapshots__/test_serializers.ambr
@@ -1,12 +1,12 @@
 # serializer version: 1
-# name: test_situation_salarie_serializer_pole_emploi_id[12345678900]
+# name: test_situation_salarie_serializer_pole_emploi_id[12345678912]
   ReturnDict({
     'cotisationsTI': None,
     'inscritPoleEmploi': True,
     'inscritPoleEmploiDepuis': '02',
     'niveauFormation': '40',
     'nomActeurCreationEntr': None,
-    'numeroIDE': '12345678',
+    'numeroIDE': '12345678912',
     'orienteur': '08',
     'revenuMensuelMoyenTI': None,
     'salarieAideSociale': False,

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -279,7 +279,7 @@ def test_situation_salarie_serializer_with_eiti_fields_filled(snapshot, kind):
     assert data["situationSalarie"] == snapshot(name="employee record update notification")
 
 
-@pytest.mark.parametrize("pole_emploi_id", ["1234567A", "12345678900", ""])
+@pytest.mark.parametrize("pole_emploi_id", ["1234567A", "12345678912", ""])
 def test_situation_salarie_serializer_pole_emploi_id(snapshot, pole_emploi_id):
     pole_emploi_since = AllocationDuration.FROM_6_TO_11_MONTHS if pole_emploi_id else ""
     employee_record = EmployeeRecordWithProfileFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'équipe RIAE met en prod une nouvelle version ce matin afin d'accepter les 11 caractères du nouveau format.