### PR TITLE
Tests: détection des oublis de `csrf_token`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -721,3 +721,17 @@ def setup_pro_connect():
 
     with pro_connect_setup():
         yield pro_connect_setup
+
+
+@pytest.fixture(autouse=True, scope="session")
+def detect_missing_csrf_token():
+    from django.template.defaulttags import CsrfTokenNode
+
+    origin_render = CsrfTokenNode.render
+
+    def render(self, context):
+        if context.get("csrf_token") is None:
+            pytest.fail(f"Missing csrf_token variable: {self.origin}")
+        return origin_render(self, context)
+
+    CsrfTokenNode.render = render

--- a/tests/www/employee_record_views/__snapshots__/test_template.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_template.ambr
@@ -7,7 +7,7 @@
   <div class="dropdown-menu" id="sendBackRecordDropDown-[Pk of EmployeeRecord]">
       
           <form method="post" action="/employee_record/create_step_5/[Pk of JobApplication]" class="js-prevent-multiple-submit">
-              
+              <input type="hidden" name="csrfmiddlewaretoken" value="CSRF_TOKEN">
               <button type="submit" class="dropdown-item" aria-label="Renvoyer la fiche salarié sans modification">Renvoyer</button>
           </form>
       

--- a/tests/www/employee_record_views/test_template.py
+++ b/tests/www/employee_record_views/test_template.py
@@ -19,7 +19,9 @@ def test_send_back_dropdown(snapshot, factory_kwargs):
         **{f"job_application__job_seeker__jobseeker_profile__{k}": v for k, v in factory_kwargs.items()}
     )
 
-    html = template.render(Context({"employee_record": employee_record, "extra_class": ""}))
+    html = template.render(
+        Context({"csrf_token": "CSRF_TOKEN", "employee_record": employee_record, "extra_class": ""})
+    )
     normalized_html = (
         html.replace(
             f"/employee_record/create/{employee_record.job_application_id}",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Comme on utilise de plus en plus de `{% include ... with ... only %}` il est assez facile d'oublier le `csrf_token`.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
