### PR TITLE
Interface: Maj de la carte "Eligibilité à l’IAE" pour les candidats

### DIFF
--- a/itou/templates/dashboard/includes/job_seeker_eligibility_card.html
+++ b/itou/templates/dashboard/includes/job_seeker_eligibility_card.html
@@ -1,24 +1,40 @@
 {% load badges %}
+
 <div class="col-12 col-md-12 col-xxl-12 {% if kind == "IAE" %}col-xxxl-6{% else %}col-xxxl-12{% endif %} mb-3 mb-md-5">
     <div class="c-box p-0 h-100">
-        <div class="p-3 p-lg-4">
-            <span class="h4 mb-0">
+        <div class="row p-3 p-lg-4">
+            <div class="col-12 col-sm">
                 {% if kind == "IAE" %}
-                    Diagnostic d’éligibilité à l’IAE
+                    <h3 class="mb-0">Diagnostic d'éligibilité à l'IAE</h3>
                     {% if not eligibility_diagnosis %}
-                        non renseigné
+                        <span class="text-warning fs-sm">Diagnostic non renseigné</span>
+                    {% elif eligibility_diagnosis.is_considered_valid %}
+                        <span class="text-success fs-sm">
+                            Critères validés le {{ eligibility_diagnosis.created_at|date:"d/m/Y" }} par {{ eligibility_diagnosis.author.get_full_name }}
+                            {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}){% endif %}
+                            {% if eligibility_diagnosis.author_prescriber_organization %}
+                                ({{ eligibility_diagnosis.author_prescriber_organization.display_name }})
+                            {% endif %}
+                        </span>
                     {% else %}
-                        {{ eligibility_diagnosis.is_considered_valid|yesno:"valide,expiré" }}
+                        <span class="text-warning fs-sm">Diagnostic expiré</span>
                     {% endif %}
                 {% elif kind == "GEIQ" %}
-                    Diagnostic public prioritaire GEIQ {{ eligibility_diagnosis.is_valid|yesno:"valide,expiré" }}
+                    <h3 class="mb-0">Diagnostic public prioritaire GEIQ</h3>
+                    {% if eligibility_diagnosis.is_valid %}
+                        <span class="text-success fs-sm">Diagnostic validé</span>
+                    {% else %}
+                        <span class="text-warning fs-sm">Diagnostic expiré</span>
+                    {% endif %}
                 {% endif %}
-            </span>
-            {% if kind == "IAE" %}
-                {% iae_eligibility_badge is_eligible=eligibility_diagnosis.is_considered_valid|default:False extra_classes="badge-sm float-end" for_job_seeker=True %}
-            {% elif kind == "GEIQ" %}
-                {% geiq_eligibility_badge is_eligible=eligibility_diagnosis.is_valid|default:False extra_classes="badge-sm float-end" for_job_seeker=True %}
-            {% endif %}
+            </div>
+            <div class="col-12 col-sm-auto">
+                {% if kind == "IAE" %}
+                    {% iae_eligibility_badge is_eligible=eligibility_diagnosis.is_considered_valid|default:False extra_classes="badge-sm" for_job_seeker=True %}
+                {% elif kind == "GEIQ" %}
+                    {% geiq_eligibility_badge is_eligible=eligibility_diagnosis.is_valid|default:False extra_classes="badge-sm" for_job_seeker=True %}
+                {% endif %}
+            </div>
         </div>
         <div class="px-3 px-lg-4">
             {% if kind == "IAE" %}
@@ -37,7 +53,6 @@
                         </li>
                     </ul>
                     <hr class="mb-3">
-
                     <p class="fs-sm mb-lg-5">
                         {% if not eligibility_diagnosis %}
                             Veuillez vous rapprocher d’un prescripteur habilité pour vérifier votre éligibilité à l’IAE.
@@ -46,16 +61,7 @@
                         {% endif %}
                     </p>
                 {% else %}
-                    <div class="fs-sm mb-lg-5">
-                        <p class="text-success mb-1">
-                            Critères validés
-                            le <span class="fw-bold">{{ eligibility_diagnosis.created_at|date:"d/m/Y" }}</span> par
-                            <strong>{{ eligibility_diagnosis.author.get_full_name }}</strong>
-                            {% if eligibility_diagnosis.author_siae %}({{ eligibility_diagnosis.author_siae.display_name }}).{% endif %}
-                            {% if eligibility_diagnosis.author_prescriber_organization %}
-                                ({{ eligibility_diagnosis.author_prescriber_organization.display_name }}).
-                            {% endif %}
-                        </p>
+                    <div>
                         {% include "includes/valid_eligibility_diagnosis_and_criteria.html" with eligibility_diagnosis=eligibility_diagnosis is_sent_by_authorized_prescriber=False flat_criteria_list=True itou_help_center_url=itou_help_center_url request=request only %}
                     </div>
                 {% endif %}
@@ -72,7 +78,8 @@
                             {% include "apply/includes/selected_administrative_criteria_display.html" with criterion=criterion request=request only %}
                         {% endfor %}
                     </ul>
-                    <p>
+                    <hr class="mb-3">
+                    <p class="fs-sm mb-lg-5">
                         <i>Ce diagnostic {{ eligibility_diagnosis.is_valid|yesno:"expire,a expiré" }} le {{ eligibility_diagnosis.expires_at|date:"d/m/Y" }}.</i>
                     </p>
                 {% endif %}

--- a/tests/www/dashboard/test_dashboard.py
+++ b/tests/www/dashboard/test_dashboard.py
@@ -841,16 +841,14 @@ class TestDashboardView:
 
     @freeze_time("2025-05-19")
     def test_jobseeker_iae_eligibility_diagnosis(self, client):
-        DIAG_TITLE = "Diagnostic d’éligibilité à l’IAE valide"
-        DIAG_BADGE = """<span class="badge badge-sm float-end rounded-pill bg-success-lighter text-success">
+        DIAG_TITLE = "Diagnostic d'éligibilité à l'IAE"
+        DIAG_BADGE = """<span class="badge badge-sm rounded-pill bg-success-lighter text-success">
             <i class="ri-check-line" aria-hidden="true"></i>Éligible à l’IAE</span>"""
-        VALIDATED_CRITERIA = """<p class="text-success mb-1">Critères validés le
-            <span class="fw-bold">%(date)s</span> par <strong>%(author)s</strong> (%(org)s).</p>"""
-        NO_DIAG_TITLE = "Diagnostic d’éligibilité à l’IAE non renseigné"
+        VALIDATED_CRITERIA = """<span class="text-success fs-sm">Critères validés le
+            %(date)s par %(author)s (%(org)s)</span>"""
         NO_DIAG_TEXT = "Veuillez vous rapprocher d’un prescripteur habilité pour vérifier votre éligibilité à l’IAE."
-        NO_DIAG_BADGE = """<span class="badge badge-sm float-end rounded-pill bg-accent-02-lighter text-primary">
+        NO_DIAG_BADGE = """<span class="badge badge-sm rounded-pill bg-accent-02-lighter text-primary">
             <i class="ri-error-warning-line" aria-hidden="true"></i>Éligibilité IAE à valider</span>"""
-        EXPIRED_DIAG_TITLE = "Diagnostic d’éligibilité à l’IAE expiré"
         EXPIRED_DIAG_TEXT = (
             "Votre diagnostic d’éligibilité IAE a expiré le %s. Pour en savoir plus, veuillez vous rapprocher "
             "d’un prescripteur habilité."
@@ -863,9 +861,8 @@ class TestDashboardView:
 
         # No diagnosis
         response = client.get(url)
-        assertNotContains(response, DIAG_TITLE, html=True)
         assertNotContains(response, DIAG_BADGE, html=True)
-        assertContains(response, NO_DIAG_TITLE, html=True, count=1)
+        assertContains(response, DIAG_TITLE, html=True)
         assertContains(response, NO_DIAG_TEXT, html=True, count=1)
         assertContains(response, NO_DIAG_BADGE, html=True, count=1)
         assertNotContains(response, INFO_BOX)
@@ -877,9 +874,8 @@ class TestDashboardView:
             criteria_kinds=[random.choice(list(CERTIFIABLE_ADMINISTRATIVE_CRITERIA_KINDS))],
         )
         response = client.get(url)
-        assertNotContains(response, DIAG_TITLE, html=True)
         assertNotContains(response, DIAG_BADGE, html=True)
-        assertContains(response, NO_DIAG_TITLE, html=True, count=1)
+        assertContains(response, DIAG_TITLE, html=True)
         assertContains(response, NO_DIAG_TEXT, html=True, count=1)
         assertContains(response, NO_DIAG_BADGE, html=True, count=1)
         assertNotContains(response, INFO_BOX)
@@ -905,7 +901,6 @@ class TestDashboardView:
             html=True,
             count=1,
         )
-        assertNotContains(response, NO_DIAG_TITLE, html=True)
         assertNotContains(response, NO_DIAG_TEXT, html=True)
         assertNotContains(response, NO_DIAG_BADGE, html=True)
         assertNotContains(response, INFO_BOX)
@@ -927,7 +922,6 @@ class TestDashboardView:
                 html=True,
                 count=1,
             )
-            assertNotContains(response, NO_DIAG_TITLE, html=True)
             assertNotContains(response, NO_DIAG_TEXT, html=True)
             assertNotContains(response, NO_DIAG_BADGE, html=True)
             assertNotContains(response, INFO_BOX)
@@ -937,9 +931,8 @@ class TestDashboardView:
         with freeze_time(approval.end_at + timedelta(days=1)):
             client.force_login(user)
             response = client.get(url)
-            assertNotContains(response, DIAG_TITLE, html=True)
             assertNotContains(response, DIAG_BADGE, html=True)
-            assertContains(response, EXPIRED_DIAG_TITLE, html=True, count=1)
+            assertContains(response, DIAG_TITLE, html=True)
             assertContains(response, EXPIRED_DIAG_TEXT % "19/11/2025", html=True, count=1)
             assertContains(response, NO_DIAG_BADGE, html=True, count=1)
             assertNotContains(response, INFO_BOX)
@@ -963,22 +956,19 @@ class TestDashboardView:
             html=True,
             count=1,
         )
-        assertNotContains(response, NO_DIAG_TITLE, html=True)
         assertNotContains(response, NO_DIAG_TEXT, html=True)
         assertNotContains(response, NO_DIAG_BADGE, html=True)
         assertNotContains(response, INFO_BOX)
 
     @freeze_time("2025-05-19")
     def test_jobseeker_geiq_eligibility_diagnosis(self, client, administrative_criteria_annex_1):
-        DIAG_TITLE = "Diagnostic public prioritaire GEIQ valide"
-        DIAG_BADGE = """<span class="badge badge-sm float-end rounded-pill bg-success-lighter text-success">
+        DIAG_TITLE = "Diagnostic d'éligibilité à l'IAE"
+        DIAG_BADGE = """<span class="badge badge-sm rounded-pill bg-success-lighter text-success">
             <i class="ri-check-line" aria-hidden="true"></i>Éligibilité GEIQ confirmée</span>"""
-        DIAG_EXPIRATION = "<i>Ce diagnostic expire le %s.</i>"
         VALIDATED_ELIGIBILITY = """<p>Éligibilité GEIQ confirmée par <b>%(author)s (%(structure)s)</b></p>"""
-        EXPIRED_DIAG_TITLE = "Diagnostic public prioritaire GEIQ expiré"
-        EXPIRED_DIAG_BADGE = """<span class="badge badge-sm float-end rounded-pill bg-accent-02-lighter text-primary">
+        EXPIRED_DIAG_BADGE = """<span class="badge badge-sm rounded-pill bg-accent-02-lighter text-primary">
             <i class="ri-error-warning-line" aria-hidden="true"></i>Éligibilité GEIQ non confirmée</span>"""
-        EXPIRED_DIAG_EXPIRATION = "<i>Ce diagnostic a expiré le %s.</i>"
+        EXPIRED_DIAG_EXPIRATION = """<p class="fs-sm mb-lg-5">Ce diagnostic a expiré le %s.</p>"""
         INFO_BOX = "Pourquoi certains critères peuvent-ils être certifiés"
 
         user = JobSeekerFactory(with_address=True)
@@ -987,7 +977,7 @@ class TestDashboardView:
 
         # No diagnosis
         response = client.get(url)
-        assertNotContains(response, DIAG_TITLE)
+        assertContains(response, DIAG_TITLE)
         assertNotContains(response, DIAG_BADGE, html=True)
 
         # A diagnosis from an employer without criteria (hence without allowance)
@@ -996,7 +986,7 @@ class TestDashboardView:
             job_seeker=user,
         )
         response = client.get(url)
-        assertNotContains(response, DIAG_TITLE)
+        assertContains(response, DIAG_TITLE)
         assertNotContains(response, DIAG_BADGE, html=True)
         assertNotContains(
             response,
@@ -1021,19 +1011,12 @@ class TestDashboardView:
             html=True,
             count=1,
         )
-        assertContains(
-            response,
-            DIAG_EXPIRATION % "19/11/2025",
-            html=True,
-            count=1,
-        )
         assertNotContains(response, INFO_BOX)
 
         # An expired diagnosis from an employer with criteria (hence with allowance)
         with freeze_time(diagnosis.expires_at + timedelta(days=1)):
             client.force_login(user)
             response = client.get(url)
-            assertContains(response, EXPIRED_DIAG_TITLE, count=1)
             assertContains(response, EXPIRED_DIAG_BADGE, html=True, count=1)
             assertContains(
                 response,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Lié à la demande d'harmonisation des infos affichées, de leur wording et de la UI 
https://www.notion.so/gip-inclusion/Harmoniser-le-bloc-Eligibilit-l-IAE-et-GEIQ-1de5f321b6048065925bdbf1cda975e9?v=18a5f321b604811bad80000cf7934cee&source=copy_link

La maj des autres cas/ecrans arrive avec [cette PR](https://github.com/gip-inclusion/les-emplois/pull/6897)
