### PR TITLE
Tests : correction d'un test bagottant sur la modale de nouveauté

### DIFF
--- a/tests/communications/test_campaigns.py
+++ b/tests/communications/test_campaigns.py
@@ -80,15 +80,24 @@ class TestRenderAnnouncementCampaign:
     def test_campaign_rendered_dashboard(self, client, snapshot):
         MODAL_ID = "news-modal"
         campaign = AnnouncementCampaignFactory(max_items=3, start_date=date.today().replace(day=1), live=True)
-        AnnouncementItemFactory(campaign=campaign, title="Item A", description="Item A", priority=0)
-        AnnouncementItemFactory(campaign=campaign, title="Item B", description="Item B", priority=1)
-        AnnouncementItemFactory(campaign=campaign, title="Item D", description="Item D", priority=3)
-        AnnouncementItemFactory(campaign=campaign, title="Item C", description="Item C", priority=2)
+        user = random_user_kind_factory()
+        AnnouncementItemFactory(
+            campaign=campaign, title="Item A", description="Item A", priority=0, user_kind_tags=[user.kind]
+        )
+        AnnouncementItemFactory(
+            campaign=campaign, title="Item B", description="Item B", priority=1, user_kind_tags=[user.kind]
+        )
+        AnnouncementItemFactory(
+            campaign=campaign, title="Item D", description="Item D", priority=3, user_kind_tags=[user.kind]
+        )
+        AnnouncementItemFactory(
+            campaign=campaign, title="Item C", description="Item C", priority=2, user_kind_tags=[user.kind]
+        )
 
         response = client.get(reverse("search:employers_home"))
         assertNotContains(response, MODAL_ID)
 
-        client.force_login(random_user_kind_factory())
+        client.force_login(user)
         response = client.get(reverse("search:employers_home"))
         assertContains(response, MODAL_ID)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les candidats ne voient pas tous les éléments des annonces. Si `random_user_kind_factory` renvoie `JobSeekerFactory` et que les `AnnouncementItemFactory` ont du `user_kind_tags` sans `UserKind.JOB_SEEKER`, alors le test casse.

https://github.com/gip-inclusion/les-emplois/actions/runs/16073642999/job/45363693853

## :cake: Comment ? <!-- optionnel -->

Solution retenue : aligner le `user_kind_tags` sur le type d'utilisateur pour être sûr que celui-ci soit concerné par l'annonce.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
