### PR TITLE
Accessibilité: Vérifier et corriger le markup des onglets

### DIFF
--- a/itou/templates/geiq_assessments_views/_assessment_base_for_geiq.html
+++ b/itou/templates/geiq_assessments_views/_assessment_base_for_geiq.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block title_extra %}
-    <ul class="s-tabs-01__nav nav nav-tabs mb-0" role="tablist" data-it-sliding-tabs="true">
+    <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
         <li class="nav-item">
             <a class="nav-link{% if active_tab == active_tab.MAIN %} active{% endif %}" href="{% url 'geiq_assessments_views:details_for_geiq' pk=assessment.pk %}">{{ active_tab.MAIN.label }}</a>
         </li>

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -26,10 +26,10 @@
 {% endblock %}
 
 {% block title_extra %}
-    <ul class="s-tabs-01__nav nav nav-tabs mb-0" role="tablist" data-it-sliding-tabs="true">
+    <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
         {% for tab in AssessmentContractDetailsTab %}
             <li class="nav-item">
-                <a class="nav-link{% if active_tab == tab %} active{% endif %}" id="{{ tab.value }}-tab" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}</a>
+                <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/itou/templates/job_seekers_views/details.html
+++ b/itou/templates/job_seekers_views/details.html
@@ -63,7 +63,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
                     <div class="tab-content">
-                        <div class="tab-pane fade show active" id="informations" role="tabpanel" aria-labelledby="informations-tab">
+                        <div class="tab-pane fade show active">
                             <div class="row">
                                 <div class="col-12 {% if approval %}col-xxl-8 col-xxxl-9 order-2 order-xxl-1{% endif %}">
                                     <h2>Informations</h2>

--- a/itou/templates/job_seekers_views/includes/nav_tabs.html
+++ b/itou/templates/job_seekers_views/includes/nav_tabs.html
@@ -1,20 +1,14 @@
 {% load matomo %}
 
-<ul class="s-tabs-01__nav nav nav-tabs mb-0" role="tablist" data-it-sliding-tabs="true">
-    <li class="nav-item" role="presentation">
-        <a id="informations-tab"
-           class="nav-link{% if active_nav_tab == "details" %} active{% endif %}"
+<ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+    <li class="nav-item">
+        <a class="nav-link{% if active_nav_tab == "details" %} active{% endif %}"
            href="{% url 'job_seekers_views:details' public_id=job_seeker.public_id %}?back_url={% url 'job_seekers_views:list' %}"
-           aria-controls="informations"
-           aria-selected="{% if active_nav_tab == "details" %}true{% else %}false{% endif %}"
            {% matomo_event "candidat" "clic-onglet" "informations candidat" %}>Informations générales</a>
     </li>
-    <li class="nav-item" role="presentation">
-        <a id="job-applications-tab"
-           class="nav-link{% if active_nav_tab == "job-applications" %} active{% endif %}"
+    <li class="nav-item">
+        <a class="nav-link{% if active_nav_tab == "job-applications" %} active{% endif %}"
            href="{% url 'job_seekers_views:job_applications' public_id=job_seeker.public_id %}?back_url={% url 'job_seekers_views:list' %}"
-           aria-controls="candidatures"
-           aria-selected="{% if active_nav_tab == "job-applications" %}true{% else %}false{% endif %}"
            {% matomo_event "candidat" "clic-onglet" "candidatures" %}>Candidatures</a>
     </li>
 </ul>

--- a/itou/templates/job_seekers_views/job_applications.html
+++ b/itou/templates/job_seekers_views/job_applications.html
@@ -44,7 +44,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
                     <div class="tab-content">
-                        <div class="tab-pane fade show active" id="candidatures" role="tabpanel" aria-labelledby="job-applications-tab">
+                        <div class="tab-pane fade show active">
                             <h2>Candidatures envoyées par ma structure</h2>
                             <hr>
                             {% matomo_event "candidat" "clic" "detail-candidature" as matomo_event_attrs %}

--- a/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_approval_box.ambr
@@ -273,60 +273,6 @@
   
   '''
 # ---
-# name: test_expired_pe_approval
-  '''
-  <html>
-      <head>
-      </head>
-      <body>
-          <div class="c-box c-box--pass bg-danger-lightest border-danger">
-              <div class="mb-3 mb-md-4">
-                  <span class="badge badge-base rounded-pill bg-danger text-white">
-                      <i aria-hidden="true" class="ri-pass-expired-line">
-                      </i>
-                      Agrément expiré
-                  </span>
-              </div>
-              <ul class="list-data">
-                  <li>
-                      <small>
-                          Numéro d’agrément
-                      </small>
-                      <strong>
-                          <span>
-                              12345
-                          </span>
-                          <span class="ms-1">
-                              67
-                          </span>
-                          <span class="ms-1">
-                              89012
-                          </span>
-                      </strong>
-                  </li>
-                  <li>
-                      <small>
-                          Date de début
-                      </small>
-                      <strong>
-                          01/01/2022
-                      </strong>
-                  </li>
-                  <li>
-                      <small>
-                          A expiré le
-                      </small>
-                      <strong class="text-danger">
-                          31/12/2023
-                      </strong>
-                  </li>
-              </ul>
-          </div>
-      </body>
-  </html>
-  
-  '''
-# ---
 # name: test_future_approval
   '''
   <html>
@@ -921,76 +867,6 @@
                       Afficher le PASS IAE
                   </span>
               </a>
-          </div>
-      </body>
-  </html>
-  
-  '''
-# ---
-# name: test_valid_pe_approval
-  '''
-  <html>
-      <head>
-      </head>
-      <body>
-          <div class="c-box c-box--pass bg-success-lightest border-success">
-              <div class="mb-3 mb-md-4">
-                  <span class="badge badge-base rounded-pill bg-success text-white">
-                      <i aria-hidden="true" class="ri-pass-valid-line">
-                      </i>
-                      Agrément valide
-                  </span>
-              </div>
-              <ul class="list-data">
-                  <li>
-                      <small>
-                          Numéro d’agrément
-                      </small>
-                      <strong>
-                          <span>
-                              12345
-                          </span>
-                          <span class="ms-1">
-                              67
-                          </span>
-                          <span class="ms-1">
-                              89012
-                          </span>
-                      </strong>
-                  </li>
-                  <li>
-                      <small>
-                          Date de début
-                      </small>
-                      <strong>
-                          01/01/2024
-                      </strong>
-                  </li>
-                  <li>
-                      <small>
-                          Date de fin prévisionnelle
-                          <i aria-label="Cette date de fin est susceptible d’évoluer avec les éventuelles suspensions et prolongations du PASS IAE." class="ri-information-line ri-xl text-info" data-bs-title="Cette date de fin est susceptible d’évoluer avec les éventuelles suspensions et prolongations du PASS IAE." data-bs-toggle="tooltip" role="button" tabindex="0">
-                          </i>
-                      </small>
-                      <strong>
-                          31/12/2025
-                      </strong>
-                  </li>
-                  <li>
-                      <small>
-                          Durée de validité
-                          <i aria-label="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." class="ri-information-line ri-xl text-info" data-bs-title="Le reliquat est calculé sur la base d’un nombre de jours calendaires. Si le PASS IAE n’est pas suspendu, il décroît donc tous les jours (samedi, dimanche et jours fériés compris)." data-bs-toggle="tooltip" role="button" tabindex="0">
-                          </i>
-                      </small>
-                      <strong class="text-success">
-                          513 jours (Environ 1 an et 4 mois)
-                          <br/>
-                          <a class="btn-link has-external-link" href="https://aide.emplois.inclusion.beta.gouv.fr/hc/fr/articles/14733528375185--PASS-IAE-Comment-%C3%A7a-marche" target="_blank">
-                              Comment est calculée cette durée ?
-                          </a>
-                      </strong>
-                  </li>
-              </ul>
           </div>
       </body>
   </html>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -1105,7 +1105,7 @@
   
                               
                               
-      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
+      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
           <li class="nav-item">
               <a class="nav-link active" href="/geiq-assessments/00000000-1111-2222-3333-444444444444">Mon dossier</a>
           </li>
@@ -1405,7 +1405,7 @@
                           </button>
                       </div>
                   </div>
-                  <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
+                  <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
                       <li class="nav-item">
                           <a class="nav-link active" href="/geiq-assessments/00000000-1111-2222-3333-444444444444">
                               Mon dossier
@@ -1525,7 +1525,7 @@
   
                               
                               
-      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
+      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
           <li class="nav-item">
               <a class="nav-link" href="/geiq-assessments/00000000-1111-2222-3333-444444444444">Mon dossier</a>
           </li>
@@ -1803,7 +1803,7 @@
   
                               
                               
-      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
+      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
           <li class="nav-item">
               <a class="nav-link" href="/geiq-assessments/00000000-1111-2222-3333-444444444444">Mon dossier</a>
           </li>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -34,14 +34,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -55,7 +55,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -306,14 +306,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -327,7 +327,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -562,14 +562,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -583,7 +583,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -772,14 +772,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -793,7 +793,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -1061,14 +1061,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -1082,7 +1082,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="job-applications-tab" class="tab-pane fade show active" id="candidatures" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <h2>
                                   Candidatures envoyées par ma structure
                               </h2>
@@ -1984,14 +1984,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -2005,7 +2005,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -2269,14 +2269,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -2290,7 +2290,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -2523,14 +2523,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -2544,7 +2544,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -2726,14 +2726,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -2747,7 +2747,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -2987,14 +2987,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -3008,7 +3008,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -3241,14 +3241,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -3262,7 +3262,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12">
                                       <h2>
@@ -3444,14 +3444,14 @@
                               </a>
                           </div>
                       </div>
-                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true" role="tablist">
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="informations" aria-selected="true" class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="informations-tab">
+                      <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
+                          <li class="nav-item">
+                              <a class="nav-link active" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="informations candidat" href="/job-seekers/details/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Informations générales
                               </a>
                           </li>
-                          <li class="nav-item" role="presentation">
-                              <a aria-controls="candidatures" aria-selected="false" class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list" id="job-applications-tab">
+                          <li class="nav-item">
+                              <a class="nav-link" data-matomo-action="clic-onglet" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="candidatures" href="/job-seekers/job_applications/7614fc4b-aef9-4694-ab17-12324300180a?back_url=/job-seekers/list">
                                   Candidatures
                               </a>
                           </li>
@@ -3465,7 +3465,7 @@
               <div class="s-section__row row">
                   <div class="s-section__col col-12">
                       <div class="tab-content">
-                          <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
+                          <div class="tab-pane fade show active">
                               <div class="row">
                                   <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
                                       <h2>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Le markup accessible des onglets est différent de celui des simples liens
https://www.notion.so/gip-inclusion/A11Y-Corriger-les-aria-role-en-trop-sur-les-faux-onglets-2795f321b604809fbb98e0452ed6080e?v=18a5f321b604811bad80000cf7934cee&source=copy_link
