### PR TITLE
Vie privée : ne pas relancer la suppression des emails finissant par .old dans Brevo

### DIFF
--- a/itou/utils/brevo.py
+++ b/itou/utils/brevo.py
@@ -79,6 +79,11 @@ class BrevoClient:
             )
             if response.status_code == 404:
                 return
+            # Brevo excludes HTTP DELETE calls for email addresses ending by .old .back .zip
+            # We do not want to try these tasks again every 10 minutes during 90 days.
+            if response.status_code == 403:
+                logger.error("Brevo API: unable to delete email=%s", email)
+                return
             response.raise_for_status()
         except httpx.RequestError as e:
             logger.error("Brevo API: Request failed: %s", str(e))


### PR DESCRIPTION
## :thinking: Pourquoi ?

Brevo exclut les appels HTTP DELETE pour les adresses e-mail se terminant par .old .back .zip.
Nous ne pouvons pas supprimer ces adresses par l'appel à leur API.

## :cake: Comment ? <!-- optionnel -->

Logger une fois l'erreur 403 dans Sentry sans la relancer toutes les 10 min pendant 90 jours.

