### PR TITLE
Vie privée : suppression de la fiche salariée lors de l'archivage du candidat

### DIFF
--- a/itou/archive/management/commands/anonymize_jobseekers.py
+++ b/itou/archive/management/commands/anonymize_jobseekers.py
@@ -24,6 +24,7 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import JobDescription
 from itou.eligibility.models.geiq import GEIQEligibilityDiagnosis
 from itou.eligibility.models.iae import EligibilityDiagnosis
+from itou.employee_record.models import EmployeeRecord
 from itou.files.models import File
 from itou.gps.models import FollowUpGroup
 from itou.job_applications.enums import JobApplicationState
@@ -386,6 +387,7 @@ class Command(BaseCommand):
 
     def _delete_jobapplications_with_related_objects(self, jobapplications):
         resume_pks = list(File.objects.filter(jobapplication__in=jobapplications).values_list("pk", flat=True))
+        EmployeeRecord.objects.filter(job_application__in=jobapplications).delete()
         jobapplications.delete()
         File.objects.filter(pk__in=resume_pks).delete()
 

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -56,6 +56,7 @@ from tests.eligibility.factories import (
     GEIQEligibilityDiagnosisFactory,
     IAEEligibilityDiagnosisFactory,
 )
+from tests.employee_record.factories import EmployeeRecordFactory
 from tests.files.factories import FileFactory
 from tests.gps.factories import FollowUpGroupMembershipFactory
 from tests.institutions.factories import InstitutionMembershipFactory
@@ -939,7 +940,7 @@ class TestAnonymizeJobseekersManagementCommand:
             user__public_id=uuid4(),
         )
 
-        # approval with eligibility diag, prolongation, suspension and accepted job application
+        # approval with eligibility diag, prolongation, suspension, accepted job application and employee record
         approval_with_few_datas = ApprovalFactory(
             origin_sender_kind=SenderKind.PRESCRIBER,
             origin_prescriber_organization_kind=PrescriberOrganizationKind.CCAS,
@@ -955,17 +956,17 @@ class TestAnonymizeJobseekersManagementCommand:
         SuspensionFactory(
             approval=approval_with_few_datas, start_at=datetime.date(2020, 5, 17), end_at=datetime.date(2020, 6, 10)
         )
-        JobApplicationFactory(
-            job_seeker=approval_with_few_datas.user,
-            approval=approval_with_few_datas,
-            eligibility_diagnosis=approval_with_few_datas.eligibility_diagnosis,
-            created_at=timezone.make_aware(datetime.datetime(2023, 2, 16)),
-            processed_at=timezone.make_aware(datetime.datetime(2023, 2, 16)),
-            to_company__department=76,
-            to_company__naf="4567A",
-            to_company__kind=CompanyKind.EI,
-            state=JobApplicationState.ACCEPTED,
-            hiring_start_at=datetime.date(2023, 2, 2),
+        EmployeeRecordFactory(
+            job_application__job_seeker=approval_with_few_datas.user,
+            job_application__approval=approval_with_few_datas,
+            job_application__eligibility_diagnosis=approval_with_few_datas.eligibility_diagnosis,
+            job_application__created_at=timezone.make_aware(datetime.datetime(2023, 2, 16)),
+            job_application__processed_at=timezone.make_aware(datetime.datetime(2023, 2, 16)),
+            job_application__to_company__department=76,
+            job_application__to_company__naf="4567A",
+            job_application__to_company__kind=CompanyKind.EI,
+            job_application__state=JobApplicationState.ACCEPTED,
+            job_application__hiring_start_at=datetime.date(2023, 2, 2),
         )
 
         # approval with 3 prolongations, 2 suspensions and 2 job applications


### PR DESCRIPTION
## :thinking: Pourquoi ?

Une candidature n'est pas supprimable lorsqu'elle est liée à une fiche salariée.

## :cake: Comment ? <!-- optionnel -->

1.correction de données incohérentes sur le PASS 79234, en prérequis de cette PR
2.ajout de la suppression de `EmployeeRecord` dans la commande `anonymize_jobseekers`
3.ajout d'un commentaire prevenant d'une issue similaire avec les `EvaluatedJobApplication`

## ⚠️ Note

#6775 et #6785 doivent être toutes les deux fusionnées avant de relancer le traitement d'anonymisation des candidats