### PR TITLE
[API] Pole emploi : utilisation d'un client en gestionnaire de contexte

### DIFF
--- a/itou/jobs/management/commands/sync_romes_and_appellations.py
+++ b/itou/jobs/management/commands/sync_romes_and_appellations.py
@@ -34,9 +34,11 @@ class Command(BaseCommand):
 
     def handle(self, *, wet_run, **options):
         now = timezone.now()
-        pe_client = pole_emploi_partenaire_api_client()
 
-        romes_data = pe_client.referentiel(pe_api_enums.REFERENTIEL_ROME)
+        with pole_emploi_partenaire_api_client() as client:
+            romes_data = client.referentiel(pe_api_enums.REFERENTIEL_ROME)
+            appellations_data = client.appellations()
+
         for item in yield_sync_diff(romes_data, "code", Rome.objects.all(), "code", [("libelle", "name")]):
             self.logger.info(item.label)
 
@@ -51,7 +53,6 @@ class Command(BaseCommand):
             )
             self.logger.info("len=%d ROME entries have been created or updated.", len(romes))
 
-        appellations_data = pe_client.appellations()
         for item in yield_sync_diff(
             appellations_data, "code", Appellation.objects.all(), "code", [("libelle", "name")]
         ):

--- a/tests/jobs/management/test_sync_romes_and_appellations.py
+++ b/tests/jobs/management/test_sync_romes_and_appellations.py
@@ -46,6 +46,10 @@ def test_sync_rome_appellation(caplog, respx_mock):
     assert caplog.messages[:-1] == [
         'HTTP Request: POST https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire "HTTP/1.1 200 OK"',
         'HTTP Request: GET https://pe.fake/offresdemploi/v2/referentiel/metiers "HTTP/1.1 200 OK"',
+        (
+            "HTTP Request: GET https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code) "
+            '"HTTP/1.1 200 OK"'
+        ),
         "count=1 label=Rome had the same key in collection and queryset",
         "\tCHANGED name=Patisserie changed to value=Pâtisserie avec accent",
         "count=1 label=Rome added by collection",
@@ -54,10 +58,6 @@ def test_sync_rome_appellation(caplog, respx_mock):
         "\tREMOVED Métiers du corps (B001)",
         "\tREMOVED Arts de la table (F002)",  # not really removed though by our command, see docstring
         "len=2 ROME entries have been created or updated.",
-        (
-            "HTTP Request: GET https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code) "
-            '"HTTP/1.1 200 OK"'
-        ),
         "count=2 label=Appellation had the same key in collection and queryset",
         "\tCHANGED name=Entraîneur sportif changed to value=Entraîneur sportif avéré",
         "\tCHANGED name=Chef cuistot d'élite changed to value=Chef cuistor d'élite",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Réutiliser le client HTTPX permet de réutiliser la connexion TCP (au lieu d'en recréer une pour chaque requête) entre plusieurs requêtes consécutives.
[Lire la documentation pour en savoir plus](https://www.python-httpx.org/advanced/clients/#why-use-a-client)

Voir aussi  https://github.com/gip-inclusion/les-emplois/pull/4971/commits/487faee04ceffd2c8178e53bca9381739cd07e24

## :cake: Comment ?

Ajout d'un client HTTP privé à la classe pour créer un client réutilisable entre chaque requête lorsque `pole_emploi_agent_pole_emploi_partenaire_api_client` est utilisé en gestionnaire de contexte.