### PR TITLE
Admin: garder la dernière date de connexion lors de la fusion de deux utilisateurs

### DIFF
--- a/itou/www/itou_staff_views/merge_utils.py
+++ b/itou/www/itou_staff_views/merge_utils.py
@@ -203,6 +203,8 @@ def merge_users(to_user, from_user, update_personal_data):
     support_remark = f"{timezone.localdate()}: Fusion des utilisateurs {to_user.email} et {from_user.email}"
     for model, field_name in get_users_relations():
         migrate_field(model, field_name, from_user, to_user)
+    # Keep the most recent last_login to prevent the kept account from being archived
+    to_user.last_login = max(filter(None, [to_user.last_login, from_user.last_login]), default=None)
     if update_personal_data:
         logger.info(get_log_prefix(to_user, from_user) + "Updated personal data")
         to_user.username = from_user.username

--- a/tests/www/itou_staff_views/tests.py
+++ b/tests/www/itou_staff_views/tests.py
@@ -777,6 +777,33 @@ class TestMergeUsers:
             "HTTP 302 Found",
         ]
 
+    def test_merge_last_login(self, client, caplog, subtests):
+        client.force_login(ItouStaffFactory(is_superuser=True))
+
+        old_last_login = timezone.now() - datetime.timedelta(days=10)
+        recent_last_login = timezone.now()
+
+        for last_login_1, last_login_2, expected_last_login in [
+            (None, None, None),
+            (None, recent_last_login, recent_last_login),
+            (recent_last_login, None, recent_last_login),
+            (old_last_login, recent_last_login, recent_last_login),
+            (recent_last_login, old_last_login, recent_last_login),
+        ]:
+            employer_1 = EmployerFactory(last_login=last_login_1)
+            employer_2 = EmployerFactory(last_login=last_login_2)
+            url = reverse("itou_staff_views:merge_users_confirm", args=(employer_1.public_id, employer_2.public_id))
+            caplog.clear()
+            client.post(url, data={"user_to_keep": "to_user"})
+            merged_user = User.objects.get(pk=employer_1.pk)
+            assert not User.objects.filter(pk=employer_2.pk).exists()
+            assert merged_user.last_login == expected_last_login
+
+            assert caplog.messages == [
+                f"Fusion utilisateurs {employer_1.pk} ← {employer_2.pk} — Done !",
+                "HTTP 302 Found",
+            ]
+
 
 class TestOTP:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, le compte conservé peut être celui sur lequel l'utilisateur ne s'est pas connecté depuis 3 ans et être tout prêt à se faire archiver.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
