### PR TITLE
Vie privée : correction de la prédiction du genre à partir du NIR

### DIFF
--- a/itou/archive/management/commands/anonymize_jobseekers.py
+++ b/itou/archive/management/commands/anonymize_jobseekers.py
@@ -23,6 +23,8 @@ BATCH_SIZE = 100
 
 
 def anonymized_jobseeker(user):
+    profile = user.jobseeker_profile
+
     return AnonymizedJobSeeker(
         date_joined=get_year_month_or_none(user.date_joined),
         first_login=get_year_month_or_none(user.first_login),
@@ -31,12 +33,12 @@ def anonymized_jobseeker(user):
         department=user.department,
         title=user.title,
         identity_provider=user.identity_provider,
-        had_pole_emploi_id=bool(user.jobseeker_profile.pole_emploi_id),
-        had_nir=bool(user.jobseeker_profile.nir),
-        lack_of_nir_reason=user.jobseeker_profile.lack_of_nir_reason,
-        nir_sex=user.jobseeker_profile.nir[0] if user.jobseeker_profile.nir else None,
-        nir_year=user.jobseeker_profile.nir[1:3] if user.jobseeker_profile.nir else None,
-        birth_year=user.jobseeker_profile.birthdate.year if user.jobseeker_profile.birthdate else None,
+        had_pole_emploi_id=bool(profile.pole_emploi_id),
+        had_nir=bool(profile.nir),
+        lack_of_nir_reason=profile.lack_of_nir_reason,
+        nir_sex=profile.nir[0] if profile.nir and profile.nir[0] in ("1", "2") else None,
+        nir_year=profile.nir[1:3] if profile.nir else None,
+        birth_year=profile.birthdate.year if profile.birthdate else None,
         count_accepted_applications=user.count_accepted_applications,
         count_IAE_applications=user.count_IAE_applications,
         count_total_applications=user.count_total_applications,

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -1,9 +1,9 @@
 # serializer version: 1
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_not_is_active][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 10, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '', 'title': 'M', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 7, 'nir_year': 41, 'birth_year': 1964, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 0}]>
+  <QuerySet [{'date_joined': datetime.date(2023, 10, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '', 'title': 'M', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': None, 'nir_year': 41, 'birth_year': 1964, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 0}]>
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2021, 12, 1), 'first_login': datetime.date(2021, 12, 1), 'last_login': datetime.date(2021, 12, 1), 'user_signup_kind': 'employer', 'department': '', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': True, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 6, 'nir_year': 55, 'birth_year': 1990, 'count_accepted_applications': 1, 'count_IAE_applications': 0, 'count_total_applications': 2}]>
+  <QuerySet [{'date_joined': datetime.date(2021, 12, 1), 'first_login': datetime.date(2021, 12, 1), 'last_login': datetime.date(2021, 12, 1), 'user_signup_kind': 'employer', 'department': '', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': True, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 55, 'birth_year': 1990, 'count_accepted_applications': 1, 'count_IAE_applications': 0, 'count_total_applications': 2}]>
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_body]
   '''
@@ -22,7 +22,7 @@
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2020, 4, 1), 'first_login': datetime.date(2020, 4, 1), 'last_login': datetime.date(2020, 4, 1), 'user_signup_kind': 'prescriber', 'department': '', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': True, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 8, 'nir_year': 55, 'birth_year': 1985, 'count_accepted_applications': 1, 'count_IAE_applications': 2, 'count_total_applications': 2}]>
+  <QuerySet [{'date_joined': datetime.date(2020, 4, 1), 'first_login': datetime.date(2020, 4, 1), 'last_login': datetime.date(2020, 4, 1), 'user_signup_kind': 'prescriber', 'department': '', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': True, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': None, 'nir_year': 55, 'birth_year': 1985, 'count_accepted_applications': 1, 'count_IAE_applications': 2, 'count_total_applications': 2}]>
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_body]
   '''

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -484,7 +484,7 @@ class TestAnonymizeJobseekersManagementCommand:
                     "last_login": timezone.make_aware(datetime.datetime(2021, 12, 14, 0, 0)),
                     "created_by": EmployerFactory,
                     "jobseeker_profile__pole_emploi_id": "45678123",
-                    "jobseeker_profile__nir": "655456789012345",
+                    "jobseeker_profile__nir": "255456789012345",
                     "jobseeker_profile__lack_of_nir_reason": "",
                     "jobseeker_profile__birthdate": datetime.date(1990, 12, 15),
                 },


### PR DESCRIPTION
## :thinking: Pourquoi ?

`nir_sex` est imprévisible lorsque le demandeur d'emploi a un NIR temporaire commençant par 3,4,7 ou 8

