### PR TITLE
Admin : Rendre visible la source d’une SIAE (Structure mère ou Antenne) [GEN-2631]

### DIFF
--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -125,7 +125,7 @@ class CompanyAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, OrganizationAdmin):
         )
 
     change_form_template = "admin/companies/change_company_form.html"
-    list_display = ("pk", "siret", "kind", "name", "department", "geocoding_score", "member_count", "created_at")
+    list_display = ("pk", "siret", "kind", "name", "department", "source", "member_count", "created_at")
     list_filter = (HasMembersFilter, "kind", "block_job_applications", "source", "department")
     raw_id_fields = ("created_by", "convention")
     fieldsets = (


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour faciliter la vie du support.

## :cake: Comment ?

En remplaçant l'inutile colonne existante "score de geocoding".

## :computer: Captures d'écran

<img width="533" height="254" alt="image" src="https://github.com/user-attachments/assets/492fe59e-2582-4e2e-abc1-ebcdb83648e6" />
