### PR TITLE
Retirer l’environnement FAST-MACHINE

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -504,7 +504,7 @@ STATS_SIAE_USER_PK_WHITELIST = json.loads(os.getenv("STATS_SIAE_USER_PK_WHITELIS
 # Slack notifications sent by Metabase cronjobs.
 SLACK_CRON_WEBHOOK_URL = os.getenv("SLACK_CRON_WEBHOOK_URL")
 
-# Production instances (`PROD`, `DEMO`, `PENTEST`, `FAST-MACHINE`, ...) share the same redis but different DB
+# Production instances (`PROD`, `DEMO`, `PENTEST`, ...) share the same redis but different DB
 redis_url = os.environ["REDIS_URL"]
 redis_db = os.environ["REDIS_DB"]
 redis_common_django_settings = {
@@ -543,8 +543,6 @@ HUEY = {
         "workers": 2,
         "worker_type": "thread",
     },
-    # Send emails immediately in FAST-MACHINE, there are no queue consumers in that environment.
-    "immediate": ITOU_ENVIRONMENT == ItouEnvironment.FAST_MACHINE,
 }
 
 # Email https://anymail.readthedocs.io/en/stable/esps/mailjet/

--- a/itou/templates/account/email/email_confirmation_subject.txt
+++ b/itou/templates/account/email/email_confirmation_subject.txt
@@ -1,3 +1,3 @@
 {% autoescape off %}
-{% if itou_environment != "PROD" and itou_environment != "FAST-MACHINE" %}[{{ itou_environment }}] {% endif %}Confirmez votre adresse e-mail
+{% if itou_environment != "PROD" %}[{{ itou_environment }}] {% endif %}Confirmez votre adresse e-mail
 {% endautoescape %}

--- a/itou/templates/account/email/password_reset_key_subject.txt
+++ b/itou/templates/account/email/password_reset_key_subject.txt
@@ -1,3 +1,3 @@
 {% autoescape off %}
-{% if itou_environment != "PROD" and itou_environment != "FAST-MACHINE" %}[{{ itou_environment }}] {% endif %}Réinitialisation de votre mot de passe
+{% if itou_environment != "PROD" %}[{{ itou_environment }}] {% endif %}Réinitialisation de votre mot de passe
 {% endautoescape %}

--- a/itou/templates/layout/base_email_signature.txt
+++ b/itou/templates/layout/base_email_signature.txt
@@ -1,4 +1,4 @@
 ---
-{% if itou_environment != "PROD" and itou_environment != "FAST-MACHINE" %}[{{ itou_environment }}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{ itou_environment }}]{% endif %}
+{% if itou_environment != "PROD" %}[{{ itou_environment }}] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [{{ itou_environment }}]{% endif %}
 Les emplois de l'inclusion
 {{ base_url }}

--- a/itou/utils/emails.py
+++ b/itou/utils/emails.py
@@ -32,11 +32,7 @@ def get_email_text_template(template, context):
 
 
 def get_email_message(to, context, subject, body, from_email=settings.DEFAULT_FROM_EMAIL, bcc=None, cc=None):
-    subject_prefix = (
-        ""
-        if settings.ITOU_ENVIRONMENT in (ItouEnvironment.PROD, ItouEnvironment.FAST_MACHINE)
-        else f"[{settings.ITOU_ENVIRONMENT}] "
-    )
+    subject_prefix = "" if settings.ITOU_ENVIRONMENT == ItouEnvironment.PROD else f"[{settings.ITOU_ENVIRONMENT}] "
     # Mailjet max subject length is 255
     subject = textwrap.shorten(
         subject_prefix + get_email_text_template(subject, context), width=250, placeholder="..."

--- a/itou/utils/enums.py
+++ b/itou/utils/enums.py
@@ -6,5 +6,4 @@ class ItouEnvironment(enum.StrEnum):
     DEMO = "DEMO"
     PENTEST = "PENTEST"
     REVIEW_APP = "REVIEW-APP"
-    FAST_MACHINE = "FAST-MACHINE"
     DEV = "DEV"

--- a/scripts/create-fast-machine.sh
+++ b/scripts/create-fast-machine.sh
@@ -25,7 +25,7 @@ clever create "$APP_NAME" --type python --region par --alias "$APP_NAME" --org I
 clever link "$APP_NAME" --org Itou
 clever scale --flavor XL --alias "$APP_NAME"
 
-clever env set ITOU_ENVIRONMENT "FAST-MACHINE" --alias "$APP_NAME"
+clever env set ITOU_ENVIRONMENT "PROD" --alias "$APP_NAME"
 # By default Clever creates a python app with CC_PYTHON_VERSION set to "3"
 clever env rm CC_PYTHON_VERSION --alias "$APP_NAME"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

c1-worker est maintenant utilisé pour la plupart des commandes. L’environnement `FAST-MACHINE` étant moins utilisé, il sera moins bien maintenu. Autant tout basculer sur PROD et éviter la gestion d’un autre environnement.
