### PR TITLE
Vie privée : supprimer EmailAddress (allauth) des professionnels anonymisés mais non effacés

### DIFF
--- a/itou/archive/management/commands/anonymize_professionals.py
+++ b/itou/archive/management/commands/anonymize_professionals.py
@@ -1,3 +1,4 @@
+from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.db import transaction
@@ -146,6 +147,8 @@ class Command(BaseCommand):
         user_ids = [user.id for user in users]
         for model in [CompanyMembership, InstitutionMembership, PrescriberMembership]:
             model.objects.filter(user_id__in=user_ids).update(is_active=False)
+
+        EmailAddress.objects.filter(user_id__in=user_ids).delete()
 
         User.objects.filter(id__in=user_ids).update(
             is_active=False,

--- a/itou/archive/migrations/0014_delete_emailadress_of_anonymized_professionals.py
+++ b/itou/archive/migrations/0014_delete_emailadress_of_anonymized_professionals.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.db import migrations
+
+from itou.utils.enums import ItouEnvironment
+
+
+def delete_emailaddress_of_anonymized_professionals(apps, schema_editor):
+    if settings.ITOU_ENVIRONMENT != ItouEnvironment.PROD:
+        return
+
+    EmailAddress = apps.get_model("account", "EmailAddress")
+    EmailAddress.objects.filter(user__email__isnull=True).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("archive", "0013_remove_evaluated_jobseekers"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=delete_emailaddress_of_anonymized_professionals, reverse_code=migrations.RunPython.noop, elidable=True
+        ),
+    ]

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -6,6 +6,7 @@ from uuid import uuid1, uuid4
 
 import httpx
 import pytest
+from allauth.account.models import EmailAddress
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.management import call_command
@@ -1422,6 +1423,7 @@ class TestAnonymizeProfessionalManagementCommand:
                     "user__coords": city.coords,
                     "user__insee_city": city,
                     "user__email": f"test{city.post_codes[0]}@mail.com",
+                    "user__with_verified_email": True,
                 }
             else:
                 kwargs = {
@@ -1478,6 +1480,7 @@ class TestAnonymizeProfessionalManagementCommand:
             )
         )
         assert users == snapshot(name="anonymized_professionals_without_deletion")
+        assert not EmailAddress.objects.exists()
         assert get_fields_list_for_snapshot(AnonymizedProfessional) == snapshot(
             name="deleted_anonymized_professionals"
         )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les professionnels à anonymiser, liés à des objets dans la base de données, ne peuvent pas être supprimés. Ils sont simplement anonymisés, càd notamment que la valeur de leur email est mis à `None`.

Les professionnels à anonymiser, non liés à des objets dans la base de données, sont effacés. Le modèle `EmailAddress` est `on_delete=Cascade`. Ces cas ne sont pas concernés.

## :cake: Comment ? <!-- optionnel -->

1. Compléter l'anonymisation est supprimant l'objet `EmailAddress`
2. Reprise du stock

