### PR TITLE
Admin: Ajout de la date de première connexion d'un candidat

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -472,6 +472,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
                 "follow_up_groups_or_members",
                 "upcoming_deletion_notified_at",
                 "external_data_source_history_formatted",
+                "first_login",
             ]
         )
         if not request.user.is_superuser:
@@ -527,7 +528,15 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
         assert "last_login" in fieldsets[-2][1]["fields"]
         fieldsets[-2] = (
             "Dates importantes",
-            {"fields": ("last_login", "date_joined", "last_checked_at", "upcoming_deletion_notified_at")},
+            {
+                "fields": (
+                    "last_login",
+                    "first_login",
+                    "date_joined",
+                    "last_checked_at",
+                    "upcoming_deletion_notified_at",
+                )
+            },
         )
 
         assert fieldsets[2][0] == "Permissions"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela permet de facilement répondre à un prescripteur/employeur qui affirme qu'un candidat n'a jamais pris le contrôle de son compte. 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
