### PR TITLE
Pilotage : Rendre le téléversement du flux IAE plus robuste

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -8,6 +8,7 @@
   "5 * * * * $ROOT/clevercloud/run_management_command.sh update_companies_job_app_score",
   "10 * * * * $ROOT/clevercloud/run_management_command.sh pe_certify_users --wet-run",
   "15 * * * * $ROOT/clevercloud/run_management_command.sh sanitize_employee_records",
+  "30 * * * * $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
   "0 * * * * $ROOT/clevercloud/run_management_command.sh resolve_insee_cities --wet-run --mode=companies",
   "20 * * * * $ROOT/clevercloud/run_management_command.sh resolve_insee_cities --wet-run --mode=prescribers",
   "40 * * * * $ROOT/clevercloud/run_management_command.sh resolve_insee_cities --wet-run --mode=job_seekers",
@@ -37,7 +38,6 @@
   "0 6 * * MON-FRI $ROOT/clevercloud/run_management_command.sh anonymize_cancelled_approvals --wet-run",
   "0 12 * * MON-FRI $ROOT/clevercloud/run_management_command.sh import_ea_eatt --from-asp --wet-run",
 
-  "0 9-12 * * MON $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
   "0 0 * * MON CRON_ENABLED=1 $ROOT/clevercloud/run_management_command.sh shorten_active_sessions",
   "0 1 * * MON $ROOT/clevercloud/run_management_command.sh delete_unused_files",
   "0 2 * * MON $ROOT/clevercloud/run_management_command.sh populate_metabase_matomo --wet-run",

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -82,6 +82,8 @@ METABASE_DATABASE = os.getenv("METABASE_DATABASE", os.getenv("PGDATABASE", "meta
 AWS_STORAGE_BUCKET_NAME = "dev"
 CONTENT_SECURITY_POLICY["DIRECTIVES"]["img-src"].append(f"{AWS_S3_ENDPOINT_URL}{AWS_STORAGE_BUCKET_NAME}/news-images/")  # noqa: F405
 
+PILOTAGE_DATASTORE_S3_BUCKET_NAME = AWS_STORAGE_BUCKET_NAME
+
 # Don't use json formatter in dev
 del LOGGING["handlers"]["console"]["formatter"]  # noqa: F405
 

--- a/tests/metabase/management/__snapshots__/test_upload_data_to_pilotage.ambr
+++ b/tests/metabase/management/__snapshots__/test_upload_data_to_pilotage.ambr
@@ -1,10 +1,34 @@
 # serializer version: 1
 # name: test_command_call
   list([
-    "Files in datastore's 'flux-iae/': []",
     "Files in local's 'test_command_call0': ['fluxIAE_ITOU_.tar.gz']",
-    "Files to upload: ['fluxIAE_ITOU_.tar.gz']",
-    "Uploading 'fluxIAE_ITOU_.tar.gz'...",
+    "Checking that 'fluxIAE_ITOU_.tar.gz' match with 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    "'fluxIAE_ITOU_.tar.gz' doesn't match with 'flux-iae/fluxIAE_ITOU_.tar.gz': datastore_content_length=None local_content_length=11",
+    "Uploading 'fluxIAE_ITOU_.tar.gz' to 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
     '> fluxIAE_ITOU_.tar.gz: 11\xa0octets/11\xa0octets transferred (100%).',
+    "'fluxIAE_ITOU_.tar.gz' match with 'flux-iae/fluxIAE_ITOU_.tar.gz'!",
+  ])
+# ---
+# name: test_command_check_content_length
+  list([
+    "Files in local's 'test_command_check_content_len0': ['fluxIAE_ITOU_.tar.gz']",
+    "Checking that 'fluxIAE_ITOU_.tar.gz' match with 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    "'fluxIAE_ITOU_.tar.gz' doesn't match with 'flux-iae/fluxIAE_ITOU_.tar.gz': datastore_content_length=0 local_content_length=11",
+    "Uploading 'fluxIAE_ITOU_.tar.gz' to 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    '> fluxIAE_ITOU_.tar.gz: 11\xa0octets/11\xa0octets transferred (100%).',
+    "'fluxIAE_ITOU_.tar.gz' match with 'flux-iae/fluxIAE_ITOU_.tar.gz'!",
+  ])
+# ---
+# name: test_command_retries
+  list([
+    "Files in local's 'test_command_retries0': ['fluxIAE_ITOU_.tar.gz']",
+    "Checking that 'fluxIAE_ITOU_.tar.gz' match with 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    "'fluxIAE_ITOU_.tar.gz' doesn't match with 'flux-iae/fluxIAE_ITOU_.tar.gz': datastore_content_length=None local_content_length=0",
+    "Uploading 'fluxIAE_ITOU_.tar.gz' to 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    "'fluxIAE_ITOU_.tar.gz' doesn't match with 'flux-iae/fluxIAE_ITOU_.tar.gz': datastore_content_length=None local_content_length=0",
+    "Uploading 'fluxIAE_ITOU_.tar.gz' to 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    "'fluxIAE_ITOU_.tar.gz' doesn't match with 'flux-iae/fluxIAE_ITOU_.tar.gz': datastore_content_length=None local_content_length=0",
+    "Uploading 'fluxIAE_ITOU_.tar.gz' to 'flux-iae/fluxIAE_ITOU_.tar.gz'...",
+    "'fluxIAE_ITOU_.tar.gz' still doesn't match with 'flux-iae/fluxIAE_ITOU_.tar.gz' after 3 tries.",
   ])
 # ---

--- a/tests/metabase/management/test_upload_data_to_pilotage.py
+++ b/tests/metabase/management/test_upload_data_to_pilotage.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
@@ -35,3 +37,33 @@ def test_command_idempotence(tmp_path, settings):
     assert response["KeyCount"] == 1
     assert response["Contents"][0]["Key"] == f"flux-iae/{filename}"
     assert response["Contents"][0]["LastModified"] == modified_at
+
+
+@pytest.mark.usefixtures("temporary_bucket")
+def test_command_check_content_length(caplog, snapshot, tmp_path, settings):
+    client = pilotage_s3_client()
+    filename = "fluxIAE_ITOU_.tar.gz"
+    tmp_path.joinpath(filename).write_bytes(b"Hello World")
+
+    client.upload_fileobj(io.BytesIO(), Bucket=settings.PILOTAGE_DATASTORE_S3_BUCKET_NAME, Key=f"flux-iae/{filename}")
+    call_command("upload_data_to_pilotage", tmp_path.as_posix(), "--wet-run")
+    assert (
+        client.get_object(Bucket=settings.PILOTAGE_DATASTORE_S3_BUCKET_NAME, Key=f"flux-iae/{filename}")["Body"].read()
+        == b"Hello World"
+    )
+    assert caplog.messages[:-1] == snapshot
+    assert caplog.messages[-1].startswith(
+        "Management command itou.metabase.management.commands.upload_data_to_pilotage succeeded in"
+    )
+
+
+def test_command_retries(caplog, snapshot, tmp_path, settings, mocker):
+    filename = "fluxIAE_ITOU_.tar.gz"
+    tmp_path.joinpath(filename).touch()
+    mocker.patch("itou.metabase.management.commands.upload_data_to_pilotage.Command._upload_file", return_value=None)
+
+    call_command("upload_data_to_pilotage", tmp_path.as_posix(), "--wet-run")
+    assert caplog.messages[:-1] == snapshot
+    assert caplog.messages[-1].startswith(
+        "Management command itou.metabase.management.commands.upload_data_to_pilotage succeeded in"
+    )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il arrive régulièrement que le fichier téléversé soit incomplet, même sans mise en prod, mais cela n'arrive jamais quand on relance la commande manuellement...
Dans la version actuelle de la commande, il faut aller supprimer le fichier dans la console scaleway et ensuite relancer la commande, ce qui n'est pas très pratique :).

@leo-naeka Je te met en relecteur vu que tu es le prochain SupportiX, donc si tu veux t'éviter du boulot dans les prochaines semaines c'est le bon moment :grin:.