### PR TITLE
GEIQ : Ajout du filtre "Aide demandée" pour la sélection des contrats du bilan d'exécution

### DIFF
--- a/itou/templates/geiq_assessments_views/includes/assessment_contracts_filters/allowance_requested.html
+++ b/itou/templates/geiq_assessments_views/includes/assessment_contracts_filters/allowance_requested.html
@@ -1,0 +1,18 @@
+{% load django_bootstrap5 %}
+
+<fieldset>
+    <legend>
+        <button class="btn btn-outline-transparent has-collapse-caret collapsed"
+                data-bs-toggle="collapse"
+                data-bs-target="#collapse-allowance-requested"
+                type="button"
+                aria-expanded="false"
+                aria-controls="collapse-allowance-requested">Aide demandée</button>
+    </legend>
+    <div class="my-3 collapse" id="collapse-allowance-requested">
+        <ul>
+            <li>{% bootstrap_field filters_form.allowance_requested_on wrapper_class="" %}</li>
+            <li>{% bootstrap_field filters_form.allowance_requested_off wrapper_class="" %}</li>
+        </ul>
+    </div>
+</fieldset>

--- a/itou/templates/geiq_assessments_views/includes/assessment_contracts_filters/offcanvas.html
+++ b/itou/templates/geiq_assessments_views/includes/assessment_contracts_filters/offcanvas.html
@@ -12,6 +12,10 @@
         <div class="offcanvas-body">
             <div id="form-errors-container">{% bootstrap_form_errors filters_form %}</div>
             {% include "geiq_assessments_views/includes/assessment_contracts_filters/duration.html" with assessment=assessment request=request filters_form=filters_form only %}
+            {% if request.from_employer %}
+                <hr>
+                {% include "geiq_assessments_views/includes/assessment_contracts_filters/allowance_requested.html" with filters_form=filters_form only %}
+            {% endif %}
             <hr>
             {% include "geiq_assessments_views/includes/assessment_contracts_filters/start_date.html" with filters_form=filters_form only %}
         </div>

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -235,6 +235,7 @@ class ContractFilterForm(forms.Form):
     FILTER_GROUPS = [
         ["duration_longer_or_equal_90", "duration_strictly_shorter_90"],
         ["start_date_lower", "start_date_upper"],
+        ["allowance_requested_on", "allowance_requested_off"],
     ]
 
     start_date_lower = forms.DateField(label="À partir du", required=False, widget=DuetDatePickerWidget())
@@ -245,6 +246,8 @@ class ContractFilterForm(forms.Form):
     )
     duration_longer_or_equal_90 = forms.BooleanField(label="Oui", required=False)
     duration_strictly_shorter_90 = forms.BooleanField(label="Non", required=False)
+    allowance_requested_on = forms.BooleanField(label="Oui", required=False)
+    allowance_requested_off = forms.BooleanField(label="Non", required=False)
 
     def clean(self):
         """
@@ -288,6 +291,17 @@ class ContractFilterForm(forms.Form):
                 queryset = queryset.filter(nb_days_in_campaign_year__lt=90)
             case _:
                 # (True, True) or (False, False) = no filter
+                pass
+
+        match (
+            self.cleaned_data.get("allowance_requested_on"),
+            self.cleaned_data.get("allowance_requested_off"),
+        ):
+            case (True, False):
+                queryset = queryset.filter(allowance_requested=True)
+            case (False, True):
+                queryset = queryset.filter(allowance_requested=False)
+            case _:
                 pass
 
         return queryset

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -1495,6 +1495,7 @@ class TestAssessmentContractsListView:
             "start_date_lower": "2024-06-01",
             "start_date_upper": "2024-06-30",
             "duration_longer_or_equal_90": "on",
+            "allowance_requested_off": "on",
         }
 
         response = client.get(self.url, filter_data)
@@ -1594,3 +1595,40 @@ class TestAssessmentContractsListView:
 
         assertContains(response, "La date de fin doit être postérieure à la date de début.")
         assertContains(response, 'id="form-errors-container"')
+
+    @pytest.mark.parametrize(
+        "query_params, expected_in, expected_not_in",
+        [
+            ({"allowance_requested_on": "on"}, ["contract_allowance_requested"], ["contract_non_allowance_requested"]),
+            (
+                {"allowance_requested_off": "on"},
+                ["contract_non_allowance_requested"],
+                ["contract_allowance_requested"],
+            ),
+            (
+                {"allowance_requested_on": "on", "allowance_requested_off": "on"},
+                ["contract_allowance_requested", "contract_non_allowance_requested"],
+                [],
+            ),
+        ],
+    )
+    def test_contract_list_filter_by_allowance_requested(self, client, query_params, expected_in, expected_not_in):
+        contract_allowance_requested = EmployeeContractFactory(
+            employee__assessment=self.assessment, allowance_requested=True
+        )
+        contract_non_allowance_requested = EmployeeContractFactory(
+            employee__assessment=self.assessment, allowance_requested=False
+        )
+
+        contratcs_map = {
+            "contract_allowance_requested": contract_allowance_requested,
+            "contract_non_allowance_requested": contract_non_allowance_requested,
+        }
+        response = client.get(self.url, query_params)
+
+        assert response.status_code == 200
+        contracts_in_page = response.context["contracts_page"].object_list
+        for key in expected_in:
+            assert contratcs_map[key] in contracts_in_page
+        for key in expected_not_in:
+            assert contratcs_map[key] not in contracts_in_page


### PR DESCRIPTION
…tracts

## :thinking: Pourquoi ?

Les contrats GEIQ sont importés sur des périodes très larges, ce qui rend la sélection difficile pour les utilisateurs (GEIQ) lors de l'établissement du bilan.
L'objectif est d'améliorer l'expérience utilisateur en permettant de filtrer les contrats par "aide demandée".
Réf : [carte notion refonte](https://www.notion.so/gip-inclusion/Filtres-contrats-GEIQ-3285f321b604802ca1e3f6743af31923) + [description du filtre](https://www.notion.so/gip-inclusion/2845f321b60480348f9bc3c2c5fdf002?v=2845f321b60480bd9ef6000c92a2d6ab&p=2ff5f321b60480bdb3b6c4d07dbc502b&pm=s)
## :cake: Comment ? <!-- optionnel -->

- Utilisation d'HTMX pour mettre à jour la liste des contrats

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

1. Se connecter en tant que GEIQ 
2. Aller sur "Bilan d'exécution"
3. Cliquer sur le bilan d'exécution qui s'affiche s'il y en a, sinon le créer
4. Dans la partie "Détail et sélection des contrats", cliquer sur "Consulter la sélection" qui vous redirige sur geiq-assessments/[uid]/contracts.
5. Appliquer le filtre "Aide demandée" : vérifier la surbrillance du filtre et l'apparition du bouton "Tout effacer".
6. Observer l'indicateur de loading lors du rafraîchissement HTMX.
7. Vérifier que les statistiques globales en haut de page ne changent pas lors du filtrage de la liste.
8. Vérifier que le compteur de résultat se met bien à jour de façon dynamique

## :computer: Captures d'écran <!-- optionnel -->
<img width="473" height="906" alt="image" src="https://github.com/user-attachments/assets/522d1e09-f4c4-4889-ab09-0bac4f9907b0" />

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
