### PR TITLE
Tests : corriger un test qui ne passe plus en python 3.13.6

### DIFF
--- a/tests/utils/test_widgets.py
+++ b/tests/utils/test_widgets.py
@@ -17,6 +17,7 @@ class TestEasyMDEEditor:
             <div>
             <label for="id_description">Description :</label>
             <textarea class="easymde-box" cols="40" id="id_description" name="description" required rows="10">
+            </textarea>
             </div>
             """,
         )
@@ -46,6 +47,7 @@ class TestEasyMDEEditor:
                 name="description"
                 required
                 rows="10">
+            </textarea>
             </div>
             """,
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

La CI semble planter depuis qu'elle est passée en python 3.13.6.
En local, on reproduit avec cette version également.

Deux choses m'interrogent : 
- pourquoi dans le test la balise `<textarea>` n'était pas fermée ?
- pourquoi est-ce un changement de version python qui fait planter le test ?

