### PR TITLE
Invitations : vérifier que request.current_organization n'est pas None avant de l'utiliser

### DIFF
--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 from allauth.account.adapter import get_adapter
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import PermissionDenied
 from django.contrib.auth.decorators import login_not_required
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.forms import modelformset_factory
@@ -143,9 +144,9 @@ class BaseInviteUserView(UserPassesTestMixin, TemplateView):
 
     def setup(self, request, *args, **kwargs):
         self.organization = request.current_organization
-        self.invitation_left = MAX_PENDING_INVITATION - self.organization.invitations.pending().count()
         if self.organization is None:
-            raise PermissionError
+            raise PermissionDenied
+        self.invitation_left = MAX_PENDING_INVITATION - self.organization.invitations.pending().count()
         return super().setup(request, *args, **kwargs)
 
     def dispatch(self, request, *args, **kwargs):

--- a/tests/www/invitations_views/test_generic.py
+++ b/tests/www/invitations_views/test_generic.py
@@ -308,6 +308,11 @@ class TestSendPrescriberInvitation(PrescriberMixin, BaseTestSendInvitation):
         # The form is prefilled with GET params (if valid)
         assertContains(response, "Emma")
 
+    def test_prescriber_without_organization(self, client):
+        client.force_login(PrescriberFactory())
+        response = client.get(self.invitation_url)
+        assert response.status_code == 403
+
 
 class TestSendCompanyInvitation(CompanyMixin, BaseTestSendInvitation):
     pass


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une erreur est remontée : https://inclusion.sentry.io/issues/53631664

