### PR TITLE
Interface: Amélioration des templates de retrait des collaborateurs de structure

### DIFF
--- a/itou/templates/companies/deactivate_member.html
+++ b/itou/templates/companies/deactivate_member.html
@@ -1,12 +1,21 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Retrait d'un collaborateur {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Retrait d'un collaborateur</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     {% with base_url="companies_views" %}
                         {% include "includes/deactivate_member.html" %}
                     {% endwith %}

--- a/itou/templates/companies/update_admins.html
+++ b/itou/templates/companies/update_admins.html
@@ -1,6 +1,19 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Gestion des administrateurs {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            {% if action == "remove" %}
+                <h1>Retrait des droits d'administrateur</h1>
+            {% else %}
+                <h1>Ajout des droits d'administrateur</h1>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/includes/deactivate_member.html
+++ b/itou/templates/includes/deactivate_member.html
@@ -1,11 +1,10 @@
 {% load buttons_form %}
 
-<div class="content-small">
+<div class="c-form">
     {% with request.user.is_employer|yesno:"structure,organisation" as org_display %}
-        <h1>Retrait d'un collaborateur</h1>
-        <p>
+        <div class="alert alert-warning">
             Êtes-vous sûr de vouloir retirer <b>{{ target_member.get_full_name }}</b> de votre {{ org_display }} <b>{{ structure.display_name }}</b> ?
-        </p>
+        </div>
 
         <p class="mb-0">Une fois retiré :</p>
         <ul>
@@ -33,6 +32,6 @@
     <form action="{% url base_url|add:":deactivate_member" target_member.public_id %}" method="post">
         {% url base_url|add:":members" as reset_url %}
         {% csrf_token %}
-        {% itou_buttons_form primary_label="Retirer l'utilisateur" reset_url=reset_url %}
+        {% itou_buttons_form show_mandatory_fields_mention=False primary_label="Retirer l'utilisateur" reset_url=reset_url %}
     </form>
 </div>

--- a/itou/templates/includes/update_admin.html
+++ b/itou/templates/includes/update_admin.html
@@ -1,18 +1,14 @@
 {% load buttons_form %}
 
-<div class="content-small">
+<div class="c-form">
     {% with request.user.is_employer|yesno:"structure,organisation" as org_display %}
         {% if action == "remove" %}
-            <h1>Retrait des droits d'administrateur</h1>
-            <h2 class="text-muted">{{ structure.display_name }}</h2>
-            <div class="mt-4 alert alert-warning">
-                Vous allez retirer les droits d'administrateur de votre {{ org_display }} à <b>{{ target_member.get_full_name }}</b>
+            <div class="alert alert-warning">
+                Vous allez retirer les droits d'administrateur de votre {{ org_display }} <b>{{ structure.display_name }}</b> à <b>{{ target_member.get_full_name }}</b>
             </div>
         {% else %}
-            <h1>Ajout des droits d'administrateur</h1>
-            <h2 class="text-muted">{{ structure.display_name }}</h2>
-            <div class="mt-4 alert alert-warning">
-                Vous allez ajouter les droits d'administrateur de votre {{ org_display }} à <b>{{ target_member.get_full_name }}</b>
+            <div class="alert alert-warning">
+                Vous allez ajouter les droits d'administrateur de votre {{ org_display }} <b>{{ structure.display_name }}</b> à <b>{{ target_member.get_full_name }}</b>
             </div>
         {% endif %}
 
@@ -26,9 +22,9 @@
             {% url base_url|add:":members" as reset_url %}
             {% csrf_token %}
             {% if action == "remove" %}
-                {% itou_buttons_form primary_label="Retirer les droits administrateur" reset_url=reset_url %}
+                {% itou_buttons_form show_mandatory_fields_mention=False primary_label="Retirer les droits administrateur" reset_url=reset_url %}
             {% else %}
-                {% itou_buttons_form primary_label="Ajouter les droits administrateur" reset_url=reset_url %}
+                {% itou_buttons_form show_mandatory_fields_mention=False primary_label="Ajouter les droits administrateur" reset_url=reset_url %}
             {% endif %}
         </form>
     {% endwith %}

--- a/itou/templates/institutions/deactivate_member.html
+++ b/itou/templates/institutions/deactivate_member.html
@@ -1,12 +1,21 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Retrait d'un collaborateur {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Retrait d'un collaborateur</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     {% with base_url="institutions_views" %}
                         {% include "includes/deactivate_member.html" %}
                     {% endwith %}

--- a/itou/templates/institutions/update_admins.html
+++ b/itou/templates/institutions/update_admins.html
@@ -1,6 +1,19 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Gestion des administrateurs {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            {% if action == "remove" %}
+                <h1>Retrait des droits d'administrateur</h1>
+            {% else %}
+                <h1>Ajout des droits d'administrateur</h1>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">

--- a/itou/templates/prescribers/deactivate_member.html
+++ b/itou/templates/prescribers/deactivate_member.html
@@ -1,12 +1,21 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Retrait d'un collaborateur {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>Retrait d'un collaborateur</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="row">
-                <div class="col-12">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     {% with base_url="prescribers_views" %}
                         {% include "includes/deactivate_member.html" %}
                     {% endwith %}

--- a/itou/templates/prescribers/update_admins.html
+++ b/itou/templates/prescribers/update_admins.html
@@ -1,6 +1,19 @@
 {% extends "layout/base.html" %}
+{% load components %}
 
 {% block title %}Gestion des administrateurs {{ block.super }}{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            {% if action == "remove" %}
+                <h1>Retrait des droits d'administrateur</h1>
+            {% else %}
+                <h1>Ajout des droits d'administrateur</h1>
+            {% endif %}
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
 
 {% block content %}
     <section class="s-section">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Ecrans qui datent un peu

## :computer: Captures d'écran <!-- optionnel -->
**Avant**
<img width="1241" height="487" alt="capture 2025-09-04 à 11 30 36" src="https://github.com/user-attachments/assets/4471d212-39f1-4d6c-bb5c-e743c14f7215" />

**Apres**
<img width="1298" height="590" alt="capture 2025-09-04 à 11 30 43" src="https://github.com/user-attachments/assets/2eb6d328-e531-4f54-b880-b06118c9b5d4" />

---

**Avant**
<img width="1249" height="479" alt="capture 2025-09-04 à 11 31 23" src="https://github.com/user-attachments/assets/74c5c92c-28c8-4a96-aa9f-adadfadc69ca" />

**Apres**
<img width="1300" height="520" alt="capture 2025-09-04 à 11 30 56" src="https://github.com/user-attachments/assets/27146090-52c6-498f-91bf-56ecb5d37489" />


