### PR TITLE
Limiter l’accès au site à 30 requêtes par minute

### DIFF
--- a/itou/utils/throttling.py
+++ b/itou/utils/throttling.py
@@ -2,6 +2,15 @@ from django.core.cache import caches
 from rest_framework import throttling
 
 
+class FailSafeAnonRateThrottle(throttling.AnonRateThrottle):
+    rate = "30/minute"
+
+    @property
+    def cache(self):
+        # The property allows swapping cache configuration in tests.
+        return caches["failsafe"]
+
+
 class FailSafeUserRateThrottle(throttling.UserRateThrottle):
     rate = "60/minute"
 

--- a/tests/www/test_throttling.py
+++ b/tests/www/test_throttling.py
@@ -7,33 +7,19 @@ from tests.users.factories import PrescriberFactory
 
 @pytest.fixture
 def one_request_per_minute(mocker):
+    mocker.patch("itou.utils.throttling.FailSafeAnonRateThrottle.rate", "1/minute")
     mocker.patch("itou.utils.throttling.FailSafeUserRateThrottle.rate", "1/minute")
 
 
-def test_throttling(client, one_request_per_minute):
-    client.force_login(PrescriberFactory())
-    response = client.get(reverse("dashboard:index"))
+@pytest.mark.parametrize("user_factory", [None, PrescriberFactory])
+def test_throttling(client, user_factory, one_request_per_minute):
+    if user_factory is not None:
+        client.force_login(user_factory())
+    response = client.get(reverse("search:employers_home"))
     assert response.status_code == 200
-    response = client.get(reverse("dashboard:index"))
+    response = client.get(reverse("search:employers_home"))
     assertContains(
         response,
         "<p>Vous avez effectué trop de requêtes. Réessayez dans 60 secondes.</p>",
         status_code=429,
     )
-
-
-def test_throttling_ignores_public_views(client, one_request_per_minute):
-    client.force_login(PrescriberFactory())
-    response = client.get(reverse("search:employers_home"))
-    assert response.status_code == 200
-    response = client.get(reverse("search:employers_home"))
-    # Middleware let the request through.
-    assert response.status_code == 200
-
-
-def test_throttling_ignores_anonymous_user(client, one_request_per_minute):
-    response = client.get(reverse("search:employers_home"))
-    assert response.status_code == 200
-    response = client.get(reverse("search:employers_home"))
-    # Middleware let the request through.
-    assert response.status_code == 200


### PR DESCRIPTION
## :thinking: Pourquoi ?

Depuis ce matin, nous recevons environ 80K requêtes par heure, au lieu des 5K habituelles en heures de pointe.

Le traffic additionnel semble provenir de robots qui parcourent le site sans ménagement.

## :cake: Comment ? <!-- optionnel -->

Modifier l’intergiciel de régulation du trafic qui existait pour les utilisateurs connectés afin qu’il limite également le trafic pour les requêtes anonymes.
