### PR TITLE
Tech : Correction du contexte manquant pour les management commands

### DIFF
--- a/itou/approvals/management/commands/prolongation_requests_chores.py
+++ b/itou/approvals/management/commands/prolongation_requests_chores.py
@@ -1,6 +1,5 @@
 from dateutil.relativedelta import relativedelta
 from django.core.management.base import CommandError
-from django.db import transaction
 from django.db.models import F, Q
 from django.template.defaultfilters import pluralize
 from django.utils import timezone
@@ -13,11 +12,12 @@ from itou.utils.command import BaseCommand, dry_runnable
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         parser.add_argument("command", choices=["email_reminder"])
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    @transaction.atomic
     def send_reminder_to_prescriber_organization_other_members(self):
         first_reminder = Q(reminder_sent_at=None, created_at__date__lte=timezone.localdate() - relativedelta(days=10))
         subsequent_reminders = Q(reminder_sent_at__date__lte=timezone.localdate() - relativedelta(days=10))

--- a/itou/archive/management/commands/notify_inactive_jobseekers.py
+++ b/itou/archive/management/commands/notify_inactive_jobseekers.py
@@ -1,4 +1,3 @@
-from django.db import transaction
 from django.db.models import Exists, OuterRef
 from django.utils import timezone
 from sentry_sdk.crons import monitor
@@ -39,6 +38,8 @@ def inactive_jobseekers_without_related_objects(inactive_since, batch_size):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
@@ -55,7 +56,6 @@ class Command(BaseCommand):
             help="Number of job seekers to process in a batch",
         )
 
-    @transaction.atomic
     def notify_inactive_jobseekers(self):
         now = timezone.now()
         inactive_since = now - INACTIVITY_PERIOD

--- a/itou/archive/management/commands/notify_inactive_professionals.py
+++ b/itou/archive/management/commands/notify_inactive_professionals.py
@@ -1,4 +1,3 @@
-from django.db import transaction
 from django.utils import timezone
 from sentry_sdk.crons import monitor
 
@@ -12,6 +11,8 @@ BATCH_SIZE = 200
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
@@ -28,7 +29,6 @@ class Command(BaseCommand):
             help="Number of professionals to process in a batch",
         )
 
-    @transaction.atomic
     def notify_inactive_professionals(self):
         now = timezone.now()
         inactive_since = now - INACTIVITY_PERIOD

--- a/itou/asp/management/commands/sync_communes.py
+++ b/itou/asp/management/commands/sync_communes.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from django.contrib.postgres.search import TrigramSimilarity
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import transaction
 from django.db.models import F, Q
 from django.db.models.deletion import RestrictedError
 
@@ -55,6 +54,8 @@ def guess_commune(code, name, at=None):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     help = "Synchronizes communes with the latest CSV from the ASP and latest known Cities"
 
     def add_arguments(self, parser):
@@ -67,7 +68,6 @@ class Command(BaseCommand):
             help="Path of the ASP CSV file to import",
         )
 
-    @transaction.atomic
     def handle(self, *, file_path, wet_run, **options):
         communes_from_csv = list(csv_import_communes(file_path))
 

--- a/itou/companies/management/commands/import_ea_eatt.py
+++ b/itou/companies/management/commands/import_ea_eatt.py
@@ -4,7 +4,6 @@ import zipfile
 
 import pandas as pd
 from django.conf import settings
-from django.db import transaction
 from django.utils import timezone
 from sentry_sdk.crons import monitor
 
@@ -61,6 +60,8 @@ class Command(BaseCommand):
     EATT = "Entreprise adaptée de travail temporaire".
     """
 
+    ATOMIC_HANDLE = True
+
     help = 'Import EA and EATT data into the database using the "flux EA2"'
 
     NUMBER_OF_ARCHIVES_TO_KEEP = 3
@@ -113,7 +114,6 @@ class Command(BaseCommand):
                     sftp.remove(filename)
                     self.logger.info("Old archive '%s' was deleted", filename)
 
-    @transaction.atomic
     def process_file(self, file, *, wet_run=False):
         header = next(file)
         if not header.startswith("L|ASP|EA|"):  # Start of file header

--- a/itou/companies/management/commands/import_geiq.py
+++ b/itou/companies/management/commands/import_geiq.py
@@ -113,6 +113,8 @@ class Command(BaseCommand):
         django-admin import_geiq --wet-run
     """
 
+    ATOMIC_HANDLE = True
+
     help = "Import the content of the GEIQ csv file into the database."
 
     def add_arguments(self, parser):

--- a/itou/companies/management/commands/import_siae.py
+++ b/itou/companies/management/commands/import_siae.py
@@ -16,7 +16,6 @@ name instead of hardcoding column numbers as in `field = row[42]`.
 """
 
 from django.core.management.base import CommandError
-from django.db import transaction
 
 from itou.companies.management.commands._import_siae.convention import (
     check_convention_data_consistency,
@@ -55,6 +54,8 @@ class Command(BaseCommand):
         django-admin import_siae
     """
 
+    ATOMIC_HANDLE = True
+
     help = "Update and sync SIAE data based on latest ASP exports."
 
     def add_arguments(self, parser):
@@ -62,7 +63,6 @@ class Command(BaseCommand):
 
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    @transaction.atomic
     def handle(self, wet_run, **options):
         errors = 0
 

--- a/itou/emails/management/commands/delete_old_emails.py
+++ b/itou/emails/management/commands/delete_old_emails.py
@@ -8,6 +8,8 @@ from itou.utils.command import BaseCommand, dry_runnable
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 

--- a/itou/employee_record/management/commands/archive_employee_records.py
+++ b/itou/employee_record/management/commands/archive_employee_records.py
@@ -3,6 +3,8 @@ from itou.utils.command import BaseCommand, dry_runnable
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
 

--- a/itou/employee_record/management/commands/employee_record.py
+++ b/itou/employee_record/management/commands/employee_record.py
@@ -26,6 +26,8 @@ class Command(BaseCommand):
             n'est pas gênant.
     """
 
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser: argparse.ArgumentParser):
         super().add_arguments(parser)
         subparsers = parser.add_subparsers(dest="command", required=True)

--- a/itou/employee_record/management/commands/resend_employee_records.py
+++ b/itou/employee_record/management/commands/resend_employee_records.py
@@ -1,5 +1,3 @@
-from django.db import transaction
-
 from itou.companies.models import Company
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
@@ -7,13 +5,14 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
 
         parser.add_argument("siae_id", type=int)
         parser.add_argument("--wet-run", action="store_true")
 
-    @transaction.atomic()
     def handle(self, *, siae_id, wet_run, **options):
         siae = Company.objects.select_related("convention").get(pk=siae_id)
         self.stdout.write(

--- a/itou/employee_record/management/commands/unarchive_employee_records.py
+++ b/itou/employee_record/management/commands/unarchive_employee_records.py
@@ -1,13 +1,12 @@
 import argparse
 
-from django.db import transaction
-
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
     # TODO(rsebille): Delete this management command in 2025
 
     def add_arguments(self, parser):
@@ -20,7 +19,6 @@ class Command(BaseCommand):
         parser.add_argument("siae_id", type=int)
         parser.add_argument("--wet-run", action="store_true")
 
-    @transaction.atomic()
     def handle(self, *, employee_list_file, siae_id, wet_run, **options):
         self.stdout.write("Start moving employee records from archive")
 

--- a/itou/metabase/management/commands/metabase_data.py
+++ b/itou/metabase/management/commands/metabase_data.py
@@ -3,7 +3,6 @@ from urllib.parse import unquote
 
 from django.conf import settings
 from django.core.cache import caches
-from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -15,6 +14,8 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     CACHE_NAME = "stats"
 
     KPI_TO_FETCH = {
@@ -103,7 +104,6 @@ class Command(BaseCommand):
             print(repr(value))
             print()
 
-    @transaction.atomic()
     def fetch_stalled_job_seekers(self, *, wet_run):
         client = Client(settings.METABASE_SITE_URL)
 

--- a/itou/prescribers/management/commands/sync_ft_organizations.py
+++ b/itou/prescribers/management/commands/sync_ft_organizations.py
@@ -68,6 +68,8 @@ def fill_organization_from_api_data(obj, siret, data):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     help = "Synchronize 'agences' informations from the FT API."
 
     def add_arguments(self, parser):
@@ -139,7 +141,6 @@ class Command(BaseCommand):
                 if wet_run:
                     item.db_obj.save()
 
-    @transaction.atomic
     def handle(self, *, action, wet_run=False, **options):
         data = pole_emploi_partenaire_api_client().agences()
         match action:

--- a/itou/scripts/management/commands/add_admin_for_company_group.py
+++ b/itou/scripts/management/commands/add_admin_for_company_group.py
@@ -1,5 +1,3 @@
-from django.db import transaction
-
 from itou.communications.models import NotificationRecord, NotificationSettings
 from itou.companies.models import Company, CompanyMembership
 from itou.users.models import User
@@ -14,6 +12,8 @@ def notification_record(name):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         parser.add_argument("user", type=int, help="PK of the user to add to companies")
         parser.add_argument(
@@ -34,7 +34,6 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
-    @transaction.atomic
     def handle(self, user, sirens, *, disabled_notifications=None, wet_run=False, **options):
         user = User.objects.get(pk=user)
         self.stdout.write(f"Add {user=} for {sirens=} with {disabled_notifications=}")

--- a/itou/scripts/management/commands/create_asp_employee_records.py
+++ b/itou/scripts/management/commands/create_asp_employee_records.py
@@ -2,7 +2,6 @@ import argparse
 import csv
 
 from django.core.exceptions import ValidationError
-from django.db import transaction
 from django.utils import timezone
 
 from itou.approvals.models import Approval
@@ -17,6 +16,8 @@ from itou.utils.command import BaseCommand
 class Command(BaseCommand):
     """Used to create employee records for approvals and EITI companies already known by the ASP"""
 
+    ATOMIC_HANDLE = True
+
     CSV_SEPARATOR = ";"
 
     def add_arguments(self, parser):
@@ -27,7 +28,6 @@ class Command(BaseCommand):
         )
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    @transaction.atomic
     def handle(self, file, *, wet_run=False, **options):
         now = timezone.now()
         siret_to_siaes = {}

--- a/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
+++ b/itou/siae_evaluations/management/commands/evaluation_campaign_notify.py
@@ -1,5 +1,4 @@
 from dateutil.relativedelta import relativedelta
-from django.db import transaction
 from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 
@@ -10,7 +9,8 @@ from itou.utils.emails import send_email_messages
 
 
 class Command(BaseCommand):
-    @transaction.atomic
+    ATOMIC_HANDLE = True
+
     def handle(self, **options):
         today = timezone.localdate()
         campaigns = EvaluationCampaign.objects.filter(ended_at=None).select_related("institution")

--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.models import Group, Permission
-from django.db import transaction
 
 from itou.utils.command import BaseCommand
 
@@ -152,9 +151,10 @@ def to_perm_codenames(model, perms_set):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     help = "Synchronize groups and permissions."
 
-    @transaction.atomic
     def handle(self, **options):
         for group, raw_permissions in sorted(get_permissions_dict().items()):
             all_codenames = [


### PR DESCRIPTION
## :thinking: Pourquoi ?

Erreur en prod :
[LES-EMPLOIS-PROD-E5](https://inclusion.sentry.io/issues/51937791/)
[LES-EMPLOIS-PROD-E6](https://inclusion.sentry.io/issues/51978404/)

Le `set_config()` est local donc si il est appelé en dehors d'un bloc transactionnel la valeur est "perdue".

Ce n'est pas visible dans les tests car une transaction est ouverte par défaut, donc à défaut je lève une exception dans `triggers.context()` si on n'est pas dans un bloc _atomic_ afin d'orienter plus facilement sur le problème :).

## :desert_island: Comment tester ?

Lancer l'import SIAE ou `metabase_data stalled-job-seekers --wet-run`
