### PR TITLE
Tech: augmentation du timeout pour la récupération du document de synthèse généré par le site label

### DIFF
--- a/itou/utils/apis/geiq_label.py
+++ b/itou/utils/apis/geiq_label.py
@@ -49,7 +49,7 @@ class LabelApiClient:
                 .json()
             )
         except (httpx.HTTPError, json.JSONDecodeError) as exc:
-            raise LabelAPIError("Error requesting Label API") from exc
+            raise LabelAPIError(f"Error requesting Label API: {exc.__class__.__name__}") from exc
         if response_data.get("status") != "Success":
             raise LabelAPIError(f"Received response with status={response_data.get('Status')}")
         return response_data["result"]
@@ -84,7 +84,7 @@ class LabelApiClient:
                 params={"id": geiq_id},
             ).raise_for_status()
         except httpx.HTTPError as exc:
-            raise LabelAPIError("Error requesting Label API") from exc
+            raise LabelAPIError(f"Error requesting Label API: {exc.__class__.__name__}") from exc
         if response_data.headers["content-type"] != "application/pdf":
             raise LabelAPIError(f"Unexpected content-type: {response_data.headers.get('content-type')}")
         return response_data.content
@@ -97,7 +97,7 @@ class LabelApiClient:
                 timeout=httpx.Timeout(API_TIMEOUT_SECONDS, read=10),  # this endpoint can be slow to generate the PDF
             ).raise_for_status()
         except httpx.HTTPError as exc:
-            raise LabelAPIError("Error requesting Label API") from exc
+            raise LabelAPIError(f"Error requesting Label API: {exc.__class__.__name__}") from exc
         if response_data.headers["content-type"] != "application/pdf":
             raise LabelAPIError(f"Unexpected content-type: {response_data.headers.get('content-type')}")
         return response_data.content

--- a/itou/utils/apis/geiq_label.py
+++ b/itou/utils/apis/geiq_label.py
@@ -94,6 +94,7 @@ class LabelApiClient:
             response_data = self.client.get(
                 f"rest/{LabelCommand.SynthesePDF}",
                 params={"id": geiq_id},
+                timeout=httpx.Timeout(API_TIMEOUT_SECONDS, read=10),  # this endpoint can be slow to generate the PDF
             ).raise_for_status()
         except httpx.HTTPError as exc:
             raise LabelAPIError("Error requesting Label API") from exc

--- a/tests/utils/apis/test_geiq_label.py
+++ b/tests/utils/apis/test_geiq_label.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 
@@ -19,6 +20,12 @@ def test_improperly_configured(settings):
 
 def test_error_response(respx_mock, label_settings):
     client = geiq_label.get_client()
+
+    respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/Geiq?sort=geiq.id&n=100&p=1").mock(
+        side_effect=httpx.ReadTimeout
+    )
+    with pytest.raises(geiq_label.LabelAPIError, match="Error requesting Label API: ReadTimeout"):
+        client.get_all_geiq()
 
     respx_mock.get(f"{label_settings.API_GEIQ_LABEL_BASE_URL}/rest/Geiq?sort=geiq.id&n=100&p=1").respond(400)
     with pytest.raises(geiq_label.LabelAPIError):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Beaucoup de timeout avec la valeur par défaut de `API_TIMEOUT_SECONDS=5` secondes.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Interface                |
| Accessibilité            | Notifications            |
| Admin                    | Page d’accueil           |
| Annexes financières      | PASS IAE                 |
| Candidature              | Performances             |
| Connexion                | Pilotage                 |
| Contrôle a posteriori    | Prescripteur             |
| Demandes de prolongation | Profil salarié           |
| Demandeur d’emploi       | Recherche employeur      |
| Employeur                | Recherche fiche de poste |
| Fiche de poste           | Recherche prescripteur   |
| Fiche entreprise         | Stabilité                |
| Fiches salarié           | Statistiques             |
| GEIQ                     | Tableau de bord          |
| Inscription              | Vie privée               |
+--------------------------|--------------------------+
-->
