### PR TITLE
Renommer API_ESD["AUTH_BASE_URL{,_PARTENAIRE}"]

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -451,7 +451,7 @@ GEIQ_ASSESSMENT_CAMPAIGN_POSTCODE_PREFIXES = (
 # same depending on the environment
 # Please note that some of APIs have a dry run mode which is handled through (possibly undocumented) scopes
 API_ESD = {
-    "AUTH_BASE_URL": os.getenv("API_ESD_AUTH_BASE_URL"),
+    "AUTH_BASE_URL_PARTENAIRE": os.getenv("API_ESD_AUTH_BASE_URL_PARTENAIRE"),
     "KEY": os.getenv("API_ESD_KEY"),
     "SECRET": os.getenv("API_ESD_SECRET"),
     "BASE_URL": os.getenv("API_ESD_BASE_URL"),

--- a/itou/utils/apis/esd.py
+++ b/itou/utils/apis/esd.py
@@ -28,7 +28,7 @@ def get_access_token(scope):
 
     r = (
         httpx.post(
-            f"{settings.API_ESD['AUTH_BASE_URL']}/connexion/oauth2/access_token",
+            f"{settings.API_ESD['AUTH_BASE_URL_PARTENAIRE']}/connexion/oauth2/access_token",
             params={"realm": "/partenaire"},
             data={
                 "grant_type": "client_credentials",

--- a/itou/utils/apis/pole_emploi.py
+++ b/itou/utils/apis/pole_emploi.py
@@ -432,7 +432,7 @@ class PoleEmploiRoyaumeAgentAPIClient(BasePoleEmploiApiClient):
 def pole_emploi_partenaire_api_client():
     return PoleEmploiRoyaumePartenaireApiClient(
         settings.API_ESD["BASE_URL"],
-        settings.API_ESD["AUTH_BASE_URL"],
+        settings.API_ESD["AUTH_BASE_URL_PARTENAIRE"],
         settings.API_ESD["KEY"],
         settings.API_ESD["SECRET"],
     )

--- a/tests/approvals/test_notify_pole_emploi.py
+++ b/tests/approvals/test_notify_pole_emploi.py
@@ -36,7 +36,7 @@ def mock_api(settings):
     )
     settings.API_ESD = {
         "BASE_URL": "https://pe.fake",
-        "AUTH_BASE_URL": "https://auth.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://auth.fr",
         "KEY": "foobar",
         "SECRET": "pe-secret",
     }

--- a/tests/companies/test_sync_ft_offers.py
+++ b/tests/companies/test_sync_ft_offers.py
@@ -13,7 +13,7 @@ from itou.utils.mocks.pole_emploi import API_OFFRES
 @override_settings(
     API_ESD={
         "BASE_URL": "https://pe.fake",
-        "AUTH_BASE_URL": "https://auth.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://auth.fr",
         "KEY": "foobar",
         "SECRET": "pe-secret",
     }

--- a/tests/external_data/tests.py
+++ b/tests/external_data/tests.py
@@ -104,7 +104,7 @@ def _mock_status_failed():
 def mock_api_esd(settings):
     settings.API_ESD = {
         "BASE_URL": "https://some.auth.domain",
-        "AUTH_BASE_URL": "https://some-authentication-domain.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://some-authentication-domain.fr",
     }
 
 

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -81,7 +81,7 @@ class TestJobApplicationModel:
     def setup_method(self, settings):
         settings.API_ESD = {
             "BASE_URL": "https://base.domain",
-            "AUTH_BASE_URL": "https://authentication-domain.fr",
+            "AUTH_BASE_URL_PARTENAIRE": "https://authentication-domain.fr",
             "KEY": "foobar",
             "SECRET": "pe-secret",
         }
@@ -1300,7 +1300,7 @@ class TestJobApplicationWorkflow:
     def setup_method(self, settings):
         settings.API_ESD = {
             "BASE_URL": "https://base.domain",
-            "AUTH_BASE_URL": "https://authentication-domain.fr",
+            "AUTH_BASE_URL_PARTENAIRE": "https://authentication-domain.fr",
             "KEY": "foobar",
             "SECRET": "pe-secret",
         }

--- a/tests/jobs/management/test_sync_romes_and_appellations.py
+++ b/tests/jobs/management/test_sync_romes_and_appellations.py
@@ -7,7 +7,7 @@ from itou.jobs.models import Appellation, Rome
 @override_settings(
     API_ESD={
         "BASE_URL": "https://pe.fake",
-        "AUTH_BASE_URL": "https://auth.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://auth.fr",
         "KEY": "foobar",
         "SECRET": "pe-secret",
     }

--- a/tests/openid_connect/pe_connect/tests.py
+++ b/tests/openid_connect/pe_connect/tests.py
@@ -76,7 +76,7 @@ TEST_SETTINGS = {
     "PEAMU_AUTH_BASE_URL": "https://peamu.auth.fake.url",
     "API_ESD": {
         "BASE_URL": "https://some.auth.domain",
-        "AUTH_BASE_URL": "https://some-authentication-domain.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://some-authentication-domain.fr",
         "KEY": "somekey",
         "SECRET": "somesecret",
     },

--- a/tests/users/test_management_commands.py
+++ b/tests/users/test_management_commands.py
@@ -856,7 +856,7 @@ def test_pe_certify_users(settings, respx_mock, caplog, snapshot):
     )
     settings.API_ESD = {
         "BASE_URL": "https://pe.fake",
-        "AUTH_BASE_URL": "https://auth.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://auth.fr",
         "KEY": "foobar",
         "SECRET": "pe-secret",
     }
@@ -918,7 +918,7 @@ def test_pe_certify_users_dry_run(settings, respx_mock, caplog, snapshot):
     )
     settings.API_ESD = {
         "BASE_URL": "https://pe.fake",
-        "AUTH_BASE_URL": "https://auth.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://auth.fr",
         "KEY": "foobar",
         "SECRET": "pe-secret",
     }
@@ -953,7 +953,7 @@ def test_pe_certify_users_with_swap(settings, respx_mock, caplog, snapshot):
     )
     settings.API_ESD = {
         "BASE_URL": "https://pe.fake",
-        "AUTH_BASE_URL": "https://auth.fr",
+        "AUTH_BASE_URL_PARTENAIRE": "https://auth.fr",
         "KEY": "foobar",
         "SECRET": "pe-secret",
     }


### PR DESCRIPTION
## :thinking: Pourquoi ?

Préparer à l’arrivée de `AUTH_BASE_URL_AGENT` pour la RQTH.
