### PR TITLE
Économiser une requête sur can_create_siae_antenna

### DIFF
--- a/itou/companies/perms.py
+++ b/itou/companies/perms.py
@@ -3,7 +3,7 @@ from itou.companies.enums import CompanyKind
 
 def can_create_antenna(request):
     """
-    Only admin employers can create an antenna for their SIAE.
+    Only admin employers can create an antenna for their company.
 
     For SIAE structures (AI, ACI...) the convention has to be present to link the parent SIAE and its antenna.
     In some edge cases (e.g. SIAE created by staff and not yet officialized) the convention is absent,

--- a/itou/companies/perms.py
+++ b/itou/companies/perms.py
@@ -1,0 +1,24 @@
+from itou.companies.enums import CompanyKind
+
+
+def can_create_antenna(request):
+    """
+    Only admin employers can create an antenna for their SIAE.
+
+    For SIAE structures (AI, ACI...) the convention has to be present to link the parent SIAE and its antenna.
+    In some edge cases (e.g. SIAE created by staff and not yet officialized) the convention is absent,
+    in that case we must absolutely not allow any antenna to be created.
+
+    For non SIAE structures (EA, EATT...) the convention logic is not implemented thus no convention ever exists.
+    Antennas cannot be freely created by the user as the EA system authorities do not allow any non official SIRET
+    to be used (except for GEIQ).
+
+    Finally, for OPCS it has been decided for now to disallow it; those structures are strongly attached to
+    a given territory and thus would not need to join others.
+    """
+    return bool(
+        request.user.is_employer
+        and request.is_current_organization_admin
+        and request.current_organization.kind in [CompanyKind.GEIQ, *CompanyKind.siae_kinds()]
+        and request.current_organization.is_active
+    )

--- a/itou/templates/dashboard/includes/employer_company_card.html
+++ b/itou/templates/dashboard/includes/employer_company_card.html
@@ -38,7 +38,7 @@
                         </a>
                     </li>
                 {% endif %}
-                {% if can_create_siae_antenna %}
+                {% if can_create_antenna %}
                     <li class="d-flex justify-content-between align-items-center mb-3">
                         <a href="{% url 'companies_views:create_company' %}" class="btn-link btn-ico">
                             <i class="ri-add-line ri-lg fw-normal" aria-hidden="true"></i>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -36,7 +36,6 @@ from itou.asp.models import (
 from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.address.format import compute_hexa_address
 from itou.common_apps.address.models import AddressMixin
-from itou.companies.enums import CompanyKind
 from itou.prescribers.enums import PrescriberAuthorizationStatus
 from itou.prescribers.models import PrescriberOrganization
 from itou.users.enums import (
@@ -713,28 +712,6 @@ class User(AbstractUser, AddressMixin):
             .all()
         )
         return memberships
-
-    def can_create_siae_antenna(self, parent_siae):
-        """
-        Only admin employers can create an antenna for their SIAE.
-
-        For SIAE structures (AI, ACI...) the convention has to be present to link the parent SIAE and its antenna.
-        In some edge cases (e.g. SIAE created by staff and not yet officialized) the convention is absent,
-        in that case we must absolutely not allow any antenna to be created.
-
-        For non SIAE structures (EA, EATT...) the convention logic is not implemented thus no convention ever exists.
-        Antennas cannot be freely created by the user as the EA system authorities do not allow any non official SIRET
-        to be used (except for GEIQ).
-
-        Finally, for OPCS it has been decided for now to disallow it; those structures are strongly attached to
-        a given territory and thus would not need to join others.
-        """
-        return (
-            self.is_employer
-            and parent_siae.kind in [CompanyKind.GEIQ, *CompanyKind.siae_kinds()]
-            and parent_siae.is_active
-            and parent_siae.has_admin(self)
-        )
 
     def update_external_data_source_history_field(self, provider, field, value) -> bool:
         """

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -20,12 +20,13 @@ from itou.cities.models import City
 from itou.common_apps.address.departments import department_from_postcode
 from itou.common_apps.organizations.views import deactivate_org_member, update_org_admin_role
 from itou.companies.models import Company, JobDescription, SiaeFinancialAnnex
+from itou.companies.perms import can_create_antenna
 from itou.jobs.models import Appellation
 from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.apis.data_inclusion import DataInclusionApiClient, DataInclusionApiException
 from itou.utils.apis.exceptions import GeocodingDataError
-from itou.utils.auth import LoginNotRequiredMixin, check_user
+from itou.utils.auth import LoginNotRequiredMixin, check_request, check_user
 from itou.utils.pagination import pager
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.session import SessionNamespace, SessionNamespaceException
@@ -602,11 +603,9 @@ class CompanyCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, TemplateVie
         }
 
 
+@check_request(can_create_antenna)
 def create_company(request, template_name="companies/create_siae.html"):
     current_compny = get_current_company_or_404(request)
-    if not request.user.can_create_siae_antenna(parent_siae=current_compny):
-        raise PermissionDenied
-
     form = companies_forms.CreateCompanyForm(
         current_company=current_compny,
         current_user=request.user,

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -605,12 +605,16 @@ class CompanyCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, TemplateVie
 
 @check_request(can_create_antenna)
 def create_company(request, template_name="companies/create_siae.html"):
-    current_compny = request.current_organization
+    current_company = request.current_organization
     form = companies_forms.CreateCompanyForm(
-        current_company=current_compny,
+        current_company=current_company,
         current_user=request.user,
         data=request.POST or None,
-        initial={"siret": current_compny.siret, "kind": current_compny.kind, "department": current_compny.department},
+        initial={
+            "siret": current_company.siret,
+            "kind": current_company.kind,
+            "department": current_company.department,
+        },
     )
 
     if request.method == "POST" and form.is_valid():

--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -605,7 +605,7 @@ class CompanyCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, TemplateVie
 
 @check_request(can_create_antenna)
 def create_company(request, template_name="companies/create_siae.html"):
-    current_compny = get_current_company_or_404(request)
+    current_compny = request.current_organization
     form = companies_forms.CreateCompanyForm(
         current_company=current_compny,
         current_user=request.user,

--- a/itou/www/dashboard/views.py
+++ b/itou/www/dashboard/views.py
@@ -20,6 +20,7 @@ from rest_framework.authtoken.models import Token
 from itou.api.token_auth.views import TOKEN_ID_STR
 from itou.approvals.enums import ProlongationRequestStatus
 from itou.approvals.models import ProlongationRequest
+from itou.companies.perms import can_create_antenna
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
 from itou.eligibility.models.iae import EligibilityDiagnosis
 from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
@@ -100,7 +101,7 @@ def _employer_dashboard_context(request):
                 "evaluated_job_applications__evaluated_administrative_criteria",
             )
         ),
-        "can_create_siae_antenna": request.user.can_create_siae_antenna(parent_siae=current_org),
+        "can_create_antenna": can_create_antenna(request),
         "can_show_employee_records": current_org.can_use_employee_record,
         "can_show_financial_annexes": current_org.convention_can_be_accessed_by(request.user),
         "evaluated_siae_notifications": (
@@ -129,7 +130,7 @@ def dashboard(request, template_name="dashboard/dashboard.html"):
         "active_campaigns": [],
         "closed_campaigns": [],
         "job_applications_categories": [],
-        "can_create_siae_antenna": False,
+        "can_create_antenna": False,
         "can_show_financial_annexes": False,
         "can_show_employee_records": False,
         "can_view_gps_card": is_allowed_to_use_gps(request) and not show_gps_as_a_nav_entry(request),

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -600,7 +600,7 @@ class TestModel:
         assert not user.can_create_siae_antenna(company)
 
     def test_siae_admin_without_convention_cannot_create_siae_antenna(self):
-        company = CompanyFactory(with_membership=True, convention=None)
+        company = CompanyFactory(with_membership=True, membership__is_admin=True, convention=None)
         user = company.members.get()
         assert not user.can_create_siae_antenna(company)
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -589,30 +589,6 @@ class TestModel:
         del user.has_verified_email
         assert user.has_verified_email
 
-    def test_siae_admin_can_create_siae_antenna(self):
-        company = CompanyFactory(with_membership=True, membership__is_admin=True)
-        user = company.members.get()
-        assert user.can_create_siae_antenna(company)
-
-    def test_siae_normal_member_cannot_create_siae_antenna(self):
-        company = CompanyFactory(with_membership=True, membership__is_admin=False)
-        user = company.members.get()
-        assert not user.can_create_siae_antenna(company)
-
-    def test_siae_admin_without_convention_cannot_create_siae_antenna(self):
-        company = CompanyFactory(with_membership=True, membership__is_admin=True, convention=None)
-        user = company.members.get()
-        assert not user.can_create_siae_antenna(company)
-
-    @pytest.mark.parametrize("kind", CompanyKind)
-    def test_admin_ability_to_create_siae_antenna(self, kind):
-        company = CompanyFactory(kind=kind, with_membership=True, membership__is_admin=True)
-        user = company.members.get()
-        if kind == CompanyKind.GEIQ:
-            assert user.can_create_siae_antenna(company)
-        else:
-            assert user.can_create_siae_antenna(company) == company.should_have_convention
-
     def test_user_kind(self):
         non_staff_kinds = [
             UserKind.JOB_SEEKER,

--- a/tests/users/test_perms.py
+++ b/tests/users/test_perms.py
@@ -1,0 +1,45 @@
+import pytest
+from django.test import RequestFactory
+
+from itou.companies.enums import CompanyKind
+from itou.companies.perms import can_create_antenna
+from itou.utils.perms.middleware import ItouCurrentOrganizationMiddleware
+from tests.companies.factories import CompanyFactory
+
+
+def run_perms_middleware(user):
+    middleware = ItouCurrentOrganizationMiddleware(lambda x: x)
+    rf = RequestFactory()
+    fake_request = rf.get("/foo")
+    fake_request.user = user
+    fake_request.session = {}
+    middleware(fake_request)
+    return fake_request
+
+
+class TestCanCreateSiaeAntenna:
+    def test_siae_admin_can_create_antenna(self):
+        company = CompanyFactory(with_membership=True, membership__is_admin=True)
+        user = company.members.get()
+        request = run_perms_middleware(user)
+        assert can_create_antenna(request) is True
+
+    def test_siae_normal_member_cannot_create_antenna(self):
+        company = CompanyFactory(with_membership=True, membership__is_admin=False)
+        user = company.members.get()
+        request = run_perms_middleware(user)
+        assert can_create_antenna(request) is False
+
+    def test_siae_admin_without_convention_cannot_create_antenna(self):
+        company = CompanyFactory(with_membership=True, membership__is_admin=True, convention=None)
+        user = company.members.get()
+        request = run_perms_middleware(user)
+        assert can_create_antenna(request) is False
+
+    @pytest.mark.parametrize("kind", CompanyKind)
+    def test_admin_ability_to_create_antenna(self, kind):
+        company = CompanyFactory(kind=kind, with_membership=True, membership__is_admin=True)
+        user = company.members.get()
+        request = run_perms_middleware(user)
+        expected = company.should_have_convention or company.kind == CompanyKind.GEIQ
+        assert can_create_antenna(request) is expected

--- a/tests/users/test_perms.py
+++ b/tests/users/test_perms.py
@@ -18,17 +18,12 @@ def run_perms_middleware(user):
 
 
 class TestCanCreateSiaeAntenna:
-    def test_siae_admin_can_create_antenna(self):
-        company = CompanyFactory(with_membership=True, membership__is_admin=True)
+    @pytest.mark.parametrize("admin", [True, False])
+    def test_can_create_antenna(self, admin):
+        company = CompanyFactory(with_membership=True, membership__is_admin=admin)
         user = company.members.get()
         request = run_perms_middleware(user)
-        assert can_create_antenna(request) is True
-
-    def test_siae_normal_member_cannot_create_antenna(self):
-        company = CompanyFactory(with_membership=True, membership__is_admin=False)
-        user = company.members.get()
-        request = run_perms_middleware(user)
-        assert can_create_antenna(request) is False
+        assert can_create_antenna(request) is admin
 
     def test_siae_admin_without_convention_cannot_create_antenna(self):
         company = CompanyFactory(with_membership=True, membership__is_admin=True, convention=None)

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -28,7 +28,7 @@
 # ---
 # name: TestDashboardView.test_dashboard_siae_evaluation_campaign_notifications[view queries]
   dict({
-    'num_queries': 21,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -210,30 +210,6 @@
           WHERE ("job_applications_jobapplication"."to_company_id" = %s
                  AND "job_applications_jobapplication"."archived_at" IS NULL)
           ORDER BY "job_applications_jobapplication"."created_at" DESC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'Company.has_admin[common_apps/organizations/models.py]',
-          'User.can_create_siae_antenna[users/models.py]',
-          '_employer_dashboard_context[www/dashboard/views.py]',
-          'dashboard[www/dashboard/views.py]',
-        ]),
-        'sql': '''
-          SELECT %s AS "a"
-          FROM "users_user"
-          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
-          WHERE ("companies_companymembership"."id" IN
-                   (SELECT U0."id"
-                    FROM "companies_companymembership" U0
-                    INNER JOIN "users_user" U2 ON (U0."user_id" = U2."id")
-                    WHERE (U0."company_id" = %s
-                           AND U2."is_active"
-                           AND U0."is_active"
-                           AND U0."is_admin"
-                           AND U2."is_active"))
-                 AND "users_user"."id" = %s)
-          LIMIT 1
         ''',
       }),
       dict({

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -15,6 +15,7 @@ from pytest_django.asserts import assertContains, assertNotContains, assertRedir
 
 from itou.approvals.models import Approval
 from itou.companies.enums import CompanyKind
+from itou.companies.perms import can_create_antenna
 from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS
 from itou.eligibility.models.geiq import GEIQAdministrativeCriteria, GEIQEligibilityDiagnosis
 from itou.employee_record.enums import Status
@@ -331,13 +332,13 @@ class TestDashboardView:
         )
 
     @pytest.mark.parametrize("kind", CompanyKind)
-    def test_dashboard_can_create_siae_antenna(self, client, kind):
+    def test_dashboard_can_create_antenna(self, client, kind):
         company = CompanyFactory(kind=kind, with_membership=True, membership__is_admin=True)
         user = company.members.get()
 
         client.force_login(user)
         response = client.get(reverse("dashboard:index"))
-        assertion = assertContains if user.can_create_siae_antenna(company) else assertNotContains
+        assertion = assertContains if can_create_antenna(response.wsgi_request) else assertNotContains
         assertion(response, "Créer/rejoindre une autre structure")
 
     def test_dashboard_siae_evaluations_institution_access(self, client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cette méthode sera bientôt appelée à chaque requête, car l’option pour créer une antenne se déplace du tableau de bord vers le menu, qui est présent sur toutes les pages.
