### PR TITLE
Vie privée : empêcher `job_seekers_views:details` d'afficher les informations des utilisateurs qui ne sont pas des candidats

### DIFF
--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 class JobSeekerDetailView(UserPassesTestMixin, DetailView):
     model = User
-    queryset = User.objects.select_related("jobseeker_profile")
+    queryset = User.objects.select_related("jobseeker_profile").filter(kind=UserKind.JOB_SEEKER)
     slug_field = "public_id"
     slug_url_kwarg = "public_id"
     context_object_name = "job_seeker"

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -1382,7 +1382,8 @@
                  "users_jobseekerprofile"."fields_history"
           FROM "users_user"
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
-          WHERE "users_user"."public_id" = %s
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."public_id" = %s)
           LIMIT 21
         ''',
       }),
@@ -3881,7 +3882,8 @@
                  "users_jobseekerprofile"."fields_history"
           FROM "users_user"
           LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
-          WHERE "users_user"."public_id" = %s
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."public_id" = %s)
           LIMIT 21
         ''',
       }),

--- a/tests/www/job_seekers_views/test_details.py
+++ b/tests/www/job_seekers_views/test_details.py
@@ -1,4 +1,5 @@
 import datetime
+import random
 import uuid
 
 from django.urls import reverse
@@ -12,7 +13,13 @@ from tests.companies.factories import CompanyMembershipFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
-from tests.users.factories import JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
+from tests.users.factories import (
+    EmployerFactory,
+    ItouStaffFactory,
+    JobSeekerFactory,
+    LaborInspectorFactory,
+    PrescriberFactory,
+)
 from tests.utils.test import assertSnapshotQueries, parse_response_to_soup, pretty_indented
 
 
@@ -31,6 +38,16 @@ def test_refused_access(client):
         client.force_login(user)
         response = client.get(url)
         assert response.status_code == 403
+
+
+def test_not_a_job_seeker(client):
+    not_a_job_seeker = random.choice(
+        [PrescriberFactory(), EmployerFactory(), ItouStaffFactory(), LaborInspectorFactory()]
+    )
+    client.force_login(PrescriberFactory())
+    url = reverse("job_seekers_views:details", kwargs={"public_id": not_a_job_seeker.public_id})
+    response = client.get(url)
+    assert response.status_code == 404
 
 
 @freeze_time("2024-08-14")


### PR DESCRIPTION
## :thinking: Pourquoi ?

On ne vérifie pas le type d'utilisateur dont on affiche les infos.
En pratique, ce n'est pas trop grave car on utilise un UUID. Mais quand même.

