### PR TITLE
Pilotage : Correction du tableau de bord de présentation des prescripteurs de la DGEFP

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -753,7 +753,7 @@ def stats_dgefp_iae_showroom(request, dashboard_full_name):
         for organization in (
             PrescriberOrganization.objects.with_has_active_members()
             # Only authorized prescriber organizations
-            .filter(is_authorized=True, authorization_status=PrescriberAuthorizationStatus.VALIDATED)
+            .filter(authorization_status=PrescriberAuthorizationStatus.VALIDATED)
             # Mimic `can_view_stats_ph()`
             .filter(has_active_members=True, kind__in=utils.STATS_PH_ORGANISATION_KIND_WHITELIST)
             # Limit to the selected department


### PR DESCRIPTION
## :thinking: Pourquoi ?

Oublié lors de la transformation de `is_authorized` en propriété (e687b396) et par manque de test, mais c'est utilisé (au mieux) 1 fois tout les 3 mois donc franchement j'ai un peu la flemme de tester ça correctement.