### PR TITLE
Candidature: Correction du formulaire de recherche de poste [GEN-2588]

### DIFF
--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -40,7 +40,7 @@ class EmployerSearchBaseView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, Form
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        kwargs["data"] = self.request.GET
+        kwargs["data"] = self.request.GET or None
         return kwargs
 
     def get(self, request, *args, **kwargs):
@@ -288,7 +288,7 @@ def search_prescribers_home(request, template_name="search/prescribers_search_ho
 def search_prescribers_results(request, template_name="search/prescribers_search_results.html"):
     city = None
     distance = None
-    form = PrescriberSearchForm(data=request.GET, initial={"distance": PrescriberSearchForm.DISTANCE_DEFAULT})
+    form = PrescriberSearchForm(data=request.GET or None, initial={"distance": PrescriberSearchForm.DISTANCE_DEFAULT})
     prescriber_orgs = []
 
     if form.is_valid():


### PR DESCRIPTION
## :thinking: Pourquoi ?

Revert partiel de 0100b5b
On pourrait probablement adapter `form_valid()` pour gérer l'absence de donnée, mais c'est plus simple comme ça (et contrairement aux filtres de candidature, on n'aura pas le problème de classe `is-valid` avec des appels htmx)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
