### PR TITLE
Tech : Suppression de `@timeit`

### DIFF
--- a/itou/companies/management/commands/import_geiq.py
+++ b/itou/companies/management/commands/import_geiq.py
@@ -12,11 +12,9 @@ from itou.companies.management.commands._import_siae.utils import (
 )
 from itou.companies.models import Company
 from itou.utils.command import BaseCommand
-from itou.utils.python import timeit
 from itou.utils.validators import validate_siret
 
 
-@timeit
 def get_geiq_df(filename):
     info_stats = {}
 
@@ -121,7 +119,6 @@ class Command(BaseCommand):
         parser.add_argument("filename")
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    @timeit
     def handle(self, *, filename, wet_run, **options):
         geiq_df, info_stats = get_geiq_df(filename)
         info_stats |= sync_structures(

--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -76,7 +76,6 @@ from itou.siae_evaluations.models import (
 from itou.users.enums import UserKind
 from itou.users.models import User
 from itou.utils.command import BaseCommand
-from itou.utils.python import timeit
 
 
 def log_retry_attempt(retry_state):
@@ -530,7 +529,6 @@ class Command(BaseCommand):
         )
         populate_table(gps.MembershipsTable, batch_size=100_000, querysets=[queryset])
 
-    @timeit
     def report_data_inconsistencies(self):
         """
         Report data inconsistencies that were previously ignored during `populate_approvals` method in order to avoid
@@ -549,11 +547,9 @@ class Command(BaseCommand):
                 "manual resolution, see command output"
             )
 
-    @timeit
     def build_dbt_daily(self):
         build_dbt_daily()
 
-    @timeit
     @tenacity.retry(
         retry=tenacity.retry_if_not_exception_type(RuntimeError),
         stop=tenacity.stop_after_attempt(3),

--- a/itou/utils/python.py
+++ b/itou/utils/python.py
@@ -1,6 +1,4 @@
 import logging
-from functools import wraps
-from time import perf_counter
 
 
 logger = logging.getLogger(__name__)
@@ -11,23 +9,3 @@ class Sentinel:
 
     def __bool__(self):
         return False
-
-
-def timeit(f):
-    """
-    Quick and dirty method timer (as a decorator).
-    Could not make it work easily with the `import_siae.Command` class.
-    Thus dirty becauses uses `print` instead of `self.log`.
-
-    Maybe later we can use this builtin timer instead:
-    https://docs.python.org/3/library/timeit.html#python-interface
-    """
-
-    @wraps(f)
-    def wrap(*args, **kw):
-        ts = perf_counter()
-        result = f(*args, **kw)
-        logger.info("timeit: method=%s completed in seconds=%.2f", f.__name__, perf_counter() - ts)
-        return result
-
-    return wrap

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -1140,8 +1140,6 @@ def test_data_inconsistencies(caplog):
 
     logs = caplog.messages
     assert logs[0] == "Checking data for inconsistencies."
-    assert "timeit: method=report_data_inconsistencies completed in seconds=" in logs[1]
-    assert "timeit: method=handle completed in seconds=" in logs[2]
 
     approval.user.kind = UserKind.EMPLOYER
     approval.user.save()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Doublon avec le comportement dans notre classe de base et très peu utile dans les 2 derniers endroits l'utilisant.