### PR TITLE
Admin : autofocus sur le champ de saisie du code OTP

### DIFF
--- a/itou/www/login/forms.py
+++ b/itou/www/login/forms.py
@@ -122,7 +122,7 @@ class ItouLoginForm(LoginForm):
 class VerifyOTPForm(forms.Form):
     otp_token = forms.CharField(required=True)
 
-    otp_token.widget.attrs.update({"max_length": 6, "autocomplete": "one-time-code"})
+    otp_token.widget.attrs.update({"max_length": 6, "autocomplete": "one-time-code", "autofocus": True})
 
     def __init__(self, *args, user, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le login en tant que superutilisateur nécessite la saisie d'un code OTP dans une page de formulaire dédié. Ce champ unique n'est pas `autofocus` et necessite une action supplémentaire avant de saisir le code (tab ou clic souris)

## :cake: Comment ? <!-- optionnel -->

Ajouter l'attribut `autofocus` au champ `opt_token`

## :computer: Captures d'écran

<img width="597" height="265" alt="image" src="https://github.com/user-attachments/assets/473437d6-e647-4b10-8467-77e649d1108a" />

