### PR TITLE
Page d’accueil : prendre en compte le retour à la ligne dans la modale nouveauté [GEN-2584]

### DIFF
--- a/itou/templates/layout/_news_modal.html
+++ b/itou/templates/layout/_news_modal.html
@@ -18,7 +18,7 @@
                 </div>
                 {% for item in active_campaign_announce_items %}
                     <h6>{{ forloop.counter }}. {{ item.title }}</h6>
-                    <p>{{ item.description }}</p>
+                    <p>{{ item.description|linebreaksbr }}</p>
                 {% endfor %}
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
## :thinking: Pourquoi ?

La mise en page est bien plus sympa comme ça.

## :computer: Captures d'écran <!-- optionnel -->

Avant : 
![2025-07-01-194843_hyprshot](https://github.com/user-attachments/assets/1748e1d8-647c-470b-9198-4eed4fb78b96)



Après : 
![2025-07-01-194918_hyprshot](https://github.com/user-attachments/assets/caf3329e-bebe-40b3-baf1-de0b832b6180)



