### PR TITLE
Candidature: autoriser les utilisateurs à désactiver les notifications de mise en attente [GEN-2694]

### DIFF
--- a/itou/job_applications/notifications.py
+++ b/itou/job_applications/notifications.py
@@ -65,7 +65,6 @@ class JobApplicationPostponedForJobSeekerNotification(JobSeekerNotification, Ema
 
     name = "Mise en attente de candidature"
     category = NotificationCategory.JOB_APPLICATION
-    can_be_disabled = False
     subject_template = "apply/email/postpone_for_job_seeker_subject.txt"
     body_template = "apply/email/postpone_for_job_seeker_body.txt"
 
@@ -76,7 +75,6 @@ class JobApplicationPostponedForProxyNotification(PrescriberOrEmployerNotificati
 
     name = "Mise en attente d’une candidature envoyée"
     category = NotificationCategory.JOB_APPLICATION
-    can_be_disabled = False
     subject_template = "apply/email/postpone_for_proxy_subject.txt"
     body_template = "apply/email/postpone_for_proxy_body.txt"
 

--- a/tests/www/dashboard/__snapshots__/test_edit_user_notifications.ambr
+++ b/tests/www/dashboard/__snapshots__/test_edit_user_notifications.ambr
@@ -273,7 +273,7 @@
 # ---
 # name: test_employer_create_update_notification_settings[view queries - disable all notifications]
   dict({
-    'num_queries': 24,
+    'num_queries': 25,
     'queries': list([
       dict({
         'origin': list([
@@ -714,6 +714,24 @@
           'edit_user_notifications[www/dashboard/views.py]',
         ]),
         'sql': '''
+          SELECT "communications_notificationrecord"."id",
+                 "communications_notificationrecord"."notification_class",
+                 "communications_notificationrecord"."name",
+                 "communications_notificationrecord"."category",
+                 "communications_notificationrecord"."can_be_disabled",
+                 "communications_notificationrecord"."is_obsolete"
+          FROM "communications_notificationrecord"
+          WHERE (NOT ("communications_notificationrecord"."is_obsolete")
+                 AND "communications_notificationrecord"."notification_class" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EditUserNotificationForm.save[www/dashboard/forms.py]',
+          'edit_user_notifications[www/dashboard/views.py]',
+        ]),
+        'sql': '''
           SELECT "communications_notificationrecord"."id" AS "id"
           FROM "communications_notificationrecord"
           INNER JOIN "communications_disablednotification" ON ("communications_notificationrecord"."id" = "communications_disablednotification"."notification_record_id")
@@ -732,6 +750,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,
@@ -1192,7 +1211,7 @@
 # ---
 # name: test_job_seeker_create_update_notification_settings[view queries - disable all notifications]
   dict({
-    'num_queries': 18,
+    'num_queries': 19,
     'queries': list([
       dict({
         'origin': list([
@@ -1457,6 +1476,24 @@
           'edit_user_notifications[www/dashboard/views.py]',
         ]),
         'sql': '''
+          SELECT "communications_notificationrecord"."id",
+                 "communications_notificationrecord"."notification_class",
+                 "communications_notificationrecord"."name",
+                 "communications_notificationrecord"."category",
+                 "communications_notificationrecord"."can_be_disabled",
+                 "communications_notificationrecord"."is_obsolete"
+          FROM "communications_notificationrecord"
+          WHERE (NOT ("communications_notificationrecord"."is_obsolete")
+                 AND "communications_notificationrecord"."notification_class" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EditUserNotificationForm.save[www/dashboard/forms.py]',
+          'edit_user_notifications[www/dashboard/views.py]',
+        ]),
+        'sql': '''
           SELECT "communications_notificationrecord"."id" AS "id"
           FROM "communications_notificationrecord"
           INNER JOIN "communications_disablednotification" ON ("communications_notificationrecord"."id" = "communications_disablednotification"."notification_record_id")
@@ -1475,6 +1512,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,
@@ -1852,7 +1890,7 @@
 # ---
 # name: test_prescriber_create_update_notification_settings[view queries - disable all notifications]
   dict({
-    'num_queries': 19,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -2168,6 +2206,24 @@
           'edit_user_notifications[www/dashboard/views.py]',
         ]),
         'sql': '''
+          SELECT "communications_notificationrecord"."id",
+                 "communications_notificationrecord"."notification_class",
+                 "communications_notificationrecord"."name",
+                 "communications_notificationrecord"."category",
+                 "communications_notificationrecord"."can_be_disabled",
+                 "communications_notificationrecord"."is_obsolete"
+          FROM "communications_notificationrecord"
+          WHERE (NOT ("communications_notificationrecord"."is_obsolete")
+                 AND "communications_notificationrecord"."notification_class" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EditUserNotificationForm.save[www/dashboard/forms.py]',
+          'edit_user_notifications[www/dashboard/views.py]',
+        ]),
+        'sql': '''
           SELECT "communications_notificationrecord"."id" AS "id"
           FROM "communications_notificationrecord"
           INNER JOIN "communications_disablednotification" ON ("communications_notificationrecord"."id" = "communications_disablednotification"."notification_record_id")
@@ -2186,6 +2242,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,
@@ -2640,7 +2697,7 @@
 # ---
 # name: test_solo_adviser_create_update_notification_settings[view queries - disable all notifications]
   dict({
-    'num_queries': 18,
+    'num_queries': 19,
     'queries': list([
       dict({
         'origin': list([
@@ -2938,6 +2995,24 @@
           'edit_user_notifications[www/dashboard/views.py]',
         ]),
         'sql': '''
+          SELECT "communications_notificationrecord"."id",
+                 "communications_notificationrecord"."notification_class",
+                 "communications_notificationrecord"."name",
+                 "communications_notificationrecord"."category",
+                 "communications_notificationrecord"."can_be_disabled",
+                 "communications_notificationrecord"."is_obsolete"
+          FROM "communications_notificationrecord"
+          WHERE (NOT ("communications_notificationrecord"."is_obsolete")
+                 AND "communications_notificationrecord"."notification_class" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'EditUserNotificationForm.save[www/dashboard/forms.py]',
+          'edit_user_notifications[www/dashboard/views.py]',
+        ]),
+        'sql': '''
           SELECT "communications_notificationrecord"."id" AS "id"
           FROM "communications_notificationrecord"
           INNER JOIN "communications_disablednotification" ON ("communications_notificationrecord"."id" = "communications_disablednotification"."notification_record_id")
@@ -2956,6 +3031,7 @@
           SELECT "communications_disablednotification"."notification_record_id" AS "notification_record"
           FROM "communications_disablednotification"
           WHERE ("communications_disablednotification"."notification_record_id" IN (%s,
+                                                                                    %s,
                                                                                     %s,
                                                                                     %s,
                                                                                     %s,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Toutes les autres notifications de changement de statut sont désactivables.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
