### PR TITLE
Fiche de poste : N'afficher l'entrée dédiée aux candidatures spontanées que sur la première page de la liste

### DIFF
--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -87,23 +87,25 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {# Special row for controlling spontaneous applications #}
-                                    <tr>
-                                        <td>
-                                            <strong>Candidatures spontanées</strong>
-                                        </td>
-                                        <td>-</td>
-                                        <td>-</td>
-                                        <td>
-                                            {% include "companies/includes/buttons/spontaneous_applications_toggle.html" with csrf_token=csrf_token company=siae hx_swap_oob=False only %}
-                                        </td>
-                                        <td>
-                                            <span id="spontaneous_applications_open_since_cell">{{ siae.spontaneous_applications_open_since|default_if_none:"-"|naturaldate|capfirst }}</span>
-                                        </td>
-                                        <td class="w-100px">
-                                            {% include "companies/includes/buttons/spontaneous_applications_refresh.html" with csrf_token=csrf_token request=request company=siae only %}
-                                        </td>
-                                    </tr>
+                                    {% if page == 1 %}
+                                        {# Special row for controlling spontaneous applications #}
+                                        <tr>
+                                            <td>
+                                                <strong>Candidatures spontanées</strong>
+                                            </td>
+                                            <td>-</td>
+                                            <td>-</td>
+                                            <td>
+                                                {% include "companies/includes/buttons/spontaneous_applications_toggle.html" with csrf_token=csrf_token company=siae hx_swap_oob=False only %}
+                                            </td>
+                                            <td>
+                                                <span id="spontaneous_applications_open_since_cell">{{ siae.spontaneous_applications_open_since|default_if_none:"-"|naturaldate|capfirst }}</span>
+                                            </td>
+                                            <td class="w-100px">
+                                                {% include "companies/includes/buttons/spontaneous_applications_refresh.html" with csrf_token=csrf_token request=request company=siae only %}
+                                            </td>
+                                        </tr>
+                                    {% endif %}
                                     {% for job_description in job_pager %}
                                         <tr>
                                             <td>

--- a/tests/www/companies_views/test_job_description_views.py
+++ b/tests/www/companies_views/test_job_description_views.py
@@ -139,6 +139,13 @@ class TestJobDescriptionListView(JobDescriptionAbstract):
         response = client.get(self.url)
         assertContains(response, PAGINATION_PAGE_ONE_MARKUP % (self.list_url + "?page=1"), html=True)
 
+    @override_settings(PAGE_SIZE_DEFAULT=1)
+    def test_response_content_page_2(self, client):
+        client.force_login(self.user)
+        url = reverse("companies_views:job_description_list", query={"page": 2})
+        response = client.get(url)
+        assertNotContains(response, "<td><strong>Candidatures spontanées</strong></td>", html=True)
+
     def test_response_content_with_no_job_descriptions(self, client):
         JobDescription.objects.all().delete()
         client.force_login(self.user)


### PR DESCRIPTION
## :thinking: Pourquoi ?

La ligne est en haut du tableau, elle est assez visible, on n'a pas besoin de la voir à chaque page.

Prérequis : #6652

