### PR TITLE
[Fichiers] Anonymisation du nom des fichiers V2

### DIFF
--- a/itou/files/models.py
+++ b/itou/files/models.py
@@ -6,6 +6,17 @@ from django.db import models
 from django.utils import timezone
 
 
+def save_file(folder, file, storage=None, anonymize_filename=True):
+    if not storage:
+        storage = default_storage
+    if len(pathlib.Path(folder).parts) > 1:
+        raise NotImplementedError("File tree depth is too deep. Only one level is allowed.", folder)
+    # Only keep the final part to avoid subfolders.
+    filename = f"{uuid.uuid4()}{pathlib.Path(file.name).suffix}" if anonymize_filename else file.name
+    key = storage.save(pathlib.Path(folder) / filename, file)
+    return File.objects.create(key=key)
+
+
 class File(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
 

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
@@ -18,7 +17,7 @@ from itou.companies.models import Company, JobDescription
 from itou.eligibility.models import EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
 from itou.eligibility.utils import geiq_criteria_for_display, iae_criteria_for_display
-from itou.files.models import File
+from itou.files.models import save_file
 from itou.gps.models import FollowUpGroup
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
@@ -637,10 +636,8 @@ class ApplicationResumeView(CheckApplySessionMixin, ApplicationBaseView):
             job_application.sender_company = self.request.current_organization
 
         if resume := self.form.cleaned_data.get("resume"):
-            key = f"resume/{uuid.uuid4()}.pdf"
-            file_resume = File.objects.create(key=key)
-            storages["public"].save(key, resume)
-            job_application.resume = file_resume
+            file = save_file(folder="resume/", file=resume, storage=storages["public"])
+            job_application.resume = file
 
         # Save the job application
         job_application.save()

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -1,5 +1,4 @@
 import logging
-import pathlib
 import urllib.parse
 from datetime import timedelta
 
@@ -29,7 +28,7 @@ from itou.approvals.models import (
 )
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
-from itou.files.models import File
+from itou.files.models import save_file
 from itou.job_applications.enums import JobApplicationState
 from itou.utils import constants as global_constants
 from itou.utils.auth import check_user
@@ -359,13 +358,10 @@ def declare_prolongation(request, approval_id, template_name="approvals/declare_
                 except KeyError:
                     pass
                 else:
-                    filename = pathlib.Path(tmpfile_key).name
                     with default_storage.open(tmpfile_key) as prolongation_report:
-                        prolongation_report_key = default_storage.save(
-                            f"prolongation_report/{filename}", prolongation_report
-                        )
+                        file = save_file(folder="prolongation_report/", file=prolongation_report)
+                    prolongation.report_file = file
                     default_storage.delete(tmpfile_key)
-                    prolongation.report_file = File.objects.create(key=prolongation_report_key)
             prolongation.save()
             prolongation.notify_authorized_prescriber()
             messages.success(request, "Déclaration de prolongation enregistrée.", extra_tags="toast")

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -1,6 +1,5 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_not_required
-from django.core.files.storage import default_storage
 from django.db.models import Q
 from django.http import Http404, HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import get_list_or_404, get_object_or_404, render
@@ -11,7 +10,7 @@ from django.views import generic
 from django.views.decorators.http import require_POST, require_safe
 from django.views.generic.detail import SingleObjectMixin
 
-from itou.files.models import File
+from itou.files.models import save_file
 from itou.siae_evaluations import enums as evaluation_enums
 from itou.siae_evaluations.emails import InstitutionEmailFactory, SIAEEmailFactory
 from itou.siae_evaluations.models import (
@@ -656,9 +655,8 @@ def siae_upload_doc(
     )
 
     if request.method == "POST" and form.is_valid():
-        proof_file = form.cleaned_data["proof"]
-        proof_key = default_storage.save(f"evaluations/{proof_file.name}", proof_file)
-        evaluated_administrative_criteria.proof = File.objects.create(key=proof_key)
+        file = save_file(folder="evaluations/", file=form.cleaned_data["proof"])
+        evaluated_administrative_criteria.proof = file
         evaluated_administrative_criteria.uploaded_at = timezone.now()
         evaluated_administrative_criteria.review_state = evaluation_enums.EvaluatedAdministrativeCriteriaState.PENDING
         evaluated_administrative_criteria.submitted_at = None

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -483,7 +483,7 @@ def test_step_3_no_previous_CV(client, mocker, pdf_file):
     assertNotContains(response, PREVIOUS_RESUME_TEXT)
 
     mocker.patch(
-        "itou.www.apply.views.submit_views.uuid.uuid4",
+        "itou.files.models.uuid.uuid4",
         return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
     )
     response = client.post(transfer_step_3_url, data={"message": "blah", "resume": pdf_file})
@@ -567,7 +567,7 @@ def test_step_3_replace_previous_CV(client, mocker, pdf_file):
     assertContains(response, PREVIOUS_RESUME_TEXT)
 
     mocker.patch(
-        "itou.www.apply.views.submit_views.uuid.uuid4",
+        "itou.files.models.uuid.uuid4",
         return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
     )
     response = client.post(

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -648,7 +648,7 @@ class TestApplyAsJobSeeker:
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         with mock.patch(
-            "itou.www.apply.views.submit_views.uuid.uuid4",
+            "itou.files.models.uuid.uuid4",
             return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         ):
             response = client.post(
@@ -790,7 +790,7 @@ class TestApplyAsJobSeeker:
         apply_session = fake_session_initialization(client, company, user, {"selected_jobs": []})
 
         with mock.patch(
-            "itou.www.apply.views.submit_views.uuid.uuid4",
+            "itou.files.models.uuid.uuid4",
             return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         ):
             response = client.post(
@@ -1186,7 +1186,7 @@ class TestApplyAsAuthorizedPrescriber:
         assertContains(response, "Postuler")
 
         with mock.patch(
-            "itou.www.apply.views.submit_views.uuid.uuid4",
+            "itou.files.models.uuid.uuid4",
             return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         ):
             response = client.post(
@@ -1521,7 +1521,7 @@ class TestApplyAsAuthorizedPrescriber:
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         with mock.patch(
-            "itou.www.apply.views.submit_views.uuid.uuid4",
+            "itou.files.models.uuid.uuid4",
             return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         ):
             response = client.post(
@@ -1988,7 +1988,7 @@ class TestApplyAsPrescriber:
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url_company)
 
         with mock.patch(
-            "itou.www.apply.views.submit_views.uuid.uuid4",
+            "itou.files.models.uuid.uuid4",
             return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         ):
             response = client.post(
@@ -2565,7 +2565,7 @@ class TestApplyAsCompany:
         assertContains(response, CONFIRM_RESET_MARKUP % reset_url)
 
         with mock.patch(
-            "itou.www.apply.views.submit_views.uuid.uuid4",
+            "itou.files.models.uuid.uuid4",
             return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
         ):
             response = client.post(

--- a/tests/www/approvals_views/test_prolongation.py
+++ b/tests/www/approvals_views/test_prolongation.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import timedelta
 
 import pytest
@@ -512,9 +513,15 @@ class TestApprovalProlongation:
 
 
 @pytest.mark.usefixtures("temporary_bucket")
-def test_prolongation_report_file(client, faker, xlsx_file, mailoutbox):
-    # Check that report file object is saved and linked to prolongation
-    # Bad reason types are checked by UI (JS) and ultimately by DB constraints
+def test_prolongation_report_file(client, mocker, faker, xlsx_file, mailoutbox):
+    """
+    Check that report file object is saved and linked to prolongation
+    Bad reason types are checked by UI (JS) and ultimately by DB constraints
+    """
+    mocker.patch(
+        "itou.files.models.uuid.uuid4",
+        return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+    )
     prescriber_organization = PrescriberOrganizationWithMembershipFactory(authorized=True)
     prescriber = prescriber_organization.members.first()
 
@@ -560,7 +567,7 @@ def test_prolongation_report_file(client, faker, xlsx_file, mailoutbox):
 
     prolongation_request = approval.prolongationrequest_set.get()
     assert prolongation_request.report_file
-    assert prolongation_request.report_file.key == "prolongation_report/empty.xlsx"
+    assert prolongation_request.report_file.key == "prolongation_report/11111111-1111-1111-1111-111111111111.xlsx"
 
     [email] = mailoutbox
     assert email.to == [post_data["email"]]

--- a/tests/www/siae_evaluations_views/test_siaes_views.py
+++ b/tests/www/siae_evaluations_views/test_siaes_views.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -1038,7 +1039,11 @@ class TestSiaeUploadDocsView:
         assert evaluated_administrative_criteria == response.context["evaluated_administrative_criteria"]
 
     @pytest.mark.usefixtures("temporary_bucket")
-    def test_post(self, client, pdf_file):
+    def test_post(self, client, mocker, pdf_file):
+        mocker.patch(
+            "itou.files.models.uuid.uuid4",
+            return_value=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        )
         fake_now = timezone.now()
         client.force_login(self.user)
 
@@ -1061,6 +1066,9 @@ class TestSiaeUploadDocsView:
         post_data = {"proof": pdf_file}
         response = client.post(url, data=post_data)
         assert response.status_code == 302
+
+        evaluated_administrative_criteria.refresh_from_db()
+        assert evaluated_administrative_criteria.proof.key == "evaluations/11111111-1111-1111-1111-111111111111.pdf"
 
         next_url = (
             reverse(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Certains utilisateurs téléversaient deux fois le même fichier. Même si [Django storages en modifie le nom](https://docs.djangoproject.com/fr/5.2/ref/files/storage/#django.core.files.storage.Storage.save) s'il existe déjà dans le stockage, il n'était pas répercuté dans notre base de données et causait des `IntegrityError`.

Après discussion avec Antoine et François, nous proposons une fonction qui enregistre dans le S3 et dans la table `files_file` tout en anonymisant le nom du fichier.

Je n'ai pas touché aux fichiers de l'app Communications car il me semblait légitime de ne pas les anonymiser. L'app n'est exposée que dans l'admin Django.

Cette PR annule la précédente https://github.com/gip-inclusion/les-emplois/pull/6037

## :cake: Comment ?

Création d'une fonction et de tests.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

Normalement, tout est couvert par les tests mais vous pouvez réaliser un test manuel.
