### PR TITLE
Tech : Considérer le contexte comme vide à la sortie de `triggers.context()`

### DIFF
--- a/itou/utils/triggers/__init__.py
+++ b/itou/utils/triggers/__init__.py
@@ -39,7 +39,7 @@ def context(**kwargs):
 
     with cm:
         yield
-    _context.data = previous_data
+    _context.data, _context.last_data_set = previous_data, None
 
 
 class FieldsHistory(core.Trigger):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le problème initial a été décelé dans #6620 car un des tests utilisais `parametrize` et un contexte identique.
La première occurrence du test était _PASSED_ alors que les occurrence suivantes était _FAILED_ avec l'erreur "No context available" :
- Le `set_config()` est local donc lié à la transaction ou _savepoint_
- _pytest_ fait un _rollback_ vers un _savepoint_ précédent après chaque test afin de ne pas avoir à tout recréer à chaque fois
- La mise à jour du contexte se fait sur l'inégalité entre la valeur demandée et la dernière valeur enregistrée connue stockée dans un `threading.local` et non nettoyé entre les tests

Le _context manager_ ne refaisais donc pas un `set_config()` après le premier test car la valeur était la même mais on n'était plus dans la même transaction/_savepoint_ donc le trigger cassais (à juste titre).