### PR TITLE
Pilotage : Correction du TB AHI affiché aux DREETS et faire coincider le titre du TB "Analyse des candidatures émises par France Travail"

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -98,6 +98,9 @@ METABASE_DASHBOARDS = {
         "tally_popup_form_id": "mRG61J",
         "tally_embed_form_id": "3qLKad",
     },
+    "stats_ft_state_raw": {
+        "dashboard_id": 183,
+    },
     "stats_ft_beneficiaries": {
         "dashboard_id": 545,
         "tally_popup_form_id": "wo1GOe",

--- a/itou/www/stats/urls.py
+++ b/itou/www/stats/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
     # Legacy `pe` term is used in URLs for retroactivity in Matomo stats but in fact it means `ft`.
     path("pe/conversion/main", views.stats_ft_conversion_main, name="stats_ft_conversion_main"),
     path("pe/state/main", views.stats_ft_state_main, name="stats_ft_state_main"),
+    # The `ft_state_raw` URL is not referenced in this code base, but *is used* as a direct link in TB `ft_state_main`
+    path("pe/state/raw", views.stats_ft_state_raw, name="stats_ft_state_raw"),
     path("pe/beneficiaries", views.stats_ft_beneficiaries, name="stats_ft_beneficiaries"),
     path("pe/hiring", views.stats_ft_hiring, name="stats_ft_hiring"),
     # Authorized prescribers' stats

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -422,6 +422,17 @@ def stats_ft_state_main(request):
 
 
 @check_request(utils.can_view_stats_ft)
+def stats_ft_state_raw(request):
+    return render_stats_ft(
+        request=request,
+        page_title="Données brutes de l’état des candidatures orientées",
+        extra_params={
+            mb.PRESCRIBER_FILTER_KEY: mb.FT_PRESCRIBER_FILTER_VALUE,
+        },
+    )
+
+
+@check_request(utils.can_view_stats_ft)
 def stats_ft_beneficiaries(request):
     return render_stats_ft(
         request=request,


### PR DESCRIPTION
## :thinking: Pourquoi ?

1. Sinon on affiche le TB 160 et pas le 310 aux DREETS.
2. https://www.notion.so/gip-inclusion/Faire-coincider-les-titres-des-TB-24c5f321b604802aa900c1cd7c9b3542?v=11611994512a48c7a87b7a366129364e&source=copy_link