### PR TITLE
Prescripteur: Ajout d'un accès aux demandes de prolongation dans le menu de gauche pour les prescripteurs habilités

### DIFF
--- a/itou/utils/templatetags/nav.py
+++ b/itou/utils/templatetags/nav.py
@@ -118,6 +118,11 @@ NAV_ENTRIES = {
         matomo_event_name="clic",
         matomo_event_option="candidats-organisation",
     ),
+    "prescriber-approval-prolongations": NavItem(
+        label="Gérer les prolongations de PASS\xa0IAE",
+        target=reverse("approvals:prolongation_requests_list", query={"only_pending": "on"}),
+        active_view_names=["approvals:prolongation_requests_list"],
+    ),
     "prescriber-job-apps": NavItem(
         label="Candidatures",
         icon="ri-draft-line",
@@ -301,6 +306,8 @@ def nav(request):
             ]
             if request.current_organization:
                 jobseekers_items.append(NAV_ENTRIES["prescriber-jobseekers-organization"])
+                if request.from_authorized_prescriber:
+                    jobseekers_items.append(NAV_ENTRIES["prescriber-approval-prolongations"])
             menu_items.append(NavGroup(label="Candidats", icon="ri-user-line", items=jobseekers_items))
             if request.current_organization:
                 organization_items = [

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -1008,6 +1008,11 @@
                                       Tous les candidats de la structure
                                   </a>
                               </li>
+                              <li>
+                                  <a href="/approvals/prolongation/requests?only_pending=on">
+                                      Gérer les prolongations de PASS IAE
+                                  </a>
+                              </li>
                           </ul>
                       </div>
                   </li>


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/ETQ-prescripteur-habilit-j-ai-acc-s-la-prolongation-des-PASS-IAE-menu-de-gauche-1a55f321b60480af9a6dc3a09493fd89?v=18a5f321b604811bad80000cf7934cee&source=copy_link

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
