### PR TITLE
Import EA/EATT : Gérer le cas des lundi fériés

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -34,11 +34,12 @@
 
   "0 7 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_jobseekers --wet-run",
   "0 7 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_professionals --wet-run",
+  "0 12 * * 1-5 $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
+
   "0 9-12 * * 1 $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
   "0 0 * * 1 CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
   "0 1 * * 1 $ROOT/clevercloud/run_management_command.sh delete_unused_files",
   "0 2 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
-  "0 12 * * 1 $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
 
   "0 0 1 * * CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh delete_old_emails --wet-run",
   "0 0 2 * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --monthly",

--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -15,8 +15,8 @@
   "0 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh anonymize_jobseekers --wet-run",
   "0 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh anonymize_professionals --wet-run",
   "30 2-18/4 * * * $ROOT/clevercloud/run_management_command.sh metabase_data kpi fetch --wet-run",
-  "25 8-18/2 * * 1-5 $ROOT/clevercloud/transfer_employee_records.sh --download",
-  "55 8-18/2 * * 1-5 $ROOT/clevercloud/transfer_employee_records.sh --upload",
+  "25 8-18/2 * * MON-FRI $ROOT/clevercloud/transfer_employee_records.sh --download",
+  "55 8-18/2 * * MON-FRI $ROOT/clevercloud/transfer_employee_records.sh --upload",
 
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "30 1 * * * $ROOT/clevercloud/run_management_command.sh send_users_to_brevo --wet-run",
@@ -34,12 +34,12 @@
 
   "0 7 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_jobseekers --wet-run",
   "0 7 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_professionals --wet-run",
-  "0 12 * * 1-5 $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
+  "0 12 * * MON-FRI $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
 
-  "0 9-12 * * 1 $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
-  "0 0 * * 1 CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
-  "0 1 * * 1 $ROOT/clevercloud/run_management_command.sh delete_unused_files",
-  "0 2 * * 1 $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
+  "0 9-12 * * MON $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
+  "0 0 * * MON CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
+  "0 1 * * MON $ROOT/clevercloud/run_management_command.sh delete_unused_files",
+  "0 2 * * MON $ROOT/clevercloud/crons/populate_metabase_matomo.sh",
 
   "0 0 1 * * CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh delete_old_emails --wet-run",
   "0 0 2 * * $ROOT/clevercloud/crons/populate_metabase_emplois.sh --monthly",

--- a/itou/companies/management/commands/import_ea_eatt.py
+++ b/itou/companies/management/commands/import_ea_eatt.py
@@ -220,7 +220,7 @@ class Command(BaseCommand):
     @monitor(
         monitor_slug="import-ea-eatt",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "0 12 * * 1-5"},
+            "schedule": {"type": "crontab", "value": "0 12 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 1,

--- a/itou/employee_record/management/commands/transfer_employee_records.py
+++ b/itou/employee_record/management/commands/transfer_employee_records.py
@@ -139,7 +139,7 @@ class Command(EmployeeRecordTransferCommand):
     @monitor(
         monitor_slug="transfer-employee-records-download",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "25 8-18/2 * * 1-5"},
+            "schedule": {"type": "crontab", "value": "25 8-18/2 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 2,
@@ -154,7 +154,7 @@ class Command(EmployeeRecordTransferCommand):
     @monitor(
         monitor_slug="transfer-employee-records-upload",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "55 8-18/2 * * 1-5"},
+            "schedule": {"type": "crontab", "value": "55 8-18/2 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 2,

--- a/itou/employee_record/management/commands/transfer_employee_records_updates.py
+++ b/itou/employee_record/management/commands/transfer_employee_records_updates.py
@@ -115,7 +115,7 @@ class Command(EmployeeRecordTransferCommand):
     @monitor(
         monitor_slug="transfer-employee-records-updates-download",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "25 8-18/2 * * 1-5"},
+            "schedule": {"type": "crontab", "value": "25 8-18/2 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 2,
@@ -130,7 +130,7 @@ class Command(EmployeeRecordTransferCommand):
     @monitor(
         monitor_slug="transfer-employee-records-updates-upload",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "55 8-18/2 * * 1-5"},
+            "schedule": {"type": "crontab", "value": "55 8-18/2 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 2,

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -190,7 +190,7 @@ class Command(BaseCommand):
     @monitor(
         monitor_slug="populate-metabase-matomo",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "0 2 * * 1"},
+            "schedule": {"type": "crontab", "value": "0 2 * * MON"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 1,

--- a/tests/companies/__snapshots__/test_import_ea_eatt.ambr
+++ b/tests/companies/__snapshots__/test_import_ea_eatt.ambr
@@ -109,6 +109,200 @@
     }),
   ])
 # ---
+# name: test_command_errors[friday][logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Files matching for this week '20250714': ",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+  ])
+# ---
+# name: test_command_errors[monday][logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Files matching for this week '20250714': ",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'handle',
+      'levelno': 20,
+      'message': 'No file found, nothing to be done',
+      'module': 'import_ea_eatt',
+    }),
+  ])
+# ---
+# name: test_command_errors[thursday][logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Files matching for this week '20250714': ",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'handle',
+      'levelno': 20,
+      'message': 'No file found, nothing to be done',
+      'module': 'import_ea_eatt',
+    }),
+  ])
+# ---
+# name: test_command_errors[tuesday][logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Files matching for this week '20250714': ",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'handle',
+      'levelno': 20,
+      'message': 'No file found, nothing to be done',
+      'module': 'import_ea_eatt',
+    }),
+  ])
+# ---
+# name: test_command_errors[wednesday][logs]
+  list([
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] Opened sftp connection (server version 3)',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Connected to "0.0.0.0" as "django_tests"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': 'Current remote dir is "/"',
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': 'retrieve_archive_of_the_week',
+      'levelno': 20,
+      'message': "Files matching for this week '20250714': ",
+      'module': 'import_ea_eatt',
+    }),
+    dict({
+      'funcName': '_log',
+      'levelno': 20,
+      'message': '[chan 0] sftp session closed.',
+      'module': 'sftp',
+    }),
+    dict({
+      'funcName': 'handle',
+      'levelno': 20,
+      'message': 'No file found, nothing to be done',
+      'module': 'import_ea_eatt',
+    }),
+  ])
+# ---
 # name: test_process_file_from_archive[data]
   list([
     tuple(
@@ -199,7 +393,7 @@
     dict({
       'funcName': 'retrieve_archive_of_the_week',
       'levelno': 20,
-      'message': "Files matching for this monday '20250512': FLUX_EA2_ITOU_20250512.zip",
+      'message': "Files matching for this week '20250512': FLUX_EA2_ITOU_20250512.zip",
       'module': 'import_ea_eatt',
     }),
     dict({


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les moulinettes de l'équipe EA2 de l'ASP ne tournent semble t-il pas les jours fériés, mais rattrape tout de même le lendemain... Donc pour tout les lundi fériés le fichier est accessible à partir du mardi.

## :cake: Comment ?

Voir le commit.

J'étais parti pour utiliser [holidays](https://pypi.org/project/holidays/) afin d'expliciter cette logique mais vu que le code le gère déjà sans je me dit qu'on peux s'épargner une dépendance à usage unique.