### PR TITLE
Templates : corriger l'utilisation de `bootstrap_form{set}_errors`

### DIFF
--- a/itou/templates/invitations_views/create.html
+++ b/itou/templates/invitations_views/create.html
@@ -36,11 +36,11 @@
 
                             {{ formset.management_form }}
 
-                            {% bootstrap_formset_errors formset type="non_field_errors" %}
+                            {% bootstrap_formset_errors formset %}
 
                             <fieldset>
                                 {% for form in formset %}
-                                    {% bootstrap_form_errors form type="non_field_errors" %}
+                                    {% bootstrap_form_errors form type="non_fields" %}
                                     <div class="inline-form-row row align-items-top mb-2 g-0">
                                         {% bootstrap_form form wrapper_class="col-md pe-md-3 mb-2 inline-col" %}
                                     </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La doc (https://django-bootstrap5.readthedocs.io/en/latest/templatetags.html#bootstrap-form-errors) dit :

- `bootstrap_form_errors` a un paramètre `type` qui accepte `all`,  `fields`, `non_fields`
- `bootstrap_formset_errors` n'a pas de paramètre `type`

Bon, il y a peu d'erreurs à afficher dans ce formulaire d'invitation, mais c'est plus correct comme ça.

