### PR TITLE
MinIO : utilisation de l'image officielle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,17 @@
 services:
   minio:
-    image: bitnami/minio
+    image: minio/minio
     container_name: itou_minio
     restart: unless-stopped
     environment:
       - MINIO_ROOT_USER=minioadmin
       - MINIO_ROOT_PASSWORD=minioadmin
+    command: server /data --console-address ":9001"
     ports:
       - "127.0.0.1:${MINIO_PORT_ON_DOCKER_HOST:-9000}:9000"
       - "127.0.0.1:${MINIO_ADMIN_PORT_ON_DOCKER_HOST:-9001}:9001"
     volumes:
-      - itou_minio:/bitnami/minio/data
+      - itou_minio:/data
 
   # https://github.com/appropriate/docker-postgis
   # https://hub.docker.com/r/mdillon/postgis/tags


### PR DESCRIPTION
## :thinking: Pourquoi ?

Suite à l'acquisition de Bitnami par Broadcom, les images gratuites de la communauté ne sont plus disponibles et Bitnami ne propose plus que des images "secure" dans leur plan payant.

Cf. https://github.com/bitnami/containers/issues/83267

## :cake: Comment ? <!-- optionnel -->

Utilisation de l'image officielle

## :rotating_light: À vérifier

- [x] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [x] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

Ça concerne l'environnement local.
J'ai testé l'accès à des blob uploadés avec l'ancienne l'image, l'upload de nouveaux et la création du bucket via `make buckets`. RAS.

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
