### PR TITLE
Éligibilité : Mieux identifier la certification par l’API particulier

### DIFF
--- a/itou/eligibility/enums.py
+++ b/itou/eligibility/enums.py
@@ -114,7 +114,15 @@ class AdministrativeCriteriaKind(models.TextChoices):
             cls.SIAE_CUI,
         }
 
+    @classmethod
+    def certifiable_by_api_particulier(cls):
+        return frozenset(
+            [
+                cls.RSA,
+                cls.AAH,
+                cls.PI,
+            ]
+        )
 
-CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS = frozenset(
-    [AdministrativeCriteriaKind.RSA, AdministrativeCriteriaKind.AAH, AdministrativeCriteriaKind.PI]
-)
+
+CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS = AdministrativeCriteriaKind.certifiable_by_api_particulier()

--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -11,7 +11,7 @@ from itou.eligibility.enums import (
     AdministrativeCriteriaLevel,
     AuthorKind,
 )
-from itou.eligibility.tasks import async_certify_criteria
+from itou.eligibility.tasks import async_certify_criteria_by_api_particulier
 from itou.job_applications.enums import SenderKind
 from itou.utils.models import InclusiveDateRangeField
 
@@ -99,7 +99,7 @@ class AbstractEligibilityDiagnosisModel(models.Model):
             return SenderKind(self.sender_kind).label
 
     def schedule_certification(self):
-        async_certify_criteria(self._meta.model_name, self.pk)
+        async_certify_criteria_by_api_particulier(self._meta.model_name, self.pk)
 
 
 class AdministrativeCriteriaQuerySet(models.QuerySet):

--- a/tests/eligibility/test_iae.py
+++ b/tests/eligibility/test_iae.py
@@ -16,7 +16,7 @@ from itou.eligibility.enums import (
 )
 from itou.eligibility.models import AdministrativeCriteria, EligibilityDiagnosis
 from itou.eligibility.models.geiq import GEIQAdministrativeCriteria
-from itou.eligibility.tasks import certify_criteria
+from itou.eligibility.tasks import certify_criteria_by_api_particulier
 from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
 from itou.job_applications.models import JobApplication
 from itou.users.enums import IdentityCertificationAuthorities
@@ -466,7 +466,7 @@ def test_eligibility_diagnosis_certify_criteria(mocker, EligibilityDiagnosisFact
     eligibility_diagnosis = EligibilityDiagnosisFactory(
         job_seeker=job_seeker, certifiable=True, criteria_kinds=[criteria_kind]
     )
-    certify_criteria(eligibility_diagnosis)
+    certify_criteria_by_api_particulier(eligibility_diagnosis)
 
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
     criterion = SelectedAdministrativeCriteria.objects.get(
@@ -480,7 +480,7 @@ def test_eligibility_diagnosis_certify_criteria(mocker, EligibilityDiagnosisFact
     certification = IdentityCertification.objects.get(jobseeker_profile=job_seeker.jobseeker_profile)
     assert certification.certifier == IdentityCertificationAuthorities.API_PARTICULIER
     with freeze_time("2025-10-15"):
-        certify_criteria(eligibility_diagnosis)
+        certify_criteria_by_api_particulier(eligibility_diagnosis)
     updated_certification = IdentityCertification.objects.get(jobseeker_profile=job_seeker.jobseeker_profile)
     assert updated_certification.certifier == IdentityCertificationAuthorities.API_PARTICULIER
     assert updated_certification.certified_at > certification.certified_at
@@ -508,7 +508,7 @@ def test_eligibility_diagnosis_certify_criteria_missing_info(respx_mock, Eligibi
         certifiable=True,
         criteria_kinds=[AdministrativeCriteriaKind.RSA],
     )
-    certify_criteria(eligibility_diagnosis)
+    certify_criteria_by_api_particulier(eligibility_diagnosis)
     assert len(respx_mock.calls) == 0
     jobseeker_profile = JobSeekerProfile.objects.get(pk=job_seeker.jobseeker_profile)
     assertQuerySetEqual(jobseeker_profile.identity_certifications.all(), [])
@@ -610,7 +610,7 @@ def test_selected_administrative_criteria_certified(
         response_status, json=response
     )
 
-    certify_criteria(eligibility_diagnosis)
+    certify_criteria_by_api_particulier(eligibility_diagnosis)
 
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
     criterion = SelectedAdministrativeCriteria.objects.filter(

--- a/tests/utils/apis/test_api_particulier.py
+++ b/tests/utils/apis/test_api_particulier.py
@@ -5,7 +5,7 @@ from freezegun import freeze_time
 
 from itou.asp.models import Commune
 from itou.eligibility.enums import CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS, AdministrativeCriteriaKind
-from itou.eligibility.tasks import certify_criteria
+from itou.eligibility.tasks import certify_criteria_by_api_particulier
 from itou.utils.apis import api_particulier
 from itou.utils.mocks.api_particulier import (
     RESPONSES,
@@ -57,7 +57,7 @@ def test_not_certified(criteria_kind, factory, respx_mock, caplog):
         json=RESPONSES[criteria_kind][ResponseKind.NOT_CERTIFIED]
     )
 
-    certify_criteria(eligibility_diagnosis)
+    certify_criteria_by_api_particulier(eligibility_diagnosis)
 
     assert len(respx_mock.calls) == 1
     SelectedAdministrativeCriteria = eligibility_diagnosis.administrative_criteria.through
@@ -83,7 +83,7 @@ def test_not_found(respx_mock, caplog):
         job_seeker__first_name="Jean",
         job_seeker__last_name="Dupont",
     )
-    certify_criteria(diag)
+    certify_criteria_by_api_particulier(diag)
     crit = diag.selected_administrative_criteria.get()
     assert crit.data_returned_by_api == RESPONSES[AdministrativeCriteriaKind.RSA][ResponseKind.NOT_FOUND]
     assert crit.certified is None
@@ -103,7 +103,7 @@ def test_service_unavailable(respx_mock, caplog):
         job_seeker__first_name="Jean",
         job_seeker__last_name="Dupont",
     )
-    certify_criteria(diag)
+    certify_criteria_by_api_particulier(diag)
     crit = diag.selected_administrative_criteria.get()
     assert crit.data_returned_by_api == RESPONSES[AdministrativeCriteriaKind.RSA][ResponseKind.PROVIDER_UNKNOWN_ERROR]
     assert crit.certified is None

--- a/tests/www/apply/test_templates.py
+++ b/tests/www/apply/test_templates.py
@@ -14,7 +14,7 @@ from itou.eligibility.enums import (
     AdministrativeCriteriaKind,
     AdministrativeCriteriaLevel,
 )
-from itou.eligibility.tasks import certify_criteria
+from itou.eligibility.tasks import certify_criteria_by_api_particulier
 from itou.job_applications.enums import Origin
 from itou.jobs.models import Appellation
 from itou.utils.mocks.api_particulier import RESPONSES, ResponseKind
@@ -304,7 +304,7 @@ class TestIAEEligibilityDetail:
 
         # Certifiable and certified.
         diagnosis = IAEEligibilityDiagnosisFactory(certifiable=True, criteria_kinds=[AdministrativeCriteriaKind.RSA])
-        certify_criteria(diagnosis)
+        certify_criteria_by_api_particulier(diagnosis)
         rendered = self.template.render(Context(self.default_params(diagnosis)))
         assert certified_help_text in rendered
 
@@ -356,7 +356,7 @@ class TestGEIQEligibilityDetail:
             criteria_kinds=[criteria_kind],
         )
         self.create_job_application(diagnosis)
-        certify_criteria(diagnosis)
+        certify_criteria_by_api_particulier(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis)))
         assert self.ELIGIBILITY_TITLE in rendered
         self.assert_criteria_name_in_rendered(diagnosis, rendered)
@@ -386,7 +386,7 @@ class TestGEIQEligibilityDetail:
             return_value=RESPONSES[AdministrativeCriteriaKind.RSA][ResponseKind.CERTIFIED],
         )
         diagnosis = GEIQEligibilityDiagnosisFactory(certifiable=True, criteria_kinds=[AdministrativeCriteriaKind.RSA])
-        certify_criteria(diagnosis)
+        certify_criteria_by_api_particulier(diagnosis)
         self.create_job_application(diagnosis)
         rendered = self.template.render(Context(self.default_params_geiq(diagnosis)))
         assert certified_help_text in rendered


### PR DESCRIPTION
## :thinking: Pourquoi ?

La certification des critères ne se fait pas qu’auprès de l’API Particulier, mais va bientôt se faire aussi auprès de France Travail (RQTH).

## :cake: Comment ? <!-- optionnel -->

L’organisation du code actuelle est inadaptée à l’intégration de plusieurs sources de certification. La logique de gestion d’erreurs est spécifique à l’API particulier. Par exemple, si l’API particulier est injoignable, on réessaye immédiatement, sans continuer le traitement. Avec l’arrivée de l’API France Travail, on pourrait essayer de certifier sur France Travail.

Le plan est d’utiliser `schedule_certification` comme base pour décider quelles tâches asynchrones lancer pour un diagnostic, en fonction des critères cochés.

Pour préserver la compatibilité avec l’ancienne version du code, la nouvelle tâche pour l’API particulier est déclarée à côté de l’ancienne.
Une nouvelle tâche dédiée à la RQTH sera bientôt ajoutée.
