### PR TITLE
Interface: Supprimer les boutons “postuler/transferer” en doublon dans les fiches structures

### DIFF
--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -207,7 +207,7 @@
                                        href="{% url 'apply:job_application_external_transfer_start_session' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
                                        {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                                        aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line" aria-hidden="true"></i>
+                                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                                         <span>Transférer la candidature</span>
                                     </a>
                                 </div>
@@ -218,7 +218,7 @@
                                        href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
                                        {% matomo_event "candidature" "clic" "start_application" %}
                                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line" aria-hidden="true"></i>
+                                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                                         <span>Postuler</span>
                                     </a>
                                 </div>

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -200,30 +200,6 @@
                                 </ul>
                             </div>
                         {% endif %}
-                        {% if active_job_descriptions or siae.is_open_to_spontaneous_applications and siae.has_active_members %}
-                            {% if job_app_to_transfer %}
-                                <div class="d-flex justify-content-end mt-3">
-                                    <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
-                                       href="{% url 'apply:job_application_external_transfer_start_session' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
-                                       {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
-                                       aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                                        <span>Transférer la candidature</span>
-                                    </a>
-                                </div>
-                            {% else %}
-                                <div class="d-flex justify-content-end mt-3">
-                                    {% url 'apply:start' company_pk=siae.pk as apply_url %}
-                                    <a class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0"
-                                       href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:"" back_url=request.get_full_path %}"
-                                       {% matomo_event "candidature" "clic" "start_application" %}
-                                       aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
-                                        <span>Postuler</span>
-                                    </a>
-                                </div>
-                            {% endif %}
-                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/itou/templates/companies/card.html
+++ b/itou/templates/companies/card.html
@@ -43,7 +43,7 @@
                            class="btn btn-lg btn-white btn-block btn-ico"
                            {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                            aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                            <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
+                            <i class="ri-arrow-left-right-line fw-medium" aria-hidden="true"></i>
                             <span>Transférer la candidature</span>
                         </a>
                     </div>

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -69,7 +69,7 @@
                        href="{% url 'apply:job_application_external_transfer_start_session' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
                        {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                        aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
+                        <i class="ri-arrow-left-right-line fw-medium" aria-hidden="true"></i>
                         <span>Transférer la candidature</span>
                     </a>
                 </div>
@@ -152,7 +152,7 @@
                        href="{% url 'apply:job_application_external_transfer_start_session' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
                        {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                        aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
+                        <i class="ri-arrow-left-right-line fw-medium" aria-hidden="true"></i>
                         <span>Transférer la candidature</span>
                     </a>
                 </div>

--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -69,7 +69,7 @@
                        href="{% url 'apply:job_application_external_transfer_start_session' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
                        {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                        aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri ri-draft-line" aria-hidden="true"></i>
+                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                         <span>Transférer la candidature</span>
                     </a>
                 </div>
@@ -83,7 +83,7 @@
                        href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri ri-draft-line" aria-hidden="true"></i>
+                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                         <span>Postuler</span>
                     </a>
                 </div>
@@ -152,7 +152,7 @@
                        href="{% url 'apply:job_application_external_transfer_start_session' job_application_id=job_app_to_transfer.pk company_pk=siae.pk %}?back_url={{ request.get_full_path|urlencode }}"
                        {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                        aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri ri-draft-line" aria-hidden="true"></i>
+                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                         <span>Transférer la candidature</span>
                     </a>
                 </div>
@@ -166,7 +166,7 @@
                        href="{% url_add_query apply_url job_seeker_public_id=job_seeker.public_id|default:'' back_url=request.get_full_path %}"
                        {% matomo_event "candidature" "clic" "start_application" %}
                        aria-label="Postuler auprès de l'employeur inclusif {{ siae.display_name }}">
-                        <i class="ri ri-draft-line" aria-hidden="true"></i>
+                        <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
                         <span>Postuler</span>
                     </a>
                 </div>

--- a/itou/templates/companies/job_description_card.html
+++ b/itou/templates/companies/job_description_card.html
@@ -71,7 +71,7 @@
                                class="btn btn-lg btn-white btn-block btn-ico"
                                {% matomo_event "candidature" "clic" "start_job_app_transfer" %}
                                aria-label="Transférer la candidature à l'employeur inclusif {{ siae.display_name }}">
-                                <i class="ri-draft-line fw-medium" aria-hidden="true"></i>
+                                <i class="ri-arrow-left-right-line fw-medium" aria-hidden="true"></i>
                                 <span>Transférer la candidature</span>
                             </a>
                         </div>

--- a/tests/www/apply/test_process_external_transfer.py
+++ b/tests/www/apply/test_process_external_transfer.py
@@ -145,14 +145,14 @@ def test_step_1(client, snapshot):
     assertContains(
         response,
         f"{transfer_start_session_base_url}?back_url={quote(company_card_url)}",
-        count=2,
+        count=1,
     )
     assertContains(response, job_card_url, count=1)
     assertNotContains(response, POSTULER)
     assertContains(
         response,
         "<span>Transférer la candidature</span>",
-        count=2,
+        count=1,
     )
 
     # Check job description card

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -140,15 +140,6 @@
               </li>
           </ul>
       </div>
-      <div class="d-flex justify-content-end mt-3">
-          <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
-              <i aria-hidden="true" class="ri-draft-line fw-medium">
-              </i>
-              <span>
-                  Postuler
-              </span>
-          </a>
-      </div>
   </div>
   
   '''
@@ -243,15 +234,6 @@
                   </div>
               </li>
           </ul>
-      </div>
-      <div class="d-flex justify-content-end mt-3">
-          <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
-              <i aria-hidden="true" class="ri-draft-line fw-medium">
-              </i>
-              <span>
-                  Postuler
-              </span>
-          </a>
       </div>
   </div>
   
@@ -464,15 +446,6 @@
                   </div>
               </li>
           </ul>
-      </div>
-      <div class="d-flex justify-content-end mt-3">
-          <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
-              <i aria-hidden="true" class="ri-draft-line fw-medium">
-              </i>
-              <span>
-                  Postuler
-              </span>
-          </a>
       </div>
   </div>
   

--- a/tests/www/companies_views/__snapshots__/test_card_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_card_views.ambr
@@ -142,7 +142,7 @@
       </div>
       <div class="d-flex justify-content-end mt-3">
           <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
-              <i aria-hidden="true" class="ri-draft-line">
+              <i aria-hidden="true" class="ri-draft-line fw-medium">
               </i>
               <span>
                   Postuler
@@ -246,7 +246,7 @@
       </div>
       <div class="d-flex justify-content-end mt-3">
           <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
-              <i aria-hidden="true" class="ri-draft-line">
+              <i aria-hidden="true" class="ri-draft-line fw-medium">
               </i>
               <span>
                   Postuler
@@ -467,7 +467,7 @@
       </div>
       <div class="d-flex justify-content-end mt-3">
           <a aria-label="Postuler auprès de l'employeur inclusif Les petits jardins" class="btn btn-primary btn-ico flex-grow-1 flex-lg-grow-0" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="start_application" href="/apply/[PK of Company]/start?back_url=/company/[PK of Company]/card">
-              <i aria-hidden="true" class="ri-draft-line">
+              <i aria-hidden="true" class="ri-draft-line fw-medium">
               </i>
               <span>
                   Postuler

--- a/tests/www/companies_views/test_card_views.py
+++ b/tests/www/companies_views/test_card_views.py
@@ -346,7 +346,7 @@ class TestCardView:
         apply_url_with_job_seeker_id = reverse(
             "apply:start", kwargs={"company_pk": company.pk}, query={"job_seeker_public_id": job_seeker_public_id}
         )
-        assertContains(response, apply_url_with_job_seeker_id, count=2)
+        assertContains(response, apply_url_with_job_seeker_id, count=1)
 
         # When UUID is broken in GET parameters
         broken_url = reverse("companies_views:card", kwargs={"siae_id": company.pk}) + "?job_seeker_public_id=123"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les boutons “Postuler” et "Transférer la candidature" sont en doublons, car déjà présent dans la barre d'action

## 🎁 Bonus 
- Mise a jour du graissage (font-weight) des icones `ri-draft-line`
- Remplacement de l'icone `ri-draft-line` de "Transférer la candidature" par `ri-arrow-left-right-line`



