### PR TITLE
FranceConnect: gestion des cas d'erreur pour le passage à la version 2

### DIFF
--- a/itou/openid_connect/france_connect/apps.py
+++ b/itou/openid_connect/france_connect/apps.py
@@ -3,4 +3,4 @@ from django.apps import AppConfig
 
 class FranceConnectConfig(AppConfig):
     name = "itou.openid_connect.france_connect"
-    verbose_name = "France Connect"
+    verbose_name = "FranceConnect"

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -56,17 +56,17 @@ def france_connect_authorize(request):
 
 @login_not_required
 def france_connect_callback(request):
-    code = request.GET.get("code")
-    if code is None:
-        error_msg = "FranceConnect n’a pas transmis le paramètre « code » nécessaire à votre authentification."
-        return _redirect_to_job_seeker_login_on_error(error_msg, request)
-
     state = request.GET.get("state")
     fc_state = FranceConnectState.get_from_state(state)
     if not fc_state or not fc_state.is_valid():
         error_msg = (
             "Le paramètre « state » fourni par FranceConnect et nécessaire à votre authentification n’est pas valide."
         )
+        return _redirect_to_job_seeker_login_on_error(error_msg, request)
+
+    code = request.GET.get("code")
+    if code is None:
+        error_msg = "FranceConnect n’a pas transmis le paramètre « code » nécessaire à votre authentification."
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
     redirect_uri = get_absolute_url(reverse("france_connect:callback"))

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -58,7 +58,7 @@ def france_connect_authorize(request):
 def france_connect_callback(request):
     code = request.GET.get("code")
     if code is None:
-        error_msg = ("FranceConnect n’a pas transmis le paramètre « code » nécessaire à votre authentification.",)
+        error_msg = "FranceConnect n’a pas transmis le paramètre « code » nécessaire à votre authentification."
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
     state = request.GET.get("state")

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -58,14 +58,14 @@ def france_connect_authorize(request):
 def france_connect_callback(request):
     code = request.GET.get("code")
     if code is None:
-        error_msg = ("France Connect n’a pas transmis le paramètre « code » nécessaire à votre authentification.",)
+        error_msg = ("FranceConnect n’a pas transmis le paramètre « code » nécessaire à votre authentification.",)
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
     state = request.GET.get("state")
     fc_state = FranceConnectState.get_from_state(state)
     if not fc_state or not fc_state.is_valid():
         error_msg = (
-            "Le paramètre « state » fourni par France Connect et nécessaire à votre authentification n’est pas valide."
+            "Le paramètre « state » fourni par FranceConnect et nécessaire à votre authentification n’est pas valide."
         )
         return _redirect_to_job_seeker_login_on_error(error_msg, request)
 
@@ -115,7 +115,7 @@ def france_connect_callback(request):
         return _redirect_to_job_seeker_login_on_error(error_msg)
 
     if "sub" not in user_data:
-        # 'sub' is the unique identifier from France Connect, we need that to match a user later on
+        # 'sub' is the unique identifier from FranceConnect, we need that to match a user later on
         error_msg = "Le paramètre « sub » n'a pas été retourné par FranceConnect. Il est nécessaire pour identifier un utilisateur."  # noqa E501
         logger.error(error_msg)
         return _redirect_to_job_seeker_login_on_error(error_msg)

--- a/itou/status/probes.py
+++ b/itou/status/probes.py
@@ -101,5 +101,5 @@ class PoleEmploiAccessManagementUserAuthProbe(HttpProbe):
 
 class FranceConnectAuthProbe(HttpProbe):
     name = "auth.fc"
-    verbose_name = "France Connect"
+    verbose_name = "FranceConnect"
     url = settings.FRANCE_CONNECT_BASE_URL

--- a/itou/templates/static/legal/terms.html
+++ b/itou/templates/static/legal/terms.html
@@ -64,7 +64,7 @@
                         L’Utilisateur qui s’inscrit directement sur le site « Les emplois de l’inclusion » doit renseigner sa situation et indiquer son NIR ou son numéro SIRET ou le numéro SIREN de sa structure.
                     </p>
                     <p>
-                        Pour accéder aux Services, l’Utilisateur peut s’inscrire ou se connecter via d’autres plateformes numériques que l’on retrouve sur le site « Les emplois de l’inclusion ». L’Utilisateur peut s’inscrire ou se connecter via « France Connect », via « France Travail » en renseignant son nom d’utilisateur ou son code SAFIR ou via « Inclusion Connect » en renseignant son nom, prénom, adresse e-mail.
+                        Pour accéder aux Services, l’Utilisateur peut s’inscrire ou se connecter via d’autres plateformes numériques que l’on retrouve sur le site « Les emplois de l’inclusion ». L’Utilisateur peut s’inscrire ou se connecter via « FranceConnect », via « France Travail » en renseignant son nom d’utilisateur ou son code SAFIR ou via « Inclusion Connect » en renseignant son nom, prénom, adresse e-mail.
                     </p>
                     <h3 id="42-description-des-fonctionnalités-pour-le-candidat">4.2 Description des fonctionnalités pour le Candidat</h3>
                     <p>

--- a/itou/users/adapter.py
+++ b/itou/users/adapter.py
@@ -65,7 +65,7 @@ class UserAdapter(DefaultAccountAdapter):
                 params = {"token": token}
                 pro_connect_base_logout_url = reverse("pro_connect:logout")
                 return f"{pro_connect_base_logout_url}?{urlencode(params)}"
-        # France Connect
+        # FranceConnect
         fc_token = request.session.get(FRANCE_CONNECT_SESSION_TOKEN)
         fc_state = request.session.get(FRANCE_CONNECT_SESSION_STATE)
         if fc_token:

--- a/itou/www/dashboard/forms.py
+++ b/itou/www/dashboard/forms.py
@@ -76,7 +76,7 @@ class EditJobSeekerInfoForm(
 
         # Noboby can edit its own email.
         if self.instance.identity_provider == IdentityProvider.FRANCE_CONNECT:
-            # If the job seeker uses France Connect, point them to the modification process
+            # If the job seeker uses FranceConnect, point them to the modification process
             self.fields["email"].help_text = (
                 "Si vous souhaitez modifier votre adresse e-mail merci de "
                 f"<a href='{get_zendesk_form_url()}' target='_blank'>"

--- a/tests/openid_connect/france_connect/tests.py
+++ b/tests/openid_connect/france_connect/tests.py
@@ -254,20 +254,71 @@ class TestFranceConnect:
             "because their identity has been certified." in caplog.messages
         )
 
-    def test_callback_no_code(self, client):
+    def test_callback_nothing(self, client):
         url = reverse("france_connect:callback")
         response = client.get(url)
         assert response.status_code == 302
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    (
+                        "Le paramètre « state » fourni par FranceConnect et nécessaire à votre authentification "
+                        "n’est pas valide."
+                    ),
+                )
+            ],
+        )
 
     def test_callback_no_state(self, client):
         url = reverse("france_connect:callback")
         response = client.get(url, data={"code": "123"})
         assert response.status_code == 302
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    (
+                        "Le paramètre « state » fourni par FranceConnect et nécessaire à votre authentification "
+                        "n’est pas valide."
+                    ),
+                )
+            ],
+        )
 
     def test_callback_invalid_state(self, client):
         url = reverse("france_connect:callback")
         response = client.get(url, data={"code": "123", "state": "000"})
         assert response.status_code == 302
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    (
+                        "Le paramètre « state » fourni par FranceConnect et nécessaire à votre authentification "
+                        "n’est pas valide."
+                    ),
+                )
+            ],
+        )
+
+    def test_callback_no_code(self, client):
+        state = FranceConnectState.save_state()
+        url = reverse("france_connect:callback")
+        response = client.get(url, data={"state": state})
+        assert response.status_code == 302
+        assertMessages(
+            response,
+            [
+                messages.Message(
+                    messages.ERROR,
+                    "FranceConnect n’a pas transmis le paramètre « code » nécessaire à votre authentification.",
+                )
+            ],
+        )
 
     @respx.mock
     def test_callback(self, client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour être prêt pour la version 2 de FranceConnect:
https://docs.partenaires.franceconnect.gouv.fr/fs/migration/fs-migration-diff-v1-v2/#accordion-blMhW51TdMHL0TuUewk4E-8

## :cake: Comment ? <!-- optionnel -->

En restant compatible avec la version 1 qui ne founit pas ces codes d'erreur.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
