### PR TITLE
GEIQ : Correction de la date de rupture anticipée dans l’export Excel

### DIFF
--- a/itou/www/geiq_assessments_views/export.py
+++ b/itou/www/geiq_assessments_views/export.py
@@ -169,7 +169,7 @@ EMPLOYEE_CONTRACT_XLSX_FORMAT = {
     "CDD/CDI refusé": with_format(Format.TEXT, lambda contract: oui_non(contract.other_data.get("is_refus_cdd_cdi"))),
     "Date de rupture anticipée": with_format(
         Format.DATE,
-        lambda contract: contract.end_at if contract.end_at and contract.end_at < contract.planned_end_at else "",
+        lambda contract: contract.end_at if contract.end_at and contract.end_at < contract.planned_end_at else None,
     ),
     "Type de rupture anticipée": with_format(Format.TEXT, lambda contract: contract.rupture_kind_display()),
     "Situation post-contrat": with_format(

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -782,12 +782,14 @@ class TestAssessmentContractsExportView:
         assert response["Content-Disposition"] == 'attachment; filename="Contrats - Un Joli GEIQ - 2025-06-01.xlsx"'
         assert len(excel_export) == 4  # 3 contracts + header
         assert excel_export[0] == snapshot(name="excel export headers for the employer")
+        rupture_anticipee_idx = excel_export[0].index("Date de rupture anticipée")
         assert excel_export[1][:4] == [
             "Dupond",
             "Jean-Pierre",
             "H",
             datetime.datetime(1993, 3, 3, 0, 0),
         ]
+        assert excel_export[1][rupture_anticipee_idx] == ""
         assert excel_export[1][-1] == "Oui"  # allowance requested
         assert excel_export[2][:4] == [
             "Dupont",
@@ -795,6 +797,7 @@ class TestAssessmentContractsExportView:
             "H",
             datetime.datetime(1990, 1, 1, 0, 0),
         ]
+        assert excel_export[2][rupture_anticipee_idx] == datetime.datetime(2024, 4, 30)
         assert excel_export[2][-1] == "Non"  # allowance requested
         assert excel_export[3][:4] == [
             "Martin",
@@ -802,6 +805,8 @@ class TestAssessmentContractsExportView:
             "F",
             datetime.datetime(1992, 2, 2, 0, 0),
         ]
+        assert excel_export[3][rupture_anticipee_idx] == datetime.datetime(2024, 3, 30)
+        assert excel_export[2][-1] == "Non"  # allowance requested
         assert excel_export[3][-1] == "Oui"  # allowance requested
 
         client.force_login(ddets_membership.user)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une chaîne vide est considérée comme une valeur invalide pour une date, ce qui amène xlsx_streaming à rendre une valeur `""` pour la case, qu’Excel interprète en insérant la valeur de la date du jour, ou de la cellule située au dessus.

xslx_streaming a un petit warning en debug:
```
logger.debug("AttributeError: expected a numeric or date like value got .")
```

Son faible niveau de log nous a fait le rater.

## :desert_island: Comment tester ?

https://gip-inclusion.slack.com/archives/C01181Y04LT/p1752064124071259
