### PR TITLE
change id and department filter to facilitation à l'embauche dashboard

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -133,7 +133,7 @@ METABASE_DASHBOARDS = {
         "tally_embed_form_id": "nG6gBj",
     },
     "stats_ddets_iae_ph_prescription": {
-        "dashboard_id": 289,
+        "dashboard_id": 577,
         "tally_popup_form_id": "wbWKEo",
         "tally_embed_form_id": "wvPEvQ",
     },
@@ -172,7 +172,7 @@ METABASE_DASHBOARDS = {
         "tally_embed_form_id": "nG6gBj",
     },
     "stats_dreets_iae_ph_prescription": {
-        "dashboard_id": 289,
+        "dashboard_id": 577,
         "tally_popup_form_id": "wbWKEo",
         "tally_embed_form_id": "wvPEvQ",
     },

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -548,7 +548,11 @@ def stats_ddets_iae_auto_prescription(request):
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_ph_prescription(request):
-    return render_stats_ddets(request=request, page_title="Analyse des candidatures émises et de leur traitement")
+    return render_stats_ddets(
+        request=request,
+        page_title="Analyse des candidatures émises et de leur traitement",
+        with_department_name=False,
+    )
 
 
 @check_request(utils.can_view_stats_ddets_iae)
@@ -619,7 +623,9 @@ def stats_dreets_iae_auto_prescription(request):
 
 @check_request(utils.can_view_stats_dreets_iae)
 def stats_dreets_iae_ph_prescription(request):
-    return render_stats_dreets_iae(request=request, page_title="Analyse des candidatures émises et de leur traitement")
+    return render_stats_dreets_iae(
+        request=request, page_title="Analyse des candidatures émises et de leur traitement", with_department_name=False
+    )
 
 
 @check_request(utils.can_view_stats_dreets_iae)


### PR DESCRIPTION
- Changement de l'id_dashboard suite à la mise en place d'une nouvelle version pour le TDB "suivi des prescripteurs".
- changement de l'option with_departement_name afin de passer le numéro de département et pas le nom aux filtres