### PR TITLE
admin : Réautoriser le support à modifier les fiches salarié

### DIFF
--- a/itou/users/management/commands/sync_group_and_perms.py
+++ b/itou/users/management/commands/sync_group_and_perms.py
@@ -75,7 +75,7 @@ def get_permissions_dict():
         eligibility_models.GEIQSelectedAdministrativeCriteria: PERMS_ALL,
         eligibility_models.SelectedAdministrativeCriteria: PERMS_ALL,
         emails_models.Email: PERMS_READ,
-        employee_record_models.EmployeeRecord: PERMS_DELETE,
+        employee_record_models.EmployeeRecord: PERMS_EDIT | PERMS_DELETE,
         employee_record_models.EmployeeRecordUpdateNotification: PERMS_READ,
         employee_record_models.EmployeeRecordTransitionLog: PERMS_READ,
         external_data_models.ExternalDataImport: PERMS_DELETE,

--- a/tests/users/__snapshots__/test_sync_group_and_perms.ambr
+++ b/tests/users/__snapshots__/test_sync_group_and_perms.ambr
@@ -164,6 +164,7 @@
     'delete_selectedadministrativecriteria',
     'view_selectedadministrativecriteria',
     'view_email',
+    'change_employeerecord',
     'delete_employeerecord',
     'view_employeerecord',
     'view_employeerecordtransitionlog',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Retirée avec 2fe90e99c0b779f15c33604c6dd2c07713c8a5a4.

L’équipe support a besoin de changer l’état des FS.
