### PR TITLE
Fiche entreprise, fiche de poste : Arrêter de servir les fiches des entreprises désactivées [GEN-2627]

### DIFF
--- a/itou/www/companies_views/views.py
+++ b/itou/www/companies_views/views.py
@@ -151,7 +151,9 @@ class JobDescriptionCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, Temp
     def setup(self, request, job_description_id, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.job_description = get_object_or_404(
-            JobDescription.objects.select_related("appellation", "company", "location"), pk=job_description_id
+            JobDescription.objects.select_related("appellation", "company", "location"),
+            pk=job_description_id,
+            company__is_searchable=True,
         )
 
     def get_context_data(self, **kwargs):
@@ -569,7 +571,7 @@ class CompanyCardView(LoginNotRequiredMixin, ApplyForJobSeekerMixin, TemplateVie
 
     def setup(self, request, siae_id, *args, **kwargs):
         super().setup(request, *args, **kwargs)
-        self.company = get_object_or_404(Company.objects.with_has_active_members(), pk=siae_id)
+        self.company = get_object_or_404(Company.objects.with_has_active_members(), pk=siae_id, is_searchable=True)
 
     def get_context_data(self, **kwargs):
         back_url = get_safe_url(self.request, "back_url")

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -811,10 +811,11 @@
                  "cities_city"."coords",
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
-          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
-          WHERE "companies_jobdescription"."id" = %s
+          WHERE ("companies_company"."is_searchable"
+                 AND "companies_jobdescription"."id" = %s)
           LIMIT 21
         ''',
       }),

--- a/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_job_description_views.ambr
@@ -150,10 +150,11 @@
                  "cities_city"."coords",
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
-          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
-          WHERE "companies_jobdescription"."id" = %s
+          WHERE ("companies_company"."is_searchable"
+                 AND "companies_jobdescription"."id" = %s)
           LIMIT 21
         ''',
       }),
@@ -489,10 +490,11 @@
                  "cities_city"."coords",
                  "cities_city"."edition_mode"
           FROM "companies_jobdescription"
-          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
           LEFT OUTER JOIN "cities_city" ON ("companies_jobdescription"."location_id" = "cities_city"."id")
-          WHERE "companies_jobdescription"."id" = %s
+          WHERE ("companies_company"."is_searchable"
+                 AND "companies_jobdescription"."id" = %s)
           LIMIT 21
         ''',
       }),

--- a/tests/www/companies_views/test_card_views.py
+++ b/tests/www/companies_views/test_card_views.py
@@ -46,6 +46,12 @@ class TestCardView:
         soup = parse_response_to_soup(response, selector="#main")
         assert pretty_indented(soup) == snapshot()
 
+    def test_card_is_searchable_false(self, client):
+        company = CompanyFactory(with_membership=True, is_searchable=False)
+        url = reverse("companies_views:card", kwargs={"siae_id": company.pk})
+        response = client.get(url)
+        assert response.status_code == 404
+
     def test_card_tally_url_with_user(self, client, snapshot):
         company = CompanyFactory(with_membership=False, for_snapshot=True, pk=100)
         url = reverse("companies_views:card", kwargs={"siae_id": company.pk})
@@ -394,6 +400,13 @@ class TestJobDescriptionCardView:
         response = client.get(add_url_params(url, {"back_url": reverse("companies_views:job_description_list")}))
         navinfo = parse_response_to_soup(response, selector=".c-navinfo")
         assert pretty_indented(navinfo) == snapshot(name="navinfo")
+
+    def test_job_description_card_is_searchable_false(self, client):
+        company = CompanyWithMembershipAndJobsFactory(is_searchable=False)
+        job_description = company.job_description_through.first()
+        url = reverse("companies_views:job_description_card", kwargs={"job_description_id": job_description.pk})
+        response = client.get(url)
+        assert response.status_code == 404
 
     def test_job_description_card_render_markdown(self, client):
         company = CompanyWithMembershipAndJobsFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les fiches de poste et fiches des entreprises désactivées (`company.is_searchable=False`) ne sont pas accessibles via la recherche, mais peuvent rester indexées dans d'autres moteurs de recherche.


## :cake: Comment ? <!-- optionnel -->

Servir une 404.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
