### PR TITLE
Candidature : ne pas afficher `None` si des informations concernant le candidat sont manquantes

### DIFF
--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -48,13 +48,21 @@
     {% if can_view_personal_information %}
         <li>
             <small>Adresse e-mail</small>
-            <strong>{{ job_seeker.email }}</strong>
-            {% matomo_event "candidature" "clic" "copied_jobseeker_email" as matomo_event_attrs %}
-            {% include 'includes/copy_to_clipboard.html' with content=job_seeker.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
+            {% if job_seeker.email %}
+                <strong>{{ job_seeker.email }}</strong>
+                {% matomo_event "candidature" "clic" "copied_jobseeker_email" as matomo_event_attrs %}
+                {% include 'includes/copy_to_clipboard.html' with content=job_seeker.email css_classes="btn-link" matomo_event_attrs=matomo_event_attrs only_icon=True %}
+            {% else %}
+                <i class="text-disabled">Non renseignée</i>
+            {% endif %}
         </li>
         <li>
             <small>Date de naissance</small>
-            <strong>{{ job_seeker.jobseeker_profile.birthdate|date:"d/m/Y" }}</strong>
+            {% if job_seeker.jobseeker_profile.birthdate %}
+                <strong>{{ job_seeker.jobseeker_profile.birthdate|date:"d/m/Y" }}</strong>
+            {% else %}
+                <i class="text-disabled">Non renseignée</i>
+            {% endif %}
         </li>
         <li>
             <small>Adresse</small>

--- a/tests/www/apply/test_details.py
+++ b/tests/www/apply/test_details.py
@@ -1,0 +1,21 @@
+from django.urls import reverse
+from pytest_django.asserts import assertNotContains
+
+from tests.job_applications.factories import JobApplicationFactory
+from tests.users.factories import EmployerFactory
+
+
+def test_missing_job_seeker_info(client):
+    job_application = JobApplicationFactory(
+        job_seeker__phone="",
+        job_seeker__email=None,
+        job_seeker__jobseeker_profile__birthdate=None,
+        job_seeker__jobseeker_profile__nir="",
+        job_seeker__jobseeker_profile__pole_emploi_id="",
+    )
+    user = EmployerFactory(with_company=True, with_company__company=job_application.to_company)
+    client.force_login(user)
+    url = reverse("apply:details_for_company", kwargs={"job_application_id": job_application.pk})
+    response = client.get(url)
+
+    assertNotContains(response, "None")


### PR DESCRIPTION
## :thinking: Pourquoi ?

On a un beau "Non renseigné" pour ça.

Cela impactait le détail de candidature, le détail des fiches salarié, le détail des candidats.

J'ai rajouté un fichier de test `tests/www/apply/test_details.py` pour ne pas alourdir davantage les fichiers de tests de `apply` existants.


## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :computer: Captures d'écran <!-- optionnel -->

Avant :
![image](https://github.com/user-attachments/assets/b5732179-1cd3-443f-a789-dc03827fef5a)


Après : 
![image](https://github.com/user-attachments/assets/aab18f04-0f9a-4a3e-b6b1-6a77ffeac8f1)


<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
