### PR TITLE
Dashboard : correction de l'URL d'aide de ProConnect

### DIFF
--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -78,7 +78,7 @@
                                         <p>
                                             Ces informations doivent être modifiées sur votre compte <a href="https://app.moncomptepro.beta.gouv.fr/personal-information">ProConnect</a>.
                                             <br>
-                                            En cas de difficultés, veuillez vous rapprocher de <a href="https://agentconnect.crisp.help/fr/">leur service d’aide</a>.
+                                            En cas de difficultés, veuillez vous rapprocher de <a href="https://proconnect.crisp.help/fr/">leur service d’aide</a>.
                                         </p>
                                         <p class="mb-0">Une fois modifiées, vos informations seront mises à jour à votre prochaine connexion.</p>
                                     </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'URL précédente renvoyait vers une 404.

