### PR TITLE
Employeur : Ne pas recommander de contacter un admin inactif à l’inscription

### DIFF
--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -200,7 +200,7 @@ def company_select(request, template_name="signup/company_select.html"):
             # the template directly displays the first membership's user "as the admin".
             # that's why we only select SIAEs that have at least an active admin user.
             # it should always be the case, but lets enforce it anyway.
-            .filter(memberships__is_admin=True, memberships__user__is_active=True)
+            .filter(memberships__is_admin=True, memberships__is_active=True, memberships__user__is_active=True)
             # avoid the template issuing requests for every member and user.
             .prefetch_related("memberships__user")
         )

--- a/tests/www/signup/__snapshots__/test_siae.ambr
+++ b/tests/www/signup/__snapshots__/test_siae.ambr
@@ -140,6 +140,7 @@
                              WHERE (U1."user_id" IS NULL
                                     AND U0."id" = ("companies_company"."id"))
                              LIMIT 1))
+                 AND "companies_companymembership"."is_active"
                  AND "companies_companymembership"."is_admin"
                  AND "users_user"."is_active")
         ''',


### PR DESCRIPTION
## :thinking: Pourquoi ?

L’admin ne pourra inviter personne dans la structure.
