### PR TITLE
Pilotage - Tableau de bord : Vérification des droits en amont plutôt qu'en aval

### DIFF
--- a/itou/www/stats/utils.py
+++ b/itou/www/stats/utils.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core.cache import caches
-from django.core.exceptions import PermissionDenied
 
 from itou.common_apps.address.departments import DEPARTMENTS, REGIONS
 from itou.companies.models import Company
@@ -170,17 +169,15 @@ def can_view_stats_staff(request):
     return request.user.is_authenticated and (request.user.kind == UserKind.ITOU_STAFF or request.user.is_staff)
 
 
-def get_stats_ft_departments(request):
-    if not can_view_stats_ft(request):
-        raise PermissionDenied
-    if request.current_organization.is_dgft:
+def get_stats_ft_departments(current_organization):
+    if current_organization.is_dgft:
         return DEPARTMENTS.keys()
-    if request.current_organization.is_drft:
-        return REGIONS[request.current_organization.region]
-    if request.current_organization.is_dtft:
-        departments = DTFT_SAFIR_CODE_TO_DEPARTMENTS[request.current_organization.code_safir_pole_emploi]
-        return [request.current_organization.department] if departments is None else departments
-    return [request.current_organization.department]
+    if current_organization.is_drft:
+        return REGIONS[current_organization.region]
+    if current_organization.is_dtft:
+        departments = DTFT_SAFIR_CODE_TO_DEPARTMENTS[current_organization.code_safir_pole_emploi]
+        return [current_organization.department] if departments is None else departments
+    return [current_organization.department]
 
 
 def get_stats_for_institution(institution: Institution, datum_key: DatumKey, *, is_percentage=False):

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -517,7 +517,7 @@ def stats_ph_beneficiaries(request):
     )
 
 
-def render_stats_ddets(request, page_title, extra_context, extend_stats_to_whole_region, params=None):
+def render_stats_ddets(request, *, page_title, extra_context=None, extend_stats_to_whole_region=False):
     department = request.current_organization.department
     department_label = DEPARTMENTS[department]
     region = request.current_organization.region
@@ -532,32 +532,18 @@ def render_stats_ddets(request, page_title, extra_context, extend_stats_to_whole
     if extra_context:
         context.update(extra_context)
 
-    if params is None:
-        if extend_stats_to_whole_region:
-            params = get_params_for_region(region)
-        else:
-            params = get_params_for_departement(department)
+    params = get_params_for_region(region) if extend_stats_to_whole_region else get_params_for_departement(department)
     return render_stats(request=request, context=context, params=params)
-
-
-def render_stats_ddets_iae(request, page_title, extra_context=None, extend_stats_to_whole_region=False, params=None):
-    return render_stats_ddets(
-        request=request,
-        page_title=page_title,
-        extra_context=extra_context,
-        extend_stats_to_whole_region=extend_stats_to_whole_region,
-        params=params,
-    )
 
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_auto_prescription(request):
-    return render_stats_ddets_iae(request=request, page_title="Analyse des auto-prescriptions et de leur contrôle")
+    return render_stats_ddets(request=request, page_title="Analyse des auto-prescriptions et de leur contrôle")
 
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_ph_prescription(request):
-    return render_stats_ddets_iae(request=request, page_title="Analyse des candidatures émises et de leur traitement")
+    return render_stats_ddets(request=request, page_title="Analyse des candidatures émises et de leur traitement")
 
 
 @check_request(utils.can_view_stats_ddets_iae)
@@ -566,14 +552,14 @@ def stats_ddets_iae_siae_evaluation(request):
         "back_url": reverse("siae_evaluations_views:samples_selection"),
         "show_siae_evaluation_message": True,
     }
-    return render_stats_ddets_iae(
+    return render_stats_ddets(
         request=request, page_title="Données du contrôle a posteriori", extra_context=extra_context
     )
 
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_hiring(request):
-    return render_stats_ddets_iae(
+    return render_stats_ddets(
         request=request,
         page_title="Analyse des candidatures reçues et de leur traitement",
     )
@@ -581,7 +567,7 @@ def stats_ddets_iae_hiring(request):
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_state(request):
-    return render_stats_ddets_iae(
+    return render_stats_ddets(
         request=request,
         page_title="Analyse des candidatures émises par les acteurs AHI",
         extend_stats_to_whole_region=True,
@@ -590,24 +576,15 @@ def stats_ddets_iae_state(request):
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_orga_etp(request):
-    return render_stats_ddets_iae(
+    return render_stats_ddets(
         request=request,
         page_title="Suivi des effectifs annuels et mensuels (ETP)",
     )
 
 
-def render_stats_ddets_log(request, page_title, extend_stats_to_whole_region):
-    return render_stats_ddets(
-        request=request,
-        page_title=page_title,
-        extra_context=None,
-        extend_stats_to_whole_region=extend_stats_to_whole_region,
-    )
-
-
 @check_request(utils.can_view_stats_ddets_log)
 def stats_ddets_log_state(request):
-    return render_stats_ddets_log(
+    return render_stats_ddets(
         request=request,
         page_title="Suivi des prescriptions des AHI de ma région",
         extend_stats_to_whole_region=True,

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -353,7 +353,7 @@ def render_stats_ft(request, page_title, extra_params=None, *, with_region_param
     current_org = get_current_org_or_404(request)
     if not utils.can_view_stats_ft(request):
         raise PermissionDenied
-    departments = utils.get_stats_ft_departments(request)
+    departments = utils.get_stats_ft_departments(current_org)
     params = {
         mb.DEPARTMENT_FILTER_KEY: [DEPARTMENTS[d] for d in departments],
     }

--- a/tests/www/stats/test_utils.py
+++ b/tests/www/stats/test_utils.py
@@ -55,7 +55,7 @@ def test_can_view_stats_ft_as_regular_ft_agency():
     assert not regular_fr_agency.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_ft(request)
-    assert utils.get_stats_ft_departments(request) == ["93"]
+    assert utils.get_stats_ft_departments(regular_fr_agency) == ["93"]
 
 
 def test_can_view_stats_ft_as_dtft_with_single_department():
@@ -71,7 +71,7 @@ def test_can_view_stats_ft_as_dtft_with_single_department():
     assert not dtft_with_single_department.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_ft(request)
-    assert utils.get_stats_ft_departments(request) == ["49"]
+    assert utils.get_stats_ft_departments(dtft_with_single_department) == ["49"]
 
 
 def test_can_view_stats_ft_as_dtft_with_multiple_departments():
@@ -87,7 +87,7 @@ def test_can_view_stats_ft_as_dtft_with_multiple_departments():
     assert not dtft_with_multiple_departments.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_ft(request)
-    assert utils.get_stats_ft_departments(request) == ["72", "53"]
+    assert utils.get_stats_ft_departments(dtft_with_multiple_departments) == ["72", "53"]
 
 
 def test_can_view_stats_ft_as_drft():
@@ -103,7 +103,7 @@ def test_can_view_stats_ft_as_drft():
     assert not drft.is_dtft
     request = get_request(user)
     assert utils.can_view_stats_ft(request)
-    assert utils.get_stats_ft_departments(request) == [
+    assert utils.get_stats_ft_departments(drft) == [
         "75",
         "77",
         "78",
@@ -128,7 +128,7 @@ def test_can_view_stats_ft_as_dgft():
     assert dgft.is_dgft
     request = get_request(user)
     assert utils.can_view_stats_ft(request)
-    assert utils.get_stats_ft_departments(request)
+    assert utils.get_stats_ft_departments(dgft)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## :thinking: Pourquoi ?

- Limiter les erreurs :
  [LES-EMPLOIS-PROD-9W](https://inclusion.sentry.io/issues/45759330/)
  [LES-EMPLOIS-PROD-AN](https://inclusion.sentry.io/issues/46708856/)
  [LES-EMPLOIS-PROD-C2](https://inclusion.sentry.io/issues/49901552/)
  [LES-EMPLOIS-PROD-96](https://inclusion.sentry.io/issues/44630899/)
- Plus explicite sur l'attendu d'avoir la gestion d'accès à l'entrée de la vue que 2 ou 3 appels de fonction plus tard