### PR TITLE
Admin : Enrichir les fiches salarié avec les détails de l’entreprise

### DIFF
--- a/itou/employee_record/admin.py
+++ b/itou/employee_record/admin.py
@@ -11,7 +11,13 @@ from django.utils.html import format_html
 import itou.employee_record.models as models
 from itou.companies import models as companies_models
 from itou.employee_record.models import EmployeeRecordUpdateNotification
-from itou.utils.admin import ItouModelAdmin, ItouTabularInline, ReadonlyMixin, get_admin_view_link
+from itou.utils.admin import (
+    ItouModelAdmin,
+    ItouTabularInline,
+    ReadonlyMixin,
+    get_admin_view_link,
+    get_structure_view_link,
+)
 from itou.utils.templatetags.str_filters import pluralizefr
 
 
@@ -186,7 +192,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
         "job_application",
         "job_seeker_link",
         "job_seeker_profile_link",
-        "siret",
+        "company_link",
         "asp_id",
         "asp_measure",
         "asp_processing_type",
@@ -224,7 +230,7 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
                     "approval_number_link",
                     "job_seeker_link",
                     "job_seeker_profile_link",
-                    "siret",
+                    "company_link",
                     "asp_measure",
                     "asp_id",
                     "financial_annex",
@@ -271,6 +277,18 @@ class EmployeeRecordAdmin(ASPExchangeInformationAdminMixin, ItouModelAdmin):
     def job_seeker_profile_link(self, obj):
         job_seeker_profile = obj.job_application.job_seeker.jobseeker_profile
         return get_admin_view_link(job_seeker_profile, content=f"Profil salarié ID:{job_seeker_profile.pk}")
+
+    @admin.display(description="Structure mère")
+    def company_link(self, obj):
+        try:
+            asp_company = companies_models.Company.objects.get(
+                siret=obj.siret,
+                pk=obj.job_application.to_company.canonical_company.pk,
+            )
+        except (companies_models.Company.DoesNotExist, companies_models.Company.MultipleObjectsReturned):
+            return obj.siret
+        else:
+            return get_structure_view_link(asp_company, display_attr="display_name")
 
     @admin.display(description="type de traitement")
     def asp_processing_type(self, obj):

--- a/tests/employee_record/test_admin.py
+++ b/tests/employee_record/test_admin.py
@@ -77,13 +77,30 @@ def test_job_seeker_profile_from_employee_record(admin_client):
     assertContains(response, job_seeker.jobseeker_profile.pk)
 
 
-def test_approval_number_from_employee_record(admin_client):
+def test_related_objects_display(admin_client):
     er = factories.EmployeeRecordFactory()
+    company = er.job_application.to_company
     approval_number = Approval.objects.get(number=er.approval_number)
     employee_record_view_url = reverse("admin:employee_record_employeerecord_change", args=[er.pk])
     approval_number_url = reverse("admin:approvals_approval_change", args=[approval_number.pk])
+    company_url = reverse("admin:companies_company_change", args=(company.pk,))
     response = admin_client.get(employee_record_view_url)
     assertContains(response, f'<a href="{approval_number_url}">{approval_number.number}</a>')
+    assertContains(
+        response,
+        f"""\
+        <div class="flex-container">
+          <label>Structure mère :</label>
+          <div class="readonly">
+              <a href="{company_url}">{company.display_name}</a>
+              — SIRET {company.siret} ({company.kind})
+              — PK: {company.pk}
+          </div>
+        </div>
+        """,
+        html=True,
+        count=1,
+    )
 
 
 def test_employee_record_deletion(admin_client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lorsque c’est possible, ajouter le nom, le type et la PK de l’entreprise. Dans le cas où l’annexe financière n’est pas disponible (supprimée), continuer d’afficher simplement le SIRET.
