### PR TITLE
[RQTH] Ajout du royaume Agent au client d'API

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -273,3 +273,15 @@ class PoleEmploiRoyaumePartenaireApiClient(BasePoleEmploiApiClient):
         if safir:
             return next((agence for agence in agences if agence["codeSafir"] == str(safir)), None)
         return agences
+
+
+class PoleEmploiRoyaumeAgentAPIClient(BasePoleEmploiApiClient):
+    AUTHORIZED_SCOPES = [
+        "api_rechercher-usagerv2",
+        "rechercheusager",
+        "profil_accedant",
+        "api_donnees-rqthv1",
+        "h2a",
+    ]
+    REALM = "/agent"
+    CACHE_API_TOKEN_KEY = "pole_emploi_api_agent_client_token"

--- a/tests/utils/apis/test_pole_emploi_api.py
+++ b/tests/utils/apis/test_pole_emploi_api.py
@@ -13,6 +13,7 @@ from itou.utils.apis.pole_emploi import (
     PoleEmploiAPIBadResponse,
     PoleEmploiAPIException,
     PoleEmploiRateLimitException,
+    PoleEmploiRoyaumeAgentAPIClient,
     PoleEmploiRoyaumePartenaireApiClient,
 )
 from itou.utils.mocks import pole_emploi as pole_emploi_api_mocks
@@ -253,3 +254,29 @@ class TestPoleEmploiRoyaumePartenaireApiClient:
         )
         assert self.api_client.agences() == [expected_agence, other_agence]
         assert self.api_client.agences(safir=82001) == expected_agence
+
+
+class TestPoleEmploiRoyaumeAgentAPIClient:
+    CACHE_EXPIRY = 1499
+
+    @pytest.fixture(autouse=True)
+    def setup_method(self):
+        self.api_client = PoleEmploiRoyaumeAgentAPIClient(
+            base_url="https://pe.fake",
+            auth_base_url="https://auth.fr",
+            key="client_id",
+            secret="client_secret",
+        )
+        json_response = {
+            "token_type": "Bearer",
+            "access_token": "Catwoman",
+            "scope": "client_id h2a rechercheusager profil_accedant api_donnees-rqthv1 api_rechercher-usagerv2",
+            "expires_in": self.CACHE_EXPIRY,
+        }
+        respx.post("https://auth.fr/connexion/oauth2/access_token?realm=%2Fagent").respond(200, json=json_response)
+
+    @respx.mock
+    def test_refresh_token(self):
+        # This method is already tested on TestPoleEmploiRoyaumePartenaireApiClient.
+        token = self.api_client._refresh_token()
+        assert token == "Bearer Catwoman"


### PR DESCRIPTION
Suite de #6537 

## :thinking: Pourquoi ?

Les API `RechercherUsager` et `RQTH` sont dans le royaume Agent.

## :cake: Comment ?

Ajout du endpoint d'authentification du royaume Agent.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Rien à tester car c'est un travail préparatoire.