### PR TITLE
GPS: Nettoyage automatique de l'ID unique utilisé lors des échanges avec FT si les informations du compte candidat changent

### DIFF
--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -491,7 +491,10 @@ class User(AbstractUser, AddressMixin):
             if self.has_data_changed(["last_name", "first_name"]) and not self._state.adding:
                 self.jobseeker_profile.pe_obfuscated_nir = None
                 self.jobseeker_profile.pe_last_certification_attempt_at = None
-                self.jobseeker_profile.save(update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at"])
+                self.jobseeker_profile.ft_gps_id = None
+                self.jobseeker_profile.save(
+                    update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at", "ft_gps_id"]
+                )
                 self.jobseeker_profile.identity_certifications.filter(
                     certifier=IdentityCertificationAuthorities.API_FT_RECHERCHE_INDIVIDU_CERTIFIE
                 ).delete()
@@ -1251,8 +1254,13 @@ class JobSeekerProfile(models.Model):
         if self.has_data_changed(["birthdate", "nir"]) and not self._state.adding:
             self.pe_obfuscated_nir = None
             self.pe_last_certification_attempt_at = None
+            self.ft_gps_id = None
             if update_fields is not None:
-                update_fields = set(update_fields) | {"pe_obfuscated_nir", "pe_last_certification_attempt_at"}
+                update_fields = set(update_fields) | {
+                    "pe_obfuscated_nir",
+                    "pe_last_certification_attempt_at",
+                    "ft_gps_id",
+                }
             self.identity_certifications.filter(
                 certifier=IdentityCertificationAuthorities.API_FT_RECHERCHE_INDIVIDU_CERTIFIE
             ).delete()

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1277,7 +1277,7 @@ def test_save_creates_a_job_seeker_profile(user_kind, profile_expected):
 
 
 @freezegun.freeze_time("2022-08-10")
-def test_save_erases_pe_obfuscated_nir_if_details_change():
+def test_save_erases_ft_fields_if_details_change():
     UserFactory(
         email="foobar@truc.com",
         kind=UserKind.JOB_SEEKER,
@@ -1289,7 +1289,10 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     def reset_profile():
         user.jobseeker_profile.pe_last_certification_attempt_at = timezone.now()
         user.jobseeker_profile.pe_obfuscated_nir = "XXX_1234567890123_YYY"
-        user.jobseeker_profile.save(update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at"])
+        user.jobseeker_profile.ft_gps_id = "7f4d1259-78e3-4818-b357-5befea239990"
+        user.jobseeker_profile.save(
+            update_fields=["pe_obfuscated_nir", "pe_last_certification_attempt_at", "ft_gps_id"]
+        )
         IdentityCertification.objects.upsert_certifications(
             [
                 IdentityCertification(
@@ -1306,6 +1309,7 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     profile.refresh_from_db()
     assert profile.pe_obfuscated_nir is None
     assert profile.pe_last_certification_attempt_at is None
+    assert profile.ft_gps_id is None
     assertQuerySetEqual(profile.identity_certifications.all(), [])
 
     reset_profile()
@@ -1315,6 +1319,7 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     user.jobseeker_profile.refresh_from_db()
     assert user.jobseeker_profile.pe_obfuscated_nir is None
     assert user.jobseeker_profile.pe_last_certification_attempt_at is None
+    assert user.jobseeker_profile.ft_gps_id is None
     assertQuerySetEqual(profile.identity_certifications.all(), [])
 
     reset_profile()
@@ -1324,6 +1329,7 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     user.jobseeker_profile.refresh_from_db()
     assert user.jobseeker_profile.pe_obfuscated_nir is None
     assert user.jobseeker_profile.pe_last_certification_attempt_at is None
+    assert user.jobseeker_profile.ft_gps_id is None
     assertQuerySetEqual(profile.identity_certifications.all(), [])
 
     reset_profile()
@@ -1333,6 +1339,7 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     user.jobseeker_profile.refresh_from_db()
     assert user.jobseeker_profile.pe_obfuscated_nir is None
     assert user.jobseeker_profile.pe_last_certification_attempt_at is None
+    assert user.jobseeker_profile.ft_gps_id is None
     assertQuerySetEqual(profile.identity_certifications.all(), [])
 
     reset_profile()
@@ -1349,6 +1356,7 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     assert user.jobseeker_profile.pe_last_certification_attempt_at == datetime.datetime(
         2022, 8, 10, 0, 0, 0, 0, tzinfo=datetime.UTC
     )
+    assert user.jobseeker_profile.ft_gps_id == "7f4d1259-78e3-4818-b357-5befea239990"
     assertQuerySetEqual(
         profile.identity_certifications.values_list("certifier", flat=True),
         [IdentityCertificationAuthorities.API_FT_RECHERCHE_INDIVIDU_CERTIFIE],

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1355,20 +1355,6 @@ def test_save_erases_pe_obfuscated_nir_if_details_change():
     )
 
 
-@pytest.mark.parametrize("initial", [None, ""])
-def test_save_erases_pe_obfuscated_nir_when_the_nir_changes_after_a_failed_attempt(faker, initial):
-    profile = JobSeekerProfileFactory(
-        pe_obfuscated_nir=initial,
-        pe_last_certification_attempt_at=faker.date_time(tzinfo=datetime.UTC),
-    )
-    profile = JobSeekerProfile.objects.get(pk=profile.pk)  # trigger the .from_db() to fill `_old_values`
-
-    assert profile.pe_last_certification_attempt_at is not None
-    profile.nir = faker.ssn()
-    profile.save(update_fields={"nir"})
-    assert profile.pe_last_certification_attempt_at is None
-
-
 @pytest.mark.parametrize("user_active", [False, True])
 @pytest.mark.parametrize("membership_active", [False, True])
 @pytest.mark.parametrize("organization_authorized", [False, True])


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cet identifiant permet à FT de faciliter le calcul du référent (c'est a priori une PK de leur datalake).
Si une partie des informations de l'utilisateur change, il faut que FT vérifie et nous renvoie l'identifiant pour qu'on soit sur de récupérer le bon référent.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
