### PR TITLE
Éligibilité : Gérer la logique de certification dans schedule_certification

### DIFF
--- a/itou/eligibility/models/common.py
+++ b/itou/eligibility/models/common.py
@@ -99,7 +99,9 @@ class AbstractEligibilityDiagnosisModel(models.Model):
             return SenderKind(self.sender_kind).label
 
     def schedule_certification(self):
-        async_certify_criteria_by_api_particulier(self._meta.model_name, self.pk)
+        criteria = set(self.selected_administrative_criteria.values_list("administrative_criteria__kind", flat=True))
+        if settings.API_PARTICULIER_TOKEN and AdministrativeCriteriaKind.certifiable_by_api_particulier() & criteria:
+            async_certify_criteria_by_api_particulier(self._meta.model_name, self.pk)
 
 
 class AdministrativeCriteriaQuerySet(models.QuerySet):

--- a/itou/eligibility/models/geiq.py
+++ b/itou/eligibility/models/geiq.py
@@ -212,8 +212,7 @@ class GEIQEligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
 
         if administrative_criteria:
             result.administrative_criteria.set(administrative_criteria)
-            if any([criterion.is_certifiable for criterion in administrative_criteria]):
-                result.schedule_certification()
+            result.schedule_certification()
 
         # Sync GPS groups
         FollowUpGroup.objects.follow_beneficiary(job_seeker, author)
@@ -237,8 +236,7 @@ class GEIQEligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
         # - permission management is not handled by the model
         # - only administrative criteria are updatable
         diagnosis.administrative_criteria.set(administrative_criteria)
-        if any([criterion.is_certifiable for criterion in administrative_criteria]):
-            diagnosis.schedule_certification()
+        diagnosis.schedule_certification()
 
         return diagnosis
 

--- a/itou/eligibility/models/iae.py
+++ b/itou/eligibility/models/iae.py
@@ -243,8 +243,7 @@ class EligibilityDiagnosis(AbstractEligibilityDiagnosisModel):
         )
         if administrative_criteria:
             diagnosis.administrative_criteria.add(*administrative_criteria)
-            if any([criterion.is_certifiable for criterion in administrative_criteria]):
-                diagnosis.schedule_certification()
+            diagnosis.schedule_certification()
 
         # Sync GPS groups
         FollowUpGroup.objects.follow_beneficiary(job_seeker, author)

--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
@@ -142,18 +141,13 @@ class BaseAcceptView(UserPassesTestMixin, TemplateView):
             with transaction.atomic():
                 if form_personal_data := forms.get("personal_data"):
                     form_personal_data.save()
-                    if (
-                        self.eligibility_diagnosis
-                        and self.eligibility_diagnosis.criteria_can_be_certified()
-                        and settings.API_PARTICULIER_TOKEN
-                    ):
+                    if self.eligibility_diagnosis:
                         self.eligibility_diagnosis.schedule_certification()
                 if form_user_address := forms.get("user_address"):
                     form_user_address.save()
                 if form_birth_place := forms.get("birth_place"):
                     form_birth_place.save()
-                    if settings.API_PARTICULIER_TOKEN:
-                        self.geiq_eligibility_diagnosis.schedule_certification()
+                    self.geiq_eligibility_diagnosis.schedule_certification()
                 # Instance will be committed by the transition, performed by django-xworkflows.
                 job_application = forms["accept"].save(commit=False)
                 if creating:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Au lieu de vérifier si un critère est certifiable à de multiple reprises, laisser le planificateur de certification gérer quelles tâches lancer.

Cela permet de centraliser la logique de décision, car elle va se complexifier avec l’arrivée d’un nouvel organisme certificateur (France Travail) pour la RQTH.
