### PR TITLE
Recherche employeur: Forcer l'ouverture des menus déroulants (distance, type de structure…) par le dessous

### DIFF
--- a/itou/static/css/itou.css
+++ b/itou/static/css/itou.css
@@ -116,11 +116,6 @@ Credits go to https://stackoverflow.com/a/19229738
     white-space: break-spaces !important;
 }
 
-/* Temporary fix to display dropdown menus above sticky titles */
-.fix-zindex-1040 {
-    z-index: 1040 !important;
-}
-
 /* Missing Boostrap utilities.
 --------------------------------------------------------------------------- */
 

--- a/itou/templates/includes/btn_dropdown_filter/checkboxes.html
+++ b/itou/templates/includes/btn_dropdown_filter/checkboxes.html
@@ -9,7 +9,7 @@ Arguments:
     <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
         {{ label|default:field.label }}
     </button>
-    <ul class="dropdown-menu {{ menu_extra_classes|default:"" }}">
+    <ul class="dropdown-menu">
         {% for choice in field %}
             <li class="dropdown-item">
                 <div class="form-check">

--- a/itou/templates/includes/btn_dropdown_filter/checkboxes.html
+++ b/itou/templates/includes/btn_dropdown_filter/checkboxes.html
@@ -6,7 +6,7 @@ Arguments:
     suffix to make its input id unique.
 {% endcomment %}
 <div class="dropdown">
-    <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+    <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="outside" aria-expanded="false">
         {{ label|default:field.label }}
     </button>
     <ul class="dropdown-menu">

--- a/itou/templates/includes/btn_dropdown_filter/radio.html
+++ b/itou/templates/includes/btn_dropdown_filter/radio.html
@@ -7,7 +7,7 @@ Arguments:
     <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
         {{ label|default:field.label }}
     </button>
-    <ul class="dropdown-menu {{ menu_extra_classes|default:"" }}">
+    <ul class="dropdown-menu">
         {% for choice in field %}
             <li class="dropdown-item">
                 <div class="form-check">

--- a/itou/templates/includes/btn_dropdown_filter/radio.html
+++ b/itou/templates/includes/btn_dropdown_filter/radio.html
@@ -4,7 +4,7 @@ Arguments:
 - label: defaults to the field label
 {% endcomment %}
 <div class="dropdown">
-    <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+    <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown" data-bs-display="static" data-bs-auto-close="outside" aria-expanded="false">
         {{ label|default:field.label }}
     </button>
     <ul class="dropdown-menu">

--- a/itou/templates/search/includes/siaes_search_content.html
+++ b/itou/templates/search/includes/siaes_search_content.html
@@ -16,13 +16,13 @@
                                       hx-swap="outerHTML"
                                       hx-push-url="true">
                                     <div class="btn-dropdown-filter-group mb-3 mb-md-4">
-                                        {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance menu_extra_classes="fix-zindex-1040" only %}
-                                        {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.kinds menu_extra_classes="fix-zindex-1040" only %}
+                                        {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance only %}
+                                        {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.kinds only %}
                                         {% if form.contract_types %}
-                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.contract_types menu_extra_classes="fix-zindex-1040" only %}
+                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.contract_types only %}
                                         {% endif %}
                                         {% if form.domains %}
-                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.domains menu_extra_classes="fix-zindex-1040" only %}
+                                            {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.domains only %}
                                         {% endif %}
                                         {% include "search/includes/siaes_search_filters_departments.html" %}
                                         <div class="ms-lg-auto">

--- a/itou/templates/search/includes/siaes_search_filters_departments.html
+++ b/itou/templates/search/includes/siaes_search_filters_departments.html
@@ -1,14 +1,14 @@
 {% load django_bootstrap5 %}
 
 {% if form.departments %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.departments menu_extra_classes="fix-zindex-1040" only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.departments only %}
 {% endif %}
 {% if form.districts_13 %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_13 menu_extra_classes="fix-zindex-1040" only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_13 only %}
 {% endif %}
 {% if form.districts_69 %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_69 menu_extra_classes="fix-zindex-1040" only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_69 only %}
 {% endif %}
 {% if form.districts_75 %}
-    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_75 menu_extra_classes="fix-zindex-1040" only %}
+    {% include "includes/btn_dropdown_filter/checkboxes.html" with field=form.districts_75 only %}
 {% endif %}

--- a/itou/templates/search/prescribers_search_results.html
+++ b/itou/templates/search/prescribers_search_results.html
@@ -41,7 +41,7 @@
                               hx-swap="outerHTML"
                               hx-push-url="true">
                             <div class="btn-dropdown-filter-group my-3 my-md-4">
-                                {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance menu_extra_classes="fix-zindex-1040" only %}
+                                {% include "includes/btn_dropdown_filter/radio.html" with field=form.distance only %}
                             </div>
                         </form>
                     </div>

--- a/tests/www/apply/test_list_for_siae.py
+++ b/tests/www/apply/test_list_for_siae.py
@@ -86,7 +86,7 @@ class TestProcessListSiae:
             f"""
             <div class="dropdown">
             <button type="button" class="btn btn-dropdown-filter dropdown-toggle" data-bs-toggle="dropdown"
-                    data-bs-auto-close="outside" aria-expanded="false">
+                    data-bs-display="static" data-bs-auto-close="outside" aria-expanded="false">
                 Fiches de poste
             </button>
             <ul class="dropdown-menu">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cf https://github.com/gip-inclusion/les-emplois/pull/6615

## :cake: Comment ? <!-- optionnel -->

Via l'utilsation du `data-bs-display="static"`

