### PR TITLE
Tech : Utilisation de `@dry_runnable` pour `metabase_data`

### DIFF
--- a/itou/metabase/management/commands/metabase_data.py
+++ b/itou/metabase/management/commands/metabase_data.py
@@ -3,6 +3,7 @@ from urllib.parse import unquote
 
 from django.conf import settings
 from django.core.cache import caches
+from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -10,7 +11,7 @@ from django.utils.dateparse import parse_datetime
 from itou.metabase.models import DatumKey
 from itou.users.models import JobSeekerProfile
 from itou.utils.apis.metabase import DEPARTMENT_FILTER_KEY, REGION_FILTER_KEY, Client
-from itou.utils.command import BaseCommand
+from itou.utils.command import BaseCommand, dry_runnable
 
 
 class Command(BaseCommand):
@@ -65,7 +66,7 @@ class Command(BaseCommand):
         stalled_job_seekers = subparsers.add_parser("stalled-job-seekers")
         stalled_job_seekers.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    def fetch_kpi(self, *, wet_run):
+    def fetch_kpi(self):
         cache = caches[self.CACHE_NAME]
         client = Client(settings.METABASE_SITE_URL)
 
@@ -91,20 +92,22 @@ class Command(BaseCommand):
                     row[column_name]: converter(row[metabase_informations["select"]]) for row in results
                 }
 
-        if wet_run:
+        pprint.pp(metabase_data, sort_dicts=True)
+
+        def save_kpi():
             self.logger.info("Saving data into cache %r", self.CACHE_NAME)
             cache.set_many(metabase_data)
-        else:
-            pprint.pp(metabase_data, sort_dicts=True)
 
-    def show_kpi(self, *, wet_run):
+        transaction.on_commit(save_kpi)
+
+    def show_kpi(self):
         data = caches[self.CACHE_NAME].get_many(DatumKey)
         for key, value in data.items():
             print(repr(key))
             print(repr(value))
             print()
 
-    def fetch_stalled_job_seekers(self, *, wet_run):
+    def fetch_stalled_job_seekers(self):
         client = Client(settings.METABASE_SITE_URL)
 
         currently_stalled_job_seeker_ids = {row["ID"] for row in client.fetch_card_results(4412, fields=[54509])}
@@ -120,23 +123,23 @@ class Command(BaseCommand):
         entering_stalled_status_ids = currently_stalled_job_seeker_ids - db_stalled_job_seeker_ids
         self.logger.info("Number of job seekers entering stalled status: %d", len(entering_stalled_status_ids))
 
-        if wet_run:
-            exiting_update_count = JobSeekerProfile.objects.filter(
-                is_stalled=True, pk__in=exiting_stalled_status_ids
-            ).update(is_stalled=False)
-            entering_update_count = JobSeekerProfile.objects.filter(
-                is_stalled=False, pk__in=entering_stalled_status_ids
-            ).update(is_stalled=True)
-            converging_update_count = JobSeekerProfile.objects.filter(is_stalled=~F("is_not_stalled_anymore")).update(
-                is_not_stalled_anymore=None
-            )
-            self.logger.info(
-                "Number of job seekers updated: exiting=%d entering=%d converging=%s",
-                exiting_update_count,
-                entering_update_count,
-                converging_update_count,
-            )
+        exiting_update_count = JobSeekerProfile.objects.filter(
+            is_stalled=True, pk__in=exiting_stalled_status_ids
+        ).update(is_stalled=False)
+        entering_update_count = JobSeekerProfile.objects.filter(
+            is_stalled=False, pk__in=entering_stalled_status_ids
+        ).update(is_stalled=True)
+        converging_update_count = JobSeekerProfile.objects.filter(is_stalled=~F("is_not_stalled_anymore")).update(
+            is_not_stalled_anymore=None
+        )
+        self.logger.info(
+            "Number of job seekers updated: exiting=%d entering=%d converging=%s",
+            exiting_update_count,
+            entering_update_count,
+            converging_update_count,
+        )
 
+    @dry_runnable
     def handle(self, *, data, **options):
         match data:
             case "kpi":
@@ -144,6 +147,6 @@ class Command(BaseCommand):
                     "fetch": self.fetch_kpi,
                     "show": self.show_kpi,
                 }[options["action"]]
-                action_function(wet_run=options["wet_run"])
+                action_function()
             case "stalled-job-seekers":
-                self.fetch_stalled_job_seekers(wet_run=options["wet_run"])
+                self.fetch_stalled_job_seekers()

--- a/tests/metabase/management/__snapshots__/test_metabase_data.ambr
+++ b/tests/metabase/management/__snapshots__/test_metabase_data.ambr
@@ -8,6 +8,11 @@
     tuple(
       'itou.metabase.management.commands.metabase_data',
       20,
+      'Command launched with wet_run=False',
+    ),
+    tuple(
+      'itou.metabase.management.commands.metabase_data',
+      20,
       'Fetching datum_key=flux_iae_data_updated_at',
     ),
     tuple(
@@ -54,6 +59,11 @@
       'itou.metabase.management.commands.metabase_data',
       20,
       'Fetching datum_key=rate_of_auto_prescription group_by=region',
+    ),
+    tuple(
+      'itou.metabase.management.commands.metabase_data',
+      20,
+      'Setting transaction to be rollback as wet_run=False',
     ),
   ])
 # ---
@@ -165,15 +175,31 @@
 # name: test_fetch_kpi[True][stdout and stderr]
   CaptureResult(
     err='',
-    out='',
+    out='''
+      {<DatumKey.DATA_UPDATED_AT: 'data_updated_at'>: FakeDatetime(2024, 11, 20, 0, 0, tzinfo=datetime.timezone.utc),
+       <DatumKey.FLUX_IAE_DATA_UPDATED_AT: 'flux_iae_data_updated_at'>: FakeDatetime(2024, 11, 20, 0, 0, tzinfo=datetime.timezone.utc),
+       <DatumKey.JOB_APPLICATION_WITH_HIRING_DIFFICULTY: 'job_application_with_hiring_difficulty'>: 1175,
+       <DatumKey.JOB_APPLICATION_WITH_HIRING_DIFFICULTY_BY_DEPARTMENTS: 'job_application_with_hiring_difficulty_by_departments'>: {'Département Structure': 1175},
+       <DatumKey.JOB_APPLICATION_WITH_HIRING_DIFFICULTY_BY_REGIONS: 'job_application_with_hiring_difficulty_by_regions'>: {'Région Structure': 1175},
+       <DatumKey.JOB_SEEKER_STILL_SEEKING_AFTER_30_DAYS: 'job_seeker_still_seeking_after_30_days'>: 4413,
+       <DatumKey.JOB_SEEKER_STILL_SEEKING_AFTER_30_DAYS_BY_DEPARTMENTS: 'job_seeker_still_seeking_after_30_days_by_departments'>: {'Département': 4413},
+       <DatumKey.JOB_SEEKER_STILL_SEEKING_AFTER_30_DAYS_BY_REGIONS: 'job_seeker_still_seeking_after_30_days_by_regions'>: {'Région': 4413},
+       <DatumKey.RATE_OF_AUTO_PRESCRIPTION: 'rate_of_auto_prescription'>: 5292,
+       <DatumKey.RATE_OF_AUTO_PRESCRIPTION_BY_DEPARTMENTS: 'rate_of_auto_prescription_by_departments'>: {'Département Structure': 5292},
+       <DatumKey.RATE_OF_AUTO_PRESCRIPTION_BY_REGIONS: 'rate_of_auto_prescription_by_regions'>: {'Région Structure': 5292}}
+  
+    ''',
   )
 # ---
 # name: test_fetch_stalled_job_seekers[False][logs]
   list([
+    'Command launched with wet_run=False',
     'Number of stalled job seekers: 4',
     'Number of stalled job seekers in database: 4',
     'Number of job seekers exiting stalled status: 3',
     'Number of job seekers entering stalled status: 3',
+    'Number of job seekers updated: exiting=3 entering=3 converging=2',
+    'Setting transaction to be rollback as wet_run=False',
   ])
 # ---
 # name: test_fetch_stalled_job_seekers[True][logs]

--- a/tests/metabase/management/test_metabase_data.py
+++ b/tests/metabase/management/test_metabase_data.py
@@ -1,3 +1,5 @@
+import random
+
 import freezegun
 import pytest
 from django.core import management
@@ -44,9 +46,9 @@ def command_fixture(mocker, settings):
 
 
 @pytest.mark.parametrize("wet_run", [True, False])
-def test_fetch_kpi(caplog, capsys, snapshot, command, wet_run):
-    with freezegun.freeze_time("2024-11-20"):
-        command.fetch_kpi(wet_run=wet_run)
+def test_fetch_kpi(caplog, capsys, snapshot, django_capture_on_commit_callbacks, command, wet_run):
+    with django_capture_on_commit_callbacks(execute=True), freezegun.freeze_time("2024-11-20"):
+        command.handle(data="kpi", action="fetch", wet_run=wet_run)
     assert caches[command.CACHE_NAME].get_many(DatumKey) == snapshot(name="cache")
     assert capsys.readouterr() == snapshot(name="stdout and stderr")
     assert caplog.record_tuples == snapshot(name="logs")
@@ -55,7 +57,7 @@ def test_fetch_kpi(caplog, capsys, snapshot, command, wet_run):
 def test_show_kpi(capsys, snapshot, command):
     caches[command.CACHE_NAME].set_many({key: f"The value of '{key.value}'" for key in DatumKey})
 
-    command.show_kpi(wet_run=None)
+    command.handle(data="kpi", action="show", wet_run=random.choice([True, False]))
     assert capsys.readouterr() == snapshot(name="stdout and stderr")
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car ça va être utile pour l'ajout de la prochaine sous-commande qui récupérera les contrats du flux IAE depuis le Pilotage :).