### PR TITLE
Employeur: Désactivation des fiches de poste non mises à jour depuis plus de 1 ans [GEN-2585] 

### DIFF
--- a/itou/companies/management/commands/deactivate_old_job_descriptions.py
+++ b/itou/companies/management/commands/deactivate_old_job_descriptions.py
@@ -5,7 +5,7 @@ from itou.companies.models import JobDescription
 from itou.utils.command import BaseCommand
 
 
-DEACTIVATION_DELAY = relativedelta(years=2)
+DEACTIVATION_DELAY = relativedelta(years=1)
 
 
 class Command(BaseCommand):

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -206,7 +206,7 @@ def test_update_companies_coords(settings, capsys, respx_mock):
 def test_deactivate_old_job_description():
     create_test_romes_and_appellations(("N1101",))
     companies_factories.JobDescriptionFactory(
-        last_employer_update_at=timezone.now() - relativedelta(years=2),
+        last_employer_update_at=timezone.now() - relativedelta(years=1),
         location=None,
     )
     companies_factories.JobDescriptionFactory(
@@ -214,7 +214,7 @@ def test_deactivate_old_job_description():
         location=None,
     )
     recently_updated_job_description = companies_factories.JobDescriptionFactory(
-        last_employer_update_at=timezone.now() - relativedelta(years=2) + relativedelta(days=1),
+        last_employer_update_at=timezone.now() - relativedelta(years=1) + relativedelta(days=1),
         location=None,
     )
     assert JobDescription.objects.active().count() == 3


### PR DESCRIPTION
## :thinking: Pourquoi ?

Après avoir désactivé les fiches de poste vieilles de 2 ans, on continue avec celles vieilles de 1 an (13% des fiches actives restantes)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
