### PR TITLE
Revenir à la version du thème 2.9.9

### DIFF
--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -204,11 +204,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v3.0.2.zip",
-            "sha256": "e170243d7f8d99ca91bf8ca8b750b3e299fa9461a82e4e5e20b8389c53002839",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v2.9.9.zip",
+            "sha256": "5e12066815511dac0da9104bd3a53b354ddc87923310117e0f71f07ed2e2dd07",
         },
         "extract": {
-            "origin": "itou-theme-3.0.2/dist",
+            "origin": "itou-theme-2.9.9/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ce commit a été inclus un peu trop tôt, avant l’arrivée de https://github.com/gip-inclusion/les-emplois/pull/6465.
