### PR TITLE
Vie privée : retrait d'une mention RGPD incomprise causant beaucoup de demande au support [GEN-2678]

### DIFF
--- a/itou/templates/account/email/email_jobseeker_created_by_third_party_body.txt
+++ b/itou/templates/account/email/email_jobseeker_created_by_third_party_body.txt
@@ -20,6 +20,4 @@ Dès votre arrivée sur le site des Emplois de l’inclusion, vous serez invité
 
 Cet e-mail a été généré et envoyé automatiquement, merci de ne pas y répondre.
 
-Si un compte candidat a été créé sur les Emplois de l'inclusion par quelqu'un qui ne vous accompagne pas dans votre recherche d'emploi, vous pouvez demander sa suppression en complétant ce formulaire : https://tally.so/r/nGyqWO.
-
 {% endblock body %}

--- a/itou/templates/account/email/email_jobseeker_created_by_third_party_for_gps_body.txt
+++ b/itou/templates/account/email/email_jobseeker_created_by_third_party_for_gps_body.txt
@@ -23,6 +23,4 @@ Ce lien expirera dans 14 jours. Dès votre arrivée sur le site, vous serez invi
 
 Pour en savoir plus sur la Plateforme de l’inclusion et ses services, vous pouvez vous rendre sur https://inclusion.gouv.fr/gps-usagers.
 
-Si ce compte a été créé par quelqu’un qui ne vous accompagne pas dans vos démarches, vous pouvez demander sa suppression en remplissant ce formulaire : https://tally.so/r/nGyqWO.
-
 {% endblock body %}

--- a/tests/users/__snapshots__/test_models.ambr
+++ b/tests/users/__snapshots__/test_models.ambr
@@ -10,8 +10,6 @@
   
   Cet e-mail a été généré et envoyé automatiquement, merci de ne pas y répondre.
   
-  Si un compte candidat a été créé sur les Emplois de l'inclusion par quelqu'un qui ne vous accompagne pas dans votre recherche d'emploi, vous pouvez demander sa suppression en complétant ce formulaire : https://tally.so/r/nGyqWO.
-  
   ---
   [DEV] Cet email est envoyé depuis un environnement de démonstration, merci de ne pas en tenir compte [DEV]
   Les emplois de l'inclusion


### PR DESCRIPTION
## :thinking: Pourquoi ?

Phrase qui n’est pas bien comprise par nos utilisateurs, de nombreuses demandes arrivent.
Plus de 80% des demandes n’aboutissent pas à une suppression car l’utilisateur n’avait pas compris l’impact de sa demande.

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?
- [x] Attendre la validation de Zohra pour s'assurer que ça concerne bien le mail GPS également [[ref]](https://www.notion.so/Retirer-la-phrase-relative-la-contestation-de-cr-ation-de-compte-par-un-tiers-2565f321b60480b281c9ea8a9669e621?d=1915f321b60483eea158830933c81229&source=copy_link)

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
