### PR TITLE
Employeur : modifier le texte du bandeau d'info avant dépublication des fiches de poste [GEN-2620]

### DIFF
--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -67,7 +67,7 @@
                 {% if request.user.is_employer and request.current_organization and request.current_organization.has_job_descriptions_not_updated_recently %}
                     <div class="alert alert-info fade show" role="status" id="deactivation-job-banner">
                         <p class="mb-0">
-                            <strong>Attention</strong> : Très prochainement, vos fiches de poste qui n’ont pas été actualisées depuis plus de 3 mois seront automatiquement dépubliées. <a href="{% url "companies_views:job_description_list" %}">Pensez à les mettre à jour pour maintenir leur visibilité</a>.
+                            Une ou plusieurs de vos fiches de poste n’ont pas été actualisées depuis plus de 2 mois. Elles seront automatiquement dépubliées après 3 mois sans mise à jour. <a href="{% url "companies_views:job_description_list" %}">Pensez à les mettre à jour pour maintenir leur visibilité</a>.
                         </p>
                     </div>
                 {% endif %}

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -30,8 +30,8 @@ from tests.utils.test import assertSnapshotQueries, parse_response_to_soup, pret
 
 POSTULER = "Postuler"
 REMINDER_BANNER = (
-    '<p class="mb-0"><strong>Attention</strong> : Très prochainement, vos fiches de poste qui n’ont pas été '
-    "actualisées depuis plus de 3 mois seront automatiquement dépubliées. "
+    '<p class="mb-0"> Une ou plusieurs de vos fiches de poste n’ont pas été actualisées depuis plus de 2 mois. '
+    "Elles seront automatiquement dépubliées après 3 mois sans mise à jour. "
     f'<a href="{reverse("companies_views:job_description_list")}">Pensez à les mettre à jour pour maintenir '
     "leur visibilité</a>.</p>"
 )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour pérenniser le message.

