### PR TITLE
Activation du Tag Manager

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -703,6 +703,7 @@ ASP_FLUX_IAE_DIR = os.getenv("ASP_FLUX_IAE_DIR")
 MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL")
 MATOMO_SITE_ID = os.getenv("MATOMO_SITE_ID")
 MATOMO_AUTH_TOKEN = os.getenv("MATOMO_AUTH_TOKEN")
+MATOMO_TAG_MANAGER_CONTAINER_ID = os.getenv("MATOMO_TAG_MANAGER_CONTAINER_ID")
 
 # Content Security Policy
 # Beware, some browser extensions may prevent the reports to be sent to sentry with CORS errors.

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -72,6 +72,7 @@ API_GEO_BASE_URL = os.getenv("API_GEO_BASE_URL", "https://geo.api.gouv.fr")
 API_INSEE_METADATA_URL = os.getenv("API_INSEE_METADATA_URL", "https://api.insee.fr/metadonnees/")
 MATOMO_BASE_URL = os.getenv("MATOMO_BASE_URL", "https://matomo.inclusion.beta.gouv.fr/")
 MATOMO_SITE_ID = 220
+MATOMO_TAG_MANAGER_CONTAINER_ID = "ZZ7LPpec"
 SECURE_CSP["img-src"].append(MATOMO_BASE_URL)  # noqa: F405
 SECURE_CSP["script-src"].append(MATOMO_BASE_URL)  # noqa: F405
 SECURE_CSP["connect-src"].append(MATOMO_BASE_URL)  # noqa: F405

--- a/itou/templates/includes/tarteaucitron_matomo.html
+++ b/itou/templates/includes/tarteaucitron_matomo.html
@@ -59,6 +59,12 @@
         window._paq.push(['trackVisibleContentImpressions']);
     };
     (tarteaucitron.job = tarteaucitron.job || []).push('matomo');
+
+    {% if MATOMO_TAG_MANAGER_CONTAINER_ID %}
+    // Matomo Tag Manager :
+    tarteaucitron.user.matomotmUrl = '{{ MATOMO_BASE_URL }}js/container_{{ MATOMO_TAG_MANAGER_CONTAINER_ID }}.js';
+    (tarteaucitron.job = tarteaucitron.job || []).push('matomotm');
+    {% endif %}
     {% endif %}
     /* beautify ignore:end */
 

--- a/itou/utils/settings_context_processors.py
+++ b/itou/utils/settings_context_processors.py
@@ -30,6 +30,7 @@ def expose_settings(request):
         "ITOU_PROTOCOL": settings.ITOU_PROTOCOL,
         "MATOMO_BASE_URL": settings.MATOMO_BASE_URL,
         "MATOMO_SITE_ID": settings.MATOMO_SITE_ID,
+        "MATOMO_TAG_MANAGER_CONTAINER_ID": settings.MATOMO_TAG_MANAGER_CONTAINER_ID,
         "SHOW_DEMO_ACCOUNTS_BANNER": settings.SHOW_DEMO_ACCOUNTS_BANNER,
         "TALLY_URL": settings.TALLY_URL,
     }


### PR DESCRIPTION
**Motivation** : le tag manager de Matomo est une aubaine pour les PM et designers. Il permet d'ajouter des événements à la volée, et d'avoir rapidement des réponses sur le comportement des utilisateurs, sans avoir à utiliser les fonctions plus intrusives (enregistrement de session, heatmaps), ni avoir à demander une nouvelle mise en prod. En plus, notre agent data peut créer des triggers et des tags de manière simple et rapide.  

**Discussion** : ça n'a pas eu lieu auparavant parce que les tag managers sont une sorte de surface applicative fantôme – du code ou du quasi code qui n'est pas dans le repo.

1. Ça n'est pas tout à fait juste – 90% de l'utilisation du tag manager à la plateforme, c'est pour ajouter des événements. Le reste, c'est de l'injection de code – en l'occurence, déclencher des pop-ups Tally pour des expérimentations.
2. En parallèle de l'activation du tag manager sur ce site, je suis en train de lancer une sur-couche d'interface sur Matomo, pour rendre plus simplement visible les triggers activés, et les actions faites par les tags, avec la possibilité de désactiver facilement un trigger. Ce tableau de bord est en partie à destination des équipes tech, pour simplifier l'audit du tag manager.

**Activation** : un nouveau container a été créé pour le site. Le Tag manager ne sera activé que si son id (`TlN6Ou1K`) est ajoutée à l'env. Par symétrie avec le tracking Matomo "standard", en revanche, cette PR active le container de test sur tous les environnements dev ou staging.