### PR TITLE
[Certification] Certifier de manière asynchrone via un feature flag

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -860,3 +860,7 @@ SUSPEND_ANONYMIZE_CANCELLED_APPROVALS = os.getenv("SUSPEND_ANONYMIZE_CANCELLED_A
 # ------------------------------------------------------------------------------
 MAINTENANCE_MODE = os.getenv("MAINTENANCE_MODE", "False") == "True"
 MAINTENANCE_DESCRIPTION = os.getenv("MAINTENANCE_DESCRIPTION", None)
+
+# Criteria certification
+# ------------------------------------------------------------------------------
+CERTIFY_CRITERIA_ASYNC_MODE_ONLY = os.getenv("CERTIFY_CRITERIA_ASYNC_MODE_ONLY", "False") == "True"

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -96,6 +96,10 @@ class AbstractEligibilityDiagnosisModel(models.Model):
             return SenderKind(self.sender_kind).label
 
     def certify_criteria(self):
+        if settings.CERTIFY_CRITERIA_ASYNC_MODE_ONLY:
+            async_certify_criteria(self._meta.model_name, self.pk)
+            return
+
         try:
             # Optimistic call to show certified badge in response immediately.
             certify_criteria(self)

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -513,7 +513,7 @@ def test_eligibility_diagnosis_certify_criteria(mocker, EligibilityDiagnosisFact
         "itou.utils.apis.api_particulier._request",
         return_value=RESPONSES[criteria_kind][ResponseKind.CERTIFIED],
     )
-    job_seeker = JobSeekerFactory(with_address=True, born_in_france=True)
+    job_seeker = JobSeekerFactory(certifiable=True)
     eligibility_diagnosis = EligibilityDiagnosisFactory(
         job_seeker=job_seeker, certifiable=True, criteria_kinds=[criteria_kind]
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Avec l'arrivée de la certification RQTH, 3 nouvelles requêtes seront exécutées dans la méthode `certify_criteria` si le critère TH est sélectionné. Ces appels risquent d'allonger la durée de la requête pour l'utilisateur final qui devra simplement attendre que toutes les API aient rendu leur verdict.

Il y a néanmoins un désavantage : si le critère est en cours de certification, le badge affichera « Critère non certifié » car c'est le fonctionnement actuel. Une PR suivra pour proposer d'autres intitulés.

## :cake: Comment ?

Rendre l'appel asynchrone par défaut et mettre en place un _feature flag_ pour revenir rapidement en arrière si les utilisateurs sont perdus.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
