### PR TITLE
Vie privée : refactor des tests sensibles à leur date d'execution

### DIFF
--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -967,10 +967,114 @@
 # name: TestAnonymizeProfessionalManagementCommand.test_anonymize_professionals_notification[True][anonymized_professional_email_subject]
   '[DEV] Suppression de votre compte sur les Emplois de l’inclusion'
 # ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[authorized_prescriber_admin_membership][anonymized_professionals_with_annotations]
+# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[anonymized_professionals_with_annotations]
   list([
     dict({
-      'date_joined': datetime.date(2025, 7, 1),
+      'date_joined': datetime.date(2020, 10, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 0,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 9, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 8, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'DJANGO',
+      'kind': 'labor_inspector',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 7, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 0,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 6, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 5, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'employer',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 1,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 4, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'prescriber',
+      'last_login': None,
+      'number_of_active_memberships': 0,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 3, 1),
+      'department': '',
+      'first_login': None,
+      'had_memberships_in_authorized_organization': False,
+      'identity_provider': 'PC',
+      'kind': 'prescriber',
+      'last_login': None,
+      'number_of_active_memberships': 1,
+      'number_of_memberships': 1,
+      'number_of_memberships_as_administrator': 0,
+      'title': '',
+    }),
+    dict({
+      'date_joined': datetime.date(2020, 2, 1),
       'department': '',
       'first_login': None,
       'had_memberships_in_authorized_organization': True,
@@ -980,142 +1084,6 @@
       'number_of_active_memberships': 1,
       'number_of_memberships': 1,
       'number_of_memberships_as_administrator': 1,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[company_admin_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'PC',
-      'kind': 'employer',
-      'last_login': None,
-      'number_of_active_memberships': 1,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 1,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[company_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'PC',
-      'kind': 'employer',
-      'last_login': None,
-      'number_of_active_memberships': 1,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 0,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_company_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'PC',
-      'kind': 'employer',
-      'last_login': None,
-      'number_of_active_memberships': 0,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 1,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_institution_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'DJANGO',
-      'kind': 'labor_inspector',
-      'last_login': None,
-      'number_of_active_memberships': 0,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 1,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[disabled_prescriber_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'PC',
-      'kind': 'prescriber',
-      'last_login': None,
-      'number_of_active_memberships': 0,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 1,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[institution_admin_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'DJANGO',
-      'kind': 'labor_inspector',
-      'last_login': None,
-      'number_of_active_memberships': 1,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 1,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[institution_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'DJANGO',
-      'kind': 'labor_inspector',
-      'last_login': None,
-      'number_of_active_memberships': 1,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 0,
-      'title': '',
-    }),
-  ])
-# ---
-# name: TestAnonymizeProfessionalManagementCommand.test_anonymized_professionals_annotations[prescriber_membership][anonymized_professionals_with_annotations]
-  list([
-    dict({
-      'date_joined': datetime.date(2025, 7, 1),
-      'department': '',
-      'first_login': None,
-      'had_memberships_in_authorized_organization': False,
-      'identity_provider': 'PC',
-      'kind': 'prescriber',
-      'last_login': None,
-      'number_of_active_memberships': 1,
-      'number_of_memberships': 1,
-      'number_of_memberships_as_administrator': 0,
       'title': '',
     }),
   ])

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -1429,46 +1429,63 @@ class TestAnonymizeProfessionalManagementCommand:
             assert mailoutbox == []
         assert respx_mock.calls.call_count == 1
 
-    @pytest.mark.parametrize(
-        "factory",
-        [
-            pytest.param(
-                lambda: PrescriberMembershipFactory(user__notified_days_ago=31, organization__authorized=True),
-                id="authorized_prescriber_admin_membership",
-            ),
-            pytest.param(
-                lambda: PrescriberMembershipFactory(
-                    user__notified_days_ago=31, organization__authorized=False, is_admin=False
-                ),
-                id="prescriber_membership",
-            ),
-            pytest.param(
-                lambda: PrescriberMembershipFactory(user__notified_days_ago=31, is_active=False),
-                id="disabled_prescriber_membership",
-            ),
-            pytest.param(lambda: CompanyMembershipFactory(user__notified_days_ago=31), id="company_admin_membership"),
-            pytest.param(
-                lambda: CompanyMembershipFactory(user__notified_days_ago=31, is_admin=False), id="company_membership"
-            ),
-            pytest.param(
-                lambda: CompanyMembershipFactory(user__notified_days_ago=31, is_active=False),
-                id="disabled_company_membership",
-            ),
-            pytest.param(
-                lambda: InstitutionMembershipFactory(user__notified_days_ago=31), id="institution_admin_membership"
-            ),
-            pytest.param(
-                lambda: InstitutionMembershipFactory(user__notified_days_ago=31, is_admin=False),
-                id="institution_membership",
-            ),
-            pytest.param(
-                lambda: InstitutionMembershipFactory(user__notified_days_ago=31, is_active=False),
-                id="disabled_institution_membership",
-            ),
-        ],
-    )
-    def test_anonymized_professionals_annotations(self, factory, django_capture_on_commit_callbacks, snapshot):
-        factory()
+    def test_anonymized_professionals_annotations(self, django_capture_on_commit_callbacks, snapshot):
+        # authorized_prescriber_admin_membership
+        PrescriberMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 2, 16)),
+            user__notified_days_ago=31,
+            organization__authorized=True,
+        )
+        # prescriber_membership
+        PrescriberMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 3, 16)),
+            user__notified_days_ago=31,
+            organization__authorized=False,
+            is_admin=False,
+        )
+        # disabled_prescriber_membership
+        PrescriberMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 4, 16)),
+            user__notified_days_ago=31,
+            is_admin=False,
+            is_active=False,
+        )
+        # company_admin_membership
+        CompanyMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 5, 16)), user__notified_days_ago=31
+        )
+        # company_membership
+        CompanyMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 6, 16)),
+            user__notified_days_ago=31,
+            is_admin=False,
+        )
+        # disabled_company_membership
+        CompanyMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 7, 16)),
+            user__notified_days_ago=31,
+            is_admin=False,
+            is_active=False,
+        )
+        # institution_admin_membership
+        InstitutionMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 8, 16)),
+            user__notified_days_ago=31,
+            is_admin=True,
+        )
+        # institution_membership
+        InstitutionMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 9, 16)),
+            user__notified_days_ago=31,
+            is_admin=False,
+        )
+        # disabled_institution_membership
+        InstitutionMembershipFactory(
+            user__date_joined=timezone.make_aware(datetime.datetime(2020, 10, 16)),
+            user__notified_days_ago=31,
+            is_admin=False,
+            is_active=False,
+        )
 
         with django_capture_on_commit_callbacks(execute=True):
             call_command("anonymize_professionals", wet_run=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Rendre les tests insensibles à leur date d'execution pour ne pas faire planter la CI après un changement de mois : 

🎏  Tests concernés : 
* test_archive_jobseeker_with_several_approvals
* test_archive_jobseeker_with_eligibility_diagnosis
* test_archive_jobseeker_with_several_eligibility_diagnoses
* test_anonymized_professionals_annotations  (🎁 refactor de la paramétrisation)

🎏  Test bonus : 
* test_anonymize_professionals_notification



