### PR TITLE
Fiche de poste : Le badge 20+ candidatures sur les résultats de recherche n’est pas compris et induit en erreur [GEN-2036]

### DIFF
--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -617,17 +617,10 @@ class JobDescriptionQuerySet(models.QuerySet):
             ),
         )
 
-    def with_annotation_is_overwhelmed(self):
-        # Avoid a circular import
-        from itou.job_applications.models import JobApplicationWorkflow
-
-        job_apps_filters = {
-            "jobapplication__state__in": JobApplicationWorkflow.PENDING_STATES,
-            "jobapplication__archived_at": None,
-        }
-        annotation = self.with_job_applications_count(filters=job_apps_filters).annotate(
-            is_overwhelmed=Case(
-                When(job_applications_count__gte=self.model.OVERWHELMED_THRESHOLD, then=True),
+    def with_annotation_is_unpopular(self):
+        annotation = self.with_job_applications_count().annotate(
+            is_unpopular=Case(
+                When(job_applications_count__lte=self.model.UNPOPULAR_THRESHOLD, then=True),
                 default=False,
                 output_field=BooleanField(),
             )
@@ -661,7 +654,7 @@ class JobDescription(models.Model):
     """
 
     MAX_UI_RANK = 32767
-    OVERWHELMED_THRESHOLD = 20
+    UNPOPULAR_THRESHOLD = 1
     # Max number or workable hours per week in France (Code du Travail)
     MAX_WORKED_HOURS_PER_WEEK = 48
 

--- a/itou/templates/apply/submit/application/jobs.html
+++ b/itou/templates/apply/submit/application/jobs.html
@@ -25,9 +25,9 @@
                                 <label class="fw-bold stretched-link order-2 order-md-1 m-0" for="{{ choice.id_for_label }}">
                                     {{ choice.choice_label }}
                                 </label>
-                                {% if job_description.is_overwhelmed %}
+                                {% if job_description.is_unpopular %}
                                     <div class="order-1 order-md-2">
-                                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line" aria-hidden="true"></i>{{ job_description.OVERWHELMED_THRESHOLD }}+ candidatures</span>
+                                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-mail-send-line" aria-hidden="true"></i>Soyez parmi les premiers à postuler</span>
                                     </div>
                                 {% endif %}
                             </div>

--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -38,10 +38,10 @@
                             {{ job_description.display_name | capfirst }}
                             {% if job_description.is_external %}<i class="ri-external-link-line" aria-hidden="true"></i>{% endif %}
                         </a>
-                        {% if job_description.is_overwhelmed %}
+                        {% if job_description.is_unpopular %}
                             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
-                                <i class="ri-group-line me-1" aria-hidden="true"></i>
-                                {{ job_description.OVERWHELMED_THRESHOLD }}+<span class="ms-1">candidatures</span>
+                                <i class="ri-mail-send-line me-1" aria-hidden="true"></i>
+                                <span class="ms-1">Soyez parmi les premiers à postuler</span>
                             </span>
                         {% endif %}
                         <ul class="c-box--results__list-contact flex-md-grow-1 mt-1">

--- a/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
+++ b/itou/templates/companies/includes/_list_siae_actives_jobs_row.html
@@ -14,10 +14,10 @@
             {% endif %}
             <a href="{{ job_url }}" class="fw-bold text-decoration-none stretched-link" {% matomo_event "candidature" "clic" "clic-metiers" %}>{{ job.display_name }}</a>
         {% endif %}
-        {% if job.is_overwhelmed %}
+        {% if job.is_unpopular %}
             <span class="badge badge-sm rounded-pill bg-accent-03 text-primary">
-                <i class="ri-group-line me-1" aria-hidden="true"></i>
-                {{ job.OVERWHELMED_THRESHOLD }}+<span class="ms-1">candidatures</span>
+                <i class="ri-mail-send-line me-1" aria-hidden="true"></i>
+                <span class="ms-1">Soyez parmi les premiers à postuler</span>
             </span>
         {% endif %}
         <p class="fs-sm mb-0 mt-1">

--- a/itou/templates/companies/includes/_siae_jobdescription.html
+++ b/itou/templates/companies/includes/_siae_jobdescription.html
@@ -14,9 +14,9 @@
                        class="fw-bold stretched-link order-2 order-md-1"
                        {% matomo_event "candidature" "clic" "clic-metiers" %}>{{ job.display_name }}</a>
                 {% endif %}
-                {% if job.is_overwhelmed %}
+                {% if job.is_unpopular %}
                     <div class="order-1 order-md-2">
-                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-group-line" aria-hidden="true"></i>{{ job.OVERWHELMED_THRESHOLD }}+ candidatures</span>
+                        <span class="badge badge-sm rounded-pill bg-accent-03 text-primary ms-0 ms-lg-2 mt-1 mt-lg-0"><i class="ri-mail-send-line" aria-hidden="true"></i>Soyez parmi les premiers à postuler</span>
                     </div>
                 {% endif %}
             </div>

--- a/itou/www/apply/forms.py
+++ b/itou/www/apply/forms.py
@@ -46,7 +46,7 @@ class ApplicationJobsForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields["selected_jobs"].queryset = (
-            company.job_description_through.active().with_annotation_is_overwhelmed().prefetch_related("appellation")
+            company.job_description_through.active().with_annotation_is_unpopular().prefetch_related("appellation")
         )
 
         if company.is_open_to_spontaneous_applications:

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -14,6 +14,7 @@ from pytest_django.asserts import assertQuerySetEqual
 from itou.companies.enums import CompanyKind, ContractType
 from itou.companies.models import Company, JobDescription
 from itou.invitations.models import EmployerInvitation
+from itou.job_applications.models import JobApplication
 from tests.companies.factories import (
     CompanyAfterGracePeriodFactory,
     CompanyFactory,
@@ -456,6 +457,17 @@ class TestJobDescriptionQuerySet:
             to_company=company,
             selected_jobs=[unpopular_job_description],
             job_seeker=job_seeker,
+        )
+
+        assert JobDescription.objects.with_annotation_is_unpopular().get(pk=unpopular_job_description.pk).is_unpopular
+
+        # Test old job applications do not count towards popularity
+        JobApplicationFactory.create_batch(
+            popular_threshold,
+            to_company=company,
+            selected_jobs=[unpopular_job_description],
+            job_seeker=job_seeker,
+            created_at=timezone.now() - timezone.timedelta(weeks=JobApplication.WEEKS_BEFORE_CONSIDERED_OLD, days=1),
         )
 
         assert JobDescription.objects.with_annotation_is_unpopular().get(pk=unpopular_job_description.pk).is_unpopular

--- a/tests/www/search/__snapshots__/tests.ambr
+++ b/tests/www/search/__snapshots__/tests.ambr
@@ -931,9 +931,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                    WHERE "job_applications_jobapplication"."created_at" >= %s) AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                             WHERE ("job_applications_jobapplication"."created_at" >= %s)) <= %s THEN %s
                      ELSE %s
                  END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
@@ -989,6 +991,7 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
@@ -1320,9 +1323,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                    WHERE "job_applications_jobapplication"."created_at" >= %s) AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                             WHERE ("job_applications_jobapplication"."created_at" >= %s)) <= %s THEN %s
                      ELSE %s
                  END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
@@ -1378,6 +1383,7 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
@@ -1710,9 +1716,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                    WHERE "job_applications_jobapplication"."created_at" >= %s) AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                             WHERE ("job_applications_jobapplication"."created_at" >= %s)) <= %s THEN %s
                      ELSE %s
                  END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
@@ -1768,6 +1776,7 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
@@ -2099,9 +2108,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                    WHERE "job_applications_jobapplication"."created_at" >= %s) AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
+                                                                                                             WHERE ("job_applications_jobapplication"."created_at" >= %s)) <= %s THEN %s
                      ELSE %s
                  END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
@@ -2157,6 +2168,7 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")

--- a/tests/www/search/__snapshots__/tests.ambr
+++ b/tests/www/search/__snapshots__/tests.ambr
@@ -931,15 +931,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
                      ELSE %s
-                 END AS "is_overwhelmed",
+                 END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -993,7 +989,6 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
@@ -1325,15 +1320,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
                      ELSE %s
-                 END AS "is_overwhelmed",
+                 END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -1387,7 +1378,6 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
@@ -1720,15 +1710,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
                      ELSE %s
-                 END AS "is_overwhelmed",
+                 END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -1782,7 +1768,6 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
@@ -2114,15 +2099,11 @@
                  "companies_jobdescription"."source_url",
                  "companies_jobdescription"."field_history",
                  "companies_jobdescription"."creation_source",
-                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                    WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                           AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) AS "job_applications_count",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
                  CASE
-                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") FILTER (
-                                                                                                             WHERE ("job_applications_jobapplication"."archived_at" IS NULL
-                                                                                                                    AND "job_applications_jobapplication"."state" IN (%s, %s, %s))) >= %s THEN %s
+                     WHEN COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") <= %s THEN %s
                      ELSE %s
-                 END AS "is_overwhelmed",
+                 END AS "is_unpopular",
                  "jobs_appellation"."updated_at",
                  "jobs_appellation"."code",
                  "jobs_appellation"."name",
@@ -2176,7 +2157,6 @@
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
           LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
-          LEFT OUTER JOIN "job_applications_jobapplication" ON ("job_applications_jobapplication_selected_jobs"."jobapplication_id" = "job_applications_jobapplication"."id")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
           INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Au lieu d’indiquer `20+ candidatures`, afficher le badge `Soyez parmi les premiers à postuler` sur les postes qui ont reçu N ou moins candidatures récentes.  

N=0 pour commencer. Finalement N=1 et ce sera facile à ajuster (cf troisième commit).

## :cake: Comment ?

On change la logique du badge existant : au lieu de le montrer si 20 ou plus candidatures, on le montre si N ou moins candidatures. 

Dans le futur on pourra facilement ajuster le seuil N.

## :computer: Captures d'écran

### recherche employeurs
![image](https://github.com/user-attachments/assets/181ffe22-4f47-4ea2-b90b-9b587271bb1f)

### recherche fiches de poste
<img width="697" alt="image" src="https://github.com/user-attachments/assets/1dbc2382-7b32-4a25-8df7-32fc96b07b20" />


