### PR TITLE
Vie privée : réduction de la fréquence du traitement de notification des professionnels inactifs

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -16,9 +16,9 @@
   "*/30 7-18 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_jobseekers --wet-run",
   "0 7-20 * * MON-FRI $ROOT/clevercloud/run_management_command.sh anonymize_professionals --wet-run",
   "30 2-18/4 * * * $ROOT/clevercloud/run_management_command.sh metabase_data kpi fetch --wet-run",
-  "0 7-17/2 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_professionals --wet-run",
   "25 8-18/2 * * MON-FRI $ROOT/clevercloud/transfer_employee_records.sh --download",
   "55 8-18/2 * * MON-FRI $ROOT/clevercloud/transfer_employee_records.sh --upload",
+  "0 7,13 * * MON-FRI $ROOT/clevercloud/run_management_command.sh notify_inactive_professionals --wet-run",
 
   "30 0 * * * $ROOT/clevercloud/run_management_command.sh collect_analytics_data --save",
   "30 1 * * * $ROOT/clevercloud/run_management_command.sh send_users_to_brevo --wet-run",

--- a/itou/archive/management/commands/notify_inactive_professionals.py
+++ b/itou/archive/management/commands/notify_inactive_professionals.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
     @monitor(
         monitor_slug="notify_inactive_professionals",
         monitor_config={
-            "schedule": {"type": "crontab", "value": "0 7-17/2 * * MON-FRI"},
+            "schedule": {"type": "crontab", "value": "0 7,13 * * MON-FRI"},
             "checkin_margin": 5,
             "max_runtime": 10,
             "failure_issue_threshold": 2,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Stock traité.
Actuellement, besoin réel ~100 professionnels/jour

## :cake: Comment ? <!-- optionnel -->

Replanification à 2 traitements par jour soit 400 profesionnels/jour

🚨 vers le 22 octobre : réduire la fréquence de la commande `anonymize_professionals`