### PR TITLE
Rendre son indépendance à `scripts/delete-buckets`

### DIFF
--- a/scripts/delete-bucket
+++ b/scripts/delete-bucket
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-import contextlib
+
 import os
 import shlex
 import subprocess
 
 import boto3
-
-from itou.utils.storage.s3 import NoObjectsInBucket, delete_all_objects_versions
 
 
 def main():
@@ -40,9 +38,20 @@ def main():
         endpoint_url=f"https://{creds['CELLAR_ADDON_HOST']}",
     )
     bucket_name = creds["S3_STORAGE_BUCKET_NAME"]
-    with contextlib.suppress(NoObjectsInBucket):
-        delete_all_objects_versions(s3_client, bucket=bucket_name)
+    paginator = s3_client.get_paginator("list_object_versions")
     try:
+        for page in paginator.paginate(Bucket=bucket_name):
+            for entity_name in ["DeleteMarkers", "Versions"]:
+                # Some pages may not have 'DeleteMarkers' nor 'Versions' keys.
+                if entity_name in page:
+                    s3_client.delete_objects(
+                        Bucket=bucket_name,
+                        Delete={
+                            "Objects": [
+                                {"Key": obj["Key"], "VersionId": obj["VersionId"]} for obj in page[entity_name]
+                            ]
+                        },
+                    )
         s3_client.delete_bucket(Bucket=bucket_name)
     except s3_client.exceptions.NoSuchBucket:
         pass


### PR DESCRIPTION
## :thinking: Pourquoi ?

807f9c5a6a a introduit une dépendance de `itou` dans le script `scripts/delete-bucket`.
On que les scripts puissent être lancés de manière autonome.

On annule donc partiellement ce commit.

cf https://gip-inclusion.slack.com/archives/C0412CTV63D/p1753707583997629?thread_ts=1753707229.801169&cid=C0412CTV63D