### PR TITLE
Emails : utiliser `get_absolute_url` au lieu de construire à la main les URLs dans les gabarits

### DIFF
--- a/itou/approvals/admin_views.py
+++ b/itou/approvals/admin_views.py
@@ -25,7 +25,7 @@ from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication
 from itou.utils.apis import enums as api_enums
 from itou.utils.emails import get_email_text_template
-from itou.utils.urls import add_url_params
+from itou.utils.urls import add_url_params, get_absolute_url
 
 
 def manually_add_approval(
@@ -140,7 +140,14 @@ def manually_refuse_approval(
         "approvals/email/refuse_manually_subject.txt", {"job_application": job_application}
     )
     email_body_template = get_email_text_template(
-        "approvals/email/refuse_manually_body.txt", {"job_application": job_application}
+        "approvals/email/refuse_manually_body.txt",
+        {
+            "job_application": job_application,
+            "job_application_url": get_absolute_url(
+                reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+            ),
+            "search_url": get_absolute_url(reverse("search:prescribers_home")),
+        },
     )
 
     context = {

--- a/itou/companies/models.py
+++ b/itou/companies/models.py
@@ -430,7 +430,7 @@ class Company(AddressMixin, OrganizationAbstract):
         if self.has_members or not self.auth_email:
             raise ValidationError("Company cannot be signed up for, this should never happen.")
         to = [self.auth_email]
-        context = {"siae": self, "signup_url": reverse("signup:company_select")}
+        context = {"siae": self, "signup_url": get_absolute_url(reverse("signup:company_select"))}
         subject = "companies/email/activate_your_account_subject.txt"
         body = "companies/email/activate_your_account_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/geiq_assessments/notifications.py
+++ b/itou/geiq_assessments/notifications.py
@@ -4,7 +4,6 @@ from itou.geiq_assessments.models import (
     AssessmentInstitutionLink,
 )
 from itou.institutions.models import InstitutionMembership
-from itou.utils.urls import get_absolute_url
 
 
 @notifications_registry.register
@@ -17,11 +16,6 @@ class AssessmentSubmittedForLaborInspectorNotification(EmailNotification):
     subject_template = "geiq_assessments/email/assessment_submission_subject.txt"
     body_template = "geiq_assessments/email/assessment_submission_body.txt"
 
-    def get_context(self):
-        context = super().get_context()
-        context["base_url"] = get_absolute_url()
-        return context
-
 
 @notifications_registry.register
 class AssessmentReviewedForDREETSLaborInspectorNotification(EmailNotification):
@@ -32,11 +26,6 @@ class AssessmentReviewedForDREETSLaborInspectorNotification(EmailNotification):
     can_be_disabled = False
     subject_template = "geiq_assessments/email/assessment_review_for_dreets_subject.txt"
     body_template = "geiq_assessments/email/assessment_review_for_dreets_body.txt"
-
-    def get_context(self):
-        context = super().get_context()
-        context["base_url"] = get_absolute_url()
-        return context
 
 
 @notifications_registry.register

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -1268,8 +1268,8 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         to = [settings.ITOU_EMAIL_CONTACT]
         context = {
             "job_application": self,
-            "admin_manually_add_approval_url": reverse(
-                "admin:approvals_approval_manually_add_approval", args=[self.pk]
+            "admin_manually_add_approval_url": get_absolute_url(
+                reverse("admin:approvals_approval_manually_add_approval", args=[self.pk])
             ),
         }
         if accepted_by:
@@ -1283,7 +1283,13 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
         if not self.accepted_by:
             raise RuntimeError("Unable to determine the recipient email address.")
         to = [self.accepted_by.email]
-        context = {"job_application": self}
+        context = {
+            "job_application": self,
+            "job_application_url": get_absolute_url(
+                reverse("apply:details_for_company", kwargs={"job_application_id": self.pk})
+            ),
+            "search_url": get_absolute_url(reverse("search:prescribers_home")),
+        }
         subject = "approvals/email/refuse_manually_subject.txt"
         body = "approvals/email/refuse_manually_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/prescribers/models.py
+++ b/itou/prescribers/models.py
@@ -324,7 +324,12 @@ class PrescriberOrganization(AddressMixin, OrganizationAbstract):
         => prescriber organization authorization must be validated
         """
         to = [settings.ITOU_EMAIL_CONTACT]
-        context = {"organization": self}
+        context = {
+            "organization": self,
+            "admin_url": get_absolute_url(
+                reverse("admin:prescribers_prescriberorganization_change", kwargs={"object_id": self.pk})
+            ),
+        }
         subject = "prescribers/email/must_validate_prescriber_organization_email_subject.txt"
         body = "prescribers/email/must_validate_prescriber_organization_email_body.txt"
         return get_email_message(to, context, subject, body)

--- a/itou/templates/account/email/email_archive_user_body.txt
+++ b/itou/templates/account/email/email_archive_user_body.txt
@@ -9,5 +9,5 @@
 Bonjour {{ user.get_full_name }},
 Le {{ user.upcoming_deletion_notified_at|date:"d/m/Y" }}, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
 A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
-En cas de besoin, vous pouvez toujours vous réinscrire sur https://emplois.inclusion.beta.gouv.fr/
+En cas de besoin, vous pouvez toujours vous réinscrire sur {{ base_url }}
 {% endblock body %}

--- a/itou/templates/account/email/email_inactive_user_body.txt
+++ b/itou/templates/account/email/email_inactive_user_body.txt
@@ -10,5 +10,5 @@
 Bonjour {{ user.get_full_name }},
 Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le {% if user.last_activity %}{{ user.last_activity|date:"d/m/Y" }}{% else %}{{ user.last_login|date:"d/m/Y" }}{% endif %}.
 Sans connexion de votre part avant le {{ end_of_grace_period|date:"d/m/Y" }}, votre compte sera supprimé ainsi que toutes les données associées.
-Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
+Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur {{ base_url }}
 {% endblock body %}

--- a/itou/templates/account/email/unknown_account_message.txt
+++ b/itou/templates/account/email/unknown_account_message.txt
@@ -1,6 +1,6 @@
-Bonjour, 
+Bonjour,
 
-Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion (https://emplois.inclusion.beta.gouv.fr/).
+Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion ({{ base_url }}).
 
 Toutefois, nous n’avons trouvé aucun compte utilisateur associé à votre adresse e-mail.
 
@@ -11,7 +11,7 @@ Si vous avez fait cette demande de nouveau mot de passe :
 - Assurez-vous que vous n’aviez pas créé votre compte sur les emplois de l’inclusion depuis une autre adresse e-mail.
 - Vous pouvez créer un nouveau compte en utilisant le lien ci-dessous :
 
-https://emplois.inclusion.beta.gouv.fr/accounts/signup/ 
+{{ signup_url }}
 
 Cordialement,
 

--- a/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
+++ b/itou/templates/approvals/email/manual_delivery_required_notification_body.txt
@@ -22,6 +22,6 @@ Informations pour l'obtention d'un PASS IAE suite à l'embauche de votre candid
 - Accepté par : {{ accepted_by.get_full_name }} - {{ accepted_by.email }}{% endif %}
 
 Délivrer un PASS IAE dans l'admin :
-{{ itou_protocol }}://{{ itou_fqdn }}{{ admin_manually_add_approval_url }}
+{{ admin_manually_add_approval_url }}
 
 {% endblock body %}

--- a/itou/templates/approvals/email/refuse_manually_body.txt
+++ b/itou/templates/approvals/email/refuse_manually_body.txt
@@ -4,7 +4,7 @@
 Bonjour,
 
 Nous faisons suite à votre demande de PASS IAE pour {{ job_application.job_seeker.get_full_name }} :
-{{ itou_protocol }}://{{ itou_fqdn }}{% url 'apply:details_for_company' job_application.pk %}
+{{ job_application_url }}
 
 Nous sommes dans l'impossibilité de vous délivrer ce PASS IAE pour le motif suivant :
 
@@ -15,6 +15,6 @@ Vous avez la possibilité de contacter un prescripteur habilité pour exposer la
 Si le prescripteur habilité est favorable à une dérogation de son délai de carence, il doit vous transmettre la candidature de {{ job_application.job_seeker.get_full_name }} via les emplois de l'inclusion. Vous pourrez ensuite demander l'obtention d'un PASS IAE.
 
 Pour trouver les prescripteurs habilités proches de vous, pensez à utiliser le moteur de recherche depuis votre tableau de bord :
-{{ itou_protocol }}://{{ itou_fqdn }}{% url 'search:prescribers_home' %}
+{{ search_url }}
 
 {% endblock body %}

--- a/itou/templates/companies/email/activate_your_account_body.txt
+++ b/itou/templates/companies/email/activate_your_account_body.txt
@@ -5,7 +5,7 @@ Bonjour,
 
 Le compte de votre {{siae.kind}} SIRET {{siae.siret}} vient d’être créé sur les emplois de l’inclusion !
 
-Pour activer le compte de l’entreprise, pouvoir embaucher, obtenir des PASS IAE et créer vos fiches salarié, activez votre compte en cliquant ici {{ itou_protocol }}://{{ itou_fqdn }}{{ signup_url }}
+Pour activer le compte de l’entreprise, pouvoir embaucher, obtenir des PASS IAE et créer vos fiches salarié, activez votre compte en cliquant ici {{ signup_url }}
 
 Vous avez déjà un compte employeur sur les emplois de l’inclusion ?
 - demandez à un de vos collègues qui n’en a pas encore d’activer le compte

--- a/itou/templates/layout/base_email_signature.txt
+++ b/itou/templates/layout/base_email_signature.txt
@@ -1,4 +1,4 @@
 ---
 {% if itou_environment != "PROD" and itou_environment != "FAST-MACHINE" %}[{{ itou_environment }}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{ itou_environment }}]{% endif %}
 Les emplois de l'inclusion
-{{ itou_protocol }}://{{ itou_fqdn }}
+{{ base_url }}

--- a/itou/templates/prescribers/email/must_validate_prescriber_organization_email_body.txt
+++ b/itou/templates/prescribers/email/must_validate_prescriber_organization_email_body.txt
@@ -10,6 +10,6 @@ Une nouvelle organisation de prescripteur a été créée. L'habilitation de cet
 - ID : {{ organization.id }}
 - Type sélectionné par l’utilisateur : {{ organization.get_kind_display }}
 
-{{ itou_protocol }}://{{ itou_fqdn }}{% url 'admin:prescribers_prescriberorganization_change' organization.id %}
+{{ admin_url }}
 
 {% endblock body %}

--- a/itou/users/adapter.py
+++ b/itou/users/adapter.py
@@ -7,7 +7,7 @@ from django.utils.http import urlencode
 from itou.openid_connect.france_connect.constants import FRANCE_CONNECT_SESSION_STATE, FRANCE_CONNECT_SESSION_TOKEN
 from itou.openid_connect.pe_connect.constants import PE_CONNECT_SESSION_TOKEN
 from itou.openid_connect.pro_connect.constants import PRO_CONNECT_SESSION_KEY
-from itou.utils.urls import get_safe_url
+from itou.utils.urls import get_absolute_url, get_safe_url
 
 
 class UserAdapter(DefaultAccountAdapter):
@@ -105,4 +105,6 @@ class UserAdapter(DefaultAccountAdapter):
         context["itou_environment"] = settings.ITOU_ENVIRONMENT
         context["itou_protocol"] = settings.ITOU_PROTOCOL
         context["itou_fqdn"] = settings.ITOU_FQDN
+        context["base_url"] = get_absolute_url()
+        context["signup_url"] = get_absolute_url(reverse("signup:choose_user_kind"))
         super().send_mail(template_prefix, email, context)

--- a/itou/users/notifications.py
+++ b/itou/users/notifications.py
@@ -2,6 +2,7 @@ from django.conf import settings
 
 from itou.communications import NotificationCategory, registry as notifications_registry
 from itou.communications.dispatch import EmailNotification, PrescriberOrEmployerOrLaborInspectorNotification
+from itou.utils.urls import get_absolute_url
 
 
 @notifications_registry.register
@@ -44,6 +45,11 @@ class InactiveUser(EmailNotification):
     body_template = "account/email/email_inactive_user_body.txt"
     can_be_disabled = False
 
+    def get_context(self):
+        context = super().get_context()
+        context["base_url"] = get_absolute_url()
+        return context
+
 
 @notifications_registry.register
 class ArchiveUser(EmailNotification):
@@ -52,3 +58,8 @@ class ArchiveUser(EmailNotification):
     subject_template = "account/email/email_archive_user_subject.txt"
     body_template = "account/email/email_archive_user_body.txt"
     can_be_disabled = False
+
+    def get_context(self):
+        context = super().get_context()
+        context["base_url"] = get_absolute_url()
+        return context

--- a/itou/users/notifications.py
+++ b/itou/users/notifications.py
@@ -2,7 +2,6 @@ from django.conf import settings
 
 from itou.communications import NotificationCategory, registry as notifications_registry
 from itou.communications.dispatch import EmailNotification, PrescriberOrEmployerOrLaborInspectorNotification
-from itou.utils.urls import get_absolute_url
 
 
 @notifications_registry.register
@@ -45,11 +44,6 @@ class InactiveUser(EmailNotification):
     body_template = "account/email/email_inactive_user_body.txt"
     can_be_disabled = False
 
-    def get_context(self):
-        context = super().get_context()
-        context["base_url"] = get_absolute_url()
-        return context
-
 
 @notifications_registry.register
 class ArchiveUser(EmailNotification):
@@ -58,8 +52,3 @@ class ArchiveUser(EmailNotification):
     subject_template = "account/email/email_archive_user_subject.txt"
     body_template = "account/email/email_archive_user_body.txt"
     can_be_disabled = False
-
-    def get_context(self):
-        context = super().get_context()
-        context["base_url"] = get_absolute_url()
-        return context

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -7,6 +7,7 @@ from django.template.loader import get_template
 
 from itou.utils import constants as global_constants
 from itou.utils.enums import ItouEnvironment
+from itou.utils.urls import get_absolute_url
 
 
 def remove_extra_line_breaks(text):
@@ -24,8 +25,7 @@ def get_email_text_template(template, context):
         {
             "itou_help_center_url": global_constants.ITOU_HELP_CENTER_URL,
             "itou_environment": settings.ITOU_ENVIRONMENT,
-            "itou_fqdn": settings.ITOU_FQDN,
-            "itou_protocol": settings.ITOU_PROTOCOL,
+            "base_url": get_absolute_url(),
         }
     )
     return remove_extra_line_breaks(get_template(template).render(context).strip())

--- a/tests/approvals/__snapshots__/test_notifications.ambr
+++ b/tests/approvals/__snapshots__/test_notifications.ambr
@@ -46,7 +46,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_prolongation_request_created[subject]
@@ -105,7 +105,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_prolongation_request_created_reminder[subject]
@@ -140,7 +140,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_prolongation_request_denied_employer[subject]
@@ -173,7 +173,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_prolongation_request_denied_jobseeker[subject]
@@ -194,7 +194,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_prolongation_request_granted_employer[subject]
@@ -213,7 +213,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_prolongation_request_granted_jobseeker[subject]

--- a/tests/approvals/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/approvals/__snapshots__/test_prolongation_requests.ambr
@@ -64,7 +64,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_chores_send_reminder_to_prescriber_organization_other_members_copy_limit[subject]

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -53,7 +53,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_subject]
@@ -91,7 +91,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_subject]
@@ -129,7 +129,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker_email_subject]
@@ -346,7 +346,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_subject]
@@ -2415,7 +2415,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_in_followup_group_without_recent_activity][inactive_jobseeker_email_subject]
@@ -2431,7 +2431,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_with_job_application_without_recent_activity][inactive_jobseeker_email_subject]
@@ -2447,7 +2447,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveJobseekersManagementCommand.test_notify_inactive_jobseekers[jobseeker_without_recent_activity][inactive_jobseeker_email_subject]
@@ -2463,7 +2463,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestNotifyInactiveProfessionalsManagementCommand.test_notify_inactive_professionals[professional_without_recent_activity][inactive_professional_email_subject]

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -48,7 +48,7 @@
   Bonjour Johan ANDERSON,
   Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
-  En cas de besoin, vous pouvez toujours vous réinscrire sur https://emplois.inclusion.beta.gouv.fr/
+  En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -86,7 +86,7 @@
   Bonjour Johanna ANDREWS,
   Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
-  En cas de besoin, vous pouvez toujours vous réinscrire sur https://emplois.inclusion.beta.gouv.fr/
+  En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -124,7 +124,7 @@
   Bonjour Martin JACOBSON,
   Le XX/XX/XXXX, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
-  En cas de besoin, vous pouvez toujours vous réinscrire sur https://emplois.inclusion.beta.gouv.fr/
+  En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -341,7 +341,7 @@
   Bonjour Micheline DUBOIS,
   Le 15/01/2025, nous vous avons informé que votre compte sur les Emplois de l’inclusion serait supprimé.
   A ce jour, nous n’avons détecté aucune connexion, par conséquent nous avons supprimé l’intégralité des données associées à votre compte.
-  En cas de besoin, vous pouvez toujours vous réinscrire sur https://emplois.inclusion.beta.gouv.fr/
+  En cas de besoin, vous pouvez toujours vous réinscrire sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -2410,7 +2410,7 @@
   Bonjour Jane DOE,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
-  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
+  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -2426,7 +2426,7 @@
   Bonjour Jane DOE,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
-  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
+  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -2442,7 +2442,7 @@
   Bonjour Jane DOE,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
-  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
+  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
@@ -2458,7 +2458,7 @@
   Bonjour Micheline DUBOIS,
   Nous n’avons détecté aucune activité sur votre compte sur les Emplois de l’inclusion depuis le XX/XX/XXXX.
   Sans connexion de votre part avant le YY/YY/YYYY, votre compte sera supprimé ainsi que toutes les données associées.
-  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur https://emplois.inclusion.beta.gouv.fr/ .
+  Si vous souhaitez conserver votre espace personnel, nous vous invitons à vous reconnecter sur http://localhost:8000/
   
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]

--- a/tests/job_applications/__snapshots__/tests.ambr
+++ b/tests/job_applications/__snapshots__/tests.ambr
@@ -12,7 +12,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestJobApplicationNotifications.test_refuse[False-True][job_seeker_email]
@@ -28,7 +28,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestJobApplicationNotifications.test_refuse[False-True][prescriber_email]
@@ -50,7 +50,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestJobApplicationNotifications.test_refuse[True-False][job_seeker_email]
@@ -70,7 +70,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestJobApplicationNotifications.test_refuse[True-True][job_seeker_email]
@@ -90,7 +90,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestJobApplicationNotifications.test_refuse[True-True][prescriber_email]
@@ -112,6 +112,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/siae_evaluations/__snapshots__/test_emails.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_emails.ambr
@@ -14,7 +14,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestInstitutionEmailFactory.test_close_notifies_when_siae_has_negative_result[sanction notification email]
@@ -32,7 +32,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestInstitutionEmailFactory.test_close_notify_when_siae_has_positive_result_in_adversarial_phase[accepted result email]
@@ -48,6 +48,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_management_commands.ambr
@@ -18,6 +18,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/siae_evaluations/__snapshots__/test_models.ambr
+++ b/tests/siae_evaluations/__snapshots__/test_models.ambr
@@ -12,7 +12,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_close_no_response[no docs email body]
@@ -32,7 +32,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_close_no_response[sanction notification email body]
@@ -50,7 +50,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_close_refused_but_not_reviewed[refused email body]
@@ -68,7 +68,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_close_refused_but_not_reviewed[sanction notification email body]
@@ -86,7 +86,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_populate
@@ -583,7 +583,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase[force accepted email body]
@@ -601,7 +601,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase[institution summary email body]
@@ -629,7 +629,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase[no docs email body]
@@ -651,7 +651,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase[no response email body]
@@ -673,7 +673,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase[refused review email body]
@@ -697,7 +697,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase_accepted_but_not_reviewed[positive review email body]
@@ -713,7 +713,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase_force_accepted[force accepted email body]
@@ -731,7 +731,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase_force_accepted[institution summary email body]
@@ -747,7 +747,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase_forced_to_adversarial_stage[institution summary email body]
@@ -767,7 +767,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase_forced_to_adversarial_stage[no response email body]
@@ -789,7 +789,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestEvaluationCampaignManager.test_transition_to_adversarial_phase_refused_but_not_reviewed[negative review email body]
@@ -813,6 +813,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/users/__snapshots__/test_management_commands.ambr
+++ b/tests/users/__snapshots__/test_management_commands.ambr
@@ -292,7 +292,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestSendCheckAuthorizedMembersEmailManagementCommand.test_check_authorized_members_email_content_members_link[institution]
@@ -314,7 +314,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestSendCheckAuthorizedMembersEmailManagementCommand.test_check_authorized_members_email_content_members_link[prescriber_organization]
@@ -336,7 +336,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestSendCheckAuthorizedMembersEmailManagementCommand.test_check_authorized_members_email_content_one_admin
@@ -358,7 +358,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestSendCheckAuthorizedMembersEmailManagementCommand.test_check_authorized_members_email_content_two_admins
@@ -378,7 +378,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: test_pe_certify_users

--- a/tests/users/__snapshots__/test_models.ambr
+++ b/tests/users/__snapshots__/test_models.ambr
@@ -15,6 +15,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/www/apply/__snapshots__/test_process.ambr
+++ b/tests/www/apply/__snapshots__/test_process.ambr
@@ -5225,7 +5225,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_employer_orienter[postpone_email_to_job_seeker_subject]
@@ -5244,7 +5244,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_employer_orienter[postpone_email_to_proxy_subject]
@@ -5263,7 +5263,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_job_seeker[postpone_email_to_job_seeker_subject]
@@ -5278,7 +5278,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_prescriber[postpone_email_to_job_seeker_subject]
@@ -5293,7 +5293,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestProcessViews.test_postpone_from_prescriber[postpone_email_to_proxy_subject]

--- a/tests/www/companies_views/__snapshots__/test_members_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_members_views.ambr
@@ -15,6 +15,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -1161,7 +1161,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAssessmentDetailsForGEIQView.test_submission[submitted assessment details section]

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -22,7 +22,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAssessmentDetailsForInstitutionView.test_ddets_review_and_dreets_final_review[body of mail sent to GEIQ members]
@@ -53,7 +53,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestAssessmentDetailsForInstitutionView.test_details_for_institution[assessment details section after submission]

--- a/tests/www/institutions_views/__snapshots__/test_views.ambr
+++ b/tests/www/institutions_views/__snapshots__/test_views.ambr
@@ -13,6 +13,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/www/prescribers_views/__snapshots__/test_members.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_members.ambr
@@ -15,6 +15,6 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---

--- a/tests/www/siae_evaluations_views/test_institutions_views.py
+++ b/tests/www/siae_evaluations_views/test_institutions_views.py
@@ -2401,7 +2401,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == "RDV le lundi 8 à 15h à la DDETS"
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -2460,7 +2460,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates == InclusiveDateRange(
@@ -2806,7 +2806,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates == InclusiveDateRange(datetime.date(2023, 1, 1))
@@ -2920,7 +2920,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3070,7 +3070,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3129,7 +3129,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3182,7 +3182,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates is None
@@ -3259,7 +3259,7 @@ class TestInstitutionEvaluatedSiaeNotifyViewStep3(InstitutionEvaluatedSiaeNotify
             "[DEV] Cet email est envoyé depuis un environnement de démonstration, "
             "merci de ne pas en tenir compte [DEV]\n"
             "Les emplois de l'inclusion\n"
-            "http://localhost:8000"
+            "http://localhost:8000/"
         )
         assert evaluated_siae.sanctions.training_session == ""
         assert evaluated_siae.sanctions.suspension_dates == InclusiveDateRange(datetime.date(2023, 1, 1))

--- a/tests/www/signup/__snapshots__/test_password.ambr
+++ b/tests/www/signup/__snapshots__/test_password.ambr
@@ -1,4 +1,18 @@
 # serializer version: 1
+# name: TestPasswordReset.test_password_reset_flow[password_reset_key_message]
+  '''
+  Nous vous invitons pour cela à cliquer sur le lien ci-dessous pour le réinitialiser.
+  
+  http://testserver/accounts/password/reset/key/[Reset password key]
+  
+  Si vous n'avez pas demandé la réinitialisation de votre mot de passe, vous pouvez ignorer ce message.
+  
+  ---
+  [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
+  Les emplois de l'inclusion
+  http://localhost:8000
+  '''
+# ---
 # name: TestPasswordReset.test_password_reset_token_invalid_content
   '''
   <main class="s-main" id="main" role="main">
@@ -147,5 +161,27 @@
       </section>
   </main>
   
+  '''
+# ---
+# name: TestPasswordReset.test_password_reset_with_nonexistent_email[unknown_account_message]
+  '''
+  Bonjour, 
+  
+  Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion (https://emplois.inclusion.beta.gouv.fr/).
+  
+  Toutefois, nous n’avons trouvé aucun compte utilisateur associé à votre adresse e-mail.
+  
+  Si vous n’avez fait aucune demande de nouveau mot de passe, vous pouvez ignorer cet e-mail.
+  
+  Si vous avez fait cette demande de nouveau mot de passe :
+  
+  - Assurez-vous que vous n’aviez pas créé votre compte sur les emplois de l’inclusion depuis une autre adresse e-mail.
+  - Vous pouvez créer un nouveau compte en utilisant le lien ci-dessous :
+  
+  https://emplois.inclusion.beta.gouv.fr/accounts/signup/ 
+  
+  Cordialement,
+  
+  L’équipe des emplois de l’inclusion
   '''
 # ---

--- a/tests/www/signup/__snapshots__/test_password.ambr
+++ b/tests/www/signup/__snapshots__/test_password.ambr
@@ -165,9 +165,9 @@
 # ---
 # name: TestPasswordReset.test_password_reset_with_nonexistent_email[unknown_account_message]
   '''
-  Bonjour, 
+  Bonjour,
   
-  Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion (https://emplois.inclusion.beta.gouv.fr/).
+  Vous recevez cet e-mail parce que vous, ou quelqu’un d’autre, avez demandé à réinitialiser le mot de passe associé à votre compte sur les emplois de l’inclusion (http://localhost:8000/).
   
   Toutefois, nous n’avons trouvé aucun compte utilisateur associé à votre adresse e-mail.
   
@@ -178,7 +178,7 @@
   - Assurez-vous que vous n’aviez pas créé votre compte sur les emplois de l’inclusion depuis une autre adresse e-mail.
   - Vous pouvez créer un nouveau compte en utilisant le lien ci-dessous :
   
-  https://emplois.inclusion.beta.gouv.fr/accounts/signup/ 
+  http://localhost:8000/signup/
   
   Cordialement,
   

--- a/tests/www/signup/__snapshots__/test_password.ambr
+++ b/tests/www/signup/__snapshots__/test_password.ambr
@@ -10,7 +10,7 @@
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion
-  http://localhost:8000
+  http://localhost:8000/
   '''
 # ---
 # name: TestPasswordReset.test_password_reset_token_invalid_content


### PR DESCRIPTION
## :thinking: Pourquoi ?

On utilise principalement `get_absolute_url` pour construire les URLs dans les gabarits des templates, mais il y a quelques exceptions que cette PR vise à corriger.

