### PR TITLE
Tech : Rendre l'usage de `temporary_bucket` obligatoire

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -45,7 +45,7 @@ AWS_S3_SECRET_ACCESS_KEY = os.getenv("CELLAR_ADDON_SECRET_KEY_TEST", "minioadmin
 # S3 bucket names must be globally unique. CI uses Cellar, so the storage
 # bucket name must not exist on all of Cellar.
 # https://www.clever-cloud.com/developers/doc/addons/cellar/#name-your-bucket
-AWS_STORAGE_BUCKET_NAME = "c1-tests"
+AWS_STORAGE_BUCKET_NAME = None
 
 PILOTAGE_DATASTORE_S3_ENDPOINT_URL = AWS_S3_ENDPOINT_URL
 PILOTAGE_DATASTORE_S3_ACCESS_KEY = AWS_S3_ACCESS_KEY_ID

--- a/tests/communications/test_admin.py
+++ b/tests/communications/test_admin.py
@@ -22,6 +22,7 @@ class TestAnnouncementItemAdmin:
             buf.seek(0)
             yield buf.getvalue()
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_add_image(self, admin_client, black_pixel):
         response = admin_client.post(
             reverse("admin:communications_announcementcampaign_add"),
@@ -49,6 +50,7 @@ class TestAnnouncementItemAdmin:
         file = File.objects.get()
         assert file.key.startswith("news-images/")
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_change_image(self, admin_client, black_pixel):
         item = AnnouncementItemFactory(with_image=True)
         url = reverse("admin:communications_announcementcampaign_change", args=(item.campaign_id,))

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -25,6 +25,7 @@ from tests.job_applications.factories import JobApplicationFactory
 from tests.siae_evaluations.factories import EvaluatedAdministrativeCriteriaFactory, EvaluatedJobApplicationFactory
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_bucket_policy_for_anonymous_user():
     base_url = f"{settings.AWS_S3_ENDPOINT_URL}{settings.AWS_STORAGE_BUCKET_NAME}/{default_storage.location}"
     response = httpx.head(f"{base_url}/test_file.pdf")
@@ -126,6 +127,7 @@ def test_cellar_does_not_support_checksum_validation():
     client.put_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Body=b"", Key="file")
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_copy(pdf_file):
     key = "resume/11111111-1111-1111-1111-111111111111.pdf"
     default_storage.save(key, pdf_file)
@@ -138,6 +140,7 @@ def test_copy(pdf_file):
         assert old.read() == new.read()
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_find_orphans(caplog):
     old_orphan = FileFactory()
     job_application = JobApplicationFactory()
@@ -167,6 +170,7 @@ def test_find_orphans(caplog):
     )
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_purge_files(caplog):
     in_the_past = timezone.now() - datetime.timedelta(days=1)
     to_purge = FileFactory(deleted_at=in_the_past)

--- a/tests/www/announcements/test_views.py
+++ b/tests/www/announcements/test_views.py
@@ -111,6 +111,7 @@ class TestNewsRender:
         client.force_login(JobSeekerFactory())
         assert_content_matches_snapshot(client.get(url))
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_rendering_invalid_file_does_not_crash(self, client):
         user = JobSeekerFactory()
         item = AnnouncementItemFactory(with_image=True, user_kind_tags=[user.kind])

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -407,6 +407,7 @@ def test_step_2_without_session(client):
 
 
 @freeze_time()
+@pytest.mark.usefixtures("temporary_bucket")
 def test_step_3(client, snapshot, pdf_file):
     job_application = JobApplicationFactory(
         state=JobApplicationState.REFUSED,
@@ -458,6 +459,7 @@ def test_step_3(client, snapshot, pdf_file):
     assert transfer_log.target_company == other_company
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_step_3_no_previous_CV(client, mocker, pdf_file):
     job_application = JobApplicationFactory(state=JobApplicationState.REFUSED, resume=None)
     employer = job_application.to_company.members.get()
@@ -540,6 +542,7 @@ def test_step_3_remove_previous_CV(client):
     assert new_job_application.state == JobApplicationState.NEW
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_step_3_replace_previous_CV(client, mocker, pdf_file):
     job_application = JobApplicationFactory(state=JobApplicationState.REFUSED)
     assert job_application.resume
@@ -597,6 +600,7 @@ def test_access_step_3_without_session(client):
     assert response.status_code == 404
 
 
+@pytest.mark.usefixtures("temporary_bucket")
 def test_full_process(client, pdf_file):
     create_test_romes_and_appellations(["N1101"], appellations_per_rome=1)
     vannes = create_city_vannes()

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -543,6 +543,7 @@ class TestApplyAsJobSeeker:
             ),
         )
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_apply_as_jobseeker(self, client, pdf_file):
         """Apply as jobseeker."""
 
@@ -771,6 +772,7 @@ class TestApplyAsJobSeeker:
 
         assertContains(response, LINK_RESET_MARKUP % reset_url_job_description)
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_apply_as_job_seeker_sent_emails(self, client, pdf_file, mailoutbox):
         company = CompanyWithMembershipAndJobsFactory(romes=("N1101"))
         employer = company.members.get()
@@ -914,6 +916,7 @@ class TestApplyAsAuthorizedPrescriber:
             side_effect=mock_get_geocoding_data_by_ban_api_resolved,
         )
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_apply_as_prescriber_with_pending_authorization(self, client, pdf_file):
         """Apply as prescriber that has pending authorization."""
 
@@ -1208,6 +1211,7 @@ class TestApplyAsAuthorizedPrescriber:
         assert response.status_code == 200
 
     @freeze_time()
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_apply_as_authorized_prescriber(self, client, pdf_file, snapshot):
         company = CompanyWithMembershipAndJobsFactory(romes=("N1101", "N1105"), for_snapshot=True)
         reset_url_company = reverse("companies_views:card", kwargs={"siae_id": company.pk})
@@ -1676,6 +1680,7 @@ class TestApplyAsPrescriber:
             ),
         )
 
+    @pytest.mark.usefixtures("temporary_bucket")
     @pytest.mark.ignore_unknown_variable_template_error("job_seeker")
     def test_apply_as_prescriber(self, client, pdf_file):
         company = CompanyWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
@@ -2586,6 +2591,7 @@ class TestApplyAsCompany:
             follow_up_group__beneficiary=new_job_seeker, member=user
         ).exists()
 
+    @pytest.mark.usefixtures("temporary_bucket")
     @pytest.mark.ignore_unknown_variable_template_error("job_seeker")
     def test_apply_as_employer(self, client, pdf_file):
         company = CompanyWithMembershipAndJobsFactory(romes=("N1101", "N1105"))
@@ -2602,6 +2608,7 @@ class TestApplyAsCompany:
         )
         self._test_apply_as_company(client, employer, company, dummy_job_seeker, pdf_file)
 
+    @pytest.mark.usefixtures("temporary_bucket")
     @pytest.mark.ignore_unknown_variable_template_error("job_seeker")
     def test_apply_as_another_employer(self, client, pdf_file):
         company = CompanyFactory(with_membership=True, with_jobs=True, romes=("N1101", "N1105"))

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -362,6 +362,7 @@ class TestProlongationReportFileView:
         )
         assert response.status_code == 404
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_ok(self, client, xlsx_file):
         org = prescribers_factories.PrescriberOrganizationFactory(authorized=True)
         prescriber = users_factories.PrescriberFactory(membership__organization=org)

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -402,6 +402,7 @@ class TestAssessmentDetailsForGEIQView:
         assert str(parse_response_to_soup(response, ".s-title-02")) == snapshot(name="assessment details title")
         assert str(parse_response_to_soup(response, ".s-section")) == snapshot(name="assessment details section")
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_htmx_load(self, client, settings, label_settings, respx_mock, pdf_file):
         pdf_file_content = pdf_file.read()
         membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
@@ -812,6 +813,7 @@ class TestAssessmentSyncFile:
                 response = client.post(url)
                 assert response.status_code == expected_status
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_sync(self, client, pdf_file, respx_mock, label_settings):
         pdf_file_content = pdf_file.read()
         membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
@@ -956,6 +958,7 @@ class TestAssessmentUploadActionFinancialAssessment:
             response = client.get(url)
             assert response.status_code == expected_status
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_access_and_upload(self, client, pdf_file, settings, snapshot):
         geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
         settings.GEIQ_ASSESSMENT_CAMPAIGN_POSTCODE_PREFIXES = [geiq_membership.company.post_code[:2]]

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -859,6 +859,7 @@ class TestSiaeUploadDocsView:
         )
         assert evaluated_administrative_criteria == response.context["evaluated_administrative_criteria"]
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_post(self, client, pdf_file):
         fake_now = timezone.now()
         client.force_login(self.user)

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -450,6 +450,7 @@ class TestViewProof:
         response = client.get(url)
         assert response.status_code == 404
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_access_siae(self, client, pdf_file):
         job_app = EvaluatedJobApplicationFactory()
         key = default_storage.save("evaluations/test.pdf", pdf_file)
@@ -477,6 +478,7 @@ class TestViewProof:
         response = client.get(url)
         assert response.status_code == 404
 
+    @pytest.mark.usefixtures("temporary_bucket")
     def test_access_institution(self, client, pdf_file):
         membership = InstitutionMembershipFactory()
         job_app = EvaluatedJobApplicationFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon on continue d'utiliser un bucket fourre-tout, en dev et sur la CI :
![image](https://github.com/user-attachments/assets/88ef1851-9ab7-4eea-bda3-569c4170bf31)

## :desert_island: Comment tester ?

Supprimer le bucket `c1-tests` de votre minio local et lancer les tests
