### PR TITLE
Tech : Ajout des `updated_at` manquant lors des `.save(update_fields=...)` pour l'import des SIAE

### DIFF
--- a/itou/companies/management/commands/_import_siae/convention.py
+++ b/itou/companies/management/commands/_import_siae/convention.py
@@ -55,7 +55,7 @@ def update_existing_conventions(siret_to_siae_row, conventions_by_siae_key):
             )
             assert not SiaeConvention.objects.filter(asp_id=row.asp_id, kind=siae.kind).exists()
             convention.asp_id = row.asp_id
-            convention.save(update_fields={"asp_id"})
+            convention.save(update_fields={"asp_id", "updated_at"})
             continue
 
         # Siret_signature can change from one export to the next!
@@ -88,7 +88,7 @@ def update_existing_conventions(siret_to_siae_row, conventions_by_siae_key):
                 conventions_to_deactivate.append(convention)
 
         if updated_fields:
-            convention.save(update_fields=updated_fields)
+            convention.save(update_fields=updated_fields | {"updated_at"})
 
     print(f"{reactivations} conventions have been reactivated")
 

--- a/itou/companies/management/commands/_import_siae/financial_annex.py
+++ b/itou/companies/management/commands/_import_siae/financial_annex.py
@@ -52,7 +52,7 @@ def get_creatable_and_deletable_afs(af_number_to_row):
                 af.convention = convention
                 updated_fields.add("convention")
 
-        af.save(update_fields=updated_fields)
+        af.save(update_fields=updated_fields | {"updated_at"})
 
     creatable_af_numbers = set(af_number_to_row) - db_af_numbers
     creatable_afs = list(

--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -114,7 +114,7 @@ def update_siret_and_auth_email_of_existing_siaes(siret_to_siae_row):
             updated_fields.add("siret")
 
         if updated_fields:
-            siae.save(update_fields=updated_fields)
+            siae.save(update_fields=updated_fields | {"updated_at"})
 
     print(f"{auth_email_updates} siae.auth_email fields have been updated")
     return errors
@@ -170,7 +170,7 @@ def create_new_siaes(siret_to_siae_row, conventions_by_siae_key):
             )
             existing_siae.source = Company.SOURCE_ASP
             existing_siae.convention = None
-            existing_siae.save(update_fields={"source", "convention"})
+            existing_siae.save(update_fields={"source", "convention", "updated_at"})
 
     print("--- beginning of CSV output of all creatable_siaes ---")
     print("siret;kind;department;name;address")
@@ -249,7 +249,7 @@ def manage_staff_created_siaes():
     for siae in staff_created_siaes.filter(convention__isnull=False):
         print(f"converted staff created siae.id={siae.id} to user created siae as it has a convention")
         siae.source = Company.SOURCE_USER_CREATED
-        siae.save(update_fields={"source"})
+        siae.save(update_fields={"source", "updated_at"})
 
     recent_unconfirmed_siaes = staff_created_siaes.filter(created_at__gte=three_months_ago)
     print(

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -29,6 +29,7 @@ from tests.invitations.factories import EmployerInvitationFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.jobs.factories import create_test_romes_and_appellations
 from tests.users.factories import EmployerFactory, JobSeekerFactory, PrescriberFactory
+from tests.utils.test import normalize_fields_history
 
 
 class TestCompanyFactories:
@@ -620,25 +621,35 @@ def test_company_siret_field_history():
     company.siret = "00000000000001"
     company.save()
     company.refresh_from_db()
-    fields_history = [
-        {k: v for k, v in operation.items() if k != "_timestamp"} for operation in company.fields_history
+    assert normalize_fields_history(company.fields_history) == [
+        {
+            "before": {"siret": "00000000000000"},
+            "after": {
+                "siret": "00000000000001",
+            },
+            "_timestamp": "[TIMESTAMP]",
+        }
     ]
-    assert fields_history == [{"before": {"siret": "00000000000000"}, "after": {"siret": "00000000000001"}}]
-    assert datetime.fromisoformat(company.fields_history[0]["_timestamp"]).timestamp() == pytest.approx(
+    assert datetime.fromisoformat(company.fields_history[-1]["_timestamp"]).timestamp() == pytest.approx(
         datetime.now().timestamp()
     )
 
     company.siret = "00000000000002"
     company.save()
     company.refresh_from_db()
-    fields_history = [
-        {k: v for k, v in operation.items() if k != "_timestamp"} for operation in company.fields_history
+    assert normalize_fields_history(company.fields_history) == [
+        {
+            "before": {"siret": "00000000000000"},
+            "after": {"siret": "00000000000001"},
+            "_timestamp": "[TIMESTAMP]",
+        },
+        {
+            "before": {"siret": "00000000000001"},
+            "after": {"siret": "00000000000002"},
+            "_timestamp": "[TIMESTAMP]",
+        },
     ]
-    assert fields_history == [
-        {"before": {"siret": "00000000000000"}, "after": {"siret": "00000000000001"}},
-        {"before": {"siret": "00000000000001"}, "after": {"siret": "00000000000002"}},
-    ]
-    assert datetime.fromisoformat(company.fields_history[1]["_timestamp"]).timestamp() == pytest.approx(
+    assert datetime.fromisoformat(company.fields_history[-1]["_timestamp"]).timestamp() == pytest.approx(
         datetime.now().timestamp()
     )
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -52,6 +52,7 @@ from tests.users.factories import (
     PrescriberFactory,
     UserFactory,
 )
+from tests.utils.test import normalize_fields_history
 
 
 class TestManager:
@@ -1206,33 +1207,33 @@ def test_job_seeker_profile_asp_uid_field_history():
     profile.asp_uid = "000000000000000000000000000001"
     profile.save()
     profile.refresh_from_db()
-    fields_history = [
-        {k: v for k, v in operation.items() if k != "_timestamp"} for operation in profile.fields_history
-    ]
-    assert fields_history == [
+    assert normalize_fields_history(profile.fields_history) == [
         {
             "before": {"asp_uid": "000000000000000000000000000000"},
             "after": {"asp_uid": "000000000000000000000000000001"},
+            "_timestamp": "[TIMESTAMP]",
         }
     ]
+    assert datetime.datetime.fromisoformat(profile.fields_history[-1]["_timestamp"]).timestamp() == pytest.approx(
+        datetime.datetime.now().timestamp()
+    )
 
     profile.asp_uid = "000000000000000000000000000002"
     profile.save()
     profile.refresh_from_db()
-    fields_history = [
-        {k: v for k, v in operation.items() if k != "_timestamp"} for operation in profile.fields_history
-    ]
-    assert fields_history == [
+    assert normalize_fields_history(profile.fields_history) == [
         {
             "before": {"asp_uid": "000000000000000000000000000000"},
             "after": {"asp_uid": "000000000000000000000000000001"},
+            "_timestamp": "[TIMESTAMP]",
         },
         {
             "before": {"asp_uid": "000000000000000000000000000001"},
             "after": {"asp_uid": "000000000000000000000000000002"},
+            "_timestamp": "[TIMESTAMP]",
         },
     ]
-    assert datetime.datetime.fromisoformat(profile.fields_history[1]["_timestamp"]).timestamp() == pytest.approx(
+    assert datetime.datetime.fromisoformat(profile.fields_history[-1]["_timestamp"]).timestamp() == pytest.approx(
         datetime.datetime.now().timestamp()
     )
 

--- a/tests/utils/test.py
+++ b/tests/utils/test.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import importlib
 import inspect
@@ -390,3 +391,15 @@ CursorDebugWrapper.debug_sql = debug_sql
 
 def load_template(path):
     return Template((Path("itou/templates") / path).read_text())
+
+
+def normalize_fields_history(fields_history):
+    if not fields_history:
+        return fields_history
+
+    normalized_fields_history = copy.deepcopy(fields_history)
+    for entry in normalized_fields_history:
+        if entry["_timestamp"]:
+            entry["_timestamp"] = "[TIMESTAMP]"
+
+    return normalized_fields_history


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car c'est mieux :), et je vais avoir besoin du test pour https://github.com/gip-inclusion/les-emplois/pull/6368
