### PR TITLE
Tech: ajout de nouveau test de cohérence pour les dates de prolongation

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib import admin, messages
+from django.db.models import F, Q
 from django.urls import path, reverse_lazy
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
@@ -654,7 +655,7 @@ class ProlongationRequestAdmin(ProlongationCommonAdmin):
 
 
 @admin.register(models.Prolongation)
-class ProlongationAdmin(ProlongationCommonAdmin):
+class ProlongationAdmin(InconsistencyCheckMixin, ProlongationCommonAdmin):
     list_display = (
         "pk",
         "approval",
@@ -715,6 +716,13 @@ class ProlongationAdmin(ProlongationCommonAdmin):
             },
         ),
     )
+
+    INCONSISTENCY_CHECKS = [
+        (
+            "Prolongation hors période du PASS IAE",
+            lambda q: q.filter(Q(start_at__lt=F("approval__start_at")) | Q(end_at__gt=F("approval__end_at"))),
+        ),
+    ]
 
     @admin.display(boolean=True, description="demande")
     def from_prolongation_request(self, obj):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les suspensions et prolongations ont normalement lieu pendant la durée de vie du PASS.

~550 suspensions et ~26 prolongations n'ont apparemment pas reçu l'information :see_no_evil: 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
