### PR TITLE
Tech : Correction pour les tests utilisant `temporary_bucket` échouant "aléatoirement" sur la CI

### DIFF
--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -122,7 +122,6 @@ def test_show_view(snapshot, client):
     prolongation_request = approvals_factories.ProlongationRequestFactory(for_snapshot=True)
     client.force_login(prolongation_request.validated_by)
 
-    default_storage.location = "snapshot"
     response = client.get(
         reverse("approvals:prolongation_request_show", kwargs={"prolongation_request_id": prolongation_request.pk})
     )
@@ -136,7 +135,6 @@ def test_show_view_no_siae(client):
     )
     client.force_login(prolongation_request.validated_by)
 
-    default_storage.location = "snapshot"
     response = client.get(
         reverse("approvals:prolongation_request_show", kwargs={"prolongation_request_id": prolongation_request.pk})
     )
@@ -296,7 +294,6 @@ def test_snapshot_by_status(client, snapshot, status):
     )
     client.force_login(prolongation_request.validated_by)
 
-    default_storage.location = "snapshot"
     response = client.get(
         reverse("approvals:prolongation_request_show", kwargs={"prolongation_request_id": prolongation_request.pk})
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

3 tests dans `test_prolongation_requests.py` écrasais directement `default_storage.location`, cet écrasement était maqué par l'ancienne fixture `storage_prefix_per_test` qui n'existe plus depuis https://github.com/gip-inclusion/les-emplois/pull/6464.

A voir si on garde le commit pour 1 bucket par session ou pas.

## :desert_island: Comment tester ?

En local avec le minio, trois possibilités :
 - `pytest -p no:randomly -v tests/www/approvals_views/test_prolongation_requests.py::test_show_view tests/communications/test_admin.py`
 - `pytest -p no:randomly -v tests/www/approvals_views/test_prolongation_requests.py::test_show_view_no_siae tests/communications/test_admin.py`
- `pytest -p no:randomly -v tests/www/approvals_views/test_prolongation_requests.py::test_snapshot_by_status tests/communications/test_admin.py`
