### PR TITLE
GEIQ : Toujours permettre la modification du pays et de la commune de naissance du candidat à l’embauche

### DIFF
--- a/itou/www/apply/views/common.py
+++ b/itou/www/apply/views/common.py
@@ -51,12 +51,11 @@ class BaseAcceptView(UserPassesTestMixin, TemplateView):
             )
             forms["user_address"] = JobSeekerAddressForm(instance=self.job_seeker, data=self.request.POST or None)
         elif self.company.kind == CompanyKind.GEIQ:
-            if self.geiq_eligibility_diagnosis and self.geiq_eligibility_diagnosis.criteria_can_be_certified():
-                forms["birth_place"] = BirthPlaceWithoutBirthdateModelForm(
-                    instance=self.job_seeker.jobseeker_profile,
-                    birthdate=self.job_seeker.jobseeker_profile.birthdate,
-                    data=self.request.POST or None,
-                )
+            forms["birth_place"] = BirthPlaceWithoutBirthdateModelForm(
+                instance=self.job_seeker.jobseeker_profile,
+                birthdate=self.job_seeker.jobseeker_profile.birthdate,
+                data=self.request.POST or None,
+            )
 
         forms["accept"] = AcceptForm(
             instance=self.job_application,
@@ -147,7 +146,8 @@ class BaseAcceptView(UserPassesTestMixin, TemplateView):
                     form_user_address.save()
                 if form_birth_place := forms.get("birth_place"):
                     form_birth_place.save()
-                    self.geiq_eligibility_diagnosis.schedule_certification()
+                    if self.geiq_eligibility_diagnosis:
+                        self.geiq_eligibility_diagnosis.schedule_certification()
                 # Instance will be committed by the transition, performed by django-xworkflows.
                 job_application = forms["accept"].save(commit=False)
                 if creating:

--- a/tests/www/apply/test_forms.py
+++ b/tests/www/apply/test_forms.py
@@ -202,7 +202,11 @@ class TestJobApplicationAcceptFormWithGEIQFields:
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
         create_test_cities(["54", "57"], num_per_department=2)
 
-        job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ, state="processing")
+        job_application = JobApplicationFactory(
+            to_company__kind=CompanyKind.GEIQ,
+            state="processing",
+            job_seeker__born_outside_france=True,
+        )
         job_description = JobDescriptionFactory(company=job_application.to_company)
         city = City.objects.order_by("?").first()
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
@@ -213,6 +217,7 @@ class TestJobApplicationAcceptFormWithGEIQFields:
         assert response.status_code == 200
 
         post_data = {
+            "birth_country": job_application.job_seeker.jobseeker_profile.birth_country_id,
             "hiring_start_at": f"{datetime.now():%Y-%m-%d}",
             "hiring_end_at": f"{faker.future_date(end_date='+3M'):%Y-%m-%d}",
             "prehiring_guidance_days": faker.pyint(),
@@ -247,7 +252,11 @@ class TestJobApplicationAcceptFormWithGEIQFields:
 
     def test_geiq_inverted_vae_fields(self, client, faker):
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
-        job_application = JobApplicationFactory(to_company__kind=CompanyKind.GEIQ, state="processing")
+        job_application = JobApplicationFactory(
+            to_company__kind=CompanyKind.GEIQ,
+            state="processing",
+            job_seeker__born_outside_france=True,
+        )
         job_description = JobDescriptionFactory(company=job_application.to_company)
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
@@ -257,6 +266,7 @@ class TestJobApplicationAcceptFormWithGEIQFields:
         assert response.status_code == 200
 
         post_data = {
+            "birth_country": job_application.job_seeker.jobseeker_profile.birth_country_id,
             "hiring_start_at": f"{datetime.now():%Y-%m-%d}",
             "hiring_end_at": f"{faker.future_date(end_date='+3M'):%Y-%m-%d}",
             "hired_job": job_description.pk,
@@ -286,7 +296,9 @@ class TestJobApplicationAcceptFormWithGEIQFields:
         create_test_romes_and_appellations(("N1101", "N1105", "N1103", "N4105"))
 
         # with a SIAE
-        job_application = JobApplicationFactory(to_company__kind=CompanyKind.EI, state="processing")
+        job_application = JobApplicationFactory(
+            to_company__kind=CompanyKind.EI, state="processing", job_seeker__born_outside_france=True
+        )
         url_accept = reverse("apply:accept", kwargs={"job_application_id": job_application.pk})
 
         client.force_login(job_application.to_company.members.first())
@@ -295,6 +307,7 @@ class TestJobApplicationAcceptFormWithGEIQFields:
         assert response.status_code == 200
 
         post_data = {
+            "birth_country": job_application.job_seeker.jobseeker_profile.birth_country_id,
             "hiring_start_at": f"{faker.past_date(start_date='-1d'):%Y-%m-%d}",
             "hiring_end_at": f"{faker.future_date(end_date='+3M'):%Y-%m-%d}",
             "prehiring_guidance_days": faker.pyint(),

--- a/tests/www/apply/test_process.py
+++ b/tests/www/apply/test_process.py
@@ -3148,8 +3148,9 @@ class TestProcessAcceptViews:
         client.force_login(employer)
 
         response = client.get(url_accept)
-        assertNotContains(response, self.BIRTH_COUNTRY_LABEL)
-        assertNotContains(response, self.BIRTH_PLACE_LABEL)
+        assertion = assertContains if company.kind == CompanyKind.GEIQ else assertNotContains
+        assertion(response, self.BIRTH_COUNTRY_LABEL)
+        assertion(response, self.BIRTH_PLACE_LABEL)
 
         post_data = self._accept_view_post_data(job_application=job_application)
         del post_data["birth_country"]

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3073,7 +3073,7 @@ class TestDirectHireFullProcess:
         """Apply as GEIQ with pre-existing job seeker without previous application"""
         company = CompanyFactory(romes=("N1101", "N1105"), kind=CompanyKind.GEIQ, with_membership=True, with_jobs=True)
         reset_url_dashboard = reverse("dashboard:index")
-        job_seeker = JobSeekerFactory()
+        job_seeker = JobSeekerFactory(born_outside_france=True)
 
         user = company.members.first()
         client.force_login(user)
@@ -3173,6 +3173,7 @@ class TestDirectHireFullProcess:
 
         hiring_start_at = timezone.localdate()
         post_data = {
+            "birth_country": job_seeker.jobseeker_profile.birth_country_id,
             "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
             "hiring_end_at": "",
             "pole_emploi_id": job_seeker.jobseeker_profile.pole_emploi_id,
@@ -5590,6 +5591,8 @@ class TestHireConfirmation:
 
         hiring_start_at = timezone.localdate()
         post_data = {
+            "birth_country": self.job_seeker.jobseeker_profile.birth_country_id,
+            "birth_place": self.job_seeker.jobseeker_profile.birth_place_id,
             "hiring_start_at": hiring_start_at.strftime(DuetDatePickerWidget.INPUT_DATE_FORMAT),
             "hiring_end_at": "",
             "pole_emploi_id": self.job_seeker.jobseeker_profile.pole_emploi_id,


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter de la logique conditionnelle, se rapprocher du parcours d’embauche IAE.
https://github.com/gip-inclusion/les-emplois/pull/6895#discussion_r2372146921

On pourrait aussi imaginer utiliser les mêmes formulaires pour les données personnelles que dans l’IAE, mais ça représente plus de travail et ces formulaires sont en cours de refonte pour offrir un parcours unifié (#6732).
