### PR TITLE
Pilotage : Mise à jour du TB auto-prescription pour les DDETS/DREETS/SIAE

### DIFF
--- a/itou/utils/apis/metabase.py
+++ b/itou/utils/apis/metabase.py
@@ -48,7 +48,7 @@ METABASE_DASHBOARDS = {
         "tally_embed_form_id": "nG6J62",
     },
     "stats_siae_auto_prescription": {
-        "dashboard_id": 295,
+        "dashboard_id": 580,
         "tally_popup_form_id": "nW0zPj",
         "tally_embed_form_id": "waGd0v",
     },
@@ -128,7 +128,7 @@ METABASE_DASHBOARDS = {
     # Institution stats - DDETS IAE - department level.
     #
     "stats_ddets_iae_auto_prescription": {
-        "dashboard_id": 267,
+        "dashboard_id": 575,
         "tally_popup_form_id": "3qLpE2",
         "tally_embed_form_id": "nG6gBj",
     },
@@ -167,7 +167,7 @@ METABASE_DASHBOARDS = {
     # Institution stats - DREETS IAE - region level.
     #
     "stats_dreets_iae_auto_prescription": {
-        "dashboard_id": 267,
+        "dashboard_id": 575,
         "tally_popup_form_id": "3qLpE2",
         "tally_embed_form_id": "nG6gBj",
     },

--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -523,7 +523,9 @@ def render_stats_ddets(
 
 @check_request(utils.can_view_stats_ddets_iae)
 def stats_ddets_iae_auto_prescription(request):
-    return render_stats_ddets(request=request, page_title="Suivi des auto-prescriptions et de leur contrôle")
+    return render_stats_ddets(
+        request=request, page_title="Suivi des auto-prescriptions et de leur contrôle", with_department_name=False
+    )
 
 
 @check_request(utils.can_view_stats_ddets_iae)
@@ -597,7 +599,9 @@ def render_stats_dreets_iae(request, page_title, *, extra_context=None, with_dep
 
 @check_request(utils.can_view_stats_dreets_iae)
 def stats_dreets_iae_auto_prescription(request):
-    return render_stats_dreets_iae(request=request, page_title="Suivi des auto-prescriptions et de leur contrôle")
+    return render_stats_dreets_iae(
+        request=request, page_title="Suivi des auto-prescriptions et de leur contrôle", with_department_name=False
+    )
 
 
 @check_request(utils.can_view_stats_dreets_iae)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour modifier l'ancien tableau de bord par sa nouvelle version. 
