### PR TITLE
Candidat: Permettre de copier son ID candidat depuis le tableau de bord [GEN-2567]

### DIFF
--- a/itou/templates/dashboard/includes/dashboard_title_content.html
+++ b/itou/templates/dashboard/includes/dashboard_title_content.html
@@ -14,7 +14,10 @@
             {% if user.is_prescriber %}
                 <p>Orienteur seul</p>
             {% elif user.is_job_seeker %}
-                <p>Candidat</p>
+                <p>
+                    Copier mon ID candidat
+                    {% include 'includes/copy_to_clipboard.html' with content=user.public_id css_classes="btn-link" only_icon=True %}
+                </p>
             {% endif %}
         {% else %}
             <h1>{{ request.current_organization.display_name }}</h1>

--- a/tests/www/dashboard/__snapshots__/test_dashboard.ambr
+++ b/tests/www/dashboard/__snapshots__/test_dashboard.ambr
@@ -26,6 +26,26 @@
   
   '''
 # ---
+# name: TestDashboardView.test_dashboard_for_job_seeker
+  '''
+  <div class="c-title__main">
+      <h1>
+          Jane DOE
+      </h1>
+      <p>
+          Copier mon ID candidat
+          <button class="btn-link" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="7614fc4b-aef9-4694-ab17-12324300180a" type="button">
+              <i aria-hidden="true" class="ri-file-copy-line fw-normal">
+              </i>
+              <span class="visually-hidden">
+                  Copier
+              </span>
+          </button>
+      </p>
+  </div>
+  
+  '''
+# ---
 # name: TestDashboardView.test_dashboard_siae_evaluation_campaign_notifications[view queries]
   dict({
     'num_queries': 20,

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -86,6 +86,14 @@ class TestDashboardView:
         cities_search = parse_response_to_soup(response, selector="form[method=get]")
         assert pretty_indented(cities_search) == snapshot
 
+    def test_dashboard_for_job_seeker(self, client, snapshot):
+        user = JobSeekerFactory(for_snapshot=True)
+        client.force_login(user)
+
+        response = client.get(reverse("dashboard:index"))
+        # Job seeker may copy his ID
+        assert pretty_indented(parse_response_to_soup(response, selector=".c-title__main")) == snapshot
+
     def test_user_with_inactive_company_can_still_login_during_grace_period(self, client):
         company = CompanyPendingGracePeriodFactory(with_membership=True)
         user = EmployerFactory()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour faciliter les échanges avec le support ? (la carte notion n'explique pas pourquoi on a besoin que ce soit plus simple pour le candidat de retrouver son ID)

La maquette présente aussi un bouton dans le menu de gauche, mais ce n'est pas indiqué dans la carte notion :shrug: 
On verra en recette

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
