### PR TITLE
Admin : Empêcher la modification directe de la date de fin d’un PASS IAE

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -192,6 +192,7 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
         "assigned_company",
         "created_at",
         "created_by",
+        "end_at",
         "get_remainder_display",
         "number",
         "origin",

--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -189,21 +189,21 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
     list_display_links = ("pk", "number")
     raw_id_fields = ("user", "created_by", "eligibility_diagnosis")
     readonly_fields = (
+        "assigned_company",
         "created_at",
         "created_by",
-        "updated_at",
+        "get_remainder_display",
         "number",
         "origin",
-        "pe_notification_status",
-        "pe_notification_time",
-        "pe_notification_endpoint",
-        "pe_notification_exit_code",
-        "assigned_company",
         "origin_prescriber_organization_kind",
         "origin_sender_kind",
         "origin_siae_kind",
         "origin_siae_siret",
-        "get_remainder_display",
+        "pe_notification_endpoint",
+        "pe_notification_exit_code",
+        "pe_notification_status",
+        "pe_notification_time",
+        "updated_at",
     )
     show_full_result_count = False
     fieldsets = (

--- a/itou/approvals/admin_forms.py
+++ b/itou/approvals/admin_forms.py
@@ -35,7 +35,7 @@ class ApprovalFormMixin:
 class ApprovalAdminForm(forms.ModelForm):
     class Meta:
         model = Approval
-        fields = ["start_at", "end_at", "user", "eligibility_diagnosis"]
+        fields = ["start_at", "user", "eligibility_diagnosis"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -47,8 +47,6 @@ class ApprovalAdminForm(forms.ModelForm):
             )
             if "start_at" in self.fields:
                 self.fields["start_at"].help_text = obnoxious_warning
-            if "end_at" in self.fields:
-                self.fields["end_at"].help_text = obnoxious_warning
 
     def clean(self):
         super().clean()

--- a/tests/approvals/__snapshots__/test_admin.ambr
+++ b/tests/approvals/__snapshots__/test_admin.ambr
@@ -1,19 +1,5 @@
 # serializer version: 1
-# name: test_approval_form_has_warnings_if_suspension_or_prolongation[end_at][obnoxious start_at and end_at warning]
-  '''
-  <div class="help" id="id_end_at_helptext">
-      <div>
-          <ul class="messagelist">
-              <li class="warning">
-                  En cas de modification, vérifier la cohérence avec les périodes de suspension et de prolongation.
-              </li>
-          </ul>
-      </div>
-  </div>
-  
-  '''
-# ---
-# name: test_approval_form_has_warnings_if_suspension_or_prolongation[start_at][obnoxious start_at and end_at warning]
+# name: test_approval_form_has_warnings_if_suspension_or_prolongation[obnoxious start_at warning]
   '''
   <div class="help" id="id_start_at_helptext">
       <div>

--- a/tests/approvals/test_admin.py
+++ b/tests/approvals/test_admin.py
@@ -32,9 +32,8 @@ class TestApprovalAdmin:
         assert response.status_code == 200
 
 
-@pytest.mark.parametrize("field", ["start_at", "end_at"])
-def test_approval_form_has_warnings_if_suspension_or_prolongation(admin_client, snapshot, field):
-    selector = f"#id_{field}_helptext"
+def test_approval_form_has_warnings_if_suspension_or_prolongation(admin_client, snapshot):
+    selector = "#id_start_at_helptext"
 
     approval = ApprovalFactory()
     response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
@@ -44,13 +43,13 @@ def test_approval_form_has_warnings_if_suspension_or_prolongation(admin_client, 
     suspension = SuspensionFactory(approval=approval)
     response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
     field_helptext = parse_response_to_soup(response, selector=selector)
-    assert pretty_indented(field_helptext) == snapshot(name="obnoxious start_at and end_at warning")
+    assert pretty_indented(field_helptext) == snapshot(name="obnoxious start_at warning")
 
     suspension.delete()
     ProlongationFactory(approval=approval)
     response = admin_client.get(reverse("admin:approvals_approval_change", kwargs={"object_id": approval.pk}))
     field_helptext = parse_response_to_soup(response, selector=selector)
-    assert pretty_indented(field_helptext) == snapshot(name="obnoxious start_at and end_at warning")
+    assert pretty_indented(field_helptext) == snapshot(name="obnoxious start_at warning")
 
 
 def test_prolongation_report_file_filter(admin_client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter la mise à jour accidentelle de la date de fin du PASS IAE, dans le cas fréquent :

1. Ouverture du PASS dans l’admin depuis Zendesk
2. Ajout d’une prolongation dans un autre onglet
3. Ajout d’un commentaire dans l’admin du PASS IAE
4. Sauvegarde du PASS IAE

Dans ce déroulé, il manque une étape après 2., pour recharger la page du PASS IAE avec la nouvelle date de fin. C’est facile à oublier et cause des problèmes aux employeurs, car la durée du PASS est réduite sans raison.
