### PR TITLE
Tech: Ajout de propriétés sur les `File` pour construire les urls

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin, messages
-from django.core.files.storage import default_storage
 from django.urls import path, reverse_lazy
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -508,7 +507,7 @@ class ProlongationCommonAdmin(CreatedOrUpdatedByMixin, ItouModelAdmin):
     def report_file_link(self, obj):
         return format_html(
             "<a href='{}'>{}</a>",
-            default_storage.url(obj.report_file.key),
+            obj.report_file.url(),
             obj.report_file.key,
         )
 

--- a/itou/files/admin.py
+++ b/itou/files/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-from django.core.files.storage import default_storage
 from django.utils.html import format_html
 
 from itou.files.models import File
@@ -17,5 +16,5 @@ class FileAdmin(ItouModelAdmin):
     def link(self, obj):
         return format_html(
             "<a href='{}' target='_blank'>Télécharger</a>",
-            default_storage.url(obj.key),
+            obj.url(),
         )

--- a/itou/files/models.py
+++ b/itou/files/models.py
@@ -1,7 +1,7 @@
 import pathlib
 import uuid
 
-from django.core.files.storage import default_storage
+from django.core.files.storage import default_storage, storages
 from django.db import models
 from django.utils import timezone
 
@@ -27,3 +27,9 @@ class File(models.Model):
         with default_storage.open(self.key) as file:
             default_storage.save(new_key, file)
         return self.__class__.objects.create(key=new_key)
+
+    def url(self, *args, **kwargs):
+        return default_storage.url(self.key, *args, **kwargs)
+
+    def public_url(self, *args, **kwargs):
+        return storages["public"].url(self.key, *args, **kwargs)

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -2,7 +2,6 @@ import uuid
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.files.storage import storages
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import Case, Count, Exists, F, Func, Max, OuterRef, Prefetch, Q, Subquery, When
@@ -888,7 +887,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
     @property
     def resume_link(self):
         if self.resume_id:
-            return storages["public"].url(self.resume.key)
+            return self.resume.public_url()
         return ""
 
     def get_sender_kind_display(self):

--- a/itou/siae_evaluations/admin.py
+++ b/itou/siae_evaluations/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin, messages
-from django.core.files.storage import default_storage
 from django.utils import timezone
 from django.utils.html import format_html
 
@@ -302,7 +301,7 @@ class EvaluatedAdministrativeCriteriaAdmin(ReadonlyMixin, ItouModelAdmin):
         if obj.proof_id:
             return format_html(
                 "<a href='{}'>{}</a>",
-                default_storage.url(obj.proof.key),
+                obj.proof.url(),
                 obj.proof.key,
             )
         return ""

--- a/itou/www/approvals_views/views.py
+++ b/itou/www/approvals_views/views.py
@@ -489,7 +489,7 @@ def prolongation_request_report_file(request, prolongation_request_id):
     )
     if prolongation_request.prescriber_organization_id not in [org.pk for org in request.organizations]:
         raise Http404
-    return HttpResponseRedirect(default_storage.url(prolongation_request.report_file.key))
+    return HttpResponseRedirect(prolongation_request.report_file.url())
 
 
 class ProlongationRequestViewMixin:

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -355,12 +355,7 @@ def assessment_get_file(request, pk, *, file_field):
     if file is None:
         raise Http404
     return HttpResponseRedirect(
-        default_storage.url(
-            file.key,
-            parameters={
-                "ResponseContentDisposition": content_disposition_header("inline", filename),
-            },
-        )
+        file.url(parameters={"ResponseContentDisposition": content_disposition_header("inline", filename)})
     )
 
 

--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -735,7 +735,7 @@ def view_proof(request, evaluated_administrative_criteria_id):
         proof__isnull=False,
         **org_filter,
     )
-    return HttpResponseRedirect(default_storage.url(criteria.proof.key))
+    return HttpResponseRedirect(criteria.proof.url())
 
 
 @login_not_required

--- a/tests/files/tests.py
+++ b/tests/files/tests.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 from botocore.config import Config
 from django.conf import settings
-from django.core.files.storage import default_storage
+from django.core.files.storage import default_storage, storages
 from django.core.management import call_command
 from django.utils import timezone
 
@@ -23,6 +23,16 @@ from tests.geiq_assessments.factories import AssessmentFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.siae_evaluations.factories import EvaluatedAdministrativeCriteriaFactory, EvaluatedJobApplicationFactory
 from tests.utils.test_s3 import default_storage_ls_files
+
+
+@pytest.mark.usefixtures("temporary_bucket")
+def test_urls():
+    file = FileFactory()
+    with io.BytesIO() as content:
+        default_storage.save("test_file.pdf", content)
+
+    assert file.url() == default_storage.url(file.key)
+    assert file.public_url() == storages["public"].url(file.key)
 
 
 @pytest.mark.usefixtures("temporary_bucket")

--- a/tests/www/approvals_views/test_prolongation_requests.py
+++ b/tests/www/approvals_views/test_prolongation_requests.py
@@ -379,6 +379,6 @@ class TestProlongationReportFileView:
                     kwargs={"prolongation_request_id": request.pk},
                 )
             )
-            assertRedirects(response, default_storage.url(file.key), fetch_redirect_response=False)
+            assertRedirects(response, file.url(), fetch_redirect_response=False)
         xlsx_file.seek(0)
         assert httpx.get(response.url).content == xlsx_file.read()

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -463,7 +463,7 @@ class TestViewProof:
         # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
         with freeze_time():
             response = client.get(url)
-            assertRedirects(response, default_storage.url(crit.proof.key), fetch_redirect_response=False)
+            assertRedirects(response, crit.proof.url(), fetch_redirect_response=False)
         pdf_file.seek(0)
         assert httpx.get(response.url).content == pdf_file.read()
 
@@ -494,7 +494,7 @@ class TestViewProof:
         # https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
         with freeze_time():
             response = client.get(url)
-            assertRedirects(response, default_storage.url(crit.proof.key), fetch_redirect_response=False)
+            assertRedirects(response, crit.proof.url(), fetch_redirect_response=False)
         pdf_file.seek(0)
         assert httpx.get(response.url).content == pdf_file.read()
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter d'importer default_storage partout.

Il reste la question du téléchargement des fichiers geiq où l'on passe un paramètre supplémentaire pour définir le nom du fichier. On pourrait mettre une fonction `get_url()` à la place pour permettre de passer des kwargs additionnels

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
