### PR TITLE
[Fichiers] Ranger les fichiers GEIQ dans un « dossier » S3

### DIFF
--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -384,7 +384,7 @@ def assessment_sync_file(request, pk, *, file_field):
         try:
             client = geiq_label.get_client()
             pdf_content = getattr(client, api_method)(geiq_id=assessment.label_geiq_id)
-            key = default_storage.save(f"{uuid.uuid4()}.pdf", ContentFile(pdf_content))
+            key = default_storage.save(f"geiq-assessments/{uuid.uuid4()}.pdf", ContentFile(pdf_content))
             setattr(assessment, file_field, File.objects.create(key=key))
             assessment.save(update_fields=(file_field,))
         except Exception as e:

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -24,6 +24,7 @@ from tests.institutions.factories import InstitutionFactory, InstitutionMembersh
 from tests.users.factories import EmployerFactory, JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
 from tests.utils.htmx.test import assertSoupEqual, update_page_with_htmx
 from tests.utils.test import assertSnapshotQueries, parse_response_to_soup, pretty_indented
+from tests.utils.test_s3 import default_storage_ls_files
 
 
 @pytest.fixture
@@ -846,6 +847,7 @@ class TestAssessmentSyncFile:
         assertContains(response, reverse("geiq_assessments_views:summary_document", kwargs={"pk": assessment.pk}))
         assessment.refresh_from_db()
         assert assessment.summary_document_file is not None
+        assert len(default_storage_ls_files("geiq-assessments")) == 1
         with default_storage.open(assessment.summary_document_file.key) as f:
             assert f.read() == pdf_file_content
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ils n'étaient pas dans un dossier alors que tous les autres fichiers de nos applications le sont.

## :cake: Comment ? <!-- optionnel -->

Ajout du préfixe "geiq-assessment" à la clé.