### PR TITLE
Retirer un {{ block.super }} doublon dans la confirmation d’embauche

### DIFF
--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -26,7 +26,6 @@
 {% endblock %}
 
 {% block script %}
-    {# XXX: should this also be an include ? #}
     {{ block.super }}
     <script src="{% static 'js/split_nir.js' %}"></script>
 

--- a/itou/templates/apply/submit/hire_confirmation.html
+++ b/itou/templates/apply/submit/hire_confirmation.html
@@ -28,7 +28,6 @@
 {% block script %}
     {# XXX: should this also be an include ? #}
     {{ block.super }}
-
     <script src="{% static 'js/split_nir.js' %}"></script>
 
     <!-- Needed to use the Datepicker JS widget. -->
@@ -50,7 +49,6 @@
             });
         });
     </script>
-    {{ block.super }}
 
     {% if form_user_address %}
         {% comment %} Needed for the AddressAutocompleteWidget {% endcomment %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter d’inclure deux foix les éléments du parent (qui par chance, sont vides pour le moment).