### PR TITLE
find_orphan_files : Découvrir les relations à `File`

### DIFF
--- a/itou/files/management/commands/find_orphan_files.py
+++ b/itou/files/management/commands/find_orphan_files.py
@@ -4,28 +4,20 @@ import operator
 
 from django.utils import timezone
 
-from itou.approvals.models import Prolongation, ProlongationRequest
-from itou.communications.models import AnnouncementItem
+from itou.antivirus.models import Scan
 from itou.files.models import File
-from itou.geiq_assessments.models import Assessment
-from itou.job_applications.models import JobApplication
-from itou.siae_evaluations.models import EvaluatedAdministrativeCriteria
 from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
     def get_relations(self):
-        # Don't look at Scans FK
-        return [
-            (JobApplication, "resume"),
-            (ProlongationRequest, "report_file"),
-            (Prolongation, "report_file"),
-            (EvaluatedAdministrativeCriteria, "proof"),
-            (AnnouncementItem, "image_storage"),
-            (Assessment, "summary_document_file"),
-            (Assessment, "structure_financial_assessment_file"),
-            (Assessment, "action_financial_assessment_file"),
-        ]
+        relations = {
+            (remote_field.field.model, remote_field.field.name)
+            for remote_field in File._meta.get_fields(include_hidden=True)
+            if remote_field.is_relation
+        }
+        relations.remove((Scan, "file"))
+        return relations
 
     def handle(self, *args, **options):
         linked_files_pks = functools.reduce(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de maintenir la liste des fichiers dans l’app, et surtout d’oublier de le faire.
