### PR TITLE
Exclure Mailjet des rate limits anonymes

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -90,7 +90,11 @@ urlpatterns = [
     path("versions/", include("itou.www.releases.urls")),
     # Enable Mailjet status tracking
     # https://anymail.readthedocs.io/en/stable/esps/mailjet/#status-tracking-webhooks
-    path("webhooks/anymail/mailjet/tracking/", login_not_required(MailjetTrackingWebhookView.as_view())),
+    path(
+        "webhooks/anymail/mailjet/tracking/",
+        login_not_required(MailjetTrackingWebhookView.as_view()),
+        name="mailjet-webhook",
+    ),
     path("welcoming_tour/", include("itou.www.welcoming_tour.urls")),
     # Static pages.
     path(

--- a/tests/www/test_throttling.py
+++ b/tests/www/test_throttling.py
@@ -1,3 +1,5 @@
+import base64
+
 import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertContains
@@ -23,3 +25,34 @@ def test_throttling(client, user_factory, one_request_per_minute):
         "<p>Vous avez effectué trop de requêtes. Réessayez dans 60 secondes.</p>",
         status_code=429,
     )
+
+
+@pytest.mark.usefixtures("one_request_per_minute")
+def test_mailjet_webhook_not_rate_limited(client, settings):
+    auth = "user:password"
+    settings.ANYMAIL["WEBHOOK_SECRET"] = auth
+    encoded_auth = base64.b64encode(auth.encode())
+    for _ in range(2):
+        response = client.post(
+            reverse("mailjet-webhook"),
+            # https://dev.mailjet.com/email/guides/webhooks/#blocked-event
+            [
+                {
+                    "event": "blocked",
+                    "time": 1430812195,
+                    "MessageID": 13792286917004336,
+                    "Message_GUID": "1ab23cd4-e567-8901-2345-6789f0gh1i2j",
+                    "email": "bounce@mailjet.com",
+                    "mj_campaign_id": 0,
+                    "mj_contact_id": 0,
+                    "customcampaign": "",
+                    "CustomID": "helloworld",
+                    "Payload": "",
+                    "error_related_to": "recipient",
+                    "error": "user unknown",
+                },
+            ],
+            content_type="application/json",
+            headers={"Authorization": "Basic " + encoded_auth.decode()},
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mailjet est un partenaire pour l’envoi des emails, on peut leur accorder un certain niveau de confiance sans les rate-limiter.

## :cake: Comment ? <!-- optionnel -->

J’ai choisi de vérifier l’authentification au lieu du *endpoint* de la requête, en me disant que ça préservait le *rate limiting* sur tous les *endpoints*. Il est plus difficile de fournir l’authentification que de poster sur le *endpoint*.
