### PR TITLE
[API] FranceTravail.io : création d'une classe parent

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -29,7 +29,7 @@ from itou.job_applications import enums as job_application_enums
 from itou.prescribers import enums as prescribers_enums
 from itou.users.enums import IdentityCertificationAuthorities
 from itou.users.models import IdentityCertification
-from itou.utils.apis import enums as api_enums, pole_emploi_api_client
+from itou.utils.apis import enums as api_enums, pole_emploi_partenaire_api_client
 from itou.utils.apis.pole_emploi import DATE_FORMAT, PoleEmploiAPIBadResponse, PoleEmploiAPIException
 from itou.utils.db import or_queries
 from itou.utils.models import DateRange
@@ -344,7 +344,7 @@ class PENotificationMixin(models.Model):
         self._pe_log("!", fmt, *args, **kwargs)
 
     def pe_maj_pass(self, *, id_national_pe, siae_siret, siae_kind, sender_kind, prescriber_kind, at):
-        pe_client = pole_emploi_api_client()
+        pe_client = pole_emploi_partenaire_api_client()
 
         typologie_prescripteur = None
         if prescriber_kind:
@@ -455,7 +455,7 @@ class CancelledApproval(PENotificationMixin, CommonApprovalMixin):
             )
 
         if not self.user_id_national_pe:
-            pe_client = pole_emploi_api_client()
+            pe_client = pole_emploi_partenaire_api_client()
             try:
                 id_national = pe_client.recherche_individu_certifie(
                     first_name=self.user_first_name,
@@ -988,7 +988,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
             )
 
         if not self.user.jobseeker_profile.pe_obfuscated_nir:
-            pe_client = pole_emploi_api_client()
+            pe_client = pole_emploi_partenaire_api_client()
             try:
                 id_national = pe_client.recherche_individu_certifie(
                     first_name=self.user.first_name,
@@ -1990,7 +1990,7 @@ class PoleEmploiApproval(PENotificationMixin, CommonApprovalMixin):
     def notify_pole_emploi(self) -> api_enums.PEApiNotificationStatus:
         now = timezone.now()
 
-        pe_client = pole_emploi_api_client()
+        pe_client = pole_emploi_partenaire_api_client()
         try:
             id_national = pe_client.recherche_individu_certifie(
                 first_name=self.first_name,

--- a/itou/companies/management/commands/sync_pec_offers.py
+++ b/itou/companies/management/commands/sync_pec_offers.py
@@ -6,7 +6,7 @@ from itou.cities.models import City
 from itou.companies.enums import POLE_EMPLOI_SIRET, ContractNature, ContractType, JobSource
 from itou.companies.models import Company, JobDescription
 from itou.jobs.models import Appellation
-from itou.utils.apis import pe_api_enums, pole_emploi_api_client
+from itou.utils.apis import pe_api_enums, pole_emploi_partenaire_api_client
 from itou.utils.command import BaseCommand
 from itou.utils.sync import DiffItemKind, yield_sync_diff
 
@@ -109,7 +109,7 @@ class Command(BaseCommand):
         parser.add_argument("--delay", action="store", dest="delay", default=1, type=int, choices=range(0, 5))
 
     def handle(self, *, wet_run, delay, **options):
-        pe_client = pole_emploi_api_client()
+        pe_client = pole_emploi_partenaire_api_client()
         pe_siae = Company.unfiltered_objects.get(siret=POLE_EMPLOI_SIRET)
 
         # NOTE: using this unfiltered API we can only sync at most 1149 PEC offers. If someday there are more offers,

--- a/itou/jobs/management/commands/sync_romes_and_appellations.py
+++ b/itou/jobs/management/commands/sync_romes_and_appellations.py
@@ -1,7 +1,7 @@
 from django.utils import timezone
 
 from itou.jobs.models import Appellation, Rome
-from itou.utils.apis import pe_api_enums, pole_emploi_api_client
+from itou.utils.apis import pe_api_enums, pole_emploi_partenaire_api_client
 from itou.utils.command import BaseCommand
 from itou.utils.sync import yield_sync_diff
 
@@ -34,7 +34,7 @@ class Command(BaseCommand):
 
     def handle(self, *, wet_run, **options):
         now = timezone.now()
-        pe_client = pole_emploi_api_client()
+        pe_client = pole_emploi_partenaire_api_client()
 
         romes_data = pe_client.referentiel(pe_api_enums.REFERENTIEL_ROME)
         for item in yield_sync_diff(romes_data, "code", Rome.objects.all(), "code", [("libelle", "name")]):

--- a/itou/prescribers/management/commands/sync_ft_organizations.py
+++ b/itou/prescribers/management/commands/sync_ft_organizations.py
@@ -5,7 +5,7 @@ from itou.cities.models import City
 from itou.common_apps.address.models import BAN_API_RELIANCE_SCORE, lat_lon_to_coords
 from itou.prescribers.enums import PrescriberAuthorizationStatus, PrescriberOrganizationKind
 from itou.prescribers.models import PrescriberOrganization
-from itou.utils.apis import pole_emploi_api_client
+from itou.utils.apis import pole_emploi_partenaire_api_client
 from itou.utils.command import BaseCommand
 from itou.utils.sync import DiffItemKind, yield_sync_diff
 
@@ -141,7 +141,7 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *, action, wet_run=False, **options):
-        data = pole_emploi_api_client().agences()
+        data = pole_emploi_partenaire_api_client().agences()
         match action:
             case "fix-empty-safir":
                 self.fix_empty_safir(data, wet_run=wet_run)

--- a/itou/users/management/commands/pe_certify_users.py
+++ b/itou/users/management/commands/pe_certify_users.py
@@ -13,7 +13,7 @@ from httpx import RequestError
 
 from itou.users.enums import IdentityCertificationAuthorities, UserKind
 from itou.users.models import IdentityCertification, JobSeekerProfile, User
-from itou.utils.apis import pole_emploi_api_client
+from itou.utils.apis import pole_emploi_partenaire_api_client
 from itou.utils.apis.pole_emploi import (
     PoleEmploiAPIBadResponse,
     PoleEmploiAPIException,
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         parser.add_argument("--chunk-size", action="store", dest="chunk_size", default=200, type=int)
 
     def handle(self, wet_run, chunk_size, **options):
-        pe_client = pole_emploi_api_client()
+        pe_client = pole_emploi_partenaire_api_client()
 
         @tenacity.retry(
             stop=tenacity.stop_after_attempt(10),

--- a/itou/utils/apis/__init__.py
+++ b/itou/utils/apis/__init__.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 
-from itou.utils.apis.pole_emploi import PoleEmploiApiClient
+from itou.utils.apis.pole_emploi import PoleEmploiRoyaumePartenaireApiClient
 
 
 def pole_emploi_api_client():
-    return PoleEmploiApiClient(
+    return PoleEmploiRoyaumePartenaireApiClient(
         settings.API_ESD["BASE_URL"],
         settings.API_ESD["AUTH_BASE_URL"],
         settings.API_ESD["KEY"],

--- a/itou/utils/apis/__init__.py
+++ b/itou/utils/apis/__init__.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from itou.utils.apis.pole_emploi import PoleEmploiRoyaumePartenaireApiClient
 
 
-def pole_emploi_api_client():
+def pole_emploi_partenaire_api_client():
     return PoleEmploiRoyaumePartenaireApiClient(
         settings.API_ESD["BASE_URL"],
         settings.API_ESD["AUTH_BASE_URL"],

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -47,19 +47,6 @@ API_TIMEOUT_SECONDS = 60  # this API is pretty slow, let's give it a chance
 
 CACHE_API_TOKEN_KEY = "pole_emploi_api_client_token"
 
-# Pole Emploi also sent us a "sandbox" scope value: "api_testmaj-pass-iaev1" instead of "api_maj-pass-iaev1"
-AUTHORIZED_SCOPES = [
-    "api_maj-pass-iaev1",
-    "api_offresdemploiv2",
-    "api_rechercheindividucertifiev1",
-    "api_rome-metiersv1",
-    "nomenclatureRome",
-    "o2dsoffre",
-    "passIAE",
-    "rechercherIndividuCertifie",
-    "api_referentielagencesv1",
-    "organisationpe",
-]
 API_MAJ_PASS_SUCCESS = "S000"
 API_RECH_INDIVIDU_SUCCESS = "S001"
 DATE_FORMAT = "%Y-%m-%d"
@@ -82,19 +69,26 @@ def _pole_emploi_name(name: str, hyphenate=False, max_len=25) -> str:
     return replaced[:max_len]
 
 
-class PoleEmploiApiClient:
+class BasePoleEmploiApiClient:
+    AUTHORIZED_SCOPES = []
+    REALM = ""
+
     def __init__(self, base_url, auth_base_url, key, secret):
+        if not self.AUTHORIZED_SCOPES:
+            raise NotImplementedError("Authorized scopes missing.")
+        if not self.REALM:
+            raise NotImplementedError("Realm missing.")
         self.base_url = base_url
         self.auth_base_url = auth_base_url
         self.key = key
         self.secret = secret
 
     def _refresh_token(self):
-        scopes = " ".join(AUTHORIZED_SCOPES)
+        scopes = " ".join(self.AUTHORIZED_SCOPES)
         auth_data = (
             httpx.post(
                 f"{self.auth_base_url}/connexion/oauth2/access_token",
-                params={"realm": "/partenaire"},
+                params={"realm": self.REALM},
                 data={
                     "client_id": self.key,
                     "client_secret": self.secret,
@@ -148,6 +142,23 @@ class PoleEmploiApiClient:
             return data
         except httpx.RequestError as exc:
             raise PoleEmploiAPIException(API_CLIENT_HTTP_ERROR_CODE) from exc
+
+
+class PoleEmploiRoyaumePartenaireApiClient(BasePoleEmploiApiClient):
+    # Pole Emploi also sent us a "sandbox" scope value: "api_testmaj-pass-iaev1" instead of "api_maj-pass-iaev1"
+    AUTHORIZED_SCOPES = [
+        "api_maj-pass-iaev1",
+        "api_offresdemploiv2",
+        "api_rechercheindividucertifiev1",
+        "api_rome-metiersv1",
+        "nomenclatureRome",
+        "o2dsoffre",
+        "passIAE",
+        "rechercherIndividuCertifie",
+        "api_referentielagencesv1",
+        "organisationpe",
+    ]
+    REALM = "/partenaire"
 
     def recherche_individu_certifie(self, first_name, last_name, birthdate, nir):
         """Example data:

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -974,7 +974,8 @@ def test_pe_certify_users_retry(caplog, snapshot):
         jobseeker_profile__pe_last_certification_attempt_at=timezone.now() - datetime.timedelta(seconds=90),
     )  # recent failure that should not be called
     with mock.patch(
-        "itou.utils.apis.PoleEmploiApiClient.recherche_individu_certifie", side_effect=PoleEmploiAPIBadResponse("R010")
+        "itou.utils.apis.PoleEmploiRoyaumePartenaireApiClient.recherche_individu_certifie",
+        side_effect=PoleEmploiAPIBadResponse("R010"),
     ) as recherche:
         call_command("pe_certify_users", wet_run=True)
 

--- a/tests/utils/apis/test_pole_emploi_api.py
+++ b/tests/utils/apis/test_pole_emploi_api.py
@@ -12,21 +12,23 @@ from itou.utils.apis.pole_emploi import (
     CACHE_API_TOKEN_KEY,
     REFRESH_TOKEN_MARGIN_SECONDS,
     PoleEmploiAPIBadResponse,
-    PoleEmploiApiClient,
     PoleEmploiAPIException,
     PoleEmploiRateLimitException,
+    PoleEmploiRoyaumePartenaireApiClient,
 )
 from itou.utils.mocks import pole_emploi as pole_emploi_api_mocks
 from tests.job_applications.factories import JobApplicationFactory
 from tests.users.factories import JobSeekerFactory
 
 
-class TestPoleEmploiAPIClient:
+class TestPoleEmploiRoyaumePartenaireApiClient:
     CACHE_EXPIRY = 3600
 
     @pytest.fixture(autouse=True)
     def setup_method(self):
-        self.api_client = PoleEmploiApiClient("https://pe.fake", "https://auth.fr", "foobar", "pe-secret")
+        self.api_client = PoleEmploiRoyaumePartenaireApiClient(
+            "https://pe.fake", "https://auth.fr", "foobar", "pe-secret"
+        )
         respx.post("https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire").respond(
             200, json={"token_type": "foo", "access_token": "batman", "expires_in": self.CACHE_EXPIRY}
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour préparer l'arrivée de la certification RQTH, il faut intégrer les nouveaux périmètres qui sont sous le royaume `Agent`. L'authentification est identique au royaume `Partenaire`, seuls les périmètres diffèrent.
Deux classes enfant qui héritent d'une même classe Parent permet de distinguer les deux périmètres et les deux royaumes tout en partageant les méthodes communes.
Cette PR modifie le fonctionnement actuel. Une autre PR viendra pour intégrer le nouveau royaume Agent.

## :cake: Comment 
Création d'une classe parent et utilisation dans la classe actuelle. Changement du nom actuel.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Tout est couvert par les tests automatisés.
