### PR TITLE
Vie privée : notifier les professionnels sans activité récente

### DIFF
--- a/itou/archive/management/commands/anonymize_professionals.py
+++ b/itou/archive/management/commands/anonymize_professionals.py
@@ -111,10 +111,6 @@ class Command(BaseCommand):
             )
         )
 
-    # def get_users_to_anonymize_without_deletion(self, users):
-    #    # we do not want to anonymize users that have no email set, as they are already anonymized
-    #    return list(User.objects.filter(id__in=[user.id for user in users], email__isnull=False))
-
     def make_anonymized_professional(self, user):
         memberships = [
             *user.companymembership_set.all(),

--- a/itou/archive/management/commands/notify_inactive_professionals.py
+++ b/itou/archive/management/commands/notify_inactive_professionals.py
@@ -1,0 +1,71 @@
+from django.db import transaction
+from django.utils import timezone
+from sentry_sdk.crons import monitor
+
+from itou.users.models import User, UserKind
+from itou.users.notifications import InactiveUser
+from itou.utils.command import BaseCommand
+from itou.utils.constants import GRACE_PERIOD, INACTIVITY_PERIOD
+
+
+BATCH_SIZE = 200
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--wet-run",
+            action="store_true",
+            help="Perform the notification of inactive professionals",
+        )
+
+        parser.add_argument(
+            "--batch-size",
+            action="store",
+            type=int,
+            default=BATCH_SIZE,
+            help="Number of professionals to process in a batch",
+        )
+
+    @transaction.atomic
+    def notify_inactive_professionals(self):
+        now = timezone.now()
+        inactive_since = now - INACTIVITY_PERIOD
+        self.logger.info("Notifying inactive professionals without activity before: %s", inactive_since)
+
+        users = list(
+            User.objects.filter(
+                kind__in=UserKind.professionals(),
+                upcoming_deletion_notified_at__isnull=True,
+                last_login__lt=inactive_since,
+            )[: self.batch_size]
+        )
+
+        if self.wet_run:
+            for user in users:
+                InactiveUser(
+                    user,
+                    end_of_grace_period=now + GRACE_PERIOD,
+                ).send()
+            User.objects.filter(id__in=[user.id for user in users]).update(upcoming_deletion_notified_at=now)
+
+        self.logger.info("Notified inactive professionals without recent activity: %s", len(users))
+
+    @monitor(
+        monitor_slug="notify_inactive_professionals",
+        monitor_config={
+            "schedule": {"type": "crontab", "value": "0 7 * * MON-FRI"},
+            "checkin_margin": 5,
+            "max_runtime": 10,
+            "failure_issue_threshold": 2,
+            "recovery_threshold": 1,
+            "timezone": "UTC",
+        },
+    )
+    def handle(self, *args, wet_run, batch_size, **options):
+        self.wet_run = wet_run
+        self.batch_size = batch_size
+        self.logger.info("Start notifying inactive professionals in %s mode", "wet_run" if wet_run else "dry_run")
+
+        self.notify_inactive_professionals()

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -2453,3 +2453,19 @@
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_subject]
   '[DEV] Information avant suppression de votre compte sur les Emplois de l’inclusion'
 # ---
+# name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_body]
+  '''
+  Bonjour Micheline DUBOIS,
+  Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
+  Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
+  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
+# name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_subject]
+  '[DEV] Information avant suppression de votre compte sur les Emplois de l’inclusion'
+# ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Informer les utilisateurs professionnels qui ne se sont pas connectés depuis 700 jours (365j * 2 - 30j) de l'anonymisation de leurs données sans connection de leur part sous 30 jours.
Les utilisateurs professionnels sont du type  : `labor_inspector`, `prescriber` et `employer`

🟢 suite de #6366 
🔴 déployer à partir du 15 juillet

## :cake: Comment ? <!-- optionnel -->

réutilisation dans une commande de gestion spécifique aux profesionnels, des principes utilisés pour la notification des candidats.

