### PR TITLE
Tech : `assertSnapshotQueries()` pour les curseurs DBAPI d'une connexion Django

### DIFF
--- a/tests/metabase/conftest.py
+++ b/tests/metabase/conftest.py
@@ -31,7 +31,7 @@ def metabase_fixture(monkeypatch, settings):
 
         def __enter__(self):
             self.cursor = connection.cursor().cursor
-            return self.cursor, connection
+            return connection.make_debug_cursor(self.cursor), connection
 
         def __exit__(self, exc_type, exc_value, exc_traceback):
             if self.cursor:

--- a/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
@@ -1,0 +1,10145 @@
+# serializer version: 1
+# name: test_populate_approvals
+  dict({
+    'num_queries': 43,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "approvals_approval"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "approvals_poleemploiapproval"
+          WHERE "approvals_poleemploiapproval"."start_at" >= %s
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_pass_agréments"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_pass_agréments" ("id" integer,"type" varchar,"date_début" date,"date_fin" date,"durée" interval,"id_candidat" integer,"id_structure" integer,"type_structure" varchar,"siret_structure" varchar,"nom_structure" varchar,"département_structure_ou_org_pe" varchar,"nom_département_structure_ou_org_pe" varchar,"région_structure_ou_org_pe" varchar,"injection_ai" integer,"hash_numéro_pass_iae" varchar,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."type" IS \'Type\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."date_début" IS \'Date de début\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."date_fin" IS \'Date de fin\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."durée" IS \'Durée\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."id_candidat" IS \'ID C1 du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."id_structure" IS \'ID structure qui a embauché si PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."type_structure" IS \'Type de la structure qui a embauché si PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."siret_structure" IS \'SIRET de la structure qui a embauché si PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."nom_structure" IS \'Nom de la structure qui a embauché si PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."département_structure_ou_org_pe" IS \'Département de la structure qui a embauché si PASS\xa0IAE ou du PE qui a délivré l agrément si Agrément PE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."nom_département_structure_ou_org_pe" IS \'Nom complet du département de la structure qui a embauché si PASS\xa0IAE ou du PE qui a délivré l agrément si Agrément PE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."région_structure_ou_org_pe" IS \'Région de la structure qui a embauché si PASS\xa0IAE ou du PE qui a délivré l agrément si Agrément PE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."injection_ai" IS \'Provient des injections AI\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."hash_numéro_pass_iae" IS \'Version obfusquée du PASS\xa0IAE ou d\'\'agrément\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_pass_agréments"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id" AS "pk"
+          FROM "approvals_approval"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id" AS "pk"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 5000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."id",
+                 "approvals_approval"."start_at",
+                 "approvals_approval"."end_at",
+                 "approvals_approval"."created_at",
+                 "approvals_approval"."number",
+                 "approvals_approval"."pe_notification_status",
+                 "approvals_approval"."pe_notification_time",
+                 "approvals_approval"."pe_notification_endpoint",
+                 "approvals_approval"."pe_notification_exit_code",
+                 "approvals_approval"."user_id",
+                 "approvals_approval"."created_by_id",
+                 "approvals_approval"."origin",
+                 "approvals_approval"."eligibility_diagnosis_id",
+                 "approvals_approval"."updated_at",
+                 "approvals_approval"."origin_siae_siret",
+                 "approvals_approval"."origin_siae_kind",
+                 "approvals_approval"."origin_sender_kind",
+                 "approvals_approval"."origin_prescriber_organization_kind",
+                 "approvals_approval"."public_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."id" >= %s
+          ORDER BY "approvals_approval"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE ("users_user"."id") IN ((%s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at"
+          FROM "job_applications_jobapplication"
+          WHERE "job_applications_jobapplication"."job_seeker_id" IN (%s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_pass_agréments" ("id",
+                                       "type",
+                                       "date_début",
+                                       "date_fin",
+                                       "durée",
+                                       "id_candidat",
+                                       "id_structure",
+                                       "type_structure",
+                                       "siret_structure",
+                                       "nom_structure",
+                                       "département_structure_ou_org_pe",
+                                       "nom_département_structure_ou_org_pe",
+                                       "région_structure_ou_org_pe",
+                                       "injection_ai",
+                                       "hash_numéro_pass_iae",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_poleemploiapproval"."id" AS "pk"
+          FROM "approvals_poleemploiapproval"
+          WHERE "approvals_poleemploiapproval"."start_at" >= %s
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_poleemploiapproval"."id" AS "pk"
+          FROM "approvals_poleemploiapproval"
+          WHERE ("approvals_poleemploiapproval"."start_at" >= %s
+                 AND "approvals_poleemploiapproval"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 5000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_poleemploiapproval"."id",
+                 "approvals_poleemploiapproval"."start_at",
+                 "approvals_poleemploiapproval"."end_at",
+                 "approvals_poleemploiapproval"."created_at",
+                 "approvals_poleemploiapproval"."pe_notification_status",
+                 "approvals_poleemploiapproval"."pe_notification_time",
+                 "approvals_poleemploiapproval"."pe_notification_endpoint",
+                 "approvals_poleemploiapproval"."pe_notification_exit_code",
+                 "approvals_poleemploiapproval"."pe_structure_code",
+                 "approvals_poleemploiapproval"."number",
+                 "approvals_poleemploiapproval"."pole_emploi_id",
+                 "approvals_poleemploiapproval"."first_name",
+                 "approvals_poleemploiapproval"."last_name",
+                 "approvals_poleemploiapproval"."birth_name",
+                 "approvals_poleemploiapproval"."birthdate",
+                 "approvals_poleemploiapproval"."nir",
+                 "approvals_poleemploiapproval"."ntt_nia",
+                 "approvals_poleemploiapproval"."siae_siret",
+                 "approvals_poleemploiapproval"."siae_kind"
+          FROM "approvals_poleemploiapproval"
+          WHERE ("approvals_poleemploiapproval"."start_at" >= %s
+                 AND "approvals_poleemploiapproval"."id" >= %s)
+          ORDER BY "approvals_poleemploiapproval"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_code_safir_to_pe_org[metabase/tables/approvals.py]',
+          'get_company_or_pe_org_from_approval[metabase/tables/approvals.py]',
+          '<lambda>[metabase/tables/utils.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescriberorganization"
+          WHERE "prescribers_prescriberorganization"."code_safir_pole_emploi" IS NOT NULL
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_pass_agréments" ("id",
+                                       "type",
+                                       "date_début",
+                                       "date_fin",
+                                       "durée",
+                                       "id_candidat",
+                                       "id_structure",
+                                       "type_structure",
+                                       "siret_structure",
+                                       "nom_structure",
+                                       "département_structure_ou_org_pe",
+                                       "nom_département_structure_ou_org_pe",
+                                       "région_structure_ou_org_pe",
+                                       "injection_ai",
+                                       "hash_numéro_pass_iae",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_pass_agréments" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "pass_agréments" RENAME TO "z_old_pass_agréments"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_pass_agréments" RENAME TO "pass_agréments"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_pass_agréments" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_companies
+  dict({
+    'num_queries': 74,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT "companies_company"."id" AS "col1"
+             FROM "companies_company"
+             LEFT OUTER JOIN "job_applications_jobapplication" ON ("companies_company"."id" = "job_applications_jobapplication"."to_company_id")
+             LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplicationtransitionlog"."job_application_id")
+             WHERE (NOT ("companies_company"."siret" = %s)
+                    AND (NOT ("companies_company"."kind" IN (%s,
+                                                             %s,
+                                                             %s,
+                                                             %s,
+                                                             %s))
+                         OR "companies_company"."source" = %s
+                         OR EXISTS
+                           (SELECT %s AS "a"
+                            FROM "companies_siaeconvention" U0
+                            WHERE (U0."id" = ("companies_company"."convention_id")
+                                   AND U0."is_active")
+                            LIMIT 1)))
+             GROUP BY 1) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_structures_v0"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_structures_v0" ("id" integer,"id_asp" integer,"nom" varchar,"nom_complet" varchar,"description" varchar,"type" varchar,"siret" varchar,"source" varchar,"code_naf" varchar,"email_public" varchar,"email_authentification" varchar,"convergence_france" integer,"adresse_ligne_1" varchar,"adresse_ligne_2" varchar,"code_postal" varchar,"code_commune" varchar,"ville" varchar,"longitude" double precision,"latitude" double precision,"département" varchar,"nom_département" varchar,"région" varchar,"adresse_ligne_1_c1" varchar,"adresse_ligne_2_c1" varchar,"code_postal_c1" varchar,"code_commune_c1" varchar,"ville_c1" varchar,"longitude_c1" double precision,"latitude_c1" double precision,"département_c1" varchar,"nom_département_c1" varchar,"région_c1" varchar,"date_inscription" date,"total_membres" integer,"total_candidatures" integer,"total_candidatures_30j" integer,"total_embauches" integer,"total_embauches_30j" integer,"taux_conversion_30j" double precision,"total_auto_prescriptions" integer,"total_candidatures_autonomes" integer,"total_candidatures_via_prescripteur" integer,"total_candidatures_non_traitées" integer,"total_candidatures_en_étude" integer,"date_dernière_connexion" date,"active" integer,"date_dernière_évolution_candidature" date,"total_fiches_de_poste_actives" integer,"total_fiches_de_poste_inactives" integer,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."id" IS \'ID de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."id_asp" IS \'ID de la structure ASP correspondante\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."nom" IS \'Nom de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."nom_complet" IS \'Nom complet de la structure avec type et ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."description" IS \'Description de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."type" IS \'Type de structure (EI, ETTI, ACI, GEIQ etc..)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."siret" IS \'SIRET de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."source" IS \'Source des données de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."code_naf" IS \'naf\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."email_public" IS \'e-mail\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."email_authentification" IS \'e-mail d\'\'authentification\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."convergence_france" IS \'Convergence France (contrats PHC et CVG)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."adresse_ligne_1" IS \'Première ligne adresse de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."adresse_ligne_2" IS \'Seconde ligne adresse de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."code_postal" IS \'Code postal de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."code_commune" IS \'Code commune de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."ville" IS \'Ville de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."longitude" IS \'Longitude de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."latitude" IS \'Latitude de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."département" IS \'Département de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."nom_département" IS \'Nom complet du département de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."région" IS \'Région de la structure mère\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."adresse_ligne_1_c1" IS \'Première ligne adresse de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."adresse_ligne_2_c1" IS \'Seconde ligne adresse de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."code_postal_c1" IS \'Code postal de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."code_commune_c1" IS \'Code commune de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."ville_c1" IS \'Ville de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."longitude_c1" IS \'Longitude de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."latitude_c1" IS \'Latitude de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."département_c1" IS \'Département de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."nom_département_c1" IS \'Nom complet du département de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."région_c1" IS \'Région de la structure C1\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."date_inscription" IS \'Date inscription du premier compte employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_membres" IS \'Nombre de comptes employeur rattachés à la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_candidatures" IS \'Nombre de candidatures dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_candidatures_30j" IS \'Nombre de candidatures dans les 30 jours glissants dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_embauches" IS \'Nombre de candidatures en état accepté dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_embauches_30j" IS \'Nombre de candidatures en état accepté dans les 30 jours glissants dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."taux_conversion_30j" IS \'Taux de conversion des candidatures en embauches dans les 30 jours glissants\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_auto_prescriptions" IS \'Nombre de candidatures de source employeur dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_candidatures_autonomes" IS \'Nombre de candidatures de source candidat dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_candidatures_via_prescripteur" IS \'Nombre de candidatures de source prescripteur dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_candidatures_non_traitées" IS \'Nombre de candidatures en état nouveau dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_candidatures_en_étude" IS \'Nombre de candidatures en état étude dont la structure est destinataire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."date_dernière_connexion" IS \'Date de dernière connexion utilisateur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."active" IS \'Dernière connexion dans les 7 jours\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."date_dernière_évolution_candidature" IS \'Date de dernière évolution candidature sauf passage obsolète\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_fiches_de_poste_actives" IS \'Nombre de fiches de poste actives de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."total_fiches_de_poste_inactives" IS \'Nombre de fiches de poste inactives de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_structures_v0"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id" AS "pk"
+          FROM "companies_company"
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("companies_company"."id" = "job_applications_jobapplication"."to_company_id")
+          LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplicationtransitionlog"."job_application_id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)))
+          GROUP BY 1
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id" AS "pk"
+          FROM "companies_company"
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("companies_company"."id" = "job_applications_jobapplication"."to_company_id")
+          LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplicationtransitionlog"."job_application_id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1))
+                 AND "companies_company"."id" >= %s)
+          GROUP BY 1
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 200
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 MAX("job_applications_jobapplicationtransitionlog"."timestamp") FILTER (
+                                                                                         WHERE NOT ("job_applications_jobapplicationtransitionlog"."to_state" = %s
+                                                                                                    AND "job_applications_jobapplicationtransitionlog"."to_state" IS NOT NULL)) AS "last_job_application_transition_date",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") AS "total_candidatures",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."state" = %s) AS "total_embauches",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."created_at" >= %s) AS "total_candidatures_30j",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE ("job_applications_jobapplication"."created_at" >= %s
+                                                                                       AND "job_applications_jobapplication"."state" = %s)) AS "total_embauches_30j",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."sender_company_id" = ("job_applications_jobapplication"."to_company_id")) AS "total_auto_prescriptions",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."sender_kind" = %s) AS "total_candidatures_autonomes",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."sender_kind" = %s) AS "total_candidatures_prescripteur",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE (NOT ("job_applications_jobapplication"."sender_company_id" = ("job_applications_jobapplication"."to_company_id")
+                                                                                            AND "job_applications_jobapplication"."sender_company_id" IS NOT NULL)
+                                                                                       AND "job_applications_jobapplication"."sender_kind" = %s)) AS "total_candidatures_employeur",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."state" = %s) AS "total_candidatures_non_traitees",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."state" = %s) AS "total_candidatures_en_cours",
+                 "cities_city"."id",
+                 "cities_city"."name",
+                 "cities_city"."normalized_name",
+                 "cities_city"."slug",
+                 "cities_city"."department",
+                 "cities_city"."post_codes",
+                 "cities_city"."code_insee",
+                 "cities_city"."coords",
+                 "cities_city"."edition_mode",
+                 "companies_siaeconvention"."id",
+                 "companies_siaeconvention"."kind",
+                 "companies_siaeconvention"."siret_signature",
+                 "companies_siaeconvention"."is_active",
+                 "companies_siaeconvention"."deactivated_at",
+                 "companies_siaeconvention"."reactivated_by_id",
+                 "companies_siaeconvention"."reactivated_at",
+                 "companies_siaeconvention"."asp_id",
+                 "companies_siaeconvention"."created_at",
+                 "companies_siaeconvention"."updated_at"
+          FROM "companies_company"
+          LEFT OUTER JOIN "companies_siaeconvention" ON ("companies_company"."convention_id" = "companies_siaeconvention"."id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("companies_company"."id" = "job_applications_jobapplication"."to_company_id")
+          LEFT OUTER JOIN "job_applications_jobapplicationtransitionlog" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplicationtransitionlog"."job_application_id")
+          LEFT OUTER JOIN "cities_city" ON ("companies_company"."insee_city_id" = "cities_city"."id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1))
+                 AND "companies_company"."id" >= %s)
+          GROUP BY "companies_company"."id",
+                   "cities_city"."id",
+                   "companies_siaeconvention"."id"
+          ORDER BY "companies_company"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "cities_city"."id",
+                 "cities_city"."name",
+                 "cities_city"."normalized_name",
+                 "cities_city"."slug",
+                 "cities_city"."department",
+                 "cities_city"."post_codes",
+                 "cities_city"."code_insee",
+                 "cities_city"."coords",
+                 "cities_city"."edition_mode"
+          FROM "companies_company"
+          LEFT OUTER JOIN "cities_city" ON ("companies_company"."insee_city_id" = "cities_city"."id")
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND "companies_company"."convention_id" IN (%s))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."last_employer_update_at",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."source_tags",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source"
+          FROM "companies_jobdescription"
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
+          WHERE "companies_jobdescription"."company_id" IN (%s)
+          ORDER BY "jobs_appellation"."name" ASC,
+                   "companies_jobdescription"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT ("companies_companymembership"."company_id") AS "_prefetch_related_val_company_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          INNER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          WHERE "companies_companymembership"."company_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."company_id" IN (%s))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE "companies_companymembership"."company_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_post_code_to_insee_cities_map[metabase/tables/utils.py]',
+          'get_code_commune[metabase/tables/utils.py]',
+          '<lambda>[metabase/tables/utils.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "cities_city"."id",
+                 "cities_city"."name",
+                 "cities_city"."normalized_name",
+                 "cities_city"."slug",
+                 "cities_city"."department",
+                 "cities_city"."post_codes",
+                 "cities_city"."code_insee",
+                 "cities_city"."coords",
+                 "cities_city"."edition_mode"
+          FROM "cities_city"
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_structures_v0" ("id",
+                                      "id_asp",
+                                      "nom",
+                                      "nom_complet",
+                                      "description",
+                                      "type",
+                                      "siret",
+                                      "source",
+                                      "code_naf",
+                                      "email_public",
+                                      "email_authentification",
+                                      "convergence_france",
+                                      "adresse_ligne_1",
+                                      "adresse_ligne_2",
+                                      "code_postal",
+                                      "code_commune",
+                                      "ville",
+                                      "longitude",
+                                      "latitude",
+                                      "département",
+                                      "nom_département",
+                                      "région",
+                                      "adresse_ligne_1_c1",
+                                      "adresse_ligne_2_c1",
+                                      "code_postal_c1",
+                                      "code_commune_c1",
+                                      "ville_c1",
+                                      "longitude_c1",
+                                      "latitude_c1",
+                                      "département_c1",
+                                      "nom_département_c1",
+                                      "région_c1",
+                                      "date_inscription",
+                                      "total_membres",
+                                      "total_candidatures",
+                                      "total_candidatures_30j",
+                                      "total_embauches",
+                                      "total_embauches_30j",
+                                      "taux_conversion_30j",
+                                      "total_auto_prescriptions",
+                                      "total_candidatures_autonomes",
+                                      "total_candidatures_via_prescripteur",
+                                      "total_candidatures_non_traitées",
+                                      "total_candidatures_en_étude",
+                                      "date_dernière_connexion",
+                                      "active",
+                                      "date_dernière_évolution_candidature",
+                                      "total_fiches_de_poste_actives",
+                                      "total_fiches_de_poste_inactives",
+                                      "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_structures_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "structures_v0" RENAME TO "z_old_structures_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_structures_v0" RENAME TO "structures_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_structures_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_criteria
+  dict({
+    'num_queries': 23,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "eligibility_administrativecriteria"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_critères_iae"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_critères_iae" ("id" integer,"nom" varchar,"niveau" varchar,"description" varchar,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_critères_iae"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_critères_iae"."nom" IS \'nom\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_critères_iae"."niveau" IS \'niveau\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_critères_iae"."description" IS \'description\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_critères_iae"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_administrativecriteria"."id" AS "pk"
+          FROM "eligibility_administrativecriteria"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_administrativecriteria"."id" AS "pk"
+          FROM "eligibility_administrativecriteria"
+          WHERE "eligibility_administrativecriteria"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 10000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_administrativecriteria"."id",
+                 "eligibility_administrativecriteria"."level",
+                 "eligibility_administrativecriteria"."name",
+                 "eligibility_administrativecriteria"."desc",
+                 "eligibility_administrativecriteria"."written_proof",
+                 "eligibility_administrativecriteria"."written_proof_url",
+                 "eligibility_administrativecriteria"."written_proof_validity",
+                 "eligibility_administrativecriteria"."kind",
+                 "eligibility_administrativecriteria"."ui_rank",
+                 "eligibility_administrativecriteria"."created_at"
+          FROM "eligibility_administrativecriteria"
+          WHERE "eligibility_administrativecriteria"."id" >= %s
+          ORDER BY "eligibility_administrativecriteria"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_critères_iae" ("id",
+                                     "nom",
+                                     "niveau",
+                                     "description",
+                                     "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_critères_iae" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "critères_iae" RENAME TO "z_old_critères_iae"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_critères_iae" RENAME TO "critères_iae"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_critères_iae" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_enums
+  dict({
+    'num_queries': 61,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_c1_ref_origine_candidature"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_c1_ref_origine_candidature" ("code" text,"label" text)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_c1_ref_origine_candidature" ("code",
+                                                   "label")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_origine_candidature" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "c1_ref_origine_candidature" RENAME TO "z_old_c1_ref_origine_candidature"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_c1_ref_origine_candidature" RENAME TO "c1_ref_origine_candidature"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_origine_candidature" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_c1_ref_type_contrat"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_c1_ref_type_contrat" ("code" text,"label" text)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_c1_ref_type_contrat" ("code",
+                                            "label")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_type_contrat" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "c1_ref_type_contrat" RENAME TO "z_old_c1_ref_type_contrat"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_c1_ref_type_contrat" RENAME TO "c1_ref_type_contrat"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_type_contrat" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_c1_ref_type_prescripteur"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_c1_ref_type_prescripteur" ("code" text,"label" text)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_c1_ref_type_prescripteur" ("code",
+                                                 "label")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_type_prescripteur" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "c1_ref_type_prescripteur" RENAME TO "z_old_c1_ref_type_prescripteur"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_c1_ref_type_prescripteur" RENAME TO "c1_ref_type_prescripteur"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_type_prescripteur" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_c1_ref_motif_de_refus"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_c1_ref_motif_de_refus" ("code" text,"label" text)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_c1_ref_motif_de_refus" ("code",
+                                              "label")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_motif_de_refus" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "c1_ref_motif_de_refus" RENAME TO "z_old_c1_ref_motif_de_refus"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_c1_ref_motif_de_refus" RENAME TO "c1_ref_motif_de_refus"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_motif_de_refus" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_c1_ref_motif_suspension"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_c1_ref_motif_suspension" ("code" text,"label" text)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_c1_ref_motif_suspension" ("code",
+                                                "label")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_motif_suspension" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "c1_ref_motif_suspension" RENAME TO "z_old_c1_ref_motif_suspension"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_c1_ref_motif_suspension" RENAME TO "c1_ref_motif_suspension"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_c1_ref_motif_suspension" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'store_df[metabase/dataframes.py]',
+          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_evaluated_criteria
+  dict({
+    'num_queries': 25,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "siae_evaluations_evaluatedadministrativecriteria"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_cap_critères_iae"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_cap_critères_iae" ("id" integer,"id_critère_iae" integer,"id_cap_candidature" integer,"date_dépôt" timestamp WITH TIME ZONE,
+                                                                                                                                                                   "date_transmission" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                           "état" varchar,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."id_critère_iae" IS \'critère administratif\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."id_cap_candidature" IS \'candidature évaluée\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."date_dépôt" IS \'téléversé le\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."date_transmission" IS \'transmis le\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."état" IS \'vérification\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_critères_iae"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedadministrativecriteria"."id" AS "pk"
+          FROM "siae_evaluations_evaluatedadministrativecriteria"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedadministrativecriteria"."id" AS "pk"
+          FROM "siae_evaluations_evaluatedadministrativecriteria"
+          WHERE "siae_evaluations_evaluatedadministrativecriteria"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedadministrativecriteria"."id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."administrative_criteria_id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."proof_id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."uploaded_at",
+                 "siae_evaluations_evaluatedadministrativecriteria"."submitted_at",
+                 "siae_evaluations_evaluatedadministrativecriteria"."review_state",
+                 "siae_evaluations_evaluatedadministrativecriteria"."criteria_certified"
+          FROM "siae_evaluations_evaluatedadministrativecriteria"
+          WHERE "siae_evaluations_evaluatedadministrativecriteria"."id" >= %s
+          ORDER BY "siae_evaluations_evaluatedadministrativecriteria"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_cap_critères_iae" ("id",
+                                         "id_critère_iae",
+                                         "id_cap_candidature",
+                                         "date_dépôt",
+                                         "date_transmission",
+                                         "état",
+                                         "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_critères_iae" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "cap_critères_iae" RENAME TO "z_old_cap_critères_iae"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_cap_critères_iae" RENAME TO "cap_critères_iae"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_critères_iae" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_evaluated_job_applications
+  dict({
+    'num_queries': 24,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "siae_evaluations_evaluatedjobapplication"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_cap_candidatures"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_cap_candidatures" ("id" integer,"id_candidature" UUID,
+                                                                                             "id_cap_structure" integer,"état" varchar,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_candidatures"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_candidatures"."id_candidature" IS \'candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_candidatures"."id_cap_structure" IS \'SIAE évaluée\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_candidatures"."état" IS \'Etat du contrôle de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_candidatures"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedjobapplication"."id" AS "pk"
+          FROM "siae_evaluations_evaluatedjobapplication"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedjobapplication"."id" AS "pk"
+          FROM "siae_evaluations_evaluatedjobapplication"
+          WHERE "siae_evaluations_evaluatedjobapplication"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 20000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedjobapplication"."id",
+                 "siae_evaluations_evaluatedjobapplication"."job_application_id",
+                 "siae_evaluations_evaluatedjobapplication"."evaluated_siae_id",
+                 "siae_evaluations_evaluatedjobapplication"."labor_inspector_explanation"
+          FROM "siae_evaluations_evaluatedjobapplication"
+          WHERE "siae_evaluations_evaluatedjobapplication"."id" >= %s
+          ORDER BY "siae_evaluations_evaluatedjobapplication"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedadministrativecriteria"."id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."administrative_criteria_id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."proof_id",
+                 "siae_evaluations_evaluatedadministrativecriteria"."uploaded_at",
+                 "siae_evaluations_evaluatedadministrativecriteria"."submitted_at",
+                 "siae_evaluations_evaluatedadministrativecriteria"."review_state",
+                 "siae_evaluations_evaluatedadministrativecriteria"."criteria_certified"
+          FROM "siae_evaluations_evaluatedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("siae_evaluations_evaluatedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
+          WHERE "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id" IN (%s)
+          ORDER BY "siae_evaluations_evaluatedadministrativecriteria"."evaluated_job_application_id" ASC,
+                   "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_cap_candidatures" ("id",
+                                         "id_candidature",
+                                         "id_cap_structure",
+                                         "état",
+                                         "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_candidatures" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "cap_candidatures" RENAME TO "z_old_cap_candidatures"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_cap_candidatures" RENAME TO "cap_candidatures"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_candidatures" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_evaluated_siaes
+  dict({
+    'num_queries': 27,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "siae_evaluations_evaluatedsiae"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_cap_structures"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_cap_structures" ("id" integer,"id_cap_campagne" integer,"id_structure" integer,"état" varchar,"date_contrôle" timestamp WITH TIME ZONE,
+                                                                                                                                                                              "date_définitive_contrôle" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                             "date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."id_cap_campagne" IS \'contrôle\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."id_structure" IS \'SIAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."état" IS \'Etat du contrôle de la structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."date_contrôle" IS \'contrôlée le\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."date_définitive_contrôle" IS \'contrôle définitif le\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_structures"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedsiae"."id" AS "pk"
+          FROM "siae_evaluations_evaluatedsiae"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedsiae"."id" AS "pk"
+          FROM "siae_evaluations_evaluatedsiae"
+          WHERE "siae_evaluations_evaluatedsiae"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 5000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedsiae"."id",
+                 "siae_evaluations_evaluatedsiae"."evaluation_campaign_id",
+                 "siae_evaluations_evaluatedsiae"."siae_id",
+                 "siae_evaluations_evaluatedsiae"."reviewed_at",
+                 "siae_evaluations_evaluatedsiae"."final_reviewed_at",
+                 "siae_evaluations_evaluatedsiae"."submission_freezed_at",
+                 "siae_evaluations_evaluatedsiae"."notified_at",
+                 "siae_evaluations_evaluatedsiae"."notification_reason",
+                 "siae_evaluations_evaluatedsiae"."notification_text",
+                 "siae_evaluations_evaluatedsiae"."reminder_sent_at"
+          FROM "siae_evaluations_evaluatedsiae"
+          WHERE "siae_evaluations_evaluatedsiae"."id" >= %s
+          ORDER BY "siae_evaluations_evaluatedsiae"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluatedjobapplication"."id",
+                 "siae_evaluations_evaluatedjobapplication"."job_application_id",
+                 "siae_evaluations_evaluatedjobapplication"."evaluated_siae_id",
+                 "siae_evaluations_evaluatedjobapplication"."labor_inspector_explanation"
+          FROM "siae_evaluations_evaluatedjobapplication"
+          WHERE "siae_evaluations_evaluatedjobapplication"."evaluated_siae_id" IN (%s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EvaluatedSiae.evaluation_is_final[siae_evaluations/models.py]',
+          'EvaluatedSiae.state[siae_evaluations/models.py]',
+          '<lambda>[metabase/tables/evaluated_siaes.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluationcampaign"."id",
+                 "siae_evaluations_evaluationcampaign"."name",
+                 "siae_evaluations_evaluationcampaign"."created_at",
+                 "siae_evaluations_evaluationcampaign"."percent_set_at",
+                 "siae_evaluations_evaluationcampaign"."evaluations_asked_at",
+                 "siae_evaluations_evaluationcampaign"."ended_at",
+                 "siae_evaluations_evaluationcampaign"."submission_freeze_notified_at",
+                 "siae_evaluations_evaluationcampaign"."evaluated_period_start_at",
+                 "siae_evaluations_evaluationcampaign"."evaluated_period_end_at",
+                 "siae_evaluations_evaluationcampaign"."institution_id",
+                 "siae_evaluations_evaluationcampaign"."chosen_percent",
+                 "siae_evaluations_evaluationcampaign"."calendar_id"
+          FROM "siae_evaluations_evaluationcampaign"
+          WHERE "siae_evaluations_evaluationcampaign"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_cap_structures" ("id",
+                                       "id_cap_campagne",
+                                       "id_structure",
+                                       "état",
+                                       "date_contrôle",
+                                       "date_définitive_contrôle",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_structures" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "cap_structures" RENAME TO "z_old_cap_structures"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_cap_structures" RENAME TO "cap_structures"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_structures" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_evaluation_campaigns
+  dict({
+    'num_queries': 25,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "siae_evaluations_evaluationcampaign"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_cap_campagnes"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_cap_campagnes" ("id" integer,"nom" varchar,"id_institution" integer,"date_début" date,"date_fin" date,"pourcentage_sélection" integer,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."nom" IS \'nom de la campagne d\'\'évaluation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."id_institution" IS \'DDETS IAE responsable du contrôle\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."date_début" IS \'date de début de la période contrôlée\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."date_fin" IS \'date de fin de la période contrôlée\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."pourcentage_sélection" IS \'pourcentage de sélection\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_cap_campagnes"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluationcampaign"."id" AS "pk"
+          FROM "siae_evaluations_evaluationcampaign"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluationcampaign"."id" AS "pk"
+          FROM "siae_evaluations_evaluationcampaign"
+          WHERE "siae_evaluations_evaluationcampaign"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 10000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "siae_evaluations_evaluationcampaign"."id",
+                 "siae_evaluations_evaluationcampaign"."name",
+                 "siae_evaluations_evaluationcampaign"."created_at",
+                 "siae_evaluations_evaluationcampaign"."percent_set_at",
+                 "siae_evaluations_evaluationcampaign"."evaluations_asked_at",
+                 "siae_evaluations_evaluationcampaign"."ended_at",
+                 "siae_evaluations_evaluationcampaign"."submission_freeze_notified_at",
+                 "siae_evaluations_evaluationcampaign"."evaluated_period_start_at",
+                 "siae_evaluations_evaluationcampaign"."evaluated_period_end_at",
+                 "siae_evaluations_evaluationcampaign"."institution_id",
+                 "siae_evaluations_evaluationcampaign"."chosen_percent",
+                 "siae_evaluations_evaluationcampaign"."calendar_id"
+          FROM "siae_evaluations_evaluationcampaign"
+          WHERE "siae_evaluations_evaluationcampaign"."id" >= %s
+          ORDER BY "siae_evaluations_evaluationcampaign"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_cap_campagnes" ("id",
+                                      "nom",
+                                      "id_institution",
+                                      "date_début",
+                                      "date_fin",
+                                      "pourcentage_sélection",
+                                      "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_campagnes" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "cap_campagnes" RENAME TO "z_old_cap_campagnes"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_cap_campagnes" RENAME TO "cap_campagnes"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_cap_campagnes" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_gps_groups
+  dict({
+    'num_queries': 24,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "gps_followupgroup"
+          INNER JOIN "users_user" ON ("gps_followupgroup"."beneficiary_id" = "users_user"."id")
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_gps_groups_v1"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_gps_groups_v1" ("id" integer,"created_at" timestamp WITH TIME ZONE,
+                                                                                                          "updated_at" timestamp WITH TIME ZONE,
+                                                                                                                                           "created_in_bulk" integer,"department" text,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_groups_v1"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_groups_v1"."created_at" IS \'date de création\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_groups_v1"."updated_at" IS \'date de modification\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_groups_v1"."created_in_bulk" IS \'créé massivement\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_groups_v1"."department" IS \'Département du bénéficiaire\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_groups_v1"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroup"."id" AS "pk"
+          FROM "gps_followupgroup"
+          INNER JOIN "users_user" ON ("gps_followupgroup"."beneficiary_id" = "users_user"."id")
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroup"."id" AS "pk"
+          FROM "gps_followupgroup"
+          INNER JOIN "users_user" ON ("gps_followupgroup"."beneficiary_id" = "users_user"."id")
+          WHERE "gps_followupgroup"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroup"."id",
+                 "gps_followupgroup"."created_at",
+                 "gps_followupgroup"."created_in_bulk",
+                 "gps_followupgroup"."updated_at",
+                 "gps_followupgroup"."beneficiary_id",
+                 "users_user"."department" AS "beneficiary_department"
+          FROM "gps_followupgroup"
+          INNER JOIN "users_user" ON ("gps_followupgroup"."beneficiary_id" = "users_user"."id")
+          WHERE "gps_followupgroup"."id" >= %s
+          ORDER BY "gps_followupgroup"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_gps_groups_v1" ("id",
+                                      "created_at",
+                                      "updated_at",
+                                      "created_in_bulk",
+                                      "department",
+                                      "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_gps_groups_v1" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "gps_groups_v1" RENAME TO "z_old_gps_groups_v1"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_gps_groups_v1" RENAME TO "gps_groups_v1"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_gps_groups_v1" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_gps_memberships
+  dict({
+    'num_queries': 27,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT "gps_followupgroupmembership"."id" AS "col1"
+             FROM "gps_followupgroupmembership"
+             INNER JOIN "users_user" ON ("gps_followupgroupmembership"."member_id" = "users_user"."id")
+             LEFT OUTER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+             LEFT OUTER JOIN "companies_company" ON ("companies_companymembership"."company_id" = "companies_company"."id")
+             LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+             LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+             GROUP BY 1) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_gps_membres_v1"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_gps_membres_v1" ("id" integer,"group_id" integer,"created_at" timestamp WITH TIME ZONE,
+                                                                                                                              "updated_at" timestamp WITH TIME ZONE,
+                                                                                                                                                               "ended_at" date,"member_id" integer,"org_departments" text[],"created_in_bulk" integer,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."group_id" IS \'groupe de suivi\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."created_at" IS \'date de création\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."updated_at" IS \'date de modification\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."ended_at" IS \'date de fin de suivi\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."member_id" IS \'membre du groupe de suivi\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."org_departments" IS \'Départements de l\'\'organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."created_in_bulk" IS \'créé massivement\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_gps_membres_v1"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroupmembership"."id" AS "pk"
+          FROM "gps_followupgroupmembership"
+          INNER JOIN "users_user" ON ("gps_followupgroupmembership"."member_id" = "users_user"."id")
+          LEFT OUTER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          LEFT OUTER JOIN "companies_company" ON ("companies_companymembership"."company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          GROUP BY 1
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroupmembership"."id" AS "pk"
+          FROM "gps_followupgroupmembership"
+          INNER JOIN "users_user" ON ("gps_followupgroupmembership"."member_id" = "users_user"."id")
+          LEFT OUTER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          LEFT OUTER JOIN "companies_company" ON ("companies_companymembership"."company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE "gps_followupgroupmembership"."id" >= %s
+          GROUP BY 1
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "gps_followupgroupmembership"."id",
+                 "gps_followupgroupmembership"."is_referent_certified",
+                 "gps_followupgroupmembership"."is_active",
+                 "gps_followupgroupmembership"."created_at",
+                 "gps_followupgroupmembership"."created_in_bulk",
+                 "gps_followupgroupmembership"."last_contact_at",
+                 "gps_followupgroupmembership"."started_at",
+                 "gps_followupgroupmembership"."ended_at",
+                 "gps_followupgroupmembership"."updated_at",
+                 "gps_followupgroupmembership"."can_view_personal_information",
+                 "gps_followupgroupmembership"."follow_up_group_id",
+                 "gps_followupgroupmembership"."member_id",
+                 "gps_followupgroupmembership"."creator_id",
+                 "gps_followupgroupmembership"."reason",
+                 "gps_followupgroupmembership"."end_reason",
+                 ARRAY_AGG(DISTINCT "companies_company"."department"
+                           ORDER BY "companies_company"."department") FILTER (
+                                                                              WHERE "companies_companymembership"."is_active") AS "companies_departments",
+                 ARRAY_AGG(DISTINCT "prescribers_prescriberorganization"."department"
+                           ORDER BY "prescribers_prescriberorganization"."department") FILTER (
+                                                                                               WHERE "prescribers_prescribermembership"."is_active") AS "prescriber_departments"
+          FROM "gps_followupgroupmembership"
+          INNER JOIN "users_user" ON ("gps_followupgroupmembership"."member_id" = "users_user"."id")
+          LEFT OUTER JOIN "companies_companymembership" ON ("users_user"."id" = "companies_companymembership"."user_id")
+          LEFT OUTER JOIN "companies_company" ON ("companies_companymembership"."company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE "gps_followupgroupmembership"."id" >= %s
+          GROUP BY "gps_followupgroupmembership"."id"
+          ORDER BY "gps_followupgroupmembership"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_gps_membres_v1" ("id",
+                                       "group_id",
+                                       "created_at",
+                                       "updated_at",
+                                       "ended_at",
+                                       "member_id",
+                                       "org_departments",
+                                       "created_in_bulk",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_gps_membres_v1" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "gps_membres_v1" RENAME TO "z_old_gps_membres_v1"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_gps_membres_v1" RENAME TO "gps_membres_v1"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_gps_membres_v1" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_institutions
+  dict({
+    'num_queries': 25,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "institutions_institution"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_institutions"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_institutions" ("id" integer,"type" varchar,"département" varchar,"nom_département" varchar,"région" varchar,"nom" varchar,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."type" IS \'type\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."département" IS \'Département\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."nom_département" IS \'Nom complet du département\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."région" IS \'Région\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."nom" IS \'nom\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_institutions"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id" AS "pk"
+          FROM "institutions_institution"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id" AS "pk"
+          FROM "institutions_institution"
+          WHERE "institutions_institution"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 10000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institution"
+          WHERE "institutions_institution"."id" >= %s
+          ORDER BY "institutions_institution"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_institutions" ("id",
+                                     "type",
+                                     "département",
+                                     "nom_département",
+                                     "région",
+                                     "nom",
+                                     "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_institutions" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "institutions" RENAME TO "z_old_institutions"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_institutions" RENAME TO "institutions"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_institutions" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_job_applications
+  dict({
+    'num_queries': 52,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'get_active_companies_pks[metabase/tables/utils.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'get_active_companies_pks[metabase/tables/utils.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id" AS "pk"
+          FROM "companies_company"
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "job_applications_jobapplication"
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_candidatures"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_candidatures" ("id" UUID,
+                                                                "candidature_archivee" integer,"candidature_refusée_automatiquement" integer,"date_candidature" date,"date_début_contrat" date,"date_traitement" date,"état" varchar,"origine" varchar,"origine_détaillée" varchar,"origine_id_structure" integer,"parcours_de_création" varchar,"délai_prise_en_compte" interval,"délai_de_réponse" interval,"motif_de_refus" varchar,"id_candidat" integer,"id_structure" integer,"type_structure" varchar,"nom_structure" varchar,"nom_complet_structure" varchar,"département_structure" varchar,"nom_département_structure" varchar,"région_structure" varchar,"id_org_prescripteur" integer,"nom_org_prescripteur" varchar,"safir_org_prescripteur" varchar,"nom_prénom_conseiller" varchar,"date_embauche" date,"injection_ai" integer,"mode_attribution_pass_iae" varchar,"type_contrat" varchar,"présence_de_cv" integer,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."id" IS \'ID C1 de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."candidature_archivee" IS \'Candidature archivée coté employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."candidature_refusée_automatiquement" IS \'Candidature automatiquement refusée car en attente depuis plus de 2 mois\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."date_candidature" IS \'Date de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."date_début_contrat" IS \'Date de début du contrat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."date_traitement" IS \'Date de dernier traitement de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."état" IS \'Etat de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."origine" IS \'Origine de la candidature (employeur, candidat, prescripteur habilité, orienteur)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."origine_détaillée" IS \'Origine détaillée de la candidature (employeur EI, ACI... candidat, orienteur, prescripteur PE, ML...)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."origine_id_structure" IS \'ID de la structure d\'\'origine de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."parcours_de_création" IS \'Parcours de création de la candidature (Normale, reprise de stock AI, import agrément PE, action support...)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_prise_en_compte" IS \'Temps écoulé rétroactivement de état nouveau à état étude si la candidature est passée par ces états\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."délai_de_réponse" IS \'Temps écoulé rétroactivement de état nouveau à état accepté ou refusé si la candidature est passée par ces états\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."motif_de_refus" IS \'Motif de refus de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."id_candidat" IS \'ID C1 du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."id_structure" IS \'ID de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."type_structure" IS \'Type de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."nom_structure" IS \'Nom de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."nom_complet_structure" IS \'Nom complet de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."département_structure" IS \'Département de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."nom_département_structure" IS \'Nom complet du département de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."région_structure" IS \'Région de la structure destinaire de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."id_org_prescripteur" IS \'ID de l\'\'\'\'organisation prescriptrice\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."nom_org_prescripteur" IS \'Nom de l\'\'\'\'organisation prescriptrice\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."safir_org_prescripteur" IS \'SAFIR de l\'\'\'\'organisation prescriptrice\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."nom_prénom_conseiller" IS \'Nom prénom du conseiller PE ou SPIP\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."date_embauche" IS \'Date embauche le cas échéant\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."injection_ai" IS \'Provient des injections AI\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."mode_attribution_pass_iae" IS \'Mode d\'\'\'\'attribution du PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."type_contrat" IS \'Type de contrat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."présence_de_cv" IS \'Présence d\'\'\'\'un CV\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidatures"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id" AS "pk"
+          FROM "job_applications_jobapplication"
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s))
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id" AS "pk"
+          FROM "job_applications_jobapplication"
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s)
+                 AND "job_applications_jobapplication"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 10000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."contract_type",
+                 "users_user"."id",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 T4."id",
+                 T4."kind",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "companies_company"."id",
+                 "companies_company"."department",
+                 "companies_company"."name",
+                 "companies_company"."kind",
+                 "companies_company"."brand"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "users_user" ON ("job_applications_jobapplication"."sender_id" = "users_user"."id")
+          LEFT OUTER JOIN "companies_company" T4 ON ("job_applications_jobapplication"."sender_company_id" = T4."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("job_applications_jobapplication"."sender_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s)
+                 AND "job_applications_jobapplication"."id" >= %s)
+          ORDER BY "job_applications_jobapplication"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplicationtransitionlog"."id",
+                 "job_applications_jobapplicationtransitionlog"."transition",
+                 "job_applications_jobapplicationtransitionlog"."from_state",
+                 "job_applications_jobapplicationtransitionlog"."to_state",
+                 "job_applications_jobapplicationtransitionlog"."timestamp",
+                 "job_applications_jobapplicationtransitionlog"."job_application_id",
+                 "job_applications_jobapplicationtransitionlog"."user_id",
+                 "job_applications_jobapplicationtransitionlog"."target_company_id"
+          FROM "job_applications_jobapplicationtransitionlog"
+          WHERE "job_applications_jobapplicationtransitionlog"."job_application_id" IN (%s)
+          ORDER BY "job_applications_jobapplicationtransitionlog"."timestamp" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_candidatures" ("id",
+                                     "candidature_archivee",
+                                     "candidature_refusée_automatiquement",
+                                     "date_candidature",
+                                     "date_début_contrat",
+                                     "date_traitement",
+                                     "état",
+                                     "origine",
+                                     "origine_détaillée",
+                                     "origine_id_structure",
+                                     "parcours_de_création",
+                                     "délai_prise_en_compte",
+                                     "délai_de_réponse",
+                                     "motif_de_refus",
+                                     "id_candidat",
+                                     "id_structure",
+                                     "type_structure",
+                                     "nom_structure",
+                                     "nom_complet_structure",
+                                     "département_structure",
+                                     "nom_département_structure",
+                                     "région_structure",
+                                     "id_org_prescripteur",
+                                     "nom_org_prescripteur",
+                                     "safir_org_prescripteur",
+                                     "nom_prénom_conseiller",
+                                     "date_embauche",
+                                     "injection_ai",
+                                     "mode_attribution_pass_iae",
+                                     "type_contrat",
+                                     "présence_de_cv",
+                                     "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_candidatures" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "candidatures" RENAME TO "z_old_candidatures"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_candidatures" RENAME TO "candidatures"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_candidatures" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_job_applications.1
+  dict({
+    'num_queries': 21,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "job_applications_jobapplication"
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplication_selected_jobs"."jobapplication_id")
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s)
+                 AND NOT (EXISTS
+                            (SELECT %s AS "a"
+                             FROM "job_applications_jobapplication" U0
+                             LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" U1 ON (U0."id" = U1."jobapplication_id")
+                             WHERE (U1."jobdescription_id" IS NULL
+                                    AND U0."id" = ("job_applications_jobapplication"."id"))
+                             LIMIT 1)))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_fiches_de_poste_par_candidature"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_fiches_de_poste_par_candidature" ("id_fiche_de_poste" integer,"id_candidature" UUID,
+                                                                                                                           "date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste_par_candidature"."id_fiche_de_poste" IS \'ID fiche de poste\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste_par_candidature"."id_candidature" IS \'ID de la candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste_par_candidature"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id" AS "pk"
+          FROM "job_applications_jobapplication"
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplication_selected_jobs"."jobapplication_id")
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s)
+                 AND NOT (EXISTS
+                            (SELECT %s AS "a"
+                             FROM "job_applications_jobapplication" U0
+                             LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" U1 ON (U0."id" = U1."jobapplication_id")
+                             WHERE (U1."jobdescription_id" IS NULL
+                                    AND U0."id" = ("job_applications_jobapplication"."id"))
+                             LIMIT 1)))
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id" AS "pk"
+          FROM "job_applications_jobapplication"
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplication_selected_jobs"."jobapplication_id")
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s)
+                 AND NOT (EXISTS
+                            (SELECT %s AS "a"
+                             FROM "job_applications_jobapplication" U0
+                             LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" U1 ON (U0."id" = U1."jobapplication_id")
+                             WHERE (U1."jobdescription_id" IS NULL
+                                    AND U0."id" = ("job_applications_jobapplication"."id"))
+                             LIMIT 1))
+                 AND "job_applications_jobapplication"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 10000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id" AS "pk",
+                 "job_applications_jobapplication_selected_jobs"."jobdescription_id" AS "selected_jobs__id"
+          FROM "job_applications_jobapplication"
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("job_applications_jobapplication"."id" = "job_applications_jobapplication_selected_jobs"."jobapplication_id")
+          WHERE (NOT ("job_applications_jobapplication"."origin" = %s)
+                 AND "job_applications_jobapplication"."to_company_id" IN (%s,
+                                                                           %s)
+                 AND NOT (EXISTS
+                            (SELECT %s AS "a"
+                             FROM "job_applications_jobapplication" U0
+                             LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" U1 ON (U0."id" = U1."jobapplication_id")
+                             WHERE (U1."jobdescription_id" IS NULL
+                                    AND U0."id" = ("job_applications_jobapplication"."id"))
+                             LIMIT 1))
+                 AND "job_applications_jobapplication"."id" >= %s)
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_fiches_de_poste_par_candidature" ("id_fiche_de_poste",
+                                                        "id_candidature",
+                                                        "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_fiches_de_poste_par_candidature" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "fiches_de_poste_par_candidature" RENAME TO "z_old_fiches_de_poste_par_candidature"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_fiches_de_poste_par_candidature" RENAME TO "fiches_de_poste_par_candidature"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_fiches_de_poste_par_candidature" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_job_descriptions
+  dict({
+    'num_queries': 36,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'get_active_companies_pks[metabase/tables/utils.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'get_active_companies_pks[metabase/tables/utils.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id" AS "pk"
+          FROM "companies_company"
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT "companies_jobdescription"."id" AS "col1"
+             FROM "companies_jobdescription"
+             LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+             WHERE "companies_jobdescription"."company_id" IN (%s)
+             GROUP BY 1) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_fiches_de_poste"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_fiches_de_poste" ("id" integer,"code_rome" varchar,"nom_rome" varchar,"recrutement_ouvert" integer,"type_contrat" varchar,"id_employeur" integer,"type_employeur" varchar,"siret_employeur" varchar,"nom_employeur" varchar,"mises_a_jour_champs" JSONB,
+                                                                                                                                                                                                                                                                                              "département_employeur" varchar,"nom_département_employeur" varchar,"région_employeur" varchar,"total_candidatures" integer,"date_création" date,"date_dernière_modification" date,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."id" IS \'ID de la fiche de poste\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."code_rome" IS \'Code ROME de la fiche de poste\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."nom_rome" IS \'Nom du ROME de la fiche de poste\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."recrutement_ouvert" IS \'Recrutement ouvert à ce jour\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."type_contrat" IS \'Type de contrat proposé\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."id_employeur" IS \'ID employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."type_employeur" IS \'Type employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."siret_employeur" IS \'SIRET employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."nom_employeur" IS \'Nom employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."mises_a_jour_champs" IS \'historique des mises à jour sur le modèle\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."département_employeur" IS \'Département employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."nom_département_employeur" IS \'Nom complet du département employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."région_employeur" IS \'Région employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."total_candidatures" IS \'Total de candidatures reçues\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."date_création" IS \'Date de création\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."date_dernière_modification" IS \'Date de dernière modification\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_fiches_de_poste"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_jobdescription"."id" AS "pk"
+          FROM "companies_jobdescription"
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          WHERE "companies_jobdescription"."company_id" IN (%s)
+          GROUP BY 1
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_jobdescription"."id" AS "pk"
+          FROM "companies_jobdescription"
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          WHERE ("companies_jobdescription"."company_id" IN (%s)
+                 AND "companies_jobdescription"."id" >= %s)
+          GROUP BY 1
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 10000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_jobdescription"."id",
+                 "companies_jobdescription"."appellation_id",
+                 "companies_jobdescription"."company_id",
+                 "companies_jobdescription"."created_at",
+                 "companies_jobdescription"."updated_at",
+                 "companies_jobdescription"."is_active",
+                 "companies_jobdescription"."last_employer_update_at",
+                 "companies_jobdescription"."custom_name",
+                 "companies_jobdescription"."description",
+                 "companies_jobdescription"."ui_rank",
+                 "companies_jobdescription"."contract_type",
+                 "companies_jobdescription"."other_contract_type",
+                 "companies_jobdescription"."location_id",
+                 "companies_jobdescription"."hours_per_week",
+                 "companies_jobdescription"."open_positions",
+                 "companies_jobdescription"."profile_description",
+                 "companies_jobdescription"."is_resume_mandatory",
+                 "companies_jobdescription"."is_qpv_mandatory",
+                 "companies_jobdescription"."market_context_description",
+                 "companies_jobdescription"."source_id",
+                 "companies_jobdescription"."source_kind",
+                 "companies_jobdescription"."source_url",
+                 "companies_jobdescription"."source_tags",
+                 "companies_jobdescription"."field_history",
+                 "companies_jobdescription"."creation_source",
+                 COUNT("job_applications_jobapplication_selected_jobs"."jobapplication_id") AS "job_applications_count",
+                 "jobs_appellation"."updated_at",
+                 "jobs_appellation"."code",
+                 "jobs_appellation"."name",
+                 "jobs_appellation"."rome_id",
+                 "jobs_appellation"."full_text",
+                 "jobs_rome"."updated_at",
+                 "jobs_rome"."code",
+                 "jobs_rome"."name",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history"
+          FROM "companies_jobdescription"
+          INNER JOIN "companies_company" ON ("companies_jobdescription"."company_id" = "companies_company"."id")
+          LEFT OUTER JOIN "job_applications_jobapplication_selected_jobs" ON ("companies_jobdescription"."id" = "job_applications_jobapplication_selected_jobs"."jobdescription_id")
+          INNER JOIN "jobs_appellation" ON ("companies_jobdescription"."appellation_id" = "jobs_appellation"."code")
+          LEFT OUTER JOIN "jobs_rome" ON ("jobs_appellation"."rome_id" = "jobs_rome"."code")
+          WHERE ("companies_jobdescription"."company_id" IN (%s)
+                 AND "companies_jobdescription"."id" >= %s)
+          GROUP BY "companies_jobdescription"."id",
+                   "jobs_appellation"."code",
+                   "jobs_rome"."code",
+                   "companies_company"."id"
+          ORDER BY "companies_jobdescription"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_fiches_de_poste" ("id",
+                                        "code_rome",
+                                        "nom_rome",
+                                        "recrutement_ouvert",
+                                        "type_contrat",
+                                        "id_employeur",
+                                        "type_employeur",
+                                        "siret_employeur",
+                                        "nom_employeur",
+                                        "mises_a_jour_champs",
+                                        "département_employeur",
+                                        "nom_département_employeur",
+                                        "région_employeur",
+                                        "total_candidatures",
+                                        "date_création",
+                                        "date_dernière_modification",
+                                        "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_fiches_de_poste" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "fiches_de_poste" RENAME TO "z_old_fiches_de_poste"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_fiches_de_poste" RENAME TO "fiches_de_poste"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_fiches_de_poste" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_job_seekers
+  dict({
+    'num_queries': 85,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'get_table[metabase/tables/job_seekers.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'get_table[metabase/tables/job_seekers.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_administrativecriteria"."id",
+                 "eligibility_administrativecriteria"."level",
+                 "eligibility_administrativecriteria"."name",
+                 "eligibility_administrativecriteria"."desc",
+                 "eligibility_administrativecriteria"."written_proof",
+                 "eligibility_administrativecriteria"."written_proof_url",
+                 "eligibility_administrativecriteria"."written_proof_validity",
+                 "eligibility_administrativecriteria"."kind",
+                 "eligibility_administrativecriteria"."ui_rank",
+                 "eligibility_administrativecriteria"."created_at"
+          FROM "eligibility_administrativecriteria"
+          ORDER BY "eligibility_administrativecriteria"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT "users_user"."id" AS "col1"
+             FROM "users_user"
+             LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("users_user"."id" = "eligibility_eligibilitydiagnosis"."job_seeker_id")
+             LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+             WHERE "users_user"."kind" = %s
+             GROUP BY 1) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_candidats_v0"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_candidats_v0" ("id" integer,"hash_nir" varchar,"sexe_selon_nir" varchar,"annee_naissance_selon_nir" integer,"mois_naissance_selon_nir" integer,"age" integer,"date_inscription" date,"type_inscription" varchar,"pe_connect" integer,"pe_inscrit" integer,"date_dernière_connexion" date,"date_premiere_connexion" date,"actif" integer,"code_postal" varchar,"département" varchar,"nom_département" varchar,"région" varchar,"adresse_en_qpv" varchar,"total_candidatures" integer,"total_embauches" integer,"total_diagnostics" integer,"date_diagnostic" date,"date_expiration_diagnostic" date,"diagnostic_valide" integer,"id_auteur_diagnostic_prescripteur" integer,"id_auteur_diagnostic_employeur" integer,"type_auteur_diagnostic" varchar,"sous_type_auteur_diagnostic" varchar,"nom_auteur_diagnostic" varchar,"type_structure_dernière_embauche" varchar,"total_critères_niveau_1" integer,"total_critères_niveau_2" integer,"critère_n1_bénéficiaire_du_rsa" integer,"critère_n1_bénéficiaire_du_rsa_certifié" integer,"critère_n1_bénéficiaire_du_rsa_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          "critère_n1_bénéficiaire_du_rsa_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          "critère_n1_allocataire_ass" integer,"critère_n1_allocataire_aah" integer,"critère_n1_allocataire_aah_certifié" integer,"critère_n1_allocataire_aah_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      "critère_n1_allocataire_aah_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      "critère_n1_detld_plus_de_24_mois" integer,"critère_n2_niveau_d_étude_3_cap_bep_ou_infra" integer,"critère_n2_senior_plus_de_50_ans" integer,"critère_n2_jeune_moins_de_26_ans" integer,"critère_n2_sortant_de_l_ase" integer,"critère_n2_deld_12_à_24_mois" integer,"critère_n2_travailleur_handicapé" integer,"critère_n2_parent_isolé" integer,"critère_n2_parent_isolé_certifié" integer,"critère_n2_parent_isolé_date_certification" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    "critère_n2_parent_isolé_période_certification" daterange,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    "critère_n2_personne_sans_hébergement_ou_hébergée_ou_ayant_un_parcours_de_rue" integer,"critère_n2_réfugié_statutaire_bénéficiaire_d_une_protection_temporaire_protégé_subsidiaire_ou_demandeur_d_asile" integer,"critère_n2_résident_zrr" integer,"critère_n2_résident_qpv" integer,"critère_n2_sortant_de_détention_ou_personne_placée_sous_main_de_justice" integer,"critère_n2_maîtrise_de_la_langue_française_inférieure_au_niveau_a1" integer,"critère_n2_problème_de_mobilité" integer,"injection_ai" integer,"date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."id" IS \'ID C1 du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."hash_nir" IS \'Version obfusquée du NIR\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."sexe_selon_nir" IS \'Sexe du candidat selon le NIR\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."annee_naissance_selon_nir" IS \'Année de naissance du candidat selon le NIR\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."mois_naissance_selon_nir" IS \'Mois de naissance du candidat selon le NIR\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."age" IS \'Age du candidat en années\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."date_inscription" IS \'Date inscription du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."type_inscription" IS \'Type inscription du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."pe_connect" IS \'Le candidat utilise PE Connect\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."pe_inscrit" IS \'Le candidat a un identifiant PE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."date_dernière_connexion" IS \'Date de dernière connexion au service du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."date_premiere_connexion" IS \'Date de première connexion\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."actif" IS \'Dernière connexion dans les 7 jours\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."code_postal" IS \'Code postal du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."département" IS \'Département du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."nom_département" IS \'Nom complet du département du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."région" IS \'Région du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."adresse_en_qpv" IS \'Analyse QPV sur adresse du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."total_candidatures" IS \'Nombre de candidatures\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."total_embauches" IS \'Nombre de candidatures de type accepté\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."total_diagnostics" IS \'Nombre de diagnostics\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."date_diagnostic" IS \'Date du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."date_expiration_diagnostic" IS \'Date d\'\'expiration du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."diagnostic_valide" IS \'Validité du dernier diagnostic au moment de l\'\'import\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."id_auteur_diagnostic_prescripteur" IS \'ID auteur diagnostic si prescripteur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."id_auteur_diagnostic_employeur" IS \'ID auteur diagnostic si employeur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."type_auteur_diagnostic" IS \'Type auteur du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."sous_type_auteur_diagnostic" IS \'Sous type auteur du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."nom_auteur_diagnostic" IS \'Nom auteur du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."type_structure_dernière_embauche" IS \'Type de la structure destinataire de la dernière embauche du candidat\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."total_critères_niveau_1" IS \'Total critères de niveau 1 du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."total_critères_niveau_2" IS \'Total critères de niveau 2 du dernier diagnostic\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_bénéficiaire_du_rsa" IS \'Critère Bénéficiaire du RSA (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_bénéficiaire_du_rsa_certifié" IS \'Certification du critère Bénéficiaire du RSA (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_bénéficiaire_du_rsa_date_certification" IS \'Date de la dernière Certification du critère Bénéficiaire du RSA (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_bénéficiaire_du_rsa_période_certification" IS \'Période de Certification du critère Bénéficiaire du RSA (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_allocataire_ass" IS \'Critère Allocataire ASS (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_allocataire_aah" IS \'Critère Allocataire AAH (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_allocataire_aah_certifié" IS \'Certification du critère Allocataire AAH (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_allocataire_aah_date_certification" IS \'Date de la dernière Certification du critère Allocataire AAH (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_allocataire_aah_période_certification" IS \'Période de Certification du critère Allocataire AAH (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n1_detld_plus_de_24_mois" IS \'Critère DETLD (plus de 24 mois) (niveau 1)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_niveau_d_étude_3_cap_bep_ou_infra" IS \'Critère Niveau d étude 3 (CAP BEP) ou infra (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_senior_plus_de_50_ans" IS \'Critère Senior (plus de 50 ans) (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_jeune_moins_de_26_ans" IS \'Critère Jeune (moins de 26 ans) (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_sortant_de_l_ase" IS \'Critère Sortant de l ASE (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_deld_12_à_24_mois" IS \'Critère DELD (12 à 24 mois) (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_travailleur_handicapé" IS \'Critère Travailleur handicapé (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_parent_isolé" IS \'Critère Parent isolé (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_parent_isolé_certifié" IS \'Certification du critère Parent isolé (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_parent_isolé_date_certification" IS \'Date de la dernière Certification du critère Parent isolé (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_parent_isolé_période_certification" IS \'Période de Certification du critère Parent isolé (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_personne_sans_hébergement_ou_hébergée_ou_ayant_un_parcours_de_rue" IS \'Critère Personne sans hébergement ou hébergée ou ayant un parcours de rue (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_réfugié_statutaire_bénéficiaire_d_une_protection_temporaire_protégé_subsidiaire_ou_demandeur_d_asile" IS \'Critère Réfugié statutaire bénéficiaire d une protection temporaire protégé subsidiaire ou demandeur d asile (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_résident_zrr" IS \'Critère Résident ZRR (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_résident_qpv" IS \'Critère Résident QPV (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_sortant_de_détention_ou_personne_placée_sous_main_de_justice" IS \'Critère Sortant de détention ou personne placée sous main de justice (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_maîtrise_de_la_langue_française_inférieure_au_niveau_a1" IS \'Critère Maîtrise de la langue française inférieure au niveau A1 (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."critère_n2_problème_de_mobilité" IS \'Critère Problème de mobilité (niveau 2)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."injection_ai" IS \'Provient des injections AI\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_candidats_v0"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id" AS "pk"
+          FROM "users_user"
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("users_user"."id" = "eligibility_eligibilitydiagnosis"."job_seeker_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          WHERE "users_user"."kind" = %s
+          GROUP BY 1
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id" AS "pk"
+          FROM "users_user"
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("users_user"."id" = "eligibility_eligibilitydiagnosis"."job_seeker_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" >= %s)
+          GROUP BY 1
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 5000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update",
+                 COUNT(DISTINCT "eligibility_eligibilitydiagnosis"."id") AS "eligibility_diagnoses_count",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") AS "job_applications_count",
+                 COUNT(DISTINCT "job_applications_jobapplication"."id") FILTER (
+                                                                                WHERE "job_applications_jobapplication"."state" = %s) AS "accepted_job_applications_count",
+                 T4."id",
+                 T4."password",
+                 T4."last_login",
+                 T4."is_superuser",
+                 T4."username",
+                 T4."first_name",
+                 T4."last_name",
+                 T4."is_staff",
+                 T4."is_active",
+                 T4."date_joined",
+                 T4."address_line_1",
+                 T4."address_line_2",
+                 T4."post_code",
+                 T4."city",
+                 T4."department",
+                 T4."coords",
+                 T4."geocoding_score",
+                 T4."geocoding_updated_at",
+                 T4."ban_api_resolved_address",
+                 T4."insee_city_id",
+                 T4."title",
+                 T4."full_name_search_vector",
+                 T4."email",
+                 T4."phone",
+                 T4."kind",
+                 T4."identity_provider",
+                 T4."has_completed_welcoming_tour",
+                 T4."created_by_id",
+                 T4."external_data_source_history",
+                 T4."last_checked_at",
+                 T4."public_id",
+                 T4."address_filled_at",
+                 T4."first_login",
+                 T4."upcoming_deletion_notified_at",
+                 T4."allow_next_sso_sub_update",
+                 "users_jobseekerprofile"."user_id",
+                 "users_jobseekerprofile"."birthdate",
+                 "users_jobseekerprofile"."birth_place_id",
+                 "users_jobseekerprofile"."birth_country_id",
+                 "users_jobseekerprofile"."nir",
+                 "users_jobseekerprofile"."lack_of_nir_reason",
+                 "users_jobseekerprofile"."pole_emploi_id",
+                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
+                 "users_jobseekerprofile"."ft_gps_id",
+                 "users_jobseekerprofile"."asp_uid",
+                 "users_jobseekerprofile"."education_level",
+                 "users_jobseekerprofile"."resourceless",
+                 "users_jobseekerprofile"."rqth_employee",
+                 "users_jobseekerprofile"."oeth_employee",
+                 "users_jobseekerprofile"."pole_emploi_since",
+                 "users_jobseekerprofile"."unemployed_since",
+                 "users_jobseekerprofile"."has_rsa_allocation",
+                 "users_jobseekerprofile"."rsa_allocation_since",
+                 "users_jobseekerprofile"."ass_allocation_since",
+                 "users_jobseekerprofile"."aah_allocation_since",
+                 "users_jobseekerprofile"."are_allocation_since",
+                 "users_jobseekerprofile"."activity_bonus_since",
+                 "users_jobseekerprofile"."cape_freelance",
+                 "users_jobseekerprofile"."cesa_freelance",
+                 "users_jobseekerprofile"."actor_met_for_business_creation",
+                 "users_jobseekerprofile"."mean_monthly_income_before_process",
+                 "users_jobseekerprofile"."eiti_contributions",
+                 "users_jobseekerprofile"."hexa_lane_number",
+                 "users_jobseekerprofile"."hexa_std_extension",
+                 "users_jobseekerprofile"."hexa_non_std_extension",
+                 "users_jobseekerprofile"."hexa_lane_type",
+                 "users_jobseekerprofile"."hexa_lane_name",
+                 "users_jobseekerprofile"."hexa_additional_address",
+                 "users_jobseekerprofile"."hexa_post_code",
+                 "users_jobseekerprofile"."hexa_commune_id",
+                 "users_jobseekerprofile"."pe_obfuscated_nir",
+                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
+                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
+                 "users_jobseekerprofile"."is_stalled",
+                 "users_jobseekerprofile"."is_not_stalled_anymore",
+                 "users_jobseekerprofile"."fields_history"
+          FROM "users_user"
+          LEFT OUTER JOIN "eligibility_eligibilitydiagnosis" ON ("users_user"."id" = "eligibility_eligibilitydiagnosis"."job_seeker_id")
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
+          LEFT OUTER JOIN "users_user" T4 ON ("users_user"."created_by_id" = T4."id")
+          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "users_user"."id" >= %s)
+          GROUP BY "users_user"."id",
+                   T4."id",
+                   "users_jobseekerprofile"."user_id"
+          ORDER BY "users_user"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "col1",
+                 "col2",
+                 "col3",
+                 "col4",
+                 "col5",
+                 "col6",
+                 "col7",
+                 "col8",
+                 "col9",
+                 "level_1_count",
+                 "level_2_count",
+                 "criteria_ids",
+                 "col10",
+                 "col11",
+                 "col12",
+                 "col13",
+                 "col14",
+                 "col15",
+                 "col16",
+                 "col17",
+                 "col18",
+                 "col19",
+                 "col20",
+                 "col21",
+                 "col22",
+                 "col23",
+                 "col24",
+                 "col25",
+                 "col26",
+                 "col27",
+                 "col28",
+                 "col29",
+                 "col30",
+                 "col31",
+                 "col32",
+                 "col33",
+                 "col34",
+                 "col35",
+                 "col36",
+                 "col37",
+                 "col38",
+                 "col39",
+                 "col40",
+                 "col41",
+                 "col42",
+                 "col43",
+                 "col44",
+                 "col45",
+                 "col46",
+                 "col47",
+                 "col48",
+                 "col49",
+                 "col50",
+                 "col51",
+                 "col52",
+                 "col53",
+                 "col54",
+                 "col55",
+                 "col56",
+                 "col57",
+                 "col58",
+                 "col59",
+                 "col60",
+                 "col61",
+                 "col62",
+                 "col63",
+                 "col64",
+                 "col65",
+                 "col66",
+                 "col67",
+                 "col68",
+                 "col69",
+                 "col70",
+                 "col71",
+                 "col72",
+                 "col73",
+                 "col74",
+                 "col75",
+                 "col76"
+          FROM
+            (SELECT *
+             FROM
+               (SELECT "eligibility_eligibilitydiagnosis"."id" AS "col1",
+                       "eligibility_eligibilitydiagnosis"."author_id" AS "col2",
+                       "eligibility_eligibilitydiagnosis"."author_kind" AS "col3",
+                       "eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" AS "col4",
+                       "eligibility_eligibilitydiagnosis"."created_at" AS "col5",
+                       "eligibility_eligibilitydiagnosis"."updated_at" AS "col6",
+                       "eligibility_eligibilitydiagnosis"."expires_at" AS "col7",
+                       "eligibility_eligibilitydiagnosis"."job_seeker_id" AS "col8",
+                       "eligibility_eligibilitydiagnosis"."author_siae_id" AS "col9",
+                       COUNT("eligibility_selectedadministrativecriteria"."administrative_criteria_id") FILTER (
+                                                                                                                WHERE "eligibility_administrativecriteria"."level" = %s) AS "level_1_count",
+                       COUNT("eligibility_selectedadministrativecriteria"."administrative_criteria_id") FILTER (
+                                                                                                                WHERE "eligibility_administrativecriteria"."level" = %s) AS "level_2_count",
+                       ARRAY_AGG("eligibility_selectedadministrativecriteria"."administrative_criteria_id") AS "criteria_ids",
+                       ROW_NUMBER() OVER (PARTITION BY "eligibility_eligibilitydiagnosis"."job_seeker_id"
+                                          ORDER BY "eligibility_eligibilitydiagnosis"."created_at" DESC) AS "qual0",
+                       "prescribers_prescriberorganization"."id" AS "col10",
+                       "prescribers_prescriberorganization"."address_line_1" AS "col11",
+                       "prescribers_prescriberorganization"."address_line_2" AS "col12",
+                       "prescribers_prescriberorganization"."post_code" AS "col13",
+                       "prescribers_prescriberorganization"."city" AS "col14",
+                       "prescribers_prescriberorganization"."department" AS "col15",
+                       "prescribers_prescriberorganization"."coords" AS "col16",
+                       "prescribers_prescriberorganization"."geocoding_score" AS "col17",
+                       "prescribers_prescriberorganization"."geocoding_updated_at" AS "col18",
+                       "prescribers_prescriberorganization"."ban_api_resolved_address" AS "col19",
+                       "prescribers_prescriberorganization"."insee_city_id" AS "col20",
+                       "prescribers_prescriberorganization"."name" AS "col21",
+                       "prescribers_prescriberorganization"."created_at" AS "col22",
+                       "prescribers_prescriberorganization"."updated_at" AS "col23",
+                       "prescribers_prescriberorganization"."uid" AS "col24",
+                       "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at" AS "col25",
+                       "prescribers_prescriberorganization"."automatic_geocoding_update" AS "col26",
+                       "prescribers_prescriberorganization"."siret" AS "col27",
+                       "prescribers_prescriberorganization"."kind" AS "col28",
+                       "prescribers_prescriberorganization"."is_brsa" AS "col29",
+                       "prescribers_prescriberorganization"."phone" AS "col30",
+                       "prescribers_prescriberorganization"."email" AS "col31",
+                       "prescribers_prescriberorganization"."website" AS "col32",
+                       "prescribers_prescriberorganization"."description" AS "col33",
+                       "prescribers_prescriberorganization"."code_safir_pole_emploi" AS "col34",
+                       "prescribers_prescriberorganization"."created_by_id" AS "col35",
+                       "prescribers_prescriberorganization"."authorization_status" AS "col36",
+                       "prescribers_prescriberorganization"."authorization_updated_at" AS "col37",
+                       "prescribers_prescriberorganization"."authorization_updated_by_id" AS "col38",
+                       "prescribers_prescriberorganization"."is_gps_authorized" AS "col39",
+                       "companies_company"."id" AS "col40",
+                       "companies_company"."address_line_1" AS "col41",
+                       "companies_company"."address_line_2" AS "col42",
+                       "companies_company"."post_code" AS "col43",
+                       "companies_company"."city" AS "col44",
+                       "companies_company"."department" AS "col45",
+                       "companies_company"."coords" AS "col46",
+                       "companies_company"."geocoding_score" AS "col47",
+                       "companies_company"."geocoding_updated_at" AS "col48",
+                       "companies_company"."ban_api_resolved_address" AS "col49",
+                       "companies_company"."insee_city_id" AS "col50",
+                       "companies_company"."name" AS "col51",
+                       "companies_company"."created_at" AS "col52",
+                       "companies_company"."updated_at" AS "col53",
+                       "companies_company"."uid" AS "col54",
+                       "companies_company"."active_members_email_reminder_last_sent_at" AS "col55",
+                       "companies_company"."automatic_geocoding_update" AS "col56",
+                       "companies_company"."siret" AS "col57",
+                       "companies_company"."naf" AS "col58",
+                       "companies_company"."kind" AS "col59",
+                       "companies_company"."brand" AS "col60",
+                       "companies_company"."phone" AS "col61",
+                       "companies_company"."email" AS "col62",
+                       "companies_company"."auth_email" AS "col63",
+                       "companies_company"."website" AS "col64",
+                       "companies_company"."description" AS "col65",
+                       "companies_company"."provided_support" AS "col66",
+                       "companies_company"."source" AS "col67",
+                       "companies_company"."created_by_id" AS "col68",
+                       "companies_company"."block_job_applications" AS "col69",
+                       "companies_company"."job_applications_blocked_at" AS "col70",
+                       "companies_company"."spontaneous_applications_open_since" AS "col71",
+                       "companies_company"."convention_id" AS "col72",
+                       "companies_company"."job_app_score" AS "col73",
+                       "companies_company"."is_searchable" AS "col74",
+                       "companies_company"."rdv_solidarites_id" AS "col75",
+                       "companies_company"."fields_history" AS "col76"
+                FROM "eligibility_eligibilitydiagnosis"
+                LEFT OUTER JOIN "eligibility_selectedadministrativecriteria" ON ("eligibility_eligibilitydiagnosis"."id" = "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id")
+                LEFT OUTER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
+                LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("eligibility_eligibilitydiagnosis"."author_prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+                LEFT OUTER JOIN "companies_company" ON ("eligibility_eligibilitydiagnosis"."author_siae_id" = "companies_company"."id")
+                WHERE "eligibility_eligibilitydiagnosis"."job_seeker_id" IN (%s,
+                                                                             %s,
+                                                                             %s)
+                GROUP BY 1,
+                         14,
+                         44
+                ORDER BY "eligibility_eligibilitydiagnosis"."created_at" DESC) "qualify"
+             WHERE ("qual0" > %s
+                    AND "qual0" <= %s)) "qualify_mask"
+          ORDER BY "col5" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "eligibility_selectedadministrativecriteria"."id",
+                 "eligibility_selectedadministrativecriteria"."certified",
+                 "eligibility_selectedadministrativecriteria"."certified_at",
+                 "eligibility_selectedadministrativecriteria"."certification_period",
+                 "eligibility_selectedadministrativecriteria"."data_returned_by_api",
+                 "eligibility_selectedadministrativecriteria"."created_at",
+                 "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id",
+                 "eligibility_selectedadministrativecriteria"."administrative_criteria_id"
+          FROM "eligibility_selectedadministrativecriteria"
+          INNER JOIN "eligibility_administrativecriteria" ON ("eligibility_selectedadministrativecriteria"."administrative_criteria_id" = "eligibility_administrativecriteria"."id")
+          WHERE "eligibility_selectedadministrativecriteria"."eligibility_diagnosis_id" IN (%s,
+                                                                                            %s)
+          ORDER BY "eligibility_administrativecriteria"."level" ASC,
+                   "eligibility_administrativecriteria"."ui_rank" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "job_applications_jobapplication"."id",
+                 "job_applications_jobapplication"."job_seeker_id",
+                 "job_applications_jobapplication"."eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."geiq_eligibility_diagnosis_id",
+                 "job_applications_jobapplication"."create_employee_record",
+                 "job_applications_jobapplication"."resume_id",
+                 "job_applications_jobapplication"."sender_id",
+                 "job_applications_jobapplication"."sender_kind",
+                 "job_applications_jobapplication"."sender_company_id",
+                 "job_applications_jobapplication"."sender_prescriber_organization_id",
+                 "job_applications_jobapplication"."to_company_id",
+                 "job_applications_jobapplication"."state",
+                 "job_applications_jobapplication"."archived_at",
+                 "job_applications_jobapplication"."archived_by_id",
+                 "job_applications_jobapplication"."hired_job_id",
+                 "job_applications_jobapplication"."message",
+                 "job_applications_jobapplication"."answer",
+                 "job_applications_jobapplication"."answer_to_prescriber",
+                 "job_applications_jobapplication"."refusal_reason",
+                 "job_applications_jobapplication"."refusal_reason_shared_with_job_seeker",
+                 "job_applications_jobapplication"."hiring_start_at",
+                 "job_applications_jobapplication"."hiring_end_at",
+                 "job_applications_jobapplication"."origin",
+                 "job_applications_jobapplication"."approval_id",
+                 "job_applications_jobapplication"."approval_delivery_mode",
+                 "job_applications_jobapplication"."approval_number_sent_by_email",
+                 "job_applications_jobapplication"."approval_number_sent_at",
+                 "job_applications_jobapplication"."approval_manually_delivered_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_by_id",
+                 "job_applications_jobapplication"."approval_manually_refused_at",
+                 "job_applications_jobapplication"."transferred_at",
+                 "job_applications_jobapplication"."transferred_by_id",
+                 "job_applications_jobapplication"."transferred_from_id",
+                 "job_applications_jobapplication"."created_at",
+                 "job_applications_jobapplication"."updated_at",
+                 "job_applications_jobapplication"."processed_at",
+                 "job_applications_jobapplication"."prehiring_guidance_days",
+                 "job_applications_jobapplication"."contract_type",
+                 "job_applications_jobapplication"."nb_hours_per_week",
+                 "job_applications_jobapplication"."contract_type_details",
+                 "job_applications_jobapplication"."qualification_type",
+                 "job_applications_jobapplication"."qualification_level",
+                 "job_applications_jobapplication"."planned_training_hours",
+                 "job_applications_jobapplication"."inverted_vae_contract",
+                 "job_applications_jobapplication"."diagoriente_invite_sent_at",
+                 "companies_company"."id",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id",
+                 "companies_company"."fields_history"
+          FROM "job_applications_jobapplication"
+          INNER JOIN "companies_company" ON ("job_applications_jobapplication"."to_company_id" = "companies_company"."id")
+          WHERE "job_applications_jobapplication"."job_seeker_id" IN (%s,
+                                                                      %s,
+                                                                      %s)
+          ORDER BY "job_applications_jobapplication"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_qpv_job_seeker_pks[metabase/tables/utils.py]',
+          'get_job_seeker_qpv_info[metabase/tables/job_seekers.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT uu.id
+          FROM users_user uu
+          INNER JOIN geo_qpv gq ON ST_Contains(gq.geometry, uu.coords::geometry)
+          WHERE uu.coords IS NOT NULL
+            AND uu.geocoding_score > 0.8
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_ai_stock_job_seeker_pks[metabase/tables/utils.py]',
+          '<lambda>[metabase/tables/job_seekers.py]',
+          '<lambda>[metabase/utils.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_approval"."user_id" AS "user_id"
+          FROM "approvals_approval"
+          WHERE "approvals_approval"."origin" = %s
+          ORDER BY "approvals_approval"."created_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_candidats_v0" ("id",
+                                     "hash_nir",
+                                     "sexe_selon_nir",
+                                     "annee_naissance_selon_nir",
+                                     "mois_naissance_selon_nir",
+                                     "age",
+                                     "date_inscription",
+                                     "type_inscription",
+                                     "pe_connect",
+                                     "pe_inscrit",
+                                     "date_dernière_connexion",
+                                     "date_premiere_connexion",
+                                     "actif",
+                                     "code_postal",
+                                     "département",
+                                     "nom_département",
+                                     "région",
+                                     "adresse_en_qpv",
+                                     "total_candidatures",
+                                     "total_embauches",
+                                     "total_diagnostics",
+                                     "date_diagnostic",
+                                     "date_expiration_diagnostic",
+                                     "diagnostic_valide",
+                                     "id_auteur_diagnostic_prescripteur",
+                                     "id_auteur_diagnostic_employeur",
+                                     "type_auteur_diagnostic",
+                                     "sous_type_auteur_diagnostic",
+                                     "nom_auteur_diagnostic",
+                                     "type_structure_dernière_embauche",
+                                     "total_critères_niveau_1",
+                                     "total_critères_niveau_2",
+                                     "critère_n1_bénéficiaire_du_rsa",
+                                     "critère_n1_bénéficiaire_du_rsa_certifié",
+                                     "critère_n1_bénéficiaire_du_rsa_date_certification",
+                                     "critère_n1_bénéficiaire_du_rsa_période_certification",
+                                     "critère_n1_allocataire_ass",
+                                     "critère_n1_allocataire_aah",
+                                     "critère_n1_allocataire_aah_certifié",
+                                     "critère_n1_allocataire_aah_date_certification",
+                                     "critère_n1_allocataire_aah_période_certification",
+                                     "critère_n1_detld_plus_de_24_mois",
+                                     "critère_n2_niveau_d_étude_3_cap_bep_ou_infra",
+                                     "critère_n2_senior_plus_de_50_ans",
+                                     "critère_n2_jeune_moins_de_26_ans",
+                                     "critère_n2_sortant_de_l_ase",
+                                     "critère_n2_deld_12_à_24_mois",
+                                     "critère_n2_travailleur_handicapé",
+                                     "critère_n2_parent_isolé",
+                                     "critère_n2_parent_isolé_certifié",
+                                     "critère_n2_parent_isolé_date_certification",
+                                     "critère_n2_parent_isolé_période_certification",
+                                     "critère_n2_personne_sans_hébergement_ou_hébergée_ou_ayant_un_parcours_de_rue",
+                                     "critère_n2_réfugié_statutaire_bénéficiaire_d_une_protection_temporaire_protégé_subsidiaire_ou_demandeur_d_asile",
+                                     "critère_n2_résident_zrr",
+                                     "critère_n2_résident_qpv",
+                                     "critère_n2_sortant_de_détention_ou_personne_placée_sous_main_de_justice",
+                                     "critère_n2_maîtrise_de_la_langue_française_inférieure_au_niveau_a1",
+                                     "critère_n2_problème_de_mobilité",
+                                     "injection_ai",
+                                     "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_candidats_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "candidats_v0" RENAME TO "z_old_candidats_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_candidats_v0" RENAME TO "candidats_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_candidats_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_memberships
+  dict({
+    'num_queries': 36,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active")
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active")
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "users_user" ON ("institutions_institutionmembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "institutions_institutionmembership"."is_active")
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_collaborations"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_collaborations" ("id_utilisateur" integer,"administrateur" integer,"id_structure" integer,"id_organisation" integer,"id_institution" integer,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_collaborations"."id_utilisateur" IS \'user\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_collaborations"."administrateur" IS \'administrateur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_collaborations"."id_structure" IS \'ID structure\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_collaborations"."id_organisation" IS \'ID organisation prescripteur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_collaborations"."id_institution" IS \'ID institution\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_collaborations"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id" AS "pk"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active")
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id" AS "pk"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."id" >= %s)
+          ORDER BY "companies_companymembership"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_collaborations" ("id_utilisateur",
+                                       "administrateur",
+                                       "id_structure",
+                                       "id_organisation",
+                                       "id_institution",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id" AS "pk"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active")
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id" AS "pk"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."id" >= %s)
+          ORDER BY "prescribers_prescribermembership"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_collaborations" ("id_utilisateur",
+                                       "administrateur",
+                                       "id_structure",
+                                       "id_organisation",
+                                       "id_institution",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id" AS "pk"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "users_user" ON ("institutions_institutionmembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "institutions_institutionmembership"."is_active")
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id" AS "pk"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "users_user" ON ("institutions_institutionmembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "users_user" ON ("institutions_institutionmembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."id" >= %s)
+          ORDER BY "institutions_institutionmembership"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_collaborations" ("id_utilisateur",
+                                       "administrateur",
+                                       "id_structure",
+                                       "id_organisation",
+                                       "id_institution",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_collaborations" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "collaborations" RENAME TO "z_old_collaborations"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_collaborations" RENAME TO "collaborations"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_collaborations" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_organizations
+  dict({
+    'num_queries': 54,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'get_active_companies_pks[metabase/tables/utils.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'get_active_companies_pks[metabase/tables/utils.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_company"."id" AS "pk"
+          FROM "companies_company"
+          WHERE (NOT ("companies_company"."siret" = %s)
+                 AND (NOT ("companies_company"."kind" IN (%s,
+                                                          %s,
+                                                          %s,
+                                                          %s,
+                                                          %s))
+                      OR "companies_company"."source" = %s
+                      OR EXISTS
+                        (SELECT %s AS "a"
+                         FROM "companies_siaeconvention" U0
+                         WHERE (U0."id" = ("companies_company"."convention_id")
+                                AND U0."is_active")
+                         LIMIT 1)))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*)
+          FROM
+            (SELECT "prescribers_prescriberorganization"."id" AS "col1"
+             FROM "prescribers_prescriberorganization"
+             LEFT OUTER JOIN "job_applications_jobapplication" ON ("prescribers_prescriberorganization"."id" = "job_applications_jobapplication"."sender_prescriber_organization_id")
+             GROUP BY 1) subquery
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_organisations_v0"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_organisations_v0" ("id" integer,"siret" varchar,"nom" varchar,"type" varchar,"type_complet" varchar,"habilitée" integer,"adresse_ligne_1" varchar,"adresse_ligne_2" varchar,"code_postal" varchar,"code_commune" varchar,"ville" varchar,"longitude" double precision,"latitude" double precision,"département" varchar,"nom_département" varchar,"région" varchar,"date_inscription" date,"code_safir" varchar,"total_membres" integer,"total_candidatures" integer,"total_embauches" integer,"date_dernière_candidature" date,"date_dernière_connexion" date,"active" integer,"brsa" integer,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."id" IS \'ID organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."siret" IS \'SIRET organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."nom" IS \'Nom organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."type" IS \'Type organisation (abrégé)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."type_complet" IS \'Type organisation (détaillé)\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."habilitée" IS \'Organisation habilitée\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."adresse_ligne_1" IS \'Première ligne adresse de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."adresse_ligne_2" IS \'Seconde ligne adresse de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."code_postal" IS \'Code postal de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."code_commune" IS \'Code commune de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."ville" IS \'Ville de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."longitude" IS \'Longitude de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."latitude" IS \'Latitude de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."département" IS \'Département de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."nom_département" IS \'Nom complet du département de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."région" IS \'Région de cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."date_inscription" IS \'Date inscription du premier compte prescripteur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."code_safir" IS \'Code SAFIR Pôle emploi\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."total_membres" IS \'Nombre de comptes prescripteurs rattachés à cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."total_candidatures" IS \'Nombre de candidatures émises par cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."total_embauches" IS \'Nombre de candidatures en état accepté émises par cette organisation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."date_dernière_candidature" IS \'Date de la dernière création de candidature\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."date_dernière_connexion" IS \'Date de dernière connexion utilisateur\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."active" IS \'Dernière connexion dans les 7 jours\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."brsa" IS \'Organisation conventionnée pour le suivi des BRSA\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_organisations_v0"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'get_post_code_to_insee_cities_map[metabase/tables/utils.py]',
+          'get_code_commune[metabase/tables/utils.py]',
+          '<lambda>[metabase/tables/utils.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "cities_city"."id",
+                 "cities_city"."name",
+                 "cities_city"."normalized_name",
+                 "cities_city"."slug",
+                 "cities_city"."department",
+                 "cities_city"."post_codes",
+                 "cities_city"."code_insee",
+                 "cities_city"."coords",
+                 "cities_city"."edition_mode"
+          FROM "cities_city"
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_org_members_count[metabase/tables/organizations.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "users_user"
+          LEFT OUTER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE ("users_user"."kind" = %s
+                 AND "prescribers_prescribermembership"."id" IS NULL)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '<lambda>[metabase/tables/utils.py]',
+          '<lambda>[metabase/utils.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE "prescribers_prescribermembership"."organization_id" = %s
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          '<lambda>[metabase/tables/utils.py]',
+          '<lambda>[metabase/utils.py]',
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT %s AS "a"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE "prescribers_prescribermembership"."organization_id" = %s
+          LIMIT 1
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_organisations_v0" ("id",
+                                         "siret",
+                                         "nom",
+                                         "type",
+                                         "type_complet",
+                                         "habilitée",
+                                         "adresse_ligne_1",
+                                         "adresse_ligne_2",
+                                         "code_postal",
+                                         "code_commune",
+                                         "ville",
+                                         "longitude",
+                                         "latitude",
+                                         "département",
+                                         "nom_département",
+                                         "région",
+                                         "date_inscription",
+                                         "code_safir",
+                                         "total_membres",
+                                         "total_candidatures",
+                                         "total_embauches",
+                                         "date_dernière_candidature",
+                                         "date_dernière_connexion",
+                                         "active",
+                                         "brsa",
+                                         "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id" AS "pk"
+          FROM "prescribers_prescriberorganization"
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("prescribers_prescriberorganization"."id" = "job_applications_jobapplication"."sender_prescriber_organization_id")
+          GROUP BY 1
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id" AS "pk"
+          FROM "prescribers_prescriberorganization"
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("prescribers_prescriberorganization"."id" = "job_applications_jobapplication"."sender_prescriber_organization_id")
+          WHERE "prescribers_prescriberorganization"."id" >= %s
+          GROUP BY 1
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 %s AS "job_applications_count",
+                 %s AS "accepted_job_applications_count",
+                 NULL AS "last_job_application_creation_date",
+                 "cities_city"."id",
+                 "cities_city"."name",
+                 "cities_city"."normalized_name",
+                 "cities_city"."slug",
+                 "cities_city"."department",
+                 "cities_city"."post_codes",
+                 "cities_city"."code_insee",
+                 "cities_city"."coords",
+                 "cities_city"."edition_mode"
+          FROM "prescribers_prescriberorganization"
+          LEFT OUTER JOIN "job_applications_jobapplication" ON ("prescribers_prescriberorganization"."id" = "job_applications_jobapplication"."sender_prescriber_organization_id")
+          LEFT OUTER JOIN "cities_city" ON ("prescribers_prescriberorganization"."insee_city_id" = "cities_city"."id")
+          WHERE "prescribers_prescriberorganization"."id" >= %s
+          GROUP BY "prescribers_prescriberorganization"."id",
+                   "cities_city"."id"
+          ORDER BY "prescribers_prescriberorganization"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "users_user" ON ("prescribers_prescribermembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."organization_id" IN (%s,
+                                                                              %s))
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT ("prescribers_prescribermembership"."organization_id") AS "_prefetch_related_val_organization_id",
+                 "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          INNER JOIN "prescribers_prescribermembership" ON ("users_user"."id" = "prescribers_prescribermembership"."user_id")
+          WHERE "prescribers_prescribermembership"."organization_id" IN (%s,
+                                                                         %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id"
+          FROM "prescribers_prescribermembership"
+          WHERE "prescribers_prescribermembership"."organization_id" IN (%s,
+                                                                         %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_organisations_v0" ("id",
+                                         "siret",
+                                         "nom",
+                                         "type",
+                                         "type_complet",
+                                         "habilitée",
+                                         "adresse_ligne_1",
+                                         "adresse_ligne_2",
+                                         "code_postal",
+                                         "code_commune",
+                                         "ville",
+                                         "longitude",
+                                         "latitude",
+                                         "département",
+                                         "nom_département",
+                                         "région",
+                                         "date_inscription",
+                                         "code_safir",
+                                         "total_membres",
+                                         "total_candidatures",
+                                         "total_embauches",
+                                         "date_dernière_candidature",
+                                         "date_dernière_connexion",
+                                         "active",
+                                         "brsa",
+                                         "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_organisations_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "organisations_v0" RENAME TO "z_old_organisations_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_organisations_v0" RENAME TO "organisations_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_organisations_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_prolongation_requests
+  dict({
+    'num_queries': 35,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "approvals_prolongationrequest"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_demandes_de_prolongation"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_demandes_de_prolongation" ("id" integer,"id_pass_agrément" integer,"date_début" date,"date_fin" date,"motif" varchar,"id_utilisateur_déclarant" integer,"id_structure_déclarante" integer,"id_organisation_prescripteur" integer,"id_utilisateur_prescripteur" integer,"id_prolongation" integer,"état" varchar,"motif_de_refus" varchar,"date_de_demande" date,"date_traitement" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                  "id_utilisateur_traitant" integer,"date_envoi_rappel" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            "date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_pass_agrément" IS \'PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."date_début" IS \'date de début\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."date_fin" IS \'date de fin\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."motif" IS \'Motif renseigné\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_utilisateur_déclarant" IS \'déclarée par\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_structure_déclarante" IS \'SIAE du déclarant\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_organisation_prescripteur" IS \'organisation du prescripteur habilité\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_utilisateur_prescripteur" IS \'prescripteur habilité qui a reçu la demande de prolongation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_prolongation" IS \'ID C1 de la prolongation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."état" IS \'Etat de la demande\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."motif_de_refus" IS \'Motif de refus de la demande\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."date_de_demande" IS \'Date de la demande\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."date_traitement" IS \'date de traitement\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."id_utilisateur_traitant" IS \'traité par\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."date_envoi_rappel" IS \'rappel envoyé le\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_demandes_de_prolongation"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id" AS "pk"
+          FROM "approvals_prolongationrequest"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id" AS "pk"
+          FROM "approvals_prolongationrequest"
+          WHERE "approvals_prolongationrequest"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 50000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongationrequest"."id",
+                 "approvals_prolongationrequest"."approval_id",
+                 "approvals_prolongationrequest"."start_at",
+                 "approvals_prolongationrequest"."end_at",
+                 "approvals_prolongationrequest"."reason",
+                 "approvals_prolongationrequest"."reason_explanation",
+                 "approvals_prolongationrequest"."declared_by_id",
+                 "approvals_prolongationrequest"."declared_by_siae_id",
+                 "approvals_prolongationrequest"."prescriber_organization_id",
+                 "approvals_prolongationrequest"."created_at",
+                 "approvals_prolongationrequest"."created_by_id",
+                 "approvals_prolongationrequest"."updated_at",
+                 "approvals_prolongationrequest"."updated_by_id",
+                 "approvals_prolongationrequest"."report_file_id",
+                 "approvals_prolongationrequest"."require_phone_interview",
+                 "approvals_prolongationrequest"."contact_email",
+                 "approvals_prolongationrequest"."contact_phone",
+                 "approvals_prolongationrequest"."status",
+                 "approvals_prolongationrequest"."assigned_to_id",
+                 "approvals_prolongationrequest"."processed_at",
+                 "approvals_prolongationrequest"."processed_by_id",
+                 "approvals_prolongationrequest"."reminder_sent_at",
+                 "approvals_prolongationrequestdenyinformation"."id",
+                 "approvals_prolongationrequestdenyinformation"."request_id",
+                 "approvals_prolongationrequestdenyinformation"."reason",
+                 "approvals_prolongationrequestdenyinformation"."reason_explanation",
+                 "approvals_prolongationrequestdenyinformation"."proposed_actions",
+                 "approvals_prolongationrequestdenyinformation"."proposed_actions_explanation",
+                 "approvals_prolongationrequestdenyinformation"."created_at",
+                 "approvals_prolongationrequestdenyinformation"."updated_at",
+                 "approvals_prolongation"."id",
+                 "approvals_prolongation"."approval_id",
+                 "approvals_prolongation"."start_at",
+                 "approvals_prolongation"."end_at",
+                 "approvals_prolongation"."reason",
+                 "approvals_prolongation"."reason_explanation",
+                 "approvals_prolongation"."declared_by_id",
+                 "approvals_prolongation"."declared_by_siae_id",
+                 "approvals_prolongation"."prescriber_organization_id",
+                 "approvals_prolongation"."created_at",
+                 "approvals_prolongation"."created_by_id",
+                 "approvals_prolongation"."updated_at",
+                 "approvals_prolongation"."updated_by_id",
+                 "approvals_prolongation"."report_file_id",
+                 "approvals_prolongation"."require_phone_interview",
+                 "approvals_prolongation"."contact_email",
+                 "approvals_prolongation"."contact_phone",
+                 "approvals_prolongation"."request_id",
+                 "approvals_prolongation"."validated_by_id"
+          FROM "approvals_prolongationrequest"
+          LEFT OUTER JOIN "approvals_prolongationrequestdenyinformation" ON ("approvals_prolongationrequest"."id" = "approvals_prolongationrequestdenyinformation"."request_id")
+          LEFT OUTER JOIN "approvals_prolongation" ON ("approvals_prolongationrequest"."id" = "approvals_prolongation"."request_id")
+          WHERE "approvals_prolongationrequest"."id" >= %s
+          ORDER BY "approvals_prolongationrequest"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_demandes_de_prolongation" ("id",
+                                                 "id_pass_agrément",
+                                                 "date_début",
+                                                 "date_fin",
+                                                 "motif",
+                                                 "id_utilisateur_déclarant",
+                                                 "id_structure_déclarante",
+                                                 "id_organisation_prescripteur",
+                                                 "id_utilisateur_prescripteur",
+                                                 "id_prolongation",
+                                                 "état",
+                                                 "motif_de_refus",
+                                                 "date_de_demande",
+                                                 "date_traitement",
+                                                 "id_utilisateur_traitant",
+                                                 "date_envoi_rappel",
+                                                 "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_demandes_de_prolongation" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "demandes_de_prolongation" RENAME TO "z_old_demandes_de_prolongation"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_demandes_de_prolongation" RENAME TO "demandes_de_prolongation"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_demandes_de_prolongation" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_prolongations
+  dict({
+    'num_queries': 30,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "approvals_prolongation"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_prolongations"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_prolongations" ("id" integer,"id_pass_agrément" integer,"date_début" date,"date_fin" date,"motif" varchar,"id_utilisateur_déclarant" integer,"id_structure_déclarante" integer,"id_organisation_prescripteur" integer,"id_utilisateur_prescripteur" integer,"date_de_création" date,"id_demande_de_prolongation" integer,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id_pass_agrément" IS \'PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."date_début" IS \'date de début\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."date_fin" IS \'date de fin\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."motif" IS \'Motif renseigné\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id_utilisateur_déclarant" IS \'déclarée par\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id_structure_déclarante" IS \'SIAE du déclarant\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id_organisation_prescripteur" IS \'organisation du prescripteur habilité\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id_utilisateur_prescripteur" IS \'prescripteur habilité qui a autorisé cette prolongation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."date_de_création" IS \'Date de création\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."id_demande_de_prolongation" IS \'demande de prolongation\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_prolongations"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id" AS "pk"
+          FROM "approvals_prolongation"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id" AS "pk"
+          FROM "approvals_prolongation"
+          WHERE "approvals_prolongation"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_prolongation"."id",
+                 "approvals_prolongation"."approval_id",
+                 "approvals_prolongation"."start_at",
+                 "approvals_prolongation"."end_at",
+                 "approvals_prolongation"."reason",
+                 "approvals_prolongation"."reason_explanation",
+                 "approvals_prolongation"."declared_by_id",
+                 "approvals_prolongation"."declared_by_siae_id",
+                 "approvals_prolongation"."prescriber_organization_id",
+                 "approvals_prolongation"."created_at",
+                 "approvals_prolongation"."created_by_id",
+                 "approvals_prolongation"."updated_at",
+                 "approvals_prolongation"."updated_by_id",
+                 "approvals_prolongation"."report_file_id",
+                 "approvals_prolongation"."require_phone_interview",
+                 "approvals_prolongation"."contact_email",
+                 "approvals_prolongation"."contact_phone",
+                 "approvals_prolongation"."request_id",
+                 "approvals_prolongation"."validated_by_id"
+          FROM "approvals_prolongation"
+          WHERE "approvals_prolongation"."id" >= %s
+          ORDER BY "approvals_prolongation"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_prolongations" ("id",
+                                      "id_pass_agrément",
+                                      "date_début",
+                                      "date_fin",
+                                      "motif",
+                                      "id_utilisateur_déclarant",
+                                      "id_structure_déclarante",
+                                      "id_organisation_prescripteur",
+                                      "id_utilisateur_prescripteur",
+                                      "date_de_création",
+                                      "id_demande_de_prolongation",
+                                      "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_prolongations" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "prolongations" RENAME TO "z_old_prolongations"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_prolongations" RENAME TO "prolongations"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_prolongations" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_suspensions
+  dict({
+    'num_queries': 26,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "approvals_suspension"
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_suspensions_v0"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          CREATE TABLE IF NOT EXISTS "z_new_suspensions_v0" ("id" integer,"id_pass_agrément" integer,"date_début" date,"date_fin" date,"motif" varchar,"en_cours" integer,"date_de_création" timestamp WITH TIME ZONE,
+                                                                                                                                                                                                                 "date_mise_à_jour_metabase" date)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."id_pass_agrément" IS \'PASS\xa0IAE\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."date_début" IS \'date de début\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."date_fin" IS \'date de fin\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."motif" IS \'motif\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."en_cours" IS \'La suspension est en cours\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."date_de_création" IS \'date de création\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_suspensions_v0"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id" AS "pk"
+          FROM "approvals_suspension"
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id" AS "pk"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."id" >= %s
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 100000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "approvals_suspension"."id",
+                 "approvals_suspension"."approval_id",
+                 "approvals_suspension"."start_at",
+                 "approvals_suspension"."end_at",
+                 "approvals_suspension"."siae_id",
+                 "approvals_suspension"."reason",
+                 "approvals_suspension"."reason_explanation",
+                 "approvals_suspension"."created_at",
+                 "approvals_suspension"."created_by_id",
+                 "approvals_suspension"."updated_at",
+                 "approvals_suspension"."updated_by_id"
+          FROM "approvals_suspension"
+          WHERE "approvals_suspension"."id" >= %s
+          ORDER BY "approvals_suspension"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_suspensions_v0" ("id",
+                                       "id_pass_agrément",
+                                       "date_début",
+                                       "date_fin",
+                                       "motif",
+                                       "en_cours",
+                                       "date_de_création",
+                                       "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_suspensions_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "suspensions_v0" RENAME TO "z_old_suspensions_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_suspensions_v0" RENAME TO "suspensions_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_suspensions_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---
+# name: test_populate_users
+  dict({
+    'num_queries': 24,
+    'queries': list([
+      dict({
+        'origin': list([
+          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': "SELECT set_config('itou.context', %s, TRUE)",
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT COUNT(*) AS "__count"
+          FROM "users_user"
+          WHERE ("users_user"."is_active"
+                 AND "users_user"."kind" IN (%s,
+                                             %s,
+                                             %s))
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_new_utilisateurs_v0"',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'CREATE TABLE IF NOT EXISTS "z_new_utilisateurs_v0" ("id" integer,"email" varchar,"type" varchar,"prenom" varchar,"nom" varchar,"date_mise_à_jour_metabase" date)',
+      }),
+      dict({
+        'origin': list([
+          'create_table[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."id" IS \'ID\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."email" IS \'adresse e-mail\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."type" IS \'type\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."prenom" IS \'prénom\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."nom" IS \'nom\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMENT ON COLUMN "z_new_utilisateurs_v0"."date_mise_à_jour_metabase" IS \'Date de dernière mise à jour de Metabase\'',
+      }),
+      dict({
+        'origin': list([
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id" AS "pk"
+          FROM "users_user"
+          WHERE ("users_user"."is_active"
+                 AND "users_user"."kind" IN (%s,
+                                             %s,
+                                             %s))
+          ORDER BY 1 ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'chunked_queryset[metabase/utils.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id" AS "pk"
+          FROM "users_user"
+          WHERE ("users_user"."is_active"
+                 AND "users_user"."kind" IN (%s,
+                                             %s,
+                                             %s)
+                 AND "users_user"."id" >= %s)
+          ORDER BY 1 ASC
+          LIMIT 1
+          OFFSET 50000
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE ("users_user"."is_active"
+                 AND "users_user"."kind" IN (%s,
+                                             %s,
+                                             %s)
+                 AND "users_user"."id" >= %s)
+          ORDER BY "users_user"."id" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': '''
+          COPY "z_new_utilisateurs_v0" ("id",
+                                        "email",
+                                        "type",
+                                        "prenom",
+                                        "nom",
+                                        "date_mise_à_jour_metabase")
+          FROM STDIN WITH (FORMAT BINARY)
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'inject_chunk[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_utilisateurs_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE IF EXISTS "utilisateurs_v0" RENAME TO "z_old_utilisateurs_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'ALTER TABLE "z_new_utilisateurs_v0" RENAME TO "utilisateurs_v0"',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'DROP TABLE IF EXISTS "z_old_utilisateurs_v0" CASCADE',
+      }),
+      dict({
+        'origin': list([
+          'rename_table_atomically[metabase/db.py]',
+          'populate_table[metabase/db.py]',
+          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
+          'Command.execute[utils/command.py]',
+        ]),
+        'sql': 'COMMIT',
+      }),
+    ]),
+  })
+# ---

--- a/tests/utils/testing.py
+++ b/tests/utils/testing.py
@@ -388,7 +388,11 @@ def debug_sql(self, sql=None, params=None, use_last_executed_query=False, many=F
         yield
     # Enrich last query
     last_query = self.db.queries_log[-1]
-    last_query["raw_sql"] = sql
+    if not isinstance(sql, str):
+        raw_sql = sql.as_string(self.cursor)
+    else:
+        raw_sql = sql
+    last_query["raw_sql"] = raw_sql
     last_query["origin"] = _detect_origin(debug=bool(os.getenv("DEBUG_SQL_SNAPSHOT")))
 
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans les tests de `populate_metabase_emplois` et `metabase_fixture` on récupère un curseur depuis la connexion Django, on a donc l'instrumentation des requêtes, raison de pourquoi `assertNumQueries()` fonctionne, mais pas toutes les métadonnées habituelles.

Le cas d'utilisation est assez limité mais le changement étant simple et que ça simplifie pas mal la vie d'avoir les requêtes SQL plutôt que juste des `+= 1` je propose le changement, surtout que ça m'a permis de trouver une amélioration (-50%, -30s) pour le script donc ça peux être utile sur le long terme.