### PR TITLE
admin : Réutiliser get_structure_view_link pour Approval.assign_company

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -377,11 +377,7 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
     def assigned_company(self, obj):
         if obj.assigned_company:
             company = Company.objects.get(pk=obj.assigned_company)
-            return format_html(
-                "{} — SIRET : {}",
-                get_admin_view_link(company, content=company.display_name),
-                company.siret,
-            )
+            return get_structure_view_link(company, display_attr="display_name")
         return self.get_empty_value_display()
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mutualiser le code au lieu de réinventer la roue. Cela permettre (très) bientôt d’ajouter la PK dans l’affichage des structures.
