### PR TITLE
Candidatures : débagottage de tests

### DIFF
--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -879,6 +879,8 @@ class TestJobApplicationNotifications:
         job_application = JobApplicationFactory(
             sender__first_name="Un joli prénom",
             sender__last_name="Un nom de famille original",
+            job_seeker__first_name="Un autre joli prénom",
+            job_seeker__last_name="Un autre nom de famille original",
             selected_jobs=Appellation.objects.all(),
             **extra_kwargs,
         )
@@ -963,6 +965,8 @@ class TestJobApplicationNotifications:
         job_application = JobApplicationFactory(
             sender__first_name="Un joli prénom",
             sender__last_name="Un nom de famille original",
+            job_seeker__first_name="Un autre joli prénom",
+            job_seeker__last_name="Un autre nom de famille original",
             **extra_kwargs,
         )
         email = job_application.notifications_accept_for_proxy.build()
@@ -1222,6 +1226,8 @@ class TestJobApplicationNotifications:
             state=JobApplicationState.ACCEPTED,
             sender__first_name="Un joli prénom",
             sender__last_name="Un nom de famille original",
+            job_seeker__first_name="Un autre joli prénom",
+            job_seeker__last_name="Un autre nom de famille original",
             **extra_kwargs,
         )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Les noms aléatoires des candidats peuvent être suffisamment courts pour être similaires à des mots dans la candidatures.

eg:
```
pytest tests/job_applications/tests.py::TestJobApplicationNotifications::test_cancel_sent_by_prescriber --randomly-seed=152003495
pytest tests/job_applications/tests.py::TestJobApplicationNotifications::test_new_for_prescriber --randomly-seed=3464864558
```


