### PR TITLE
Empêcher les migrations de base de données en parallèle

### DIFF
--- a/itou/utils/db.py
+++ b/itou/utils/db.py
@@ -1,4 +1,12 @@
+import binascii
+import contextlib
+import logging
+
+from django.db import connection
 from django.db.models import Q
+
+
+logger = logging.getLogger(__name__)
 
 
 def or_queries(queries, required=True):
@@ -16,3 +24,26 @@ def dictfetchall(cursor):
     """
     columns = [col[0] for col in cursor.description]
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+
+@contextlib.contextmanager
+def statement_timeout(timeout):
+    with connection.cursor() as cursor:
+        cursor.execute("SHOW statement_timeout")
+        [original_statement_timeout_row] = cursor.fetchall()
+        [original_statement_timeout] = original_statement_timeout_row
+
+        cursor.execute("SET SESSION statement_timeout TO %s", (timeout,))
+        yield
+        cursor.execute("SET SESSION statement_timeout TO %s", (original_statement_timeout,))
+
+
+@contextlib.contextmanager
+def pg_advisory_lock(name):
+    lock_id = binascii.crc32(name.encode())
+    logger.info("Acquiring advisory lock for %s (lock id %s).", name, lock_id)
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT pg_advisory_lock(%s)", (lock_id,))
+        yield
+        cursor.execute("SELECT pg_advisory_unlock(%s)", (lock_id,))
+    logger.info("Releasing advisory lock for %s (lock id %s).", name, lock_id)

--- a/itou/utils/management/commands/migrate.py
+++ b/itou/utils/management/commands/migrate.py
@@ -1,0 +1,10 @@
+from django.core.management.commands import migrate
+
+from itou.utils.command import LoggedCommandMixin
+from itou.utils.db import pg_advisory_lock, statement_timeout
+
+
+class Command(LoggedCommandMixin, migrate.Command):
+    def handle(self, *args, **kwargs):
+        with statement_timeout(0), pg_advisory_lock("migrate"):
+            return super().handle(*args, **kwargs)


### PR DESCRIPTION

## :thinking: Pourquoi ?

Lorsque plusieurs instances de l’application servent le trafic web, CleverCloud construit une nouvelle instance pour chaque instance au déploiement. Ainsi, la commande `django-admin migrate` est appelée plusieurs fois au cours d’un seul déploiement, sans gestion de la concurrence.

Les opérations DDL étant transactionnels sur PostgreSQL, il n’y aura pas de conflits dans la plupart des cas. En revanche, les migrations de données ont souvent `atomic=False` pour éviter les longues transactions, et pourraient être exécutées en parallèle, ce qui risquerait de dupliquer le travail pour la base de données, voire de corrompre les données.

## :cake: Comment ? <!-- optionnel -->

Utilisation des _advisory locks_ de PostgreSQL pour empêcher l’exécution concurrente des migrations sur la base de données.

Voir le message de commit pour plus de détails.
