### PR TITLE
Changement du mot de passe pas défaut de l'admin

### DIFF
--- a/itou/fixtures/django/05_test_users.json
+++ b/itou/fixtures/django/05_test_users.json
@@ -28,7 +28,7 @@
       "last_checked_at": "2023-06-01T08:19:46.638Z",
       "last_login": "2025-07-31T09:25:12.380Z",
       "last_name": "",
-      "password": "pbkdf2_sha256$390000$eNyrLRNGvCTRIfxDApp5nA$zMJxqzLJzlu20MhT85T/9UQJ2M/Tq/rNTrBS56a+tX8=",
+      "password": "pbkdf2_sha256$1000000$eqpveAaNLyng2IgeZTF0Dy$Y+2Lr4MtY5Ln2r/voSnmLgCp3rzeW2g19GS9bmLwFl0=",
       "phone": "",
       "post_code": "",
       "public_id": "63b13e12-5b59-4bec-8ac6-cfeffce746e5",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Mettre celui présent dans bitwarden "Admin demo.emplois.inclusion.beta" pour éviter de devoir le refaire manuellement chaque reset de la démo.

:warning: cela change aussi le mot de passe en local avec les fixtures, et sur les recettes jetables ! 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
