### PR TITLE
Interface: Corriger bug de disparition du tooltip du bouton de copy

### DIFF
--- a/itou/utils/staticfiles.py
+++ b/itou/utils/staticfiles.py
@@ -204,11 +204,11 @@ ASSET_INFOS = {
     },
     "theme-inclusion": {
         "download": {
-            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v3.0.2.zip",
-            "sha256": "e170243d7f8d99ca91bf8ca8b750b3e299fa9461a82e4e5e20b8389c53002839",
+            "url": "https://github.com/gip-inclusion/itou-theme/archive/refs/tags/v3.0.4.zip",
+            "sha256": "d708e8f185ca28d3bfd7ab931b4d8a7f2a04421c96dc6e49d67b07395279e2bd",
         },
         "extract": {
-            "origin": "itou-theme-3.0.2/dist",
+            "origin": "itou-theme-3.0.4/dist",
             "destination": "vendor/theme-inclusion/",
             "files": [
                 "javascripts/app.js",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcque le tooltip ne restait pas assez longtemps a certains endroits
https://www.notion.so/gip-inclusion/Modifier-la-vitesse-de-disparition-du-tooltip-copier-23e5f321b6048009bd11f5cd88fa5a97

## :cake: Comment ? <!-- optionnel -->
TLDR:
La fonction [buttonCopyToClipboard()](https://github.com/gip-inclusion/itou-theme/blob/main/src/javascripts/index.js#L71) est initiée au `window:load` et au `htmx:load`. De ce fait le click sur le bouton était doublé sur les pages possédant du rechargement htmx. Donc au click sur le bouton, le tooltip était affiché puis rechargé/affiché une 2e  fois (ce qui le faisait disparaitre prématurément)

Solution trouvée, n'afficher le tooltip que s'il n'est pas déjà affiché (via la vérification de la présence de l'attr `aria-describedby` qui est injecté lors le d'affichage du tooltip)

## :desert_island: Comment tester ?
Sur la Démo > ETTI > [Fiche salarié](https://demo.emplois.inclusion.beta.gouv.fr/employees/detail/a88ad28a-d605-48a6-958a-bb63b0c92ade?approval=163&back_url=/approvals/list) (tous les copy_button x tooltip disparaissent trop vite)
vs
Sur la recette > ETTI > [Fiche salarié](https://c1-review-deloo-fix-copy-to-clipboard-on-htmx-load.cleverapps.io/employees/detail/cab520af-a9ea-42d4-a8ac-3c49ac20c953?approval=21&back_url=/approvals/list)