### PR TITLE
[Ne pas fusionner] Recherche employeur : affichage du détail des scores en local

### DIFF
--- a/itou/templates/companies/includes/_card_siae.html
+++ b/itou/templates/companies/includes/_card_siae.html
@@ -19,6 +19,15 @@
                         </span>
                     {% endif %}
                     <h3>{{ siae.display_name }}</h3>
+                    <h5>
+                        job_app_score=={{ siae.job_app_score|floatformat:2 }}
+                        / computed_job_app_score=={{ siae.computed_job_app_score|floatformat:2 }}
+                        <br>
+                        count_recent_received_job_apps=={{ siae.count_recent_received_job_apps }}
+                        / count_active_job_descriptions=={{ siae.count_active_job_descriptions }}
+                        <br>
+                        spontaneous_applications_open_since=={{ siae.is_open_to_spontaneous_applications }}
+                    </h5>
                 </div>
             </div>
             {% if siae.kind in ea_eatt_kinds %}

--- a/itou/www/search/views.py
+++ b/itou/www/search/views.py
@@ -210,6 +210,9 @@ class EmployerSearchView(EmployerSearchBaseView):
                 )
             )
             .with_is_hiring()
+            .with_count_recent_received_job_apps()
+            .with_count_active_job_descriptions()
+            .with_computed_job_app_score()
             .with_has_active_members()
             # Split results into 4 buckets shown in the following order, each bucket being internally sorted
             # by job_app_score.


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour permettre au développeur de mieux comprendre ce qui se cache derrière les scores en production, qui sans cela restent une boite noire.

Vu que je quitte bientôt l'aventure, je souhaite partager cette branche assez pratique à @leo-naeka. Attention elle n'a pas vocation à être fusionnée, car elle aurait un impact très négatif sur la perf de la recherche.

## :cake: Comment utiliser cette branche ?

En tant que dev, commencer par importer les données de production de la veille en local, puis `python manage.py update_companies_job_app_score`.

Vérifier que pour une ville donnée, les résultats de recherche sont presque identiques en prod et en local. Le mieux c'est le matin forcément, pour minimiser le delta.

Basculer sur cette branche et observer les données utiles affichées :

<img width="948" height="312" alt="image" src="https://github.com/user-attachments/assets/77accdc2-7d3b-452f-8883-81dec1388aa1" />

Dans cet exemple on a bien 2.20 = 11 / (4+1). Le +1 vient de l'ouverture aux candidatures spontanées, qui compte comme une fiche de poste active.

Et voilà, vous êtes maintenant en mesure de vérifier sur quelques recherches d'exemple que les scores ne sont pas trop déconnants en prod et qu'on montre bien en première page les entreprises les plus pertinentes (avec le moins de candidatures récentes).