### PR TITLE
Prescripteur : Supprimer le bandeau de prise de rendez-vous d'entretiens utilisateur

### DIFF
--- a/itou/templates/apply/list_prescriptions.html
+++ b/itou/templates/apply/list_prescriptions.html
@@ -21,28 +21,6 @@
             </a>
         {% endfragment %}
     {% endcomponent_title %}
-
-    {% if request.from_authorized_prescriber %}
-        <div id="prescriber-interview-2025-07" class="alert alert-important alert-dismissible-once d-none" role="status">
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
-            <div class="row">
-                <div class="col-auto pe-0">
-                    <i class="ri-information-line ri-xl text-important" aria-hidden="true"></i>
-                </div>
-                <div class="col">
-                    <p class="mb-2">
-                        <strong>Votre avis nous intéresse</strong>
-                    </p>
-                    <p class="mb-0">
-                        Aidez-nous à améliorer les Emplois de l'inclusion en partageant votre expérience au cours d’un entretien utilisateur.
-                    </p>
-                </div>
-                <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
-                    <a href="https://calendly.com/justine-moreau-beta-gouv/30min" target="_blank" rel="noreferrer" class="btn btn-sm btn-primary has-external-link">Prendre un rendez-vous</a>
-                </div>
-            </div>
-        </div>
-    {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il y a eu suffisamment de prises de rendez-vous.

https://gip-inclusion.slack.com/archives/CU8ATF54L/p1753428999514309?thread_ts=1753340123.606429&cid=CU8ATF54L

