### PR TITLE
Interface: Annoncer le fonctionnement de la barre d’actions avec les "nouvelles" candidatures

### DIFF
--- a/itou/templates/apply/includes/siae_batch_actions.html
+++ b/itou/templates/apply/includes/siae_batch_actions.html
@@ -10,7 +10,9 @@
         <div class="form-row align-items-center gx-3">
             <div class="form-group col-12 col-lg-auto">
                 {% if can_accept %}
-                    {% accept_button acceptable_job_application acceptable_job_application.geiq_eligibility_diagnosis next_url=list_url %}
+                    <div id="introjsBatchActions01">
+                        {% accept_button acceptable_job_application acceptable_job_application.geiq_eligibility_diagnosis next_url=list_url %}
+                    </div>
                 {% else %}
                     <button type="button"
                             class="btn btn-lg btn-link-white btn-block btn-ico justify-content-center"
@@ -145,6 +147,7 @@
 {% else %}
     <div id="batch-action-box" class="selection-indicator" {% if request.htmx %}hx-swap-oob="true"{% endif %}></div>
 {% endif %}
+
 {% if request.htmx %}
     {% include "apply/includes/selected_job_applications.html" with selected_nb=selected_nb request=request only %}
     {% include "apply/includes/siae_batch_actions_modals.html" %}

--- a/itou/templates/apply/list_for_siae.html
+++ b/itou/templates/apply/list_for_siae.html
@@ -72,4 +72,53 @@
     <script src='{% static "js/htmx_dropdown_filter.js" %}'></script>
     <script async src="{{ TALLY_URL }}/widgets/embed.js"></script>
     <script src='{% static "js/nps_popup.js" %}' data-delaypopup="true" data-userkind="employeur" data-page="liste-candidatures"></script>
+
+    {# djlint:off #}
+    <script nonce="{{ CSP_NONCE }}">
+        document.addEventListener("htmx:load", () => {
+            const breakpointMD = getComputedStyle(document.documentElement).getPropertyValue('--bs-breakpoint-md');
+            const applyBtn = document.getElementById('introjsBatchActions01');
+
+            function show() {
+                for (const cookie of document.cookie.split(';')) {
+                    const [name, value] = cookie.split('=');
+                    if ('introjsBatchActionsDontShowAgain' == name.trim()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            if (applyBtn && show() && window.matchMedia('(min-width: ' + breakpointMD + ')').matches) {
+                setTimeout(function() {
+                    introJs().setOptions({
+                            disableInteraction: true,
+                            showProgress: false,
+                            showBullets: false,
+                            skipLabel: '',
+                            nextLabel: 'Suivant',
+                            prevLabel: 'Précédent',
+                            doneLabel: 'Fin',
+                            steps: [{
+                                element: document.querySelector('#introjsBatchActions01'),
+                                title: 'Accepter les nouvelles candidatures',
+                                intro: 'Vous pouvez maintenant accepter les nouvelles candidatures sans avoir à les passer à l’étude.'
+                            }, {
+                                element: document.querySelector('#other_actions'),
+                                title: 'Autres actions sur les candidarures',
+                                intro: 'Cliquez sur ce bouton pour accéder aux autres actions disponibles pour cette sélection de candidatures.',
+                            }]
+                        })
+                        .onbeforechange(function() {
+
+                        })
+                        .onexit(() => {
+                            document.cookie = `introjsBatchActionsDontShowAgain=true; max-age=${90 * 24 * 60 * 60}; samesite=Lax;`;
+                        })
+                        .start();
+                }, 300)
+            }
+        });
+</script>
+    {# djlint:on #}
 {% endblock %}


### PR DESCRIPTION
## :thinking: Pourquoi ?
Annoncer le changement de fonctionnement de la barre d’actions pour les nouvelles candidatures

## :cake: Comment ? <!-- optionnel -->
Ajouter un IntroJS sur la `list_for_siae`, lancé au `htmx:load`. 
Si le bouton "Accepter" est présent dans la barre d'action (donc si les employers `can_accept`), on lance le IntroJS qui ne s'affichera qu'une fois.

Pour tester plusieurs fois, il faut supprimer le cookie `introjsBatchActionsDontShowAgain`
