### PR TITLE
Tech : Récupération des contrats depuis le Pilotage

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -337,7 +337,7 @@ class Client:
             *filters,
         ]
 
-    def build_query(self, *, select=None, table=None, where=None, group_by=None, limit=None):
+    def build_query(self, *, select=None, table=None, where=None, group_by=None, order_by=None, limit=None):
         query = {}
         if select:
             query["fields"] = [self._build_metabase_field(field) for field in select]
@@ -347,6 +347,8 @@ class Client:
             query["filter"] = [self._build_metabase_filter(field, values) for field, values in where.items()]
         if group_by:
             query["breakout"] = [self._build_metabase_field(field) for field in group_by]
+        if order_by:
+            query["order-by"] = [["asc", self._build_metabase_field(field)] for field in order_by]
         if limit:
             query["limit"] = limit
 
@@ -364,6 +366,9 @@ class Client:
         if "breakout" in query:
             into.setdefault("breakout", [])
             into["breakout"].extend(query["breakout"])
+        if "order-by" in query:
+            into.setdefault("order-by", [])
+            into["order-by"].extend(query["order-by"])
         if "limit" in query:
             into["limit"] = query["limit"]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Va être nécessaire pour [Afficher les données de contrats associés à un PASS IAE ](https://www.notion.so/gip-inclusion/Afficher-les-donn-es-de-contrats-associ-s-un-PASS-IAE-1fb5f321b60480dcb1e3e229c05315ca?v=18a5f321b604811bad80000cf7934cee&source=copy_link).

J'ai vu des erreurs, données inutiles ou manquantes dans la table actuellement générée (visible dans Metabase sous le nom "Les Emplois Contrats") donc je vais changer ça coté Pilotage et ajusterais la _query_.

La cible c'est d'avoir ces informations :
- ID du candidat des emplois
- ID ASP de la SIAE : `SiaeConvention.asp_id`
- Mesure ASP de la SIAE : 2ème élément de la clé d'unicité
- ID du contrat
- "Type" du contrat : _initial_ ou _renouvellement_
- ID du contract parent : C'est l'ID du contrat d'embauche le plus ancien (en théorie l'initial) les suivants étant des renouvellement
- Date d'embauche
- Date de fin de contrat
- Date de sortie définitive : Si non renseigné pour un groupe de contrat (contrat parent identique) alors la personne est encore employée sinon elle le sera sur le dernier contrat du groupe. Et dans le même format que les deux autres ;).

## :desert_island: Comment tester ?

Configurer `METABASE_API_KEY` (un jeton personnel devrais fonctionner vu qu'on utilise l'API _dataset_) et lancer la commande :).