### PR TITLE
Fiche entreprise : Décocher la case "Peut apparaître dans les résultats de recherche" des entreprises déconventionnées [GEN-2627]

### DIFF
--- a/itou/companies/management/commands/_import_siae/siae.py
+++ b/itou/companies/management/commands/_import_siae/siae.py
@@ -196,10 +196,15 @@ def cleanup_siaes_after_grace_period():
             siae.delete()
             deletions += 1
         else:
+            siae.is_searchable = False
+            siae.save(update_fields=["is_searchable", "updated_at"])
             blocked_deletions += 1
 
     print(f"{deletions} siaes past their grace period have been deleted")
-    print(f"{blocked_deletions} siaes past their grace period cannot be deleted")
+    print(
+        f"{blocked_deletions} siaes past their grace period cannot be deleted "
+        "but have been removed from the search results"
+    )
 
 
 def delete_user_created_siaes_without_members():

--- a/tests/companies/test_import_siae_command.py
+++ b/tests/companies/test_import_siae_command.py
@@ -340,13 +340,16 @@ def test_cleanup_siaes_after_grace_period(capsys):
         to_company__kind=CompanyKind.EI,
         to_company__convention__is_active=False,
         to_company__convention__deactivated_at=old_enough,
+        to_company__is_searchable=True,
     ).to_company
 
     cleanup_siaes_after_grace_period()
     assertQuerySetEqual(Company.objects.all(), [company_with_active_convention, undeletable_company], ordered=False)
+    undeletable_company.refresh_from_db()
+    assert undeletable_company.is_searchable is False
     stdout, stderr = capsys.readouterr()
     assert stderr == ""
     assert stdout.splitlines() == [
         "1 siaes past their grace period have been deleted",
-        "1 siaes past their grace period cannot be deleted",
+        "1 siaes past their grace period cannot be deleted but have been removed from the search results",
     ]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le déconventionnement n'empêche actuellement pas l'affichage dans la recherche. Dans le script `import_siae` qu'on lance le lundi, si une convention a expiré (modulo un petit délai), alors on essaie juste de supprimer les entreprises associées. Si ces entreprises ont des infos qu'on veut garder (contrôle a posteriori, candidatures…), alors on ne fait rien.

On retrouve donc des SIAE qui n’existe plus dans nos résultats de recherche.

## :cake: Comment ? <!-- optionnel -->

Décocher `is_searchable` sur les entreprises à désactiver qu'on ne peut pas supprimer.
