### PR TITLE
Tech: Améliorer les commandes dry-runnable

### DIFF
--- a/itou/utils/command.py
+++ b/itou/utils/command.py
@@ -101,14 +101,16 @@ def dry_runnable(func):
             if args and args[0] and isinstance(args[0], LoggedCommandMixin)
             else logging.getLogger(func.__module__)
         )
-        with transaction.atomic():
-            if not wet_run:
+
+        if not wet_run:
+            with transaction.atomic():
                 logger.info("Command launched with wet_run=%s", wet_run)
-            func(*args, **kwargs)
-            if not wet_run:
+                func(*args, **kwargs)
                 with connection.cursor() as cursor:
                     cursor.execute("SET CONSTRAINTS ALL IMMEDIATE;")
                 transaction.set_rollback(True)
                 logger.info("Setting transaction to be rollback as wet_run=%s", wet_run)
+        else:
+            func(*args, **kwargs)
 
     return wrapper

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -942,24 +942,17 @@
 # ---
 # name: TestAnonymizeProfessionalManagementCommand.test_num_queries[anonymize_professionals_queries]
   dict({
-    'num_queries': 83,
+    'num_queries': 81,
     'queries': list([
       dict({
         'origin': list([
           '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'Command.reset_notified_professionals_with_recent_activity[archive/management/commands/anonymize_professionals.py]',
+          'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[utils/command.py]',
           'Command.execute[utils/command.py]',
         ]),
         'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-          'wrapper[utils/command.py]',
-          'Command.execute[utils/command.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
       }),
       dict({
         'origin': list([
@@ -3105,14 +3098,6 @@
         'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
-          'wrapper[utils/command.py]',
-          'Command.execute[utils/command.py]',
-        ]),
-        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
           'wrapper[utils/command.py]',
           'Command.execute[utils/command.py]',
         ]),


### PR DESCRIPTION
## :thinking: Pourquoi ?

On ne souhaite pas envelopper dans une transaction lorsque la commande est en wet-run (à moins de spécifier `ATOMIC_HANDLE=True` ou d'ajouter un `transaction.atomic` explicite)

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
