### PR TITLE
Profil salarié : Ajout d’un lien supplémentaire dans l’encart IF [GEN-2648]

### DIFF
--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -51,7 +51,7 @@
                     {% if approval %}
                         {% approval_details_box approval=approval version='box' request=request extra_classes='mb-3 mb-md-4' %}
                     {% endif %}
-                    {% if link_immersion_facile %}
+                    {% if immersion_search_url %}
                         {# Immersion Facilitée proposal #}
                         <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
                             <div class="c-box__header--immersion-facile p-3 p-lg-4">
@@ -72,12 +72,12 @@
                                     {% endif %}
                                 </p>
                                 <p>
-                                    <a href="{{ link_immersion_facile }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)">
+                                    <a href="{{ immersion_search_url }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)">
                                         Rechercher une immersion
                                     </a>
                                 </p>
                                 <p>
-                                    <a href="{{ link_immersion_facile_convention }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Initier une convention (ouverture dans un nouvel onglet)">
+                                    <a href="{{ immersion_convention_url }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Initier une convention (ouverture dans un nouvel onglet)">
                                         Initier une convention
                                     </a>
                                 </p>

--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -71,9 +71,16 @@
                                         <strong>Immersion Facilitée</strong> vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
                                     {% endif %}
                                 </p>
-                                <a href="{{ link_immersion_facile }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)">
-                                    Rechercher une immersion
-                                </a>
+                                <p>
+                                    <a href="{{ link_immersion_facile }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)">
+                                        Rechercher une immersion
+                                    </a>
+                                </p>
+                                <p>
+                                    <a href="{{ link_immersion_facile_convention }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Initier une convention (ouverture dans un nouvel onglet)">
+                                        Initier une convention
+                                    </a>
+                                </p>
                             </div>
                         </div>
                     {% endif %}

--- a/itou/utils/immersion_facile.py
+++ b/itou/utils/immersion_facile.py
@@ -27,3 +27,15 @@ def immersion_search_url(user):
             params["place"] = ", ".join(address_parts)
 
     return f"{settings.IMMERSION_FACILE_SITE_URL}/recherche?{urlencode(params, quote_via=quote)}"
+
+
+def immersion_convention_url():
+    """
+    :return: a URL on Immersion Facilitée's site for initiating a convention
+    """
+    params = {
+        "mtm_campaign": "les-emplois-recherche-immersion",
+        "mtm_kwd": "les-emplois-recherche-immersion",
+    }
+
+    return f"{settings.IMMERSION_FACILE_SITE_URL}/initier-convention?{urlencode(params, quote_via=quote)}"

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -15,7 +15,7 @@ from itou.job_applications.enums import JobApplicationState
 from itou.job_applications.models import JobApplication
 from itou.users.enums import UserKind
 from itou.users.models import User
-from itou.utils.immersion_facile import immersion_search_url
+from itou.utils.immersion_facile import immersion_convention_url, immersion_search_url
 from itou.utils.perms.company import get_current_company_or_404
 from itou.utils.perms.utils import can_edit_personal_information
 from itou.utils.urls import get_safe_url
@@ -124,6 +124,7 @@ class EmployeeDetailView(DetailView):
         context["link_immersion_facile"] = None
 
         context["link_immersion_facile"] = immersion_search_url(self.object)
+        context["link_immersion_facile_convention"] = immersion_convention_url()
         context["approval_valid"] = approval and approval.is_valid()
         context["approval_expires_soon"] = approval and approval.remainder.days < 90
 

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -122,8 +122,8 @@ class EmployeeDetailView(DetailView):
         context["expired_eligibility_diagnosis"] = None
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
 
-        context["link_immersion_facile"] = immersion_search_url(self.object)
-        context["link_immersion_facile_convention"] = immersion_convention_url()
+        context["immersion_search_url"] = immersion_search_url(self.object)
+        context["immersion_convention_url"] = immersion_convention_url()
         context["approval_valid"] = approval and approval.is_valid()
         context["approval_expires_soon"] = approval and approval.remainder.days < 90
 

--- a/itou/www/employees_views/views.py
+++ b/itou/www/employees_views/views.py
@@ -121,7 +121,6 @@ class EmployeeDetailView(DetailView):
         context["eligibility_diagnosis"] = eligibility_diagnosis
         context["expired_eligibility_diagnosis"] = None
         context["back_url"] = get_safe_url(self.request, "back_url", fallback_url=reverse_lazy("approvals:list"))
-        context["link_immersion_facile"] = None
 
         context["link_immersion_facile"] = immersion_search_url(self.object)
         context["link_immersion_facile_convention"] = immersion_convention_url()

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1579,9 +1579,16 @@
               </strong>
               vous aide à lui trouver une immersion professionnelle sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
-              Rechercher une immersion
-          </a>
+          <p>
+              <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Rechercher une immersion
+              </a>
+          </p>
+          <p>
+              <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Initier une convention
+              </a>
+          </p>
       </div>
   </div>
   
@@ -1602,9 +1609,16 @@
               </strong>
               vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
-              Rechercher une immersion
-          </a>
+          <p>
+              <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Rechercher une immersion
+              </a>
+          </p>
+          <p>
+              <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Initier une convention
+              </a>
+          </p>
       </div>
   </div>
   
@@ -1627,9 +1641,16 @@
               </strong>
               vous aide à lui trouver une immersion professionnelle sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
-              Rechercher une immersion
-          </a>
+          <p>
+              <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Rechercher une immersion
+              </a>
+          </p>
+          <p>
+              <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Initier une convention
+              </a>
+          </p>
       </div>
   </div>
   
@@ -1650,9 +1671,16 @@
               </strong>
               vous aide à trouver une immersion professionnelle pour ce candidat sur son territoire.
           </p>
-          <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
-              Rechercher une immersion
-          </a>
+          <p>
+              <a aria-label="Rechercher une immersion (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/recherche?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Rechercher une immersion
+              </a>
+          </p>
+          <p>
+              <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
+                  Initier une convention
+              </a>
+          </p>
       </div>
   </div>
   

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1562,7 +1562,7 @@
     ]),
   })
 # ---
-# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expirant bientôt]
+# name: TestEmployeeDetailView.test_immersion_ad[alerte à l'opportunité immersion facile PASS expirant bientôt]
   '''
   <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
       <div class="c-box__header--immersion-facile p-3 p-lg-4">
@@ -1594,7 +1594,7 @@
   
   '''
 # ---
-# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expirant dans longtemps]
+# name: TestEmployeeDetailView.test_immersion_ad[alerte à l'opportunité immersion facile PASS expirant dans longtemps]
   '''
   <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
       <div class="c-box__header--immersion-facile p-3 p-lg-4">
@@ -1624,7 +1624,7 @@
   
   '''
 # ---
-# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS expiré]
+# name: TestEmployeeDetailView.test_immersion_ad[alerte à l'opportunité immersion facile PASS expiré]
   '''
   <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
       <div class="c-box__header--immersion-facile p-3 p-lg-4">
@@ -1656,7 +1656,7 @@
   
   '''
 # ---
-# name: TestEmployeeDetailView.test_link_immersion_facile[alerte à l'opportunité immersion facile PASS non démarré]
+# name: TestEmployeeDetailView.test_immersion_ad[alerte à l'opportunité immersion facile PASS non démarré]
   '''
   <div class="c-box p-0 mb-4" id="immersion-facile-opportunity-alert">
       <div class="c-box__header--immersion-facile p-3 p-lg-4">

--- a/tests/www/employees_views/test_detail.py
+++ b/tests/www/employees_views/test_detail.py
@@ -194,7 +194,7 @@ class TestEmployeeDetailView:
         )
 
     @override_settings(TALLY_URL="https://tally.so")
-    def test_link_immersion_facile(self, client, snapshot):
+    def test_immersion_ad(self, client, snapshot):
         today = timezone.localdate()
         approval = ApprovalFactory(
             with_jobapplication=True,
@@ -207,24 +207,24 @@ class TestEmployeeDetailView:
         client.force_login(employer)
 
         response = client.get(url)
-        assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
-        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
+        assert response.context["immersion_search_url"] == immersion_search_url(approval.user)
+        assert response.context["immersion_convention_url"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expirant bientôt")
 
         approval.end_at = today - datetime.timedelta(days=1)
         approval.save()
         response = client.get(url)
-        assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
-        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
+        assert response.context["immersion_search_url"] == immersion_search_url(approval.user)
+        assert response.context["immersion_convention_url"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expiré")
 
         approval.end_at = today + datetime.timedelta(days=90)
         approval.save()
         response = client.get(url)
-        assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
-        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
+        assert response.context["immersion_search_url"] == immersion_search_url(approval.user)
+        assert response.context["immersion_convention_url"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(
             name="alerte à l'opportunité immersion facile PASS expirant dans longtemps"
@@ -234,7 +234,7 @@ class TestEmployeeDetailView:
         approval.end_at = today + datetime.timedelta(days=365)
         approval.save()
         response = client.get(url)
-        assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
-        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
+        assert response.context["immersion_search_url"] == immersion_search_url(approval.user)
+        assert response.context["immersion_convention_url"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS non démarré")

--- a/tests/www/employees_views/test_detail.py
+++ b/tests/www/employees_views/test_detail.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
 from itou.job_applications.enums import JobApplicationState, SenderKind
-from itou.utils.immersion_facile import immersion_search_url
+from itou.utils.immersion_facile import immersion_convention_url, immersion_search_url
 from itou.utils.templatetags import format_filters
 from tests.approvals.factories import (
     ApprovalFactory,
@@ -208,6 +208,7 @@ class TestEmployeeDetailView:
 
         response = client.get(url)
         assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
+        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expirant bientôt")
 
@@ -215,6 +216,7 @@ class TestEmployeeDetailView:
         approval.save()
         response = client.get(url)
         assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
+        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS expiré")
 
@@ -222,6 +224,7 @@ class TestEmployeeDetailView:
         approval.save()
         response = client.get(url)
         assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
+        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(
             name="alerte à l'opportunité immersion facile PASS expirant dans longtemps"
@@ -232,5 +235,6 @@ class TestEmployeeDetailView:
         approval.save()
         response = client.get(url)
         assert response.context["link_immersion_facile"] == immersion_search_url(approval.user)
+        assert response.context["link_immersion_facile_convention"] == immersion_convention_url()
         alert = parse_response_to_soup(response, selector="#immersion-facile-opportunity-alert")
         assert pretty_indented(alert) == snapshot(name="alerte à l'opportunité immersion facile PASS non démarré")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Vu avec Eric et Nathalie (IF), comme on a retiré l’autre encart à la demande de la DGEFP, on peut se permettre d’ajouter un lien pour initier une convention ça reste dans le cadre autorisé par la DGEFP.

## :cake: Comment ? <!-- optionnel -->

Sur les pages de profil salariés, on va ajouter un nouveau lien "Initier une convention" dans l’encart IF  : https://immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion 

en dessous du lien existant "Rechercher une immersion".

## :computer: Captures d'écran

<img width="422" height="316" alt="image" src="https://github.com/user-attachments/assets/fe3770f5-af8f-4102-a4ab-62e597b8df02" />

