### PR TITLE
Accessibilité: Correction du dropdown .c-box--structure

### DIFF
--- a/itou/templates/includes/structures/_structure_info.html
+++ b/itou/templates/includes/structures/_structure_info.html
@@ -1,21 +1,18 @@
 {% load url_add_query %}
 
 <div class="c-box c-box--structure {{ extra_box_class|default:'' }}">
-    <div class="c-box--structure__summary"
-         role="button"
-         data-bs-toggle="collapse"
-         data-bs-target="#collapseBoxStructure"
-         aria-expanded="{{ show|default:False|yesno:'true,false' }}"
-         aria-controls="collapseBoxStructure"
-         tabindex="0">
+    <button class="c-box--structure__summary w-100"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#collapseBoxStructure"
+            aria-expanded="{{ show|default:False|yesno:'true,false' }}"
+            aria-controls="collapseBoxStructure">
         <i class="ri-community-line" aria-hidden="true"></i>
         <div>
-            <button type="button" data-bs-toggle="tooltip" data-bs-title="{{ structure.get_kind_display }}">
-                {{ structure.kind }}
-            </button>
-            <h3>{{ structure.display_name }}</h3>
+            <span data-bs-toggle="tooltip" data-bs-title="{{ structure.get_kind_display }}">{{ structure.kind }}</span>
+            <span class="d-block h3">{{ structure.display_name }}</span>
         </div>
-    </div>
+    </button>
     <div class="c-box--structure__detail collapse{% if show|default:False %} show{% endif %}" id="collapseBoxStructure">
         <hr class="my-4">
         <ul class="c-box--structure__list-contact">

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -94,18 +94,18 @@
                   <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                       <div class="c-form">
                           <div class="c-box c-box--structure mb-3 mb-md-4">
-                              <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
+                              <button aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary w-100" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" type="button">
                                   <i aria-hidden="true" class="ri-community-line">
                                   </i>
                                   <div>
-                                      <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
+                                      <span data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip">
                                           EI
-                                      </button>
-                                      <h3>
+                                      </span>
+                                      <span class="d-block h3">
                                           Acme inc.
-                                      </h3>
+                                      </span>
                                   </div>
-                              </div>
+                              </button>
                               <div class="c-box--structure__detail collapse" id="collapseBoxStructure">
                                   <hr class="my-4"/>
                                   <ul class="c-box--structure__list-contact">

--- a/tests/www/apply/__snapshots__/test_submit_from_job_seekers_list.ambr
+++ b/tests/www/apply/__snapshots__/test_submit_from_job_seekers_list.ambr
@@ -55,18 +55,18 @@
                   <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                       <div class="c-form">
                           <div class="c-box c-box--structure mb-3 mb-md-4">
-                              <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
+                              <button aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary w-100" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" type="button">
                                   <i aria-hidden="true" class="ri-community-line">
                                   </i>
                                   <div>
-                                      <button data-bs-title="Association intermédiaire" data-bs-toggle="tooltip" type="button">
+                                      <span data-bs-title="Association intermédiaire" data-bs-toggle="tooltip">
                                           AI
-                                      </button>
-                                      <h3>
+                                      </span>
+                                      <span class="d-block h3">
                                           Acme inc.
-                                      </h3>
+                                      </span>
                                   </div>
-                              </div>
+                              </button>
                               <div class="c-box--structure__detail collapse" id="collapseBoxStructure">
                                   <hr class="my-4"/>
                                   <ul class="c-box--structure__list-contact">

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -1748,18 +1748,18 @@
                           </ul>
                       </div>
                       <div class="c-box c-box--structure">
-                          <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
+                          <button aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary w-100" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" type="button">
                               <i aria-hidden="true" class="ri-community-line">
                               </i>
                               <div>
-                                  <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
+                                  <span data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip">
                                       EI
-                                  </button>
-                                  <h3>
+                                  </span>
+                                  <span class="d-block h3">
                                       Acme inc.
-                                  </h3>
+                                  </span>
                               </div>
-                          </div>
+                          </button>
                           <div class="c-box--structure__detail collapse" id="collapseBoxStructure">
                               <hr class="my-4"/>
                               <ul class="c-box--structure__list-contact">
@@ -1994,18 +1994,18 @@
                           </ul>
                       </div>
                       <div class="c-box c-box--structure">
-                          <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
+                          <button aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary w-100" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" type="button">
                               <i aria-hidden="true" class="ri-community-line">
                               </i>
                               <div>
-                                  <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
+                                  <span data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip">
                                       EI
-                                  </button>
-                                  <h3>
+                                  </span>
+                                  <span class="d-block h3">
                                       Acme inc.
-                                  </h3>
+                                  </span>
                               </div>
-                          </div>
+                          </button>
                           <div class="c-box--structure__detail collapse" id="collapseBoxStructure">
                               <hr class="my-4"/>
                               <ul class="c-box--structure__list-contact">
@@ -2270,18 +2270,18 @@
                           </ul>
                       </div>
                       <div class="c-box c-box--structure">
-                          <div aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" role="button" tabindex="0">
+                          <button aria-controls="collapseBoxStructure" aria-expanded="false" class="c-box--structure__summary w-100" data-bs-target="#collapseBoxStructure" data-bs-toggle="collapse" type="button">
                               <i aria-hidden="true" class="ri-community-line">
                               </i>
                               <div>
-                                  <button data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip" type="button">
+                                  <span data-bs-title="Entreprise d'insertion" data-bs-toggle="tooltip">
                                       EI
-                                  </button>
-                                  <h3>
+                                  </span>
+                                  <span class="d-block h3">
                                       Acme inc.
-                                  </h3>
+                                  </span>
                               </div>
-                          </div>
+                          </button>
                           <div class="c-box--structure__detail collapse" id="collapseBoxStructure">
                               <hr class="my-4"/>
                               <ul class="c-box--structure__list-contact">

--- a/tests/www/prescribers_views/test_overview.py
+++ b/tests/www/prescribers_views/test_overview.py
@@ -58,7 +58,7 @@ def test_access(client, user_factory, status_code):
     response = client.get(reverse("prescribers_views:overview"))
     assert response.status_code == status_code
     if status_code == 200:
-        assertContains(response, "<h3>Orga courante</h3>")
+        assertContains(response, '<span class="d-block h3">Orga courante</span>')
 
 
 def test_access_prescriber_with_multiple_organizations(client):
@@ -70,8 +70,8 @@ def test_access_prescriber_with_multiple_organizations(client):
     client.force_login(user)
     client.post(reverse("dashboard:switch_organization"), data={"organization_id": current_org.pk})
     response = client.get(reverse("prescribers_views:overview"))
-    assertContains(response, "<h3>Orga courante</h3>")
-    assertNotContains(response, "<h3>Une autre orga</h3>")
+    assertContains(response, '<span class="d-block h3">Orga courante</span>')
+    assertNotContains(response, 'span class="d-block h3">Une autre orga</span>')
 
 
 def test_content_ft(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?
Le dropdown de la box `.c-box--structure` retournait l'erreur suivante

> Because The element button must not appear as a descendant of an element with the attribute role=button dans `class="c-box--structure__summary"`

De plus le dropdown ne s'actionnait pas au clavier (ouverture/fermeture avec entrée) et le titre de niveau `<h3>` cassait l'ordre descendant des titres.

Bref, un coup de propre

<img width="486" height="345" alt="capture 2025-10-06 à 14 56 40" src="https://github.com/user-attachments/assets/3c906a8c-3c5a-4651-a392-085da07f198e" />

