### PR TITLE
API: Simplifier l'API SIAE

### DIFF
--- a/itou/api/siae_api/viewsets.py
+++ b/itou/api/siae_api/viewsets.py
@@ -119,7 +119,7 @@ class RestrictedUserRateThrottle(UserRateThrottle):
     rate = "12/minute"
 
 
-class SiaeViewSet(LoginNotRequiredMixin, viewsets.ReadOnlyModelViewSet):
+class SiaeViewSet(LoginNotRequiredMixin, viewsets.mixins.ListModelMixin, viewsets.GenericViewSet):
     """
     # Liste des SIAE
 
@@ -128,34 +128,8 @@ class SiaeViewSet(LoginNotRequiredMixin, viewsets.ReadOnlyModelViewSet):
 
     Les coordonnées des centres-villes sont issus de [https://geo.api.gouv.fr](https://geo.api.gouv.fr/)
 
-
-    Chaque SIAE est accompagnée d’un certain nombre de métadonnées :
-
-     - SIRET
-     - Type
-     - Raison Sociale
-     - Enseigne
-     - Site web
-     - Description de la SIAE
-     - Blocage de toutes les candidatures OUI/NON
-     - Adresse de la SIAE
-     - Complément d’adresse
-     - Code Postal
-     - Ville
-     - Département
-
-    Chaque SIAE peut proposer 0, 1 ou plusieurs postes. Pour chaque poste renvoyé, les métadonnées fournies sont :
-
-     - Appellation ROME
-     - Date de création
-     - Date de modification
-     - Recrutement ouvert OUI/NON
-     - Description du poste
-     - Appellation modifiée
-     - Type de contrat
-     - Nombre de postes ouverts
-     - Lieu
-     - Profil recherché
+    Chaque SIAE est accompagnée d’un certain nombre de métadonnées, et peut proposer 0, 1 ou plusieurs postes.
+    Pour le détail des métadonnées des SIAE et de leur postes, voir plus bas dans la section Responses
     """
 
     serializer_class = SiaeSerializer


### PR DESCRIPTION
Remove retrieve method that doesn't work since we don't send the id used to retreive a company

Clean the documentation (the response format is automatically generated, no need to write it manually)

## :thinking: Pourquoi ?

Suppression de l'action `retrieve` qui n'est jamais utilisée (l'ID nécessaire n'est pas exposé par la liste) et donc les données renvoyées sont identiques à celles de la liste.

Suppression de la description écrite à le main du format de réponse au profit de celui autogénéré par la documentation.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
