### PR TITLE
Fiches salarié : Utiliser le lien du formulaire interne de demande de régularisation du NIR au lieu du lien Tally

### DIFF
--- a/itou/templates/employee_record/includes/_regularize_nir_button.html
+++ b/itou/templates/employee_record/includes/_regularize_nir_button.html
@@ -1,7 +1,5 @@
 {% load tally %}
 
 <a class="btn btn-primary btn-block w-100 w-md-auto has-external-link"
-   href="{% tally_form_url "wzxQlg" employeerecord=employee_record.pk|default:"" jobapplication=job_application.pk|default:"" %}"
-   target="_blank"
-   rel="noopener"
+   href="{% url "job_seekers_views:nir_modification_request" public_id=job_application.job_seeker.public_id %}?back_url={{ back_url|default:"" }}"
    aria-label="Régulariser le n° de sécurité sociale de {{ job_application.job_seeker.get_full_name }} (ouverture dans un nouvel onglet)">Régulariser le n° de sécurité sociale</a>

--- a/itou/templates/employee_record/includes/list_item.html
+++ b/itou/templates/employee_record/includes/list_item.html
@@ -140,7 +140,7 @@
     <div class="c-box--results__footer">
         {% if employee_record.job_application.job_seeker.jobseeker_profile.lack_of_nir_reason == "NIR_ASSOCIATED_TO_OTHER" %}
             <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-                {% include 'employee_record/includes/_regularize_nir_button.html' with employee_record=employee_record job_application=employee_record.job_application only %}
+                {% include 'employee_record/includes/_regularize_nir_button.html' with job_application=employee_record.job_application back_url=current_url|urlencode only %}
             </div>
         {% else %}
             <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">

--- a/itou/utils/perms/employee_record.py
+++ b/itou/utils/perms/employee_record.py
@@ -1,8 +1,10 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from django.template import loader
+from django.urls import reverse
 from django.utils.html import format_html
 
+from itou.employee_record.enums import Status
 from itou.job_applications.models import JobApplication
 from itou.users.enums import LackOfNIRReason
 from itou.utils.perms.company import get_current_company_or_404
@@ -61,7 +63,12 @@ def can_create_employee_record(request, job_application_id) -> JobApplication:
                 {}""",
                 loader.render_to_string(
                     "employee_record/includes/_regularize_nir_button.html",
-                    context={"job_application": job_application},
+                    context={
+                        "job_application": job_application,
+                        "back_url": (
+                            reverse("employee_record_views:list") + f"?status={Status.NEW}&status={Status.REJECTED}"
+                        ),
+                    },
                 ),
             )
         )

--- a/tests/www/employee_record_views/__snapshots__/test_list.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_list.ambr
@@ -21,7 +21,7 @@
   '''
   <div class="c-box--results__footer">
       <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-          <a aria-label="Régulariser le n° de sécurité sociale de Jane DOE (ouverture dans un nouvel onglet)" class="btn btn-primary btn-block w-100 w-md-auto has-external-link" href="https://tally.so/r/wzxQlg?employeerecord=[PK of EmployeeRecord]&jobapplication=[PK of JobApplication]" rel="noopener" target="_blank">
+          <a aria-label="Régulariser le n° de sécurité sociale de Jane DOE (ouverture dans un nouvel onglet)" class="btn btn-primary btn-block w-100 w-md-auto has-external-link" href="/job-seekers/nir-modification/[Public ID of JobSeeker]?back_url=/employee_record/list%3Fstatus%3DNEW">
               Régulariser le n° de sécurité sociale
           </a>
       </div>

--- a/tests/www/employee_record_views/test_list.py
+++ b/tests/www/employee_record_views/test_list.py
@@ -6,7 +6,6 @@ import pgtrigger
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.template.defaultfilters import title, urlencode
-from django.test import override_settings
 from django.urls import reverse, reverse_lazy
 from django.utils import timezone
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
@@ -322,7 +321,6 @@ class TestListEmployeeRecords:
         assertNotContains(response, self.HEADER_WARNING_TITLE)
         assertNotContains(response, self.ITEM_WARNING_TITLE)
 
-    @override_settings(TALLY_URL="https://tally.so")
     def test_employee_records_with_nir_associated_to_other(self, client, snapshot):
         client.force_login(self.user)
         self.job_seeker.jobseeker_profile.nir = ""
@@ -340,11 +338,10 @@ class TestListEmployeeRecords:
                 replace_in_attr=[
                     (
                         "href",
-                        f"https://tally.so/r/wzxQlg?employeerecord={self.employee_record.pk}&jobapplication={self.job_application.pk}",
-                        (
-                            "https://tally.so/r/wzxQlg"
-                            "?employeerecord=[PK of EmployeeRecord]&jobapplication=[PK of JobApplication]"
-                        ),
+                        f"/job-seekers/nir-modification/{self.job_seeker.public_id}"
+                        "?back_url=/employee_record/list%3Fstatus%3DNEW",
+                        "/job-seekers/nir-modification/[Public ID of JobSeeker]"
+                        "?back_url=/employee_record/list%3Fstatus%3DNEW",
                     )
                 ],
             )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Il y avait un trou dans la raquette.
Après la mise en prod de ac6ba46f6d50d482c95909cd713668871370ef9c, des demandes de modification arrivaient sur Tally.

Certaines avec `jobapplication` seulement 
D'autres avec `jobapplication` et `employeerecord`

