### PR TITLE
Recherche employeur : Correctif temporaire permettant d'afficher le menus déroulants (distance, type de structure…) au-dessus du titre et des onglets

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -116,6 +116,11 @@ Credits go to https://stackoverflow.com/a/19229738
     white-space: break-spaces !important;
 }
 
+/* Temporary fix to display dropdown menus above sticky titles */
+.fix-zindex-1040 {
+    z-index: 1040 !important;
+}
+
 /* Missing Boostrap utilities.
 --------------------------------------------------------------------------- */
 

--- a/itou/templates/includes/btn_dropdown_filter/checkboxes.html
+++ b/itou/templates/includes/btn_dropdown_filter/checkboxes.html
@@ -9,7 +9,7 @@ Arguments:
     <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
         {{ label|default:field.label }}
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu {{ menu_extra_classes|default:"" }}">
         {% for choice in field %}
             <li class="dropdown-item">
                 <div class="form-check">

--- a/itou/templates/includes/btn_dropdown_filter/radio.html
+++ b/itou/templates/includes/btn_dropdown_filter/radio.html
@@ -7,7 +7,7 @@ Arguments:
     <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
         {{ label|default:field.label }}
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu {{ menu_extra_classes|default:"" }}">
         {% for choice in field %}
             <li class="dropdown-item">
                 <div class="form-check">

--- a/itou/templates/search/includes/siaes_search_content.html
+++ b/itou/templates/search/includes/siaes_search_content.html
@@ -16,13 +16,13 @@
                                       hx-swap="outerHTML"
                                       hx-push-url="true">
                                     <div class="btn-dropdown-filter-group mb-3 mb-md-4">
-                                        {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance only %}
-                                        {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.kinds only %}
+                                        {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance menu_extra_classes="fix-zindex-1040" only %}
+                                        {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.kinds menu_extra_classes="fix-zindex-1040" only %}
                                         {% if form.contract_types %}
-                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.contract_types only %}
+                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.contract_types menu_extra_classes="fix-zindex-1040" only %}
                                         {% endif %}
                                         {% if form.domains %}
-                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.domains only %}
+                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.domains menu_extra_classes="fix-zindex-1040" only %}
                                         {% endif %}
                                         {% include "search/includes/siaes_search_filters_departments.html" %}
                                         <div class="ms-lg-auto">

--- a/itou/templates/search/includes/siaes_search_filters_departments.html
+++ b/itou/templates/search/includes/siaes_search_filters_departments.html
@@ -1,14 +1,14 @@
 {% load django_bootstrap5 %}
 
 {% if form.departments %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.departments only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.departments menu_extra_classes="fix-zindex-1040" only %}
 {% endif %}
 {% if form.districts_13 %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_13 only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_13 menu_extra_classes="fix-zindex-1040" only %}
 {% endif %}
 {% if form.districts_69 %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_69 only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_69 menu_extra_classes="fix-zindex-1040" only %}
 {% endif %}
 {% if form.districts_75 %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_75 only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_75 menu_extra_classes="fix-zindex-1040" only %}
 {% endif %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -41,7 +41,7 @@
                               hx-swap="outerHTML"
                               hx-push-url="true">
                             <div class="btn-dropdown-filter-group my-3 my-md-4">
-                                {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance only %}
+                                {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance menu_extra_classes="fix-zindex-1040" only %}
                             </div>
                         </form>
                     </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sur petits écrans les menus déroulants de la recherche (Distance, Types de structure…) sont orientés vers le haut.
Ils rentrent en conflit avec la section titre `s-title-02` qui est sticky, et qui a un `z-index` supérieur.
Certaines valeurs sont donc inaccessibles.

Ce problème arrive plus fréquemment depuis 5739c32bc4cb081e8bcde8f6a9d529fa58654dee, avec le changement de breakpoints.

En attendant que @hellodeloo  puisse réorganiser le `z-index` des différents éléments dans le thème (ou toute autre solution qu'il trouvera pertinente), voilà un correctif temporaire.

cf https://gip-inclusion.slack.com/archives/C01181Y04LT/p1753692325909599


## :computer: Captures d'écran <!-- optionnel -->

Avant : 

<img width="912" height="540" alt="image" src="https://github.com/user-attachments/assets/a592a44e-9d78-4c6d-bba1-3469ca4d9c03" />

Après :

<img width="687" height="545" alt="image" src="https://github.com/user-attachments/assets/056a0b7c-d9c0-4c2e-9abc-d997c944bb5d" />


<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
