### PR TITLE
Tests: éviter un bagotage

### DIFF
--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -877,6 +877,8 @@ class TestJobApplicationNotifications:
         # Unauthorized prescriber is the default sender
         extra_kwargs = {"sent_by_authorized_prescriber_organisation": True} if is_authorized_prescriber else {}
         job_application = JobApplicationFactory(
+            sender__first_name="Un joli prénom",
+            sender__last_name="Un nom de famille original",
             selected_jobs=Appellation.objects.all(),
             **extra_kwargs,
         )
@@ -958,7 +960,11 @@ class TestJobApplicationNotifications:
     def test_accept_for_prescriber(self, is_authorized_prescriber):
         # Unauthorized prescriber is the default sender
         extra_kwargs = {"sent_by_authorized_prescriber_organisation": True} if is_authorized_prescriber else {}
-        job_application = JobApplicationFactory(**extra_kwargs)
+        job_application = JobApplicationFactory(
+            sender__first_name="Un joli prénom",
+            sender__last_name="Un nom de famille original",
+            **extra_kwargs,
+        )
         email = job_application.notifications_accept_for_proxy.build()
         # To.
         assert job_application.to_company.email not in email.to


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parfois, on retrouvait le nom ou le prénom du candidat dans le nom/prénom du prescripteur:
https://github.com/gip-inclusion/les-emplois/actions/runs/17978694761/job/51138617607

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
