### PR TITLE
FranceConnect: récupération du genre de l'utilisateur

### DIFF
--- a/itou/openid_connect/france_connect/models.py
+++ b/itou/openid_connect/france_connect/models.py
@@ -3,11 +3,14 @@ import datetime
 from typing import ClassVar
 
 from itou.openid_connect.models import OIDConnectState, OIDConnectUserData
-from itou.users.enums import IdentityProvider, UserKind
+from itou.users.enums import IdentityProvider, Title, UserKind
 
 
 class FranceConnectState(OIDConnectState):
     pass
+
+
+TITLE_MAP = {"male": Title.M, "female": Title.MME}
 
 
 @dataclasses.dataclass
@@ -20,6 +23,7 @@ class FranceConnectUserData(OIDConnectUserData):
     post_code: str | None = None
     city: str | None = None
     kind: UserKind = UserKind.JOB_SEEKER
+    title: str | None = None
     identity_provider: IdentityProvider = IdentityProvider.FRANCE_CONNECT
     allowed_identity_provider_migration: ClassVar[tuple[IdentityProvider]] = ()
 
@@ -44,4 +48,6 @@ class FranceConnectUserData(OIDConnectUserData):
                     "post_code": user_info["address"].get("postal_code"),
                     "city": user_info["address"].get("locality"),
                 }
+        if "gender" in user_info and (gender := user_info.get("gender")) in TITLE_MAP:
+            attrs |= {"title": TITLE_MAP[gender]}
         return attrs

--- a/tests/www/signup/test_job_seeker.py
+++ b/tests/www/signup/test_job_seeker.py
@@ -499,8 +499,7 @@ class TestJobSeekerSignup:
         fc_url = reverse("france_connect:authorize")
         assertContains(response, fc_url)
 
-        # New created job seeker has no title and is redirected to complete its infos
-        mock_oauth_dance(client, expected_route="dashboard:edit_user_info")
+        mock_oauth_dance(client, expected_route="dashboard:index")
         job_seeker = User.objects.get(email=FC_USERINFO["email"])
         assert nir == job_seeker.jobseeker_profile.nir
         assert job_seeker.has_jobseeker_profile
@@ -543,8 +542,7 @@ class TestJobSeekerSignup:
         fc_url = reverse("france_connect:authorize")
         assertContains(response, fc_url)
 
-        # New created job seeker has no title and is redirected to complete its infos
-        mock_oauth_dance(client, expected_route="dashboard:edit_user_info")
+        mock_oauth_dance(client, expected_route="dashboard:index")
         job_seeker = User.objects.get(email=FC_USERINFO["email"])
         assert not job_seeker.jobseeker_profile.nir
         assert job_seeker.has_jobseeker_profile


### PR DESCRIPTION
## :thinking: Pourquoi ?

FranceConnect nous le fournit déjà en v1 et continuera de le fournir en V2: autant l'utiliser.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
