### PR TITLE
Candidature: Ne plus afficher les critères IAE lorsque l'entreprise cible est un GEIQ [GEN-2665]

### DIFF
--- a/itou/templates/apply/includes/list_card_body.html
+++ b/itou/templates/apply/includes/list_card_body.html
@@ -34,7 +34,7 @@
     <hr class="m-0">
     <div class="c-box--results__body">
         <div class="c-box--results__list-data">
-            {% if job_applications_list_kind is not JobApplicationsListKind.SENT_FOR_ME and job_application.preloaded_administrative_criteria %}
+            {% if job_applications_list_kind is not JobApplicationsListKind.SENT_FOR_ME and job_application.preloaded_administrative_criteria and job_application.to_company.is_subject_to_eligibility_rules %}
                 <p class="h5">Critères administratifs IAE</p>
                 <div class="mb-3 mb-md-4">
                     <ul>

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -2568,10 +2568,82 @@
                               35 -
                                   Rennes
                           </span>
-                          <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
+                          <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-check-line">
                               </i>
-                              Éligibilité IAE à valider
+                              Éligible à l’IAE
+                          </span>
+                      </div>
+                  </div>
+              </div>
+          </div>
+          <hr class="m-0"/>
+          <div class="c-box--results__body">
+              <div class="c-box--results__list-data">
+                  <p class="h5">
+                      Critères administratifs IAE
+                  </p>
+                  <div class="mb-3 mb-md-4">
+                      <ul>
+                          <li>
+                              Allocataire ASS
+                          </li>
+                          <li>
+                              Bénéficiaire du RSA
+                          </li>
+                      </ul>
+                  </div>
+                  <div class="c-info c-info--secondary">
+                      <span class="c-info__summary">
+                          Candidature spontanée
+                      </span>
+                  </div>
+              </div>
+          </div>
+          <div class="c-box--results__footer">
+              <div class="d-flex flex-column flex-md-row justify-content-md-end align-items-md-center gap-3">
+                  <a aria-label="Gérer la candidature de J… D…" class="btn btn-outline-primary btn-block w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dlist">
+                      Voir sa candidature
+                  </a>
+              </div>
+          </div>
+      </div>
+      <div class="c-box c-box--results has-links-inside my-3 my-md-4">
+          <div class="c-box--results__header">
+              <div class="d-flex flex-column flex-lg-row gap-1 gap-lg-3 mb-3">
+                  <p class="fs-sm mb-0 flex-grow-1">
+                      Émise le 27 novembre 2024 par
+                      <strong>
+                          Vous
+                      </strong>
+                      chez
+                      <a class="btn-ico btn-link" href="/company/[PK of Company]/card?back_url=/apply/prescriptions/list%3Fdisplay%3Dlist">
+                          <i aria-hidden="true" class="ri-community-line fw-medium ri-sm me-1">
+                          </i>
+                          <span>
+                              Acme inc.
+                          </span>
+                      </a>
+                  </p>
+                  <div>
+                      <span class="badge rounded-pill text-nowrap badge-sm mb-1 bg-success" id="state_[PK of JobApplication]">
+                          Candidature acceptée
+                      </span>
+                  </div>
+              </div>
+              <div class="c-box--results__summary">
+                  <i aria-hidden="true" class="ri-user-line">
+                  </i>
+                  <div>
+                      <h3>
+                          J… D…
+                      </h3>
+                      <div class="d-flex flex-column flex-md-row align-items-start align-items-md-end gap-1 gap-md-2">
+                          <span>
+                              <i aria-hidden="true" class="ri-map-pin-2-line fw-normal me-1">
+                              </i>
+                              35 -
+                                  Rennes
                           </span>
                       </div>
                   </div>
@@ -2632,10 +2704,10 @@
                               35 -
                                   Rennes
                           </span>
-                          <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
+                          <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-check-line">
                               </i>
-                              Éligibilité IAE à valider
+                              Éligible à l’IAE
                           </span>
                       </div>
                   </div>
@@ -2644,6 +2716,19 @@
           <hr class="m-0"/>
           <div class="c-box--results__body">
               <div class="c-box--results__list-data">
+                  <p class="h5">
+                      Critères administratifs IAE
+                  </p>
+                  <div class="mb-3 mb-md-4">
+                      <ul>
+                          <li>
+                              Allocataire ASS
+                          </li>
+                          <li>
+                              Bénéficiaire du RSA
+                          </li>
+                      </ul>
+                  </div>
                   <div class="c-info c-info--secondary">
                       <span class="c-info__summary">
                           Candidature spontanée
@@ -2696,10 +2781,10 @@
                               35 -
                                   Rennes
                           </span>
-                          <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
+                          <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-check-line">
                               </i>
-                              Éligibilité IAE à valider
+                              Éligible à l’IAE
                           </span>
                       </div>
                   </div>
@@ -2708,6 +2793,19 @@
           <hr class="m-0"/>
           <div class="c-box--results__body">
               <div class="c-box--results__list-data">
+                  <p class="h5">
+                      Critères administratifs IAE
+                  </p>
+                  <div class="mb-3 mb-md-4">
+                      <ul>
+                          <li>
+                              Allocataire ASS
+                          </li>
+                          <li>
+                              Bénéficiaire du RSA
+                          </li>
+                      </ul>
+                  </div>
                   <div class="c-info c-info--secondary">
                       <span class="c-info__summary">
                           Candidature spontanée
@@ -2793,65 +2891,23 @@
                           Vous
                       </td>
                       <td>
-                          <i class="text-disabled">
-                              Aucun critère sélectionné
-                          </i>
+                          <ul class="mb-0">
+                              <li>
+                                  Allocataire ASS
+                              </li>
+                              <li>
+                                  Bénéficiaire du RSA
+                              </li>
+                          </ul>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-check-line">
                               </i>
-                              Éligibilité IAE à valider
+                              Éligible à l’IAE
                           </span>
                           <span class="d-block">
-                              Un diagnostic doit être réalisé
-                          </span>
-                      </td>
-                      <td class="text-end w-50px align-middle">
-                          <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Voir sa candidature" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dtable">
-                              <i aria-label="Gérer la candidature de J… D…" class="ri-arrow-drop-right-line fs-lg">
-                              </i>
-                          </a>
-                      </td>
-                  </tr>
-                  <tr class="align-top">
-                      <td>
-                          <a class="btn-link" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dtable">
-                              J… D…
-                          </a>
-                          <span class="d-block">
-                              35 -
-                  Rennes
-                          </span>
-                          <span class="badge rounded-pill text-nowrap badge-sm bg-info" id="state_[PK of JobApplication]">
-                              Nouvelle candidature
-                          </span>
-                      </td>
-                      <td>
-                          27/11/2024
-                      </td>
-                      <td>
-                          Acme inc.
-                      </td>
-                      <td>
-                          Candidature spontanée
-                      </td>
-                      <td>
-                          Vous
-                      </td>
-                      <td>
-                          <i class="text-disabled">
-                              Aucun critère sélectionné
-                          </i>
-                      </td>
-                      <td>
-                          <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
-                              </i>
-                              Éligibilité IAE à valider
-                          </span>
-                          <span class="d-block">
-                              Un diagnostic doit être réalisé
+                              Éligibilité validée par un prescripteur habilité
                           </span>
                       </td>
                       <td class="text-end w-50px align-middle">
@@ -2888,17 +2944,116 @@
                       </td>
                       <td>
                           <i class="text-disabled">
-                              Aucun critère sélectionné
+                              Candidature hors IAE
                           </i>
                       </td>
                       <td>
-                          <span class="badge badge-sm rounded-pill bg-warning-lighter text-warning">
-                              <i aria-hidden="true" class="ri-error-warning-line">
+                          <i class="text-disabled">
+                              Candidature hors IAE
+                          </i>
+                      </td>
+                      <td class="text-end w-50px align-middle">
+                          <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Voir sa candidature" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dtable">
+                              <i aria-label="Gérer la candidature de J… D…" class="ri-arrow-drop-right-line fs-lg">
                               </i>
-                              Éligibilité IAE à valider
+                          </a>
+                      </td>
+                  </tr>
+                  <tr class="align-top">
+                      <td>
+                          <a class="btn-link" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dtable">
+                              J… D…
+                          </a>
+                          <span class="d-block">
+                              35 -
+                  Rennes
+                          </span>
+                          <span class="badge rounded-pill text-nowrap badge-sm bg-info" id="state_[PK of JobApplication]">
+                              Nouvelle candidature
+                          </span>
+                      </td>
+                      <td>
+                          27/11/2024
+                      </td>
+                      <td>
+                          Acme inc.
+                      </td>
+                      <td>
+                          Candidature spontanée
+                      </td>
+                      <td>
+                          Vous
+                      </td>
+                      <td>
+                          <ul class="mb-0">
+                              <li>
+                                  Allocataire ASS
+                              </li>
+                              <li>
+                                  Bénéficiaire du RSA
+                              </li>
+                          </ul>
+                      </td>
+                      <td>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-check-line">
+                              </i>
+                              Éligible à l’IAE
                           </span>
                           <span class="d-block">
-                              Un diagnostic doit être réalisé
+                              Éligibilité validée par un prescripteur habilité
+                          </span>
+                      </td>
+                      <td class="text-end w-50px align-middle">
+                          <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Voir sa candidature" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="voir_candidature_prescripteur" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dtable">
+                              <i aria-label="Gérer la candidature de J… D…" class="ri-arrow-drop-right-line fs-lg">
+                              </i>
+                          </a>
+                      </td>
+                  </tr>
+                  <tr class="align-top">
+                      <td>
+                          <a class="btn-link" href="/apply/[PK of JobApplication]/prescriber/details?back_url=/apply/prescriptions/list%3Fdisplay%3Dtable">
+                              J… D…
+                          </a>
+                          <span class="d-block">
+                              35 -
+                  Rennes
+                          </span>
+                          <span class="badge rounded-pill text-nowrap badge-sm bg-success" id="state_[PK of JobApplication]">
+                              Candidature acceptée
+                          </span>
+                      </td>
+                      <td>
+                          27/11/2024
+                      </td>
+                      <td>
+                          Acme inc.
+                      </td>
+                      <td>
+                          Candidature spontanée
+                      </td>
+                      <td>
+                          Vous
+                      </td>
+                      <td>
+                          <ul class="mb-0">
+                              <li>
+                                  Allocataire ASS
+                              </li>
+                              <li>
+                                  Bénéficiaire du RSA
+                              </li>
+                          </ul>
+                      </td>
+                      <td>
+                          <span class="badge badge-sm rounded-pill bg-success-lighter text-success">
+                              <i aria-hidden="true" class="ri-check-line">
+                              </i>
+                              Éligible à l’IAE
+                          </span>
+                          <span class="d-block">
+                              Éligibilité validée par l’employeur
                           </span>
                       </td>
                       <td class="text-end w-50px align-middle">

--- a/tests/www/apply/test_list_prescriptions.py
+++ b/tests/www/apply/test_list_prescriptions.py
@@ -11,10 +11,7 @@ from freezegun import freeze_time
 from pytest_django.asserts import assertContains, assertNotContains
 
 from itou.companies.enums import CompanyKind
-from itou.eligibility.enums import (
-    AdministrativeCriteriaKind,
-    AuthorKind,
-)
+from itou.eligibility.enums import AdministrativeCriteriaKind, AuthorKind
 from itou.job_applications.enums import JobApplicationState, SenderKind
 from itou.job_applications.models import JobApplicationWorkflow
 from itou.prescribers.enums import PrescriberOrganizationKind
@@ -400,22 +397,48 @@ def test_list_snapshot(client, snapshot):
 
     job_seeker = JobSeekerFactory(for_snapshot=True)
     company = CompanyFactory(for_snapshot=True, with_membership=True)
+    geiq_company = CompanyFactory(for_snapshot=True, kind=CompanyKind.GEIQ)
     common_kwargs = {
         "job_seeker": job_seeker,
-        "eligibility_diagnosis": None,
         "to_company": company,
         "sender_kind": SenderKind.PRESCRIBER,
         "sender": prescriber,
     }
 
+    company_diagnosis = IAEEligibilityDiagnosisFactory(
+        job_seeker=job_seeker,
+        author_kind=AuthorKind.EMPLOYER,
+        author_siae=company,
+        author=company.members.first(),
+        criteria_kinds=[AdministrativeCriteriaKind.ASS, AdministrativeCriteriaKind.RSA],
+    )
+    prescriber_diagnosis = IAEEligibilityDiagnosisFactory(
+        job_seeker=job_seeker,
+        author_kind=AuthorKind.PRESCRIBER,
+        author_prescriber_organization=prescriber_org,
+        author=prescriber,
+        criteria_kinds=[AdministrativeCriteriaKind.ASS, AdministrativeCriteriaKind.RSA],
+    )
+
     job_applications = [
-        JobApplicationFactory(state=JobApplicationState.ACCEPTED, **common_kwargs),
         JobApplicationFactory(
-            state=JobApplicationState.NEW,
+            state=JobApplicationState.ACCEPTED,
+            eligibility_diagnosis=company_diagnosis,
             **common_kwargs,
         ),
         JobApplicationFactory(
+            state=JobApplicationState.NEW,
+            eligibility_diagnosis=None,
+            **common_kwargs,
+        ),
+        JobApplicationFactory(
+            state=JobApplicationState.ACCEPTED,
+            eligibility_diagnosis=prescriber_diagnosis,
+            **{**common_kwargs, "to_company": geiq_company},
+        ),  # This one should not have the IAE criteria section displayed
+        JobApplicationFactory(
             state=JobApplicationState.REFUSED,
+            eligibility_diagnosis=None,
             **common_kwargs,
         ),
     ]
@@ -427,6 +450,7 @@ def test_list_snapshot(client, snapshot):
         selector="#job-applications-section",
         replace_in_attr=itertools.chain(
             [("href", f"/company/{company.pk}/card", "/company/[PK of Company]/card")],
+            [("href", f"/company/{geiq_company.pk}/card", "/company/[PK of Company]/card")],
             *(
                 [
                     (


### PR DESCRIPTION
## :thinking: Pourquoi ?

Problème identifié : on affiche les critères administratifs IAE alors qu’il s’agit d’une candidature GEIQ

## :cake: Comment ? <!-- optionnel -->

Ne pas afficher le bloc critère admin IAE lorsque la candidature est adressée à un employeur HORS SIAE 

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
