### PR TITLE
Recherche fiche de poste: ne plus afficher le badge "Soyez parmi les premiers à postuler" pour les offres externes de France Travail

### DIFF
--- a/itou/templates/companies/includes/_card_jobdescription.html
+++ b/itou/templates/companies/includes/_card_jobdescription.html
@@ -38,7 +38,7 @@
                             {{ job_description.display_name | capfirst }}
                             {% if job_description.is_external %}<i class="ri-external-link-line" aria-hidden="true"></i>{% endif %}
                         </a>
-                        {% if job_description.is_unpopular %}
+                        {% if job_description.is_unpopular and not job_description.is_external %}
                             <span class="badge badge-sm rounded-pill bg-info text-white">
                                 <i class="ri-mail-send-line me-1" aria-hidden="true"></i>
                                 <span class="ms-1">Soyez parmi les premiers à postuler</span>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Vu qu'on ne gère pas leurs candidatures, ce badge était systématiquement présent et n'avait pas de sens.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
