### PR TITLE
[GEN-2577] [API] Client Pôle emploi : ajout du endpoint RQTH

### DIFF
--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -354,14 +354,18 @@ class PoleEmploiRoyaumeAgentAPIClient(BasePoleEmploiApiClient):
             headers = {**headers, **additional_headers}
 
         try:
-            response = httpx.request(
-                method,
-                url,
-                params=params,
-                json=data,
-                headers=headers,
-                timeout=API_TIMEOUT_SECONDS,
-            ).raise_for_status()
+            response = (
+                self._get_httpx_client()
+                .request(
+                    method,
+                    url,
+                    params=params,
+                    json=data,
+                    headers=headers,
+                    timeout=API_TIMEOUT_SECONDS,
+                )
+                .raise_for_status()
+            )
         except httpx.HTTPStatusError as exc:
             match exc.response.status_code:
                 case 429:

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -461,3 +461,12 @@ def pole_emploi_partenaire_api_client():
         settings.API_ESD["KEY"],
         settings.API_ESD["SECRET"],
     )
+
+
+def pole_emploi_agent_api_client():
+    return PoleEmploiRoyaumeAgentAPIClient(
+        settings.API_ESD["BASE_URL"],
+        settings.API_ESD["AUTH_BASE_URL"],
+        settings.API_ESD["KEY"],
+        settings.API_ESD["SECRET"],
+    )

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -366,7 +366,7 @@ class PoleEmploiRoyaumeAgentAPIClient(BasePoleEmploiApiClient):
             match exc.response.status_code:
                 case 429:
                     raise PoleEmploiRateLimitException(error_code=429)
-                case 400 | 403 as error_code:
+                case 400 | 401 | 403 as error_code:
                     # Should not retry
                     raise PoleEmploiAPIBadResponse(
                         response_code=error_code, response_data=exc.response.json()

--- a/tests/utils/apis/test_pole_emploi_api.py
+++ b/tests/utils/apis/test_pole_emploi_api.py
@@ -644,7 +644,11 @@ class TestPoleEmploiRoyaumeAgentAPIClient:
 
         respx.get("https://pe.fake/donnees-rqth/v1/rqth").respond(200, json=json_response)
 
-        data = self.api_client.certify_rqth(jobseeker_profile=JobSeekerProfileFactory())
+        # The RQTH certification calls two endpoints: rechercher_usager and donnees_rqth.
+        # Use a context manager to reuse the same HTTP client.
+        # See BasePoleEmploiApiClient._httpx_client
+        with self.api_client as client:
+            data = client.certify_rqth(jobseeker_profile=JobSeekerProfileFactory())
         for key, value in expected_data.items():
             assert data[key] == value
         assert data["raw_response"] == json_response


### PR DESCRIPTION
Suite de https://github.com/gip-inclusion/les-emplois/pull/6544

## :thinking: Pourquoi ?

Ce endpoint permet de savoir si une personne bénéficie de la RQTH. Il sera utilisé pour certifier ce critère.
[Lien vers la documentation du endpoint](https://francetravail.io/produits-partages/catalogue/donnees-rqth/documentation#/api-reference/operations/lireDonneesValiditeRQTH) (authentification nécessaire).

## :cake: Comment ?

Ajout du endpoint.