### PR TITLE
Tech: Nettoyage des vielles migrations squashée 

### DIFF
--- a/itou/scripts/management/commands/clean_old_applied_migrations.py
+++ b/itou/scripts/management/commands/clean_old_applied_migrations.py
@@ -1,0 +1,35 @@
+from django.db import connection, transaction
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.recorder import MigrationRecorder
+
+from itou.utils.command import BaseCommand
+
+
+class Command(BaseCommand):
+    """
+    Clean old applied migrations after a migration squash
+    """
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument("--wet-run", action="store_true")
+
+    def handle(self, *, wet_run, **options):
+        recorder = MigrationRecorder(connection)
+        recorded_migrations = recorder.applied_migrations()
+        loader = MigrationLoader(connection, ignore_no_migrations=True)
+        disk_migrations = loader.disk_migrations
+
+        to_delete = sorted(set(recorded_migrations) - set(disk_migrations))
+        self.logger.info(f"Deleting {len(to_delete)} old migrations from django_mirations table")
+        for app, name in to_delete:
+            migration = recorded_migrations[(app, name)]
+            self.logger.info(f"  {app}.{name} applied={migration.applied.date()}")
+
+        if wet_run:
+            with transaction.atomic():
+                for app, name in to_delete:
+                    MigrationRecorder.Migration.objects.filter(app=app, name=name).delete()
+
+        else:
+            self.logger.info("Run with wet-run to really delete these migrations")

--- a/tests/scripts/test_clean_old_applied_migrations.py
+++ b/tests/scripts/test_clean_old_applied_migrations.py
@@ -1,0 +1,33 @@
+from django.core.management import call_command
+from django.db.migrations.recorder import MigrationRecorder
+
+
+def test_command(caplog):
+    initial_count = MigrationRecorder.Migration.objects.count()
+
+    migration = MigrationRecorder.Migration.objects.create(app="app_name", name="0011_old_migration")
+    assert MigrationRecorder.Migration.objects.count() == initial_count + 1
+
+    call_command("clean_old_applied_migrations")
+    assert caplog.messages[:-1] == [
+        "Deleting 1 old migrations from django_mirations table",
+        f"  app_name.0011_old_migration applied={migration.applied.date()}",
+        "Run with wet-run to really delete these migrations",
+    ]
+    assert MigrationRecorder.Migration.objects.count() == initial_count + 1
+    assert MigrationRecorder.Migration.objects.filter(app="app_name", name="0011_old_migration").exists()
+
+    caplog.clear()
+    call_command("clean_old_applied_migrations", wet_run=True)
+    assert caplog.messages[:-1] == [
+        "Deleting 1 old migrations from django_mirations table",
+        f"  app_name.0011_old_migration applied={migration.applied.date()}",
+    ]
+    assert MigrationRecorder.Migration.objects.count() == initial_count
+    assert not MigrationRecorder.Migration.objects.filter(app="app_name", name="0011_old_migration").exists()
+
+    caplog.clear()
+    call_command("clean_old_applied_migrations", wet_run=True)
+    assert caplog.messages[:-1] == ["Deleting 0 old migrations from django_mirations table"]
+    assert MigrationRecorder.Migration.objects.count() == initial_count
+    assert not MigrationRecorder.Migration.objects.filter(app="app_name", name="0011_old_migration").exists()


### PR DESCRIPTION
## :thinking: Pourquoi ?

```
❯ ./manage.py showmigrations | wc -l
296
❯ psql -d itou_prod -c 'select count(*) from django_migrations'
 count 
-------
   754
(1 row)
```

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
