### PR TITLE
Add auto refused applications to metabase table

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -369,6 +369,7 @@ class Command(BaseCommand):
                 "approval_id",
                 "approval_delivery_mode",
                 "contract_type",
+                "refusal_reason",
                 "resume_id",
             )
             .exclude(origin=Origin.PE_APPROVAL)

--- a/itou/metabase/tables/job_applications.py
+++ b/itou/metabase/tables/job_applications.py
@@ -1,4 +1,4 @@
-from itou.job_applications.enums import JobApplicationState, Origin, SenderKind
+from itou.job_applications.enums import JobApplicationState, Origin, RefusalReason, SenderKind
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.metabase.tables.utils import MetabaseTable, get_choice, get_department_and_region_columns
 from itou.prescribers.enums import PrescriberOrganizationKind
@@ -123,6 +123,12 @@ TABLE.add_columns(
             "type": "boolean",
             "comment": "Candidature archivée coté employeur",
             "fn": lambda o: bool(o.archived_at),
+        },
+        {
+            "name": "candidature_refusée_automatiquement",
+            "type": "boolean",
+            "comment": "Candidature automatiquement refusée car en attente depuis plus de 2 mois",
+            "fn": lambda o: bool(o.refusal_reason == RefusalReason.AUTO),
         },
         {
             "name": "date_candidature",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -513,7 +513,7 @@ def test_populate_job_applications():
         assert rows == [
             (
                 ja.pk,
-                0,  # archived_at
+                False,  # archived_at
                 False,  # auto rerused
                 ja.created_at.date(),
                 ja.hiring_start_at,
@@ -539,7 +539,7 @@ def test_populate_job_applications():
                 None,
                 None,
                 None,
-                0,
+                False,
                 "",
                 ja.contract_type,
                 True,

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -514,6 +514,7 @@ def test_populate_job_applications():
             (
                 ja.pk,
                 0,  # archived_at
+                False,  # auto rerused
                 ja.created_at.date(),
                 ja.hiring_start_at,
                 ja.processed_at.date(),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour prendre en compte ces candidatures dans les tableaux de bord.
https://www.notion.so/gip-inclusion/Remplacer-intitul-auto-dans-les-motifs-de-refus-2015f321b60480278f71cb43d191b96f?source=copy_link
