### PR TITLE
Vie privée : ignorer la suppression de l'email dans Brevo pour les utilisateurs desactivés par le support dans l'admin

### DIFF
--- a/itou/utils/brevo.py
+++ b/itou/utils/brevo.py
@@ -73,7 +73,10 @@ class BrevoClient:
                 self._import_contacts(batch, list_id, serializer)
 
     def delete_contact(self, email):
-        if not email:
+        # Brevo rejects with 400 status code, HTTP DELETE calls for addresses ending by "_old"
+        # These address are made when Support Team disable a user in admin
+        # We do not want to call Brevo in that case
+        if not email or email.endswith("_old"):
             return
         try:
             response = self.client.delete(

--- a/tests/archive/tests_tasks.py
+++ b/tests/archive/tests_tasks.py
@@ -38,6 +38,7 @@ def test_async_delete_contact_retries_warning(
         assert warning_record.message == snapshot(name=f"attempting-to-delete-email-{retries}-retries")
 
 
-def test_async_delete_contact_when_email_is_none(respx_mock):
-    async_delete_contact(None)
-    assert not respx_mock.calls.called
+def test_async_delete_contact_does_not_send_HTTP_request(respx_mock):
+    for email in [None, "somebody@email.com_old"]:
+        async_delete_contact(None)
+        assert not respx_mock.calls.called


### PR DESCRIPTION
## :thinking: Pourquoi ?

L'action `free_sso_email` dans l'admin django, génère une adresse email en `*_old`. Brevo rejette les demandes de suppression de ces adresses avec un code erreur 400.
Par ailleurs, ces adresses n'existent pas, de manière certaine, dans Brevo, l'appel DELETE est donc systématiquement inutile.

## :cake: Comment ? <!-- optionnel -->

Ne pas appeler Brevo pour ces adresses.

