### PR TITLE
Candidatures : correction du bug de candidatures sélectionnées après un retour

### DIFF
--- a/itou/templates/apply/includes/list_table.html
+++ b/itou/templates/apply/includes/list_table.html
@@ -4,7 +4,7 @@
         <tr>
             {% if job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
                 <th scope="col" class="text-start w-50px">
-                    <input class="form-check-input" type="checkbox" id="select-all-applications" data-emplois-select-all-target-input-name="selected-application">
+                    <input class="form-check-input" type="checkbox" id="select-all-applications" data-emplois-select-all-target-input-name="selected-application" autocomplete="off">
                     <label class="visually-hidden" for="select-all-applications">Sélectionner toutes les candidatures</label>
                 </th>
             {% endif %}

--- a/itou/templates/apply/includes/list_tr.html
+++ b/itou/templates/apply/includes/list_tr.html
@@ -17,7 +17,7 @@
 <tr class="align-top">
     {% if job_applications_list_kind is JobApplicationsListKind.RECEIVED %}
         <th scope="row" class="text-start w-50px">
-            <input class="form-check-input" type="checkbox" name="selected-application" value="{{ job_application.pk }}" id="select-{{ job_application.pk }}">
+            <input class="form-check-input" type="checkbox" name="selected-application" value="{{ job_application.pk }}" id="select-{{ job_application.pk }}" autocomplete="off">
             <label class="visually-hidden" for="select-{{ job_application.pk }}">Sélectionner cette candidature</label>
         </th>
     {% endif %}

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -7622,7 +7622,7 @@
                   <thead>
                       <tr>
                           <th class="text-start w-50px" scope="col">
-                              <input class="form-check-input" data-emplois-select-all-target-input-name="selected-application" id="select-all-applications" type="checkbox"/>
+                              <input autocomplete="off" class="form-check-input" data-emplois-select-all-target-input-name="selected-application" id="select-all-applications" type="checkbox"/>
                               <label class="visually-hidden" for="select-all-applications">
                                   Sélectionner toutes les candidatures
                               </label>
@@ -7656,7 +7656,7 @@
                   <tbody>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -7706,7 +7706,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -7754,7 +7754,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -7913,7 +7913,7 @@
                   <thead>
                       <tr>
                           <th class="text-start w-50px" scope="col">
-                              <input class="form-check-input" data-emplois-select-all-target-input-name="selected-application" id="select-all-applications" type="checkbox"/>
+                              <input autocomplete="off" class="form-check-input" data-emplois-select-all-target-input-name="selected-application" id="select-all-applications" type="checkbox"/>
                               <label class="visually-hidden" for="select-all-applications">
                                   Sélectionner toutes les candidatures
                               </label>
@@ -7947,7 +7947,7 @@
                   <tbody>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -8000,7 +8000,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -8046,7 +8046,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -8094,7 +8094,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -8149,7 +8149,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -8197,7 +8197,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>
@@ -8252,7 +8252,7 @@
                       </tr>
                       <tr class="align-top">
                           <th class="text-start w-50px" scope="row">
-                              <input class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
+                              <input autocomplete="off" class="form-check-input" id="select-[PK of JobApplication]" name="selected-application" type="checkbox" value="[PK of JobApplication]"/>
                               <label class="visually-hidden" for="select-[PK of JobApplication]">
                                   Sélectionner cette candidature
                               </label>


### PR DESCRIPTION
## :thinking: Pourquoi ?
Si après une action par lot, on utilise le bouton Page précédente du navigateur (a priori Chrome* seulement), les checkbox restent cochées, et le bandeau d'action n'apparaît pas.


https://github.com/user-attachments/assets/f3b78410-f9d3-48ac-9c33-8e88c9791a41


