### PR TITLE
admin : Afficher la PK de la structure

### DIFF
--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -29,6 +29,8 @@ def get_structure_view_link(structure, display_attr="name"):
         format_kwargs["siret"] = structure.siret
     format_string += " ({kind})"
     format_kwargs["kind"] = structure.kind
+    format_string += " — PK: {pk}"
+    format_kwargs["pk"] = structure.pk
     return format_html(format_string, **format_kwargs)
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

La clé primaire est souvent requise pour les `raw_id_fields`, par exemple pour les demandes de prolongation. L’afficher fréquemment évite des actions supplémentaires pour trouver la clé primaire d’une organisation.
