### PR TITLE
Vie privée : rendre les snapshots plus lisibles dans les tests

### DIFF
--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -24,10 +24,56 @@
   ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_not_is_active][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 10, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '', 'title': 'M', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 7, 'nir_year': 41, 'birth_year': 1964, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 0, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1964,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 0,
+      'date_joined': datetime.date(2023, 10, 1),
+      'department': '',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 7,
+      'nir_year': 41,
+      'title': 'M',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2021, 12, 1), 'first_login': datetime.date(2021, 12, 1), 'last_login': datetime.date(2021, 12, 1), 'user_signup_kind': 'employer', 'department': '', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': True, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 6, 'nir_year': 55, 'birth_year': 1990, 'count_accepted_applications': 1, 'count_IAE_applications': 0, 'count_total_applications': 2, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1990,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 1,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 2,
+      'date_joined': datetime.date(2021, 12, 1),
+      'department': '',
+      'first_approval_start_at': None,
+      'first_login': datetime.date(2021, 12, 1),
+      'had_nir': True,
+      'had_pole_emploi_id': True,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': datetime.date(2021, 12, 1),
+      'nir_sex': 6,
+      'nir_year': 55,
+      'title': 'MME',
+      'user_signup_kind': 'employer',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_employer][archived_jobseeker_email_body]
   '''
@@ -46,7 +92,30 @@
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2020, 4, 1), 'first_login': datetime.date(2020, 4, 1), 'last_login': datetime.date(2020, 4, 1), 'user_signup_kind': 'prescriber', 'department': '', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': True, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 8, 'nir_year': 55, 'birth_year': 1985, 'count_accepted_applications': 1, 'count_IAE_applications': 2, 'count_total_applications': 2, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1985,
+      'count_IAE_applications': 2,
+      'count_accepted_applications': 1,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 2,
+      'date_joined': datetime.date(2020, 4, 1),
+      'department': '',
+      'first_approval_start_at': None,
+      'first_login': datetime.date(2020, 4, 1),
+      'had_nir': True,
+      'had_pole_emploi_id': True,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': datetime.date(2020, 4, 1),
+      'nir_sex': 8,
+      'nir_year': 55,
+      'title': 'MME',
+      'user_signup_kind': 'prescriber',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_all_datas_created_by_prescriber][archived_jobseeker_email_body]
   '''
@@ -65,7 +134,30 @@
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2022, 11, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '', 'title': 'M', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': False, 'lack_of_nir_reason': 'reason', 'nir_sex': None, 'nir_year': None, 'birth_year': None, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 0, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': None,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 0,
+      'date_joined': datetime.date(2022, 11, 1),
+      'department': '',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': False,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': 'reason',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': None,
+      'nir_year': None,
+      'title': 'M',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_inactive_jobseekers_after_grace_period[jobseeker_with_very_few_datas][archived_jobseeker_email_body]
   '''
@@ -356,52 +448,459 @@
   ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_jobseeker_with_several_approvals[anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 8, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '35', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1990, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 0, 'count_approvals': 2, 'first_approval_start_at': datetime.date(2019, 4, 1), 'last_approval_end_at': datetime.date(2023, 5, 1), 'count_eligibility_diagnoses': 2}]>
+  list([
+    dict({
+      'birth_year': 1990,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 0,
+      'count_approvals': 2,
+      'count_eligibility_diagnoses': 2,
+      'count_total_applications': 0,
+      'date_joined': datetime.date(2023, 8, 1),
+      'department': '35',
+      'first_approval_start_at': datetime.date(2019, 4, 1),
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': datetime.date(2023, 5, 1),
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_jobseeker_with_several_eligibility_diagnoses[anonymized_geiq_eligibility_diagnoses]
-  <QuerySet [{'created_at': datetime.date(2025, 7, 1), 'expired_at': datetime.date(2026, 1, 1), 'job_seeker_birth_year': 1990, 'job_seeker_department': '35', 'author_kind': 'prescriber', 'author_prescriber_organization_kind': 'FT', 'number_of_administrative_criteria': 0, 'number_of_administrative_criteria_level_1': 0, 'number_of_administrative_criteria_level_2': 0, 'number_of_certified_administrative_criteria': 0, 'selected_administrative_criteria': [None], 'number_of_job_applications': 0, 'number_of_accepted_job_applications': 0}]>
+  list([
+    dict({
+      'author_kind': 'prescriber',
+      'author_prescriber_organization_kind': 'FT',
+      'created_at': datetime.date(2025, 7, 1),
+      'expired_at': datetime.date(2026, 1, 1),
+      'job_seeker_birth_year': 1990,
+      'job_seeker_department': '35',
+      'number_of_accepted_job_applications': 0,
+      'number_of_administrative_criteria': 0,
+      'number_of_administrative_criteria_level_1': 0,
+      'number_of_administrative_criteria_level_2': 0,
+      'number_of_certified_administrative_criteria': 0,
+      'number_of_job_applications': 0,
+      'selected_administrative_criteria': list([
+        None,
+      ]),
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_jobseeker_with_several_eligibility_diagnoses[anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 8, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '35', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1990, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 0, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 3}]>
+  list([
+    dict({
+      'birth_year': 1990,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 3,
+      'count_total_applications': 0,
+      'date_joined': datetime.date(2023, 8, 1),
+      'department': '35',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_jobseeker_with_several_eligibility_diagnoses[anonymized_siae_eligibility_diagnoses]
-  <QuerySet [{'created_at': datetime.date(2025, 7, 1), 'expired_at': datetime.date(2026, 1, 1), 'job_seeker_birth_year': 1990, 'job_seeker_department': '35', 'author_kind': 'prescriber', 'author_prescriber_organization_kind': 'FT', 'number_of_administrative_criteria': 0, 'number_of_administrative_criteria_level_1': 0, 'number_of_administrative_criteria_level_2': 0, 'number_of_certified_administrative_criteria': 0, 'selected_administrative_criteria': [None], 'number_of_job_applications': 0, 'number_of_accepted_job_applications': 0, 'author_siae_kind': None, 'number_of_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None}, {'created_at': datetime.date(2025, 7, 1), 'expired_at': datetime.date(2026, 1, 1), 'job_seeker_birth_year': 1990, 'job_seeker_department': '35', 'author_kind': 'prescriber', 'author_prescriber_organization_kind': 'FT', 'number_of_administrative_criteria': 0, 'number_of_administrative_criteria_level_1': 0, 'number_of_administrative_criteria_level_2': 0, 'number_of_certified_administrative_criteria': 0, 'selected_administrative_criteria': [None], 'number_of_job_applications': 0, 'number_of_accepted_job_applications': 0, 'author_siae_kind': None, 'number_of_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None}]>
+  list([
+    dict({
+      'author_kind': 'prescriber',
+      'author_prescriber_organization_kind': 'FT',
+      'author_siae_kind': None,
+      'created_at': datetime.date(2025, 7, 1),
+      'expired_at': datetime.date(2026, 1, 1),
+      'first_approval_start_at': None,
+      'job_seeker_birth_year': 1990,
+      'job_seeker_department': '35',
+      'last_approval_end_at': None,
+      'number_of_accepted_job_applications': 0,
+      'number_of_administrative_criteria': 0,
+      'number_of_administrative_criteria_level_1': 0,
+      'number_of_administrative_criteria_level_2': 0,
+      'number_of_approvals': 0,
+      'number_of_certified_administrative_criteria': 0,
+      'number_of_job_applications': 0,
+      'selected_administrative_criteria': list([
+        None,
+      ]),
+    }),
+    dict({
+      'author_kind': 'prescriber',
+      'author_prescriber_organization_kind': 'FT',
+      'author_siae_kind': None,
+      'created_at': datetime.date(2025, 7, 1),
+      'expired_at': datetime.date(2026, 1, 1),
+      'first_approval_start_at': None,
+      'job_seeker_birth_year': 1990,
+      'job_seeker_department': '35',
+      'last_approval_end_at': None,
+      'number_of_accepted_job_applications': 0,
+      'number_of_administrative_criteria': 0,
+      'number_of_administrative_criteria_level_1': 0,
+      'number_of_administrative_criteria_level_2': 0,
+      'number_of_approvals': 0,
+      'number_of_certified_administrative_criteria': 0,
+      'number_of_job_applications': 0,
+      'selected_administrative_criteria': list([
+        None,
+      ]),
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_authorized_prescriber][anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '76', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1978, 'count_accepted_applications': 0, 'count_IAE_applications': 1, 'count_total_applications': 1, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1978,
+      'count_IAE_applications': 1,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 1,
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '76',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_authorized_prescriber][archived_application]
-  <QuerySet [{'job_seeker_birth_year': 1978, 'job_seeker_department_same_as_company_department': False, 'sender_kind': 'prescriber', 'sender_company_kind': None, 'sender_prescriber_organization_kind': 'FT', 'sender_prescriber_organization_authorization_status': 'VALIDATED', 'company_kind': 'EITI', 'company_department': '14', 'company_naf': '8888Y', 'company_has_convention': True, 'applied_at': datetime.date(2025, 2, 1), 'processed_at': None, 'last_transition_at': datetime.date(2025, 2, 1), 'had_resume': True, 'origin': 'default', 'state': 'prior_to_hire', 'refusal_reason': '', 'had_been_transferred': False, 'number_of_jobs_applied_for': 0, 'had_diagoriente_invitation': False, 'had_approval': False, 'hiring_rome': None, 'hiring_contract_type': None, 'hiring_start_date': datetime.date(2025, 2, 1)}]>
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '14',
+      'company_has_convention': True,
+      'company_kind': 'EITI',
+      'company_naf': '8888Y',
+      'had_approval': False,
+      'had_been_transferred': False,
+      'had_diagoriente_invitation': False,
+      'had_resume': True,
+      'hiring_contract_type': None,
+      'hiring_rome': None,
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': False,
+      'last_transition_at': datetime.date(2025, 2, 1),
+      'number_of_jobs_applied_for': 0,
+      'origin': 'default',
+      'processed_at': None,
+      'refusal_reason': '',
+      'sender_company_kind': None,
+      'sender_kind': 'prescriber',
+      'sender_prescriber_organization_authorization_status': 'VALIDATED',
+      'sender_prescriber_organization_kind': 'FT',
+      'state': 'prior_to_hire',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_company][anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '76', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1978, 'count_accepted_applications': 0, 'count_IAE_applications': 1, 'count_total_applications': 1, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1978,
+      'count_IAE_applications': 1,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 1,
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '76',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[application_sent_by_company][archived_application]
-  <QuerySet [{'job_seeker_birth_year': 1978, 'job_seeker_department_same_as_company_department': True, 'sender_kind': 'employer', 'sender_company_kind': 'EI', 'sender_prescriber_organization_kind': None, 'sender_prescriber_organization_authorization_status': None, 'company_kind': 'EI', 'company_department': '76', 'company_naf': '4567A', 'company_has_convention': False, 'applied_at': datetime.date(2025, 2, 1), 'processed_at': None, 'last_transition_at': datetime.date(2025, 2, 1), 'had_resume': True, 'origin': 'default', 'state': 'processing', 'refusal_reason': '', 'had_been_transferred': False, 'number_of_jobs_applied_for': 0, 'had_diagoriente_invitation': False, 'had_approval': False, 'hiring_rome': None, 'hiring_contract_type': None, 'hiring_start_date': datetime.date(2025, 2, 1)}]>
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '76',
+      'company_has_convention': False,
+      'company_kind': 'EI',
+      'company_naf': '4567A',
+      'had_approval': False,
+      'had_been_transferred': False,
+      'had_diagoriente_invitation': False,
+      'had_resume': True,
+      'hiring_contract_type': None,
+      'hiring_rome': None,
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': True,
+      'last_transition_at': datetime.date(2025, 2, 1),
+      'number_of_jobs_applied_for': 0,
+      'origin': 'default',
+      'processed_at': None,
+      'refusal_reason': '',
+      'sender_company_kind': 'EI',
+      'sender_kind': 'employer',
+      'sender_prescriber_organization_authorization_status': None,
+      'sender_prescriber_organization_kind': None,
+      'state': 'processing',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[hired_jobseeker_with_3_jobs][anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '76', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1978, 'count_accepted_applications': 1, 'count_IAE_applications': 0, 'count_total_applications': 1, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1978,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 1,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 1,
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '76',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[hired_jobseeker_with_3_jobs][archived_application]
-  <QuerySet [{'job_seeker_birth_year': 1978, 'job_seeker_department_same_as_company_department': True, 'sender_kind': 'job_seeker', 'sender_company_kind': None, 'sender_prescriber_organization_kind': None, 'sender_prescriber_organization_authorization_status': None, 'company_kind': 'GEIQ', 'company_department': '76', 'company_naf': '1234Z', 'company_has_convention': True, 'applied_at': datetime.date(2025, 2, 1), 'processed_at': datetime.date(2025, 2, 1), 'last_transition_at': datetime.date(2025, 3, 1), 'had_resume': True, 'origin': 'default', 'state': 'accepted', 'refusal_reason': '', 'had_been_transferred': False, 'number_of_jobs_applied_for': 3, 'had_diagoriente_invitation': False, 'had_approval': False, 'hiring_rome': "Conduite d'engins de déplacement des charges (N1101)", 'hiring_contract_type': 'FIXED_TERM_TREMPLIN', 'hiring_start_date': datetime.date(2025, 2, 1)}]>
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '76',
+      'company_has_convention': True,
+      'company_kind': 'GEIQ',
+      'company_naf': '1234Z',
+      'had_approval': False,
+      'had_been_transferred': False,
+      'had_diagoriente_invitation': False,
+      'had_resume': True,
+      'hiring_contract_type': 'FIXED_TERM_TREMPLIN',
+      'hiring_rome': "Conduite d'engins de déplacement des charges (N1101)",
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': True,
+      'last_transition_at': datetime.date(2025, 3, 1),
+      'number_of_jobs_applied_for': 3,
+      'origin': 'default',
+      'processed_at': datetime.date(2025, 2, 1),
+      'refusal_reason': '',
+      'sender_company_kind': None,
+      'sender_kind': 'job_seeker',
+      'sender_prescriber_organization_authorization_status': None,
+      'sender_prescriber_organization_kind': None,
+      'state': 'accepted',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[refused_application_with_1_jobs][anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '76', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1978, 'count_accepted_applications': 0, 'count_IAE_applications': 0, 'count_total_applications': 1, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1978,
+      'count_IAE_applications': 0,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 1,
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '76',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[refused_application_with_1_jobs][archived_application]
-  <QuerySet [{'job_seeker_birth_year': 1978, 'job_seeker_department_same_as_company_department': True, 'sender_kind': 'job_seeker', 'sender_company_kind': None, 'sender_prescriber_organization_kind': None, 'sender_prescriber_organization_authorization_status': None, 'company_kind': 'OPCS', 'company_department': '76', 'company_naf': '4567A', 'company_has_convention': True, 'applied_at': datetime.date(2025, 2, 1), 'processed_at': datetime.date(2025, 2, 1), 'last_transition_at': datetime.date(2025, 2, 1), 'had_resume': False, 'origin': 'default', 'state': 'refused', 'refusal_reason': 'reason', 'had_been_transferred': False, 'number_of_jobs_applied_for': 1, 'had_diagoriente_invitation': False, 'had_approval': False, 'hiring_rome': None, 'hiring_contract_type': None, 'hiring_start_date': datetime.date(2025, 2, 1)}]>
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '76',
+      'company_has_convention': True,
+      'company_kind': 'OPCS',
+      'company_naf': '4567A',
+      'had_approval': False,
+      'had_been_transferred': False,
+      'had_diagoriente_invitation': False,
+      'had_resume': False,
+      'hiring_contract_type': None,
+      'hiring_rome': None,
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': True,
+      'last_transition_at': datetime.date(2025, 2, 1),
+      'number_of_jobs_applied_for': 1,
+      'origin': 'default',
+      'processed_at': datetime.date(2025, 2, 1),
+      'refusal_reason': 'reason',
+      'sender_company_kind': None,
+      'sender_kind': 'job_seeker',
+      'sender_prescriber_organization_authorization_status': None,
+      'sender_prescriber_organization_kind': None,
+      'state': 'refused',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[sent_by_jobseeker_without_sender][anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '76', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1978, 'count_accepted_applications': 0, 'count_IAE_applications': 1, 'count_total_applications': 1, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1978,
+      'count_IAE_applications': 1,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 1,
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '76',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[sent_by_jobseeker_without_sender][archived_application]
-  <QuerySet [{'job_seeker_birth_year': 1978, 'job_seeker_department_same_as_company_department': True, 'sender_kind': 'job_seeker', 'sender_company_kind': None, 'sender_prescriber_organization_kind': None, 'sender_prescriber_organization_authorization_status': None, 'company_kind': 'EI', 'company_department': '76', 'company_naf': '7820Z', 'company_has_convention': True, 'applied_at': datetime.date(2025, 2, 1), 'processed_at': None, 'last_transition_at': datetime.date(2025, 3, 1), 'had_resume': True, 'origin': 'default', 'state': 'new', 'refusal_reason': '', 'had_been_transferred': False, 'number_of_jobs_applied_for': 3, 'had_diagoriente_invitation': False, 'had_approval': False, 'hiring_rome': None, 'hiring_contract_type': None, 'hiring_start_date': datetime.date(2025, 2, 1)}]>
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '76',
+      'company_has_convention': True,
+      'company_kind': 'EI',
+      'company_naf': '7820Z',
+      'had_approval': False,
+      'had_been_transferred': False,
+      'had_diagoriente_invitation': False,
+      'had_resume': True,
+      'hiring_contract_type': None,
+      'hiring_rome': None,
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': True,
+      'last_transition_at': datetime.date(2025, 3, 1),
+      'number_of_jobs_applied_for': 3,
+      'origin': 'default',
+      'processed_at': None,
+      'refusal_reason': '',
+      'sender_company_kind': None,
+      'sender_kind': 'job_seeker',
+      'sender_prescriber_organization_authorization_status': None,
+      'sender_prescriber_organization_kind': None,
+      'state': 'new',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[transferred_application_with_diagoriente_invitation][anonymized_jobseeker]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'user_signup_kind': None, 'department': '76', 'title': 'MME', 'identity_provider': 'DJANGO', 'had_pole_emploi_id': False, 'had_nir': True, 'lack_of_nir_reason': '', 'nir_sex': 2, 'nir_year': 90, 'birth_year': 1978, 'count_accepted_applications': 0, 'count_IAE_applications': 1, 'count_total_applications': 1, 'count_approvals': 0, 'first_approval_start_at': None, 'last_approval_end_at': None, 'count_eligibility_diagnoses': 0}]>
+  list([
+    dict({
+      'birth_year': 1978,
+      'count_IAE_applications': 1,
+      'count_accepted_applications': 0,
+      'count_approvals': 0,
+      'count_eligibility_diagnoses': 0,
+      'count_total_applications': 1,
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '76',
+      'first_approval_start_at': None,
+      'first_login': None,
+      'had_nir': True,
+      'had_pole_emploi_id': False,
+      'identity_provider': 'DJANGO',
+      'lack_of_nir_reason': '',
+      'last_approval_end_at': None,
+      'last_login': None,
+      'nir_sex': 2,
+      'nir_year': 90,
+      'title': 'MME',
+      'user_signup_kind': None,
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_archive_not_eligible_jobapplications_of_inactive_jobseekers_after_grace_period[transferred_application_with_diagoriente_invitation][archived_application]
-  <QuerySet [{'job_seeker_birth_year': 1978, 'job_seeker_department_same_as_company_department': True, 'sender_kind': 'employer', 'sender_company_kind': 'EI', 'sender_prescriber_organization_kind': None, 'sender_prescriber_organization_authorization_status': None, 'company_kind': 'EI', 'company_department': '76', 'company_naf': '4567A', 'company_has_convention': True, 'applied_at': datetime.date(2025, 2, 1), 'processed_at': None, 'last_transition_at': datetime.date(2025, 2, 1), 'had_resume': True, 'origin': 'default', 'state': 'postponed', 'refusal_reason': '', 'had_been_transferred': True, 'number_of_jobs_applied_for': 0, 'had_diagoriente_invitation': True, 'had_approval': False, 'hiring_rome': None, 'hiring_contract_type': None, 'hiring_start_date': datetime.date(2025, 2, 1)}]>
+  list([
+    dict({
+      'applied_at': datetime.date(2025, 2, 1),
+      'company_department': '76',
+      'company_has_convention': True,
+      'company_kind': 'EI',
+      'company_naf': '4567A',
+      'had_approval': False,
+      'had_been_transferred': True,
+      'had_diagoriente_invitation': True,
+      'had_resume': True,
+      'hiring_contract_type': None,
+      'hiring_rome': None,
+      'hiring_start_date': datetime.date(2025, 2, 1),
+      'job_seeker_birth_year': 1978,
+      'job_seeker_department_same_as_company_department': True,
+      'last_transition_at': datetime.date(2025, 2, 1),
+      'number_of_jobs_applied_for': 0,
+      'origin': 'default',
+      'processed_at': None,
+      'refusal_reason': '',
+      'sender_company_kind': 'EI',
+      'sender_kind': 'employer',
+      'sender_prescriber_organization_authorization_status': None,
+      'sender_prescriber_organization_kind': None,
+      'state': 'postponed',
+    }),
+  ])
 # ---
 # name: TestAnonymizeJobseekersManagementCommand.test_suspend_command_setting[False-False][suspend_anonymize_jobseekers_command_log]
   'Command launched with wet_run=False'
@@ -419,10 +918,38 @@
   <UserQuerySet [{'is_active': False, 'password': 'pbkdf2_sha256$test$hash', 'phone': '', 'address_line_1': '', 'address_line_2': '', 'post_code': '', 'city': '', 'coords': None, 'insee_city': None, 'upcoming_deletion_notified_at': FakeDatetime(2025, 1, 15, 0, 0, tzinfo=datetime.timezone.utc), 'first_name': 'Pierre', 'last_name': 'Dupont'}]>
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_after_grace_period[no_related_objects_and_is_anonymized][anonymized_professional]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'department': '44', 'title': '', 'kind': 'labor_inspector', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'DJANGO'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '44',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_after_grace_period[no_related_objects_and_not_anonymized][anonymized_professional]
-  <QuerySet [{'date_joined': datetime.date(2023, 3, 1), 'first_login': None, 'last_login': None, 'department': '44', 'title': '', 'kind': 'employer', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2023, 3, 1),
+      'department': '44',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_body]
   '''
@@ -441,31 +968,157 @@
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[authorized_prescriber_admin_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'prescriber', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': True, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': True,
+      'identity_provider': 'PC',
+      'kind': 'prescriber',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[company_admin_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'employer', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[company_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'employer', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 0, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_company_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'employer', 'number_of_memberships': 1, 'number_of_active_memberships': 0, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 0,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_institution_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'labor_inspector', 'number_of_memberships': 1, 'number_of_active_memberships': 0, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'DJANGO'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 0,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_prescriber_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'prescriber', 'number_of_memberships': 1, 'number_of_active_memberships': 0, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'prescriber',
+      'last_login': None,
+      'number_of_active_memberships': 0,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[institution_admin_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'labor_inspector', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 1, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'DJANGO'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[institution_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'labor_inspector', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 0, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'DJANGO'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[prescriber_membership][anonymized_professionals_with_annotations]
-  <QuerySet [{'date_joined': datetime.date(2025, 7, 1), 'first_login': None, 'last_login': None, 'department': '', 'title': '', 'kind': 'prescriber', 'number_of_memberships': 1, 'number_of_active_memberships': 1, 'number_of_memberships_as_administrator': 0, 'had_memberships_in_authorized_organization': False, 'identity_provider': 'PC'}]>
+  list([
+    dict({
+      'date_joined': datetime.date(2025, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'prescriber',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+  ])
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_num_queries[anonymize_professionals_queries]
   dict({

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -93,7 +93,7 @@ def city_fixture():
 def get_fields_list_for_snapshot(model):
     exclude = {"id", "anonymized_at"}
     fields = [f.name for f in model._meta.get_fields() if f.concrete and f.name not in exclude]
-    return model.objects.values(*fields)
+    return list(model.objects.values(*fields))
 
 
 class TestNotifyInactiveJobseekersManagementCommand:
@@ -984,8 +984,8 @@ class TestAnonymizeJobseekersManagementCommand:
 
         assert not Approval.objects.exists()
 
-        assert list(get_fields_list_for_snapshot(AnonymizedApproval)) == snapshot(name="anonymized_approval")
-        assert list(get_fields_list_for_snapshot(AnonymizedApplication)) == snapshot(name="anonymized_application")
+        assert get_fields_list_for_snapshot(AnonymizedApproval) == snapshot(name="anonymized_approval")
+        assert get_fields_list_for_snapshot(AnonymizedApplication) == snapshot(name="anonymized_application")
 
     def test_archive_jobseeker_with_several_approvals(self, snapshot):
         jobseeker = JobSeekerFactory(
@@ -1084,11 +1084,11 @@ class TestAnonymizeJobseekersManagementCommand:
 
         assert not EligibilityDiagnosis.objects.exists()
         assert not GEIQEligibilityDiagnosis.objects.exists()
-        assert list(get_fields_list_for_snapshot(AnonymizedJobSeeker)) == snapshot(name="anonymized_jobseeker")
-        assert list(get_fields_list_for_snapshot(AnonymizedSIAEEligibilityDiagnosis)) == snapshot(
+        assert get_fields_list_for_snapshot(AnonymizedJobSeeker) == snapshot(name="anonymized_jobseeker")
+        assert get_fields_list_for_snapshot(AnonymizedSIAEEligibilityDiagnosis) == snapshot(
             name="anonymized_iae_diagnosis"
         )
-        assert list(get_fields_list_for_snapshot(AnonymizedGEIQEligibilityDiagnosis)) == snapshot(
+        assert get_fields_list_for_snapshot(AnonymizedGEIQEligibilityDiagnosis) == snapshot(
             name="anonymized_geiq_diagnosis"
         )
 
@@ -1556,7 +1556,7 @@ class TestAnonymizeCancelledApprovalsManagementCommand:
 
         call_command("anonymize_cancelled_approvals", wet_run=True)
 
-        assert list(get_fields_list_for_snapshot(AnonymizedCancelledApproval)) == snapshot(
+        assert get_fields_list_for_snapshot(AnonymizedCancelledApproval) == snapshot(
             name="anonymized_cancelled_approval"
         )
         assert not CancelledApproval.objects.exists()


### PR DESCRIPTION
## :thinking: Pourquoi ?

cf titre

## :cake: Comment ? <!-- optionnel -->

retourner des listes au lieu de `queryset` pour l'évaluation des snapshots

