### PR TITLE
Fiche salarié: correction de l'utilitaire `employee_record`

### DIFF
--- a/itou/employee_record/models.py
+++ b/itou/employee_record/models.py
@@ -330,7 +330,7 @@ class EmployeeRecord(ASPExchangeInformation, xwf_models.WorkflowEnabled):
     # Business methods
 
     @xwf_models.transition()
-    def ready(self, *, user=None):
+    def ready(self, *, user=None, save=True):
         """
         Prepare the employee record for transmission
         """

--- a/tests/employee_record/test_employee_record_command.py
+++ b/tests/employee_record/test_employee_record_command.py
@@ -1,0 +1,49 @@
+from django.core import management
+
+from itou.employee_record.enums import Status
+from itou.employee_record.models import EmployeeRecord
+from tests.employee_record import factories
+
+
+def test_create_with_siret(caplog):
+    er = factories.EmployeeRecordFactory(ready_for_transfer=True, job_application__to_company__siret="12345678901234")
+
+    management.call_command(
+        "employee_record",
+        "create",
+        er.job_application.pk,
+        siret="12345678904321",
+        wet_run=True,
+    )
+    assert (
+        EmployeeRecord.objects.filter(
+            job_application=er.job_application,
+            siret="12345678904321",
+        )
+        .exclude(pk=er.pk)
+        .exists()
+    )
+    assert "Management command itou.employee_record.management.commands.employee_record succeeded" in caplog.text
+
+
+def test_create_with_siret_and_ready(caplog):
+    er = factories.EmployeeRecordFactory(ready_for_transfer=True, job_application__to_company__siret="12345678901234")
+
+    management.call_command(
+        "employee_record",
+        "create",
+        er.job_application.pk,
+        siret="12345678904321",
+        ready=True,
+        wet_run=True,
+    )
+    assert (
+        EmployeeRecord.objects.filter(
+            job_application=er.job_application,
+            siret="12345678904321",
+            status=Status.READY,
+        )
+        .exclude(pk=er.pk)
+        .exists()
+    )
+    assert "Management command itou.employee_record.management.commands.employee_record succeeded" in caplog.text


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour pouvoir renvoyer une fiche salarié existante sur un ancien SIRET.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
