### PR TITLE
Éligibilité : Ne pas certifier les critères au sein de la requête web

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -866,11 +866,6 @@ SUSPEND_ANONYMIZE_CANCELLED_APPROVALS = os.getenv("SUSPEND_ANONYMIZE_CANCELLED_A
 MAINTENANCE_MODE = os.getenv("MAINTENANCE_MODE", "False") == "True"
 MAINTENANCE_DESCRIPTION = os.getenv("MAINTENANCE_DESCRIPTION", None)
 
-# Criteria certification
-# ------------------------------------------------------------------------------
-CERTIFY_CRITERIA_ASYNC_MODE_ONLY = os.getenv("CERTIFY_CRITERIA_ASYNC_MODE_ONLY", "False") == "True"
-
-
 # Page size (lists)
 # ------------------------------------------------------------------------------
 PAGE_SIZE_DEFAULT = 20

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -11,7 +11,7 @@ from itou.eligibility.enums import (
     AdministrativeCriteriaLevel,
     AuthorKind,
 )
-from itou.eligibility.tasks import async_certify_criteria, certify_criteria
+from itou.eligibility.tasks import async_certify_criteria
 from itou.job_applications.enums import SenderKind
 from itou.utils.models import InclusiveDateRangeField
 
@@ -99,16 +99,7 @@ class AbstractEligibilityDiagnosisModel(models.Model):
             return SenderKind(self.sender_kind).label
 
     def certify_criteria(self):
-        if settings.CERTIFY_CRITERIA_ASYNC_MODE_ONLY:
-            async_certify_criteria(self._meta.model_name, self.pk)
-            return
-
-        try:
-            # Optimistic call to show certified badge in response immediately.
-            certify_criteria(self)
-        except Exception:  # Do not fail the web request if the criteria could not be certified.
-            logger.info("Could not certify criteria synchronously.", exc_info=True)
-            async_certify_criteria(self._meta.model_name, self.pk)
+        async_certify_criteria(self._meta.model_name, self.pk)
 
 
 class AdministrativeCriteriaQuerySet(models.QuerySet):

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -1,13 +1,11 @@
 import datetime
 from functools import partial
-from unittest import mock
 
 import pytest
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.utils import timezone
 from freezegun import freeze_time
-from huey.exceptions import RetryTask
 from pytest_django.asserts import assertQuerySetEqual
 
 from itou.eligibility.enums import (
@@ -18,6 +16,7 @@ from itou.eligibility.enums import (
 )
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
+from itou.eligibility.tasks import certify_criteria
 from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
 from itou.job_applications.models import JobApplication
 from itou.users.enums import IdentityCertificationAuthorities
@@ -496,7 +495,7 @@ def test_eligibility_diagnosis_certify_criteria(mocker, EligibilityDiagnosisFact
     eligibility_diagnosis = EligibilityDiagnosisFactory(
         job_seeker=job_seeker, certifiable=True, criteria_kinds=[criteria_kind]
     )
-    eligibility_diagnosis.certify_criteria()
+    certify_criteria(eligibility_diagnosis)
 
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
     criterion = SelectedAdministrativeCriteria.objects.get(
@@ -510,36 +509,10 @@ def test_eligibility_diagnosis_certify_criteria(mocker, EligibilityDiagnosisFact
     certification = IdentityCertification.objects.get(jobseeker_profile=job_seeker.jobseeker_profile)
     assert certification.certifier == IdentityCertificationAuthorities.API_PARTICULIER
     with freeze_time("2025-10-15"):
-        eligibility_diagnosis.certify_criteria()
+        certify_criteria(eligibility_diagnosis)
     updated_certification = IdentityCertification.objects.get(jobseeker_profile=job_seeker.jobseeker_profile)
     assert updated_certification.certifier == IdentityCertificationAuthorities.API_PARTICULIER
     assert updated_certification.certified_at > certification.certified_at
-
-
-@pytest.mark.parametrize(
-    "async_mode_only, certify_criteria_called, async_certify_criteria_called, side_effect",
-    [
-        pytest.param(True, False, True, None, id="async_mode_only"),
-        pytest.param(False, True, False, None, id="sync_mode_only"),
-        pytest.param(False, True, True, RetryTask, id="sync_mode_with_retry_task"),
-    ],
-)
-@freeze_time("2024-09-12")
-def test_eligibility_diagnosis_certify_criteria_retry_on_error(
-    settings, async_mode_only, certify_criteria_called, async_certify_criteria_called, side_effect
-):
-    eligibility_diagnosis = IAEEligibilityDiagnosisFactory(
-        certifiable=True, criteria_kinds=[AdministrativeCriteriaKind.RSA]
-    )
-
-    settings.CERTIFY_CRITERIA_ASYNC_MODE_ONLY = async_mode_only
-    with (
-        mock.patch("itou.eligibility.models.common.certify_criteria", side_effect=side_effect) as sync_mock,
-        mock.patch("itou.eligibility.models.common.async_certify_criteria") as async_mock,
-    ):
-        eligibility_diagnosis.certify_criteria()
-        assert sync_mock.called is certify_criteria_called
-        assert async_mock.called is async_certify_criteria_called
 
 
 @pytest.mark.parametrize(
@@ -564,7 +537,7 @@ def test_eligibility_diagnosis_certify_criteria_missing_info(respx_mock, Eligibi
         certifiable=True,
         criteria_kinds=[AdministrativeCriteriaKind.RSA],
     )
-    eligibility_diagnosis.certify_criteria()
+    certify_criteria(eligibility_diagnosis)
     assert len(respx_mock.calls) == 0
     jobseeker_profile = JobSeekerProfile.objects.get(pk=job_seeker.jobseeker_profile)
     assertQuerySetEqual(jobseeker_profile.identity_certifications.all(), [])
@@ -665,7 +638,7 @@ def test_selected_administrative_criteria_certified(
         response_status, json=response
     )
 
-    eligibility_diagnosis.certify_criteria()
+    certify_criteria(eligibility_diagnosis)
 
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
     criterion = SelectedAdministrativeCriteria.objects.filter(

--- a/tests/utils/apis/test_api_particulier.py
+++ b/tests/utils/apis/test_api_particulier.py
@@ -53,7 +53,7 @@ def test_not_certified(criteria_kind, factory, respx_mock, caplog):
     )
     respx_mock.get(ENDPOINTS[criteria_kind]).respond(json=RESPONSES[criteria_kind][ResponseKind.NOT_CERTIFIED])
 
-    eligibility_diagnosis.certify_criteria()
+    certify_criteria(eligibility_diagnosis)
 
     assert len(respx_mock.calls) == 1
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through


### PR DESCRIPTION
## :thinking: Pourquoi ?

La méthode qui certifie les critères peut déjà émettre 3 requêtes HTTP vers l’API Particulier. Si cette API est lente, tout le site peut tomber.
L’ajout de la certification de la RQTH ajoutera 2 ou 3 requêtes supplémentaires, vers l’API de France Travail. Si cette API est lente, tout le site peut tomber.

Grâce à l’ajout de badges pour la certification (https://github.com/gip-inclusion/les-emplois/pull/6755), les utilisateurs sont maintenant informés que la certification est en cours. Ils pourront ainsi patienter si le résultat de la certification n’arrive pas immédiatement.
