### PR TITLE
Empêcher des candidats multiples d’utiliser le même PASS IAE

### DIFF
--- a/itou/job_applications/migrations/0021_jobapplication_one_job_seeker_per_approval.py
+++ b/itou/job_applications/migrations/0021_jobapplication_one_job_seeker_per_approval.py
@@ -1,0 +1,27 @@
+import django.contrib.postgres.constraints
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("approvals", "0013_alter_approval_options"),
+        ("companies", "0023_fill_last_employer_update_at"),
+        ("eligibility", "0015_geiqselectedadministrativecriteria_empty_certification_period"),
+        ("files", "0009_alter_file_id"),
+        ("job_applications", "0020_alter_and_sync_sender_kind"),
+        ("prescribers", "0015_drop_is_head_office_for_real"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="jobapplication",
+            constraint=django.contrib.postgres.constraints.ExclusionConstraint(
+                condition=models.Q(("approval_id", None), _negated=True),
+                expressions=[("approval_id", "="), ("job_seeker_id", "<>")],
+                name="one_job_seeker_per_approval",
+                violation_error_message="Le PASS IAE est déjà utilisé par un autre candidat.",
+            ),
+        ),
+    ]

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -202,6 +202,14 @@ class TestJobApplicationModel:
         assert membership.member == user
         assert membership.creator == user
 
+    def test_multiple_jobseekers_for_approval(self):
+        job_application = JobApplicationFactory(with_approval=True)
+        with pytest.raises(
+            IntegrityError,
+            match=r'conflicting key value violates exclusion constraint "one_job_seeker_per_approval"',
+        ):
+            JobApplicationFactory(approval=job_application.approval)
+
 
 @pytest.mark.parametrize(
     "factory, validation_should_pass",


### PR DESCRIPTION
## :thinking: Pourquoi ?

12 cas d’erreur ont été identifiés et sont en train d’être résolus. À l’avenir, la base de données peut nous protéger contre ces erreurs.

https://gip-inclusion.slack.com/archives/C02J7LWNT6Z/p1752570411069969
