### PR TITLE
Tech : Utilisation d'un logger pour `populate_metabase_matomo`

### DIFF
--- a/tests/metabase/management/__snapshots__/test_populate_metabase_matomo.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_matomo.ambr
@@ -1,76 +1,76 @@
 # serializer version: 1
 # name: test_matomo_empty_output[empty output]
   list([
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 116 - Recrutement',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 129 - Analyse des publics',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 140 - ETP conventionnés',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 144 - Contrôle à posteriori',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension',
-    "\t! empty matomo values for date=2022-06-13 dashboard=tb 216 - Les femmes dans l'IAE",
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 217 - Suivi pass IAE',
-    "\t! empty matomo values for date=2022-06-13 dashboard=tb 218 - Cartographie de l'IAE",
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 287 - Conventionnements IAE',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 306 - Zoom sur les ESAT',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 325 - Analyses autour des conventionnements IAE',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 336 - Suivi des prolongations',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 337 - Bilan de la phase de candidatures en IAE',
-    "\t! empty matomo values for date=2022-06-13 dashboard=tb 406 - Requêtage des données de l'expérimentation RSA",
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 408 - Candidats dans la file active',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 43 - Statistiques des emplois',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 471 - Zoom sur les ESAT (2024)',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 54 - Typologie des employeurs',
-    '\t! empty matomo values for date=2022-06-13 dashboard=tb 90 - Analyse des métiers',
-    "\t! empty matomo values for date=2022-06-13 dashboard=tb Analyse de l'offre d'insertion sur le territoire",
-    '\t> fetching date=2022-06-13 dashboard=tb 116 - Recrutement pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/',
-    '\t> fetching date=2022-06-13 dashboard=tb 129 - Analyse des publics pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-des-publics/',
-    '\t> fetching date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/prescripteurs-habilites/',
-    '\t> fetching date=2022-06-13 dashboard=tb 140 - ETP conventionnés pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/',
-    '\t> fetching date=2022-06-13 dashboard=tb 144 - Contrôle à posteriori pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-controle-a-posteriori/',
-    '\t> fetching date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/',
-    "\t> fetching date=2022-06-13 dashboard=tb 216 - Les femmes dans l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/femmes-iae/",
-    '\t> fetching date=2022-06-13 dashboard=tb 217 - Suivi pass IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-pass-iae/',
-    "\t> fetching date=2022-06-13 dashboard=tb 218 - Cartographie de l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/cartographies-iae/",
-    '\t> fetching date=2022-06-13 dashboard=tb 287 - Conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/conventionnements-iae/',
-    '\t> fetching date=2022-06-13 dashboard=tb 306 - Zoom sur les ESAT pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat/',
-    '\t> fetching date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/',
-    '\t> fetching date=2022-06-13 dashboard=tb 325 - Analyses autour des conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyses-conventionnements-iae/',
-    '\t> fetching date=2022-06-13 dashboard=tb 336 - Suivi des prolongations pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-demandes-prolongation/',
-    '\t> fetching date=2022-06-13 dashboard=tb 337 - Bilan de la phase de candidatures en IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/bilan-candidatures-iae/',
-    "\t> fetching date=2022-06-13 dashboard=tb 406 - Requêtage des données de l'expérimentation RSA pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/requetage-ft/",
-    '\t> fetching date=2022-06-13 dashboard=tb 408 - Candidats dans la file active pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/candidat-file-active-IAE/',
-    '\t> fetching date=2022-06-13 dashboard=tb 43 - Statistiques des emplois pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/statistiques-emplois/',
-    '\t> fetching date=2022-06-13 dashboard=tb 471 - Zoom sur les ESAT (2024) pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat-24/',
-    '\t> fetching date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-prescripteurs/',
-    '\t> fetching date=2022-06-13 dashboard=tb 54 - Typologie des employeurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/',
-    '\t> fetching date=2022-06-13 dashboard=tb 90 - Analyse des métiers pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/',
-    "\t> fetching date=2022-06-13 dashboard=tb Analyse de l'offre d'insertion sur le territoire pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-offre-insertion-sur-le-territoire/",
     '> about to fetch count=23 public dashboards from Matomo.',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 200 OK"',
+    '\t> fetching date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/',
     'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription',
+    '\t> fetching date=2022-06-13 dashboard=tb 43 - Statistiques des emplois pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/statistiques-emplois/',
     'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 200 OK"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 43 - Statistiques des emplois',
+    '\t> fetching date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-prescripteurs/',
     'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs',
+    '\t> fetching date=2022-06-13 dashboard=tb 54 - Typologie des employeurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 54 - Typologie des employeurs',
+    '\t> fetching date=2022-06-13 dashboard=tb 90 - Analyse des métiers pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 90 - Analyse des métiers',
+    '\t> fetching date=2022-06-13 dashboard=tb 116 - Recrutement pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 116 - Recrutement',
+    '\t> fetching date=2022-06-13 dashboard=tb 129 - Analyse des publics pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-des-publics/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 129 - Analyse des publics',
+    '\t> fetching date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/prescripteurs-habilites/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités',
+    '\t> fetching date=2022-06-13 dashboard=tb 140 - ETP conventionnés pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 140 - ETP conventionnés',
+    '\t> fetching date=2022-06-13 dashboard=tb 144 - Contrôle à posteriori pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-controle-a-posteriori/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 144 - Contrôle à posteriori',
+    '\t> fetching date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension',
+    "\t> fetching date=2022-06-13 dashboard=tb 216 - Les femmes dans l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/femmes-iae/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 200 OK"',
+    "\t! empty matomo values for date=2022-06-13 dashboard=tb 216 - Les femmes dans l'IAE",
+    '\t> fetching date=2022-06-13 dashboard=tb 217 - Suivi pass IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-pass-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 217 - Suivi pass IAE',
+    "\t> fetching date=2022-06-13 dashboard=tb 218 - Cartographie de l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/cartographies-iae/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 200 OK"',
+    "\t! empty matomo values for date=2022-06-13 dashboard=tb 218 - Cartographie de l'IAE",
+    '\t> fetching date=2022-06-13 dashboard=tb 287 - Conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/conventionnements-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 287 - Conventionnements IAE',
+    '\t> fetching date=2022-06-13 dashboard=tb 306 - Zoom sur les ESAT pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 306 - Zoom sur les ESAT',
+    '\t> fetching date=2022-06-13 dashboard=tb 325 - Analyses autour des conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyses-conventionnements-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 325 - Analyses autour des conventionnements IAE',
+    '\t> fetching date=2022-06-13 dashboard=tb 336 - Suivi des prolongations pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-demandes-prolongation/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 336 - Suivi des prolongations',
+    '\t> fetching date=2022-06-13 dashboard=tb 337 - Bilan de la phase de candidatures en IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/bilan-candidatures-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 337 - Bilan de la phase de candidatures en IAE',
+    "\t> fetching date=2022-06-13 dashboard=tb 406 - Requêtage des données de l'expérimentation RSA pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/requetage-ft/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 200 OK"',
+    "\t! empty matomo values for date=2022-06-13 dashboard=tb 406 - Requêtage des données de l'expérimentation RSA",
+    '\t> fetching date=2022-06-13 dashboard=tb 408 - Candidats dans la file active pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/candidat-file-active-IAE/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 408 - Candidats dans la file active',
+    '\t> fetching date=2022-06-13 dashboard=tb 471 - Zoom sur les ESAT (2024) pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat-24/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 200 OK"',
+    '\t! empty matomo values for date=2022-06-13 dashboard=tb 471 - Zoom sur les ESAT (2024)',
+    "\t> fetching date=2022-06-13 dashboard=tb Analyse de l'offre d'insertion sur le territoire pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-offre-insertion-sur-le-territoire/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 200 OK"',
+    "\t! empty matomo values for date=2022-06-13 dashboard=tb Analyse de l'offre d'insertion sur le territoire",
   ])
 # ---
 # name: test_matomo_populate_public[exported rows]
@@ -2080,375 +2080,375 @@
 # ---
 # name: test_matomo_retry[retry output]
   list([
-    '\t> fetching date=2022-06-13 dashboard=tb 116 - Recrutement pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/',
-    '\t> fetching date=2022-06-13 dashboard=tb 129 - Analyse des publics pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-des-publics/',
-    '\t> fetching date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/prescripteurs-habilites/',
-    '\t> fetching date=2022-06-13 dashboard=tb 140 - ETP conventionnés pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/',
-    '\t> fetching date=2022-06-13 dashboard=tb 144 - Contrôle à posteriori pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-controle-a-posteriori/',
-    '\t> fetching date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/',
-    "\t> fetching date=2022-06-13 dashboard=tb 216 - Les femmes dans l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/femmes-iae/",
-    '\t> fetching date=2022-06-13 dashboard=tb 217 - Suivi pass IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-pass-iae/',
-    "\t> fetching date=2022-06-13 dashboard=tb 218 - Cartographie de l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/cartographies-iae/",
-    '\t> fetching date=2022-06-13 dashboard=tb 287 - Conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/conventionnements-iae/',
-    '\t> fetching date=2022-06-13 dashboard=tb 306 - Zoom sur les ESAT pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat/',
-    '\t> fetching date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/',
-    '\t> fetching date=2022-06-13 dashboard=tb 325 - Analyses autour des conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyses-conventionnements-iae/',
-    '\t> fetching date=2022-06-13 dashboard=tb 336 - Suivi des prolongations pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-demandes-prolongation/',
-    '\t> fetching date=2022-06-13 dashboard=tb 337 - Bilan de la phase de candidatures en IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/bilan-candidatures-iae/',
-    "\t> fetching date=2022-06-13 dashboard=tb 406 - Requêtage des données de l'expérimentation RSA pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/requetage-ft/",
-    '\t> fetching date=2022-06-13 dashboard=tb 408 - Candidats dans la file active pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/candidat-file-active-IAE/',
-    '\t> fetching date=2022-06-13 dashboard=tb 43 - Statistiques des emplois pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/statistiques-emplois/',
-    '\t> fetching date=2022-06-13 dashboard=tb 471 - Zoom sur les ESAT (2024) pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat-24/',
-    '\t> fetching date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-prescripteurs/',
-    '\t> fetching date=2022-06-13 dashboard=tb 54 - Typologie des employeurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/',
-    '\t> fetching date=2022-06-13 dashboard=tb 90 - Analyse des métiers pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/',
-    "\t> fetching date=2022-06-13 dashboard=tb Analyse de l'offre d'insertion sur le territoire pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-offre-insertion-sur-le-territoire/",
     '> about to fetch count=23 public dashboards from Matomo.',
-    'Error when executing itou.metabase.management.commands.populate_metabase_matomo',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '\t> fetching date=2022-06-13 dashboard=tb 32 - Acceptés en auto-prescription pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/auto-prescription/',
     'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 500 Internal Server Error"',
-    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 500 Internal Server Error"',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
     '''
       attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F "HTTP/1.1 500 Internal Server Error"',
     '''
       attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F "HTTP/1.1 500 Internal Server Error"',
     '''
       attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fauto-prescription%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 43 - Statistiques des emplois pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/statistiques-emplois/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 500 Internal Server Error"',
     '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F'
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 500 Internal Server Error"',
     '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F'
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F "HTTP/1.1 500 Internal Server Error"',
     '''
       attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fstatistiques-emplois%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 52 - Typologie de prescripteurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-prescripteurs/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 500 Internal Server Error"',
     '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F'
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 500 Internal Server Error"',
     '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F'
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
-    '''
-      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F'
-      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
-    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F "HTTP/1.1 500 Internal Server Error"',
     '''
       attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-prescripteurs%252F'
       For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
     ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 54 - Typologie des employeurs pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-employeurs/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-employeurs%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 90 - Analyse des métiers pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/metiers/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fmetiers%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 116 - Recrutement pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etat-suivi-candidatures/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetat-suivi-candidatures%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 129 - Analyse des publics pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-des-publics/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-des-publics%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 136 - Prescripteurs habilités pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/prescripteurs-habilites/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fprescripteurs-habilites%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 140 - ETP conventionnés pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/etp-conventionnes/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fetp-conventionnes%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 144 - Contrôle à posteriori pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-controle-a-posteriori/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-controle-a-posteriori%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 150 - Fiches de poste en tension pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/postes-en-tension/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fpostes-en-tension%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    "\t> fetching date=2022-06-13 dashboard=tb 216 - Les femmes dans l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/femmes-iae/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Ffemmes-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 217 - Suivi pass IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-pass-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-pass-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    "\t> fetching date=2022-06-13 dashboard=tb 218 - Cartographie de l'IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/cartographies-iae/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcartographies-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 287 - Conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/conventionnements-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fconventionnements-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 306 - Zoom sur les ESAT pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 325 - Analyses autour des conventionnements IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyses-conventionnements-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyses-conventionnements-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 336 - Suivi des prolongations pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/suivi-demandes-prolongation/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fsuivi-demandes-prolongation%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 337 - Bilan de la phase de candidatures en IAE pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/bilan-candidatures-iae/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fbilan-candidatures-iae%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    "\t> fetching date=2022-06-13 dashboard=tb 406 - Requêtage des données de l'expérimentation RSA pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/requetage-ft/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Frequetage-ft%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 408 - Candidats dans la file active pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/candidat-file-active-IAE/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fcandidat-file-active-IAE%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    '\t> fetching date=2022-06-13 dashboard=tb 471 - Zoom sur les ESAT (2024) pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/zoom-esat-24/',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fzoom-esat-24%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    "\t> fetching date=2022-06-13 dashboard=tb Analyse de l'offre d'insertion sur le territoire pageUrl=https://pilotage.inclusion.beta.gouv.fr/tableaux-de-bord/analyse-offre-insertion-sur-le-territoire/",
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=1 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=2 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'HTTP Request: GET https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F "HTTP/1.1 500 Internal Server Error"',
+    '''
+      attempt=3 failed with outcome=Server error '500 Internal Server Error' for url 'https://mato.mo/index.php?expanded=1&filter_limit=-1&format=CSV&format_metrics=1&language=en&method=API.get&module=API&period=week&translateColumnNames=1&date=2022-06-13&token_auth=foobar&idSite=146&segment=pageUrl%3D%3Dhttps%253A%252F%252Fpilotage.inclusion.beta.gouv.fr%252Ftableaux-de-bord%252Fanalyse-offre-insertion-sur-le-territoire%252F'
+      For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500
+    ''',
+    'Error when executing itou.metabase.management.commands.populate_metabase_matomo',
   ])
 # ---

--- a/tests/metabase/management/test_populate_metabase_matomo.py
+++ b/tests/metabase/management/test_populate_metabase_matomo.py
@@ -54,10 +54,10 @@ def test_matomo_retry(monkeypatch, respx_mock, caplog, snapshot):
         content=f"{MATOMO_HEADERS}\n{MATOMO_ONLINE_CONTENT}".encode("utf-16"),
     )
     with pytest.raises(tenacity.RetryError):
-        management.call_command("populate_metabase_matomo", wet_run=True)
+        # Use pool_size=1 for stable output
+        management.call_command("populate_metabase_matomo", wet_run=True, pool_size=1)
 
-    # sort the output because it's random (ThreadPoolExecutor)
-    assert sorted(caplog.messages[:-1]) == snapshot(name="retry output")
+    assert caplog.messages[:-1] == snapshot(name="retry output")
     assert caplog.messages[-1].startswith(
         "Management command itou.metabase.management.commands.populate_metabase_matomo failed in"
     )
@@ -96,10 +96,11 @@ def test_matomo_empty_output(respx_mock, caplog, snapshot):
         200,
         content=f"{MATOMO_HEADERS}\n{MATOMO_ONLINE_EMPTY_CONTENT}".encode("utf-16"),
     )
-    management.call_command("populate_metabase_matomo", wet_run=True)
 
-    # sort the output because it's random (ThreadPoolExecutor)
-    assert sorted(caplog.messages[:-1]) == snapshot(name="empty output")
+    # Use pool_size=1 for stable output
+    management.call_command("populate_metabase_matomo", wet_run=True, pool_size=1)
+
+    assert caplog.messages[:-1] == snapshot(name="empty output")
     assert caplog.messages[-1].startswith(
         "Management command itou.metabase.management.commands.populate_metabase_matomo succeeded in"
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour corriger le fait que depuis 31e649aa50043c0f726aecdab88158fd2d71843d on n'utilise plus `tee` et donc que la sortie de la commande était "perdue".
