### PR TITLE
Insertion : Ajout d'une page de visualisation d'une structure d'insertion

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -89,6 +89,7 @@ urlpatterns = [
     path("prescribers/", include("itou.www.prescribers_views.urls")),
     path("search/", include("itou.www.search_views.urls")),
     path("company/", include("itou.www.companies_views.urls")),
+    path("insertion/", include("itou.www.insertion_views.urls")),
     re_path(r"^siae/.*$", redirect_legacy_views.redirect_siaes_views),
     path("siae_evaluation/", include("itou.www.siae_evaluations_views.urls")),
     path("login/", include("itou.www.login.urls")),

--- a/itou/insertion/models.py
+++ b/itou/insertion/models.py
@@ -37,6 +37,17 @@ class GeolocatedAddressMixin(models.Model):
 
     coordinates = gis_models.PointField(geography=True, null=True, blank=True)
 
+    @property
+    def address_on_one_line(self):
+        if not all([self.address_line_1, self.post_code, self.city]):
+            return None
+        fields = [
+            self.address_line_1,
+            self.address_line_2,
+            f"{self.post_code} {self.city}",
+        ]
+        return ", ".join(field for field in fields if field)
+
     class Meta:
         abstract = True
 

--- a/itou/templates/insertion/structure_card.html
+++ b/itou/templates/insertion/structure_card.html
@@ -1,0 +1,111 @@
+{% extends "layout/base.html" %}
+
+{% load components %}
+{% load format_filters %}
+{% load markdownify %}
+{% load matomo %}
+{% load static %}
+
+
+{% block title %}{{ structure.name }} {{ block.super }}{% endblock %}
+
+{% block canonical %}
+    {% if structure.source.value == "dora" and structure.source_link %}
+        <link rel="canonical" href="{{ structure.source_link }}">
+    {% endif %}
+{% endblock %}
+
+{% block title_navinfo %}
+    {% component_navinfo c_navinfo__back_url=back_url %}
+    {% endcomponent_navinfo %}
+{% endblock %}
+
+{% block title_content %}
+    {% component_title c_title__main=c_title__main %}
+        {% fragment as c_title__main %}
+            <h1>{{ structure.name }}</h1>
+        {% endfragment %}
+    {% endcomponent_title %}
+{% endblock %}
+
+{% block content %}
+    <section class="s-section">
+        <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                    <div class="c-box">
+                        <article>
+                            <h3>Présentation de la structure</h3>
+                            {{ structure.description|markdownify }}
+                        </article>
+                    </div>
+                </div>
+                <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2">
+                    <div class="c-box mb-3 mb-md-4">
+                        <h3>Informations pratiques</h3>
+                        <button class="btn btn-secondary btn-block" type="button" data-bs-toggle="modal" data-bs-target="#structure-contact-modal" {% matomo_event "fiche-structure" "clic" "voir-coordonnees-structure" %}>
+                            Voir les coordonnées de la structure
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+{% endblock %}
+
+{% block modals %}
+    <div class="modal fade" id="structure-contact-modal" tabindex="-1" aria-labelledby="structure-contact-modal-label" aria-modal="true" role="dialog">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title" id="structure-contact-modal-label">Coordonnées de contact</h3>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                </div>
+                <div class="modal-body">
+                    {% if structure.address_on_one_line %}
+                        <div class="d-flex">
+                            <i class="ri-map-pin-2-line me-2" aria-hidden="true"></i>
+                            <address class="m-0">{{ structure.address_on_one_line }}</address>
+                        </div>
+                        {% if structure.email or structure.phone or structure.website %}<hr class="my-3">{% endif %}
+                    {% endif %}
+                    {% if structure.email or structure.phone or structure.website %}
+                        <ul class="list-unstyled mb-0">
+                            {% if structure.email %}
+                                <li>
+                                    <i class="ri-mail-line fw-normal me-2" aria-hidden="true"></i>
+                                    <a href="mailto:{{ structure.email }}" aria-label="Contact par mail" class="text-break">{{ structure.email }}</a>
+                                    {% matomo_event "fiche-structure" "clic" "copier-email-contact" as matomo_event_attrs %}
+                                    {% include "includes/copy_to_clipboard.html" with content=structure.email css_classes="btn-link fw-medium ms-1" only_icon=True text="Copier l’adresse e-mail" matomo_event_attrs=matomo_event_attrs %}
+                                </li>
+                            {% endif %}
+                            {% if structure.phone %}
+                                <li>
+                                    <i class="ri-phone-line fw-normal me-2" aria-hidden="true"></i>
+                                    {{ structure.phone|format_phone }}
+                                    {% include 'includes/copy_to_clipboard.html' with content=structure.phone|cut:" " css_classes="btn-link fw-medium ms-1" only_icon=True %}
+                                </li>
+                            {% endif %}
+                            {% if structure.website %}
+                                <li>
+                                    <i class="ri-global-line fw-normal me-2" aria-hidden="true"></i>
+                                    <a href="{{ structure.website }}"
+                                       rel="noopener noreferrer"
+                                       target="_blank"
+                                       class="btn-link fw-medium has-external-link"
+                                       aria-label="Voir le site web de la structure (ouverture dans un nouvel onglet)"
+                                       {% matomo_event "fiche-structure" "clic" "lien-site-web" %}>
+                                        {{ structure.website }}
+                                    </a>
+                                </li>
+                            {% endif %}
+                        </ul>
+                    {% endif %}
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Terminer</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/itou/templates/layout/base.html
+++ b/itou/templates/layout/base.html
@@ -39,6 +39,7 @@
         <link rel="stylesheet" href="{% static "vendor/easymde/easymde.min.css" %}">
         <link rel="stylesheet" href="{% static "vendor/theme-inclusion/stylesheets/app.css" %}">
         <link rel="stylesheet" href="{% static "css/itou.css" %}">
+        {% block canonical %}{% endblock %}
     </head>
     <body class="{% if user.is_authenticated %}l-authenticated {% endif %}{% block body_class %}{% endblock %}">
         <noscript>

--- a/itou/utils/templatetags/format_filters.py
+++ b/itou/utils/templatetags/format_filters.py
@@ -22,10 +22,17 @@ def format_phone(phone_number):
     Usage:
         {% load format_filters %}
         {{ user.phone|format_phone }}
+
+    French E.164 numbers (+33 …) are shown in national form (leading 0).
     """
     if not phone_number:
         return ""
-    return " ".join(wrap(phone_number, 2))
+    normalized = phone_number.strip()
+    if normalized.startswith("+33"):
+        rest = re.sub(r"\D", "", normalized[3:])
+        if rest:
+            normalized = f"0{rest}"
+    return " ".join(wrap(normalized, 2))
 
 
 @register.filter

--- a/itou/www/insertion_views/urls.py
+++ b/itou/www/insertion_views/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from itou.www.insertion_views import views
+
+
+app_name = "insertion_views"
+
+urlpatterns = [
+    path("structure/<str:structure_uid>/card", views.StructureCardView.as_view(), name="structure_card"),
+]

--- a/itou/www/insertion_views/views.py
+++ b/itou/www/insertion_views/views.py
@@ -1,0 +1,32 @@
+from django.db.models import Prefetch
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.views.generic.base import TemplateView
+
+from itou.insertion.models import Service, Structure
+from itou.utils.auth import LoginNotRequiredMixin
+from itou.utils.readonly import ReadonlyViewMixin
+from itou.utils.urls import get_safe_url
+
+
+class StructureCardView(LoginNotRequiredMixin, ReadonlyViewMixin, TemplateView):
+    template_name = "insertion/structure_card.html"
+
+    def setup(self, request, structure_uid, *args, **kwargs):
+        super().setup(request, *args, **kwargs)
+        self.structure = get_object_or_404(
+            Structure.objects.select_related("source").prefetch_related(
+                Prefetch(
+                    "services",
+                    queryset=Service.objects.order_by("name").select_related("kind"),
+                ),
+            ),
+            uid=structure_uid,
+        )
+
+    def get_context_data(self, **kwargs):
+        return super().get_context_data(**kwargs) | {
+            "structure": self.structure,
+            "matomo_custom_title": "Fiche structure d’insertion",
+            "back_url": get_safe_url(self.request, "back_url", fallback_url=reverse("home:hp")),
+        }

--- a/tests/insertion/factories.py
+++ b/tests/insertion/factories.py
@@ -1,0 +1,25 @@
+import factory
+from django.utils import timezone
+
+from itou.insertion.models import GenericReferenceItem, GenericReferenceItemKind, GenericReferenceItemSource, Structure
+
+
+class GenericReferenceItemFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = GenericReferenceItem
+
+    source = GenericReferenceItemSource.DATA_INCLUSION
+    kind = GenericReferenceItemKind.SOURCE
+    value = factory.Sequence(lambda n: f"source-{n}")
+    label = factory.Faker("word", locale="fr_FR")
+
+
+class StructureFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Structure
+
+    uid = factory.Sequence(lambda n: f"structure-uid-{n}")
+    source = factory.SubFactory(GenericReferenceItemFactory)
+    name = factory.Faker("company", locale="fr_FR")
+    description = factory.Faker("paragraph", locale="fr_FR")
+    updated_on = factory.LazyFunction(timezone.localdate)

--- a/tests/insertion/test_models.py
+++ b/tests/insertion/test_models.py
@@ -1,0 +1,72 @@
+import pytest
+
+from tests.insertion.factories import StructureFactory
+
+
+@pytest.mark.no_django_db
+@pytest.mark.parametrize(
+    "address_kwargs,expected",
+    [
+        pytest.param(
+            {
+                "address_line_1": "12 rue des terreaux",
+                "address_line_2": "Bât. B",
+                "post_code": "38110",
+                "city": "La Tour du Pin",
+            },
+            "12 rue des terreaux, Bât. B, 38110 La Tour du Pin",
+            id="complete_address",
+        ),
+        pytest.param(
+            {
+                "address_line_1": "12 rue des terreaux",
+                "address_line_2": "",
+                "post_code": "38110",
+                "city": "La Tour du Pin",
+            },
+            "12 rue des terreaux, 38110 La Tour du Pin",
+            id="without_address_line_2",
+        ),
+    ],
+)
+def test_address_on_one_line(address_kwargs, expected):
+    structure = StructureFactory.build(**address_kwargs)
+    assert structure.address_on_one_line == expected
+
+
+@pytest.mark.no_django_db
+@pytest.mark.parametrize(
+    "address_kwargs",
+    [
+        pytest.param(
+            {
+                "address_line_1": "",
+                "address_line_2": "Bât. B",
+                "post_code": "38110",
+                "city": "La Tour du Pin",
+            },
+            id="missing_address_line_1",
+        ),
+        pytest.param(
+            {
+                "address_line_1": "12 rue des terreaux",
+                "address_line_2": "Bât. B",
+                "post_code": "",
+                "city": "La Tour du Pin",
+            },
+            id="missing_post_code",
+        ),
+        pytest.param(
+            {
+                "address_line_1": "12 rue des terreaux",
+                "address_line_2": "Bât. B",
+                "post_code": "38110",
+                "city": "",
+            },
+            id="missing_city",
+        ),
+    ],
+)
+def test_address_on_one_line_incomplete_returns_none(address_kwargs):
+    structure = StructureFactory.build(**address_kwargs)
+    assert structure.address_on_one_line is None

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -870,6 +870,8 @@ class TestUtilsTemplateFilters:
         """Test `format_phone` template filter."""
         assert format_filters.format_phone("") == ""
         assert format_filters.format_phone("0102030405") == "01 02 03 04 05"
+        assert format_filters.format_phone("+33612345678") == "06 12 34 56 78"
+        assert format_filters.format_phone("+33 6 12 34 56 78") == "06 12 34 56 78"
 
     def test_get_dict_item(self):
         """Test `get_dict_item` template filter."""

--- a/tests/www/structures_views/__snapshots__/test_views.ambr
+++ b/tests/www/structures_views/__snapshots__/test_views.ambr
@@ -1,0 +1,177 @@
+# serializer version: 1
+# name: test_card_view_anonymous_renders_description_tab
+  dict({
+    'num_queries': 2,
+    'queries': list([
+      dict({
+        'origin': list([
+          'StructureCardView.setup[www/insertion_views/views.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "insertion_structure"."id",
+                 "insertion_structure"."address_line_1",
+                 "insertion_structure"."address_line_2",
+                 "insertion_structure"."post_code",
+                 "insertion_structure"."city",
+                 "insertion_structure"."insee_city_id",
+                 "insertion_structure"."coordinates",
+                 "insertion_structure"."uid",
+                 "insertion_structure"."source_id",
+                 "insertion_structure"."source_link",
+                 "insertion_structure"."siret",
+                 "insertion_structure"."name",
+                 "insertion_structure"."description",
+                 "insertion_structure"."website",
+                 "insertion_structure"."email",
+                 "insertion_structure"."phone",
+                 "insertion_structure"."updated_on",
+                 "insertion_structure"."created_at",
+                 "insertion_structure"."updated_at",
+                 "insertion_genericreferenceitem"."id",
+                 "insertion_genericreferenceitem"."source",
+                 "insertion_genericreferenceitem"."kind",
+                 "insertion_genericreferenceitem"."value",
+                 "insertion_genericreferenceitem"."label",
+                 "insertion_genericreferenceitem"."description",
+                 "insertion_genericreferenceitem"."created_at",
+                 "insertion_genericreferenceitem"."updated_at"
+          FROM "insertion_structure"
+          INNER JOIN "insertion_genericreferenceitem" ON ("insertion_structure"."source_id" = "insertion_genericreferenceitem"."id")
+          WHERE "insertion_structure"."uid" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'StructureCardView.setup[www/insertion_views/views.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "insertion_service"."id",
+                 "insertion_service"."address_line_1",
+                 "insertion_service"."address_line_2",
+                 "insertion_service"."post_code",
+                 "insertion_service"."city",
+                 "insertion_service"."insee_city_id",
+                 "insertion_service"."coordinates",
+                 "insertion_service"."uid",
+                 "insertion_service"."source_id",
+                 "insertion_service"."source_link",
+                 "insertion_service"."structure_id",
+                 "insertion_service"."name",
+                 "insertion_service"."description",
+                 "insertion_service"."description_short",
+                 "insertion_service"."kind_id",
+                 "insertion_service"."fee_id",
+                 "insertion_service"."fee_details",
+                 "insertion_service"."publics_details",
+                 "insertion_service"."access_conditions_di",
+                 "insertion_service"."access_conditions_dora",
+                 "insertion_service"."mobilizations_details",
+                 "insertion_service"."mobilization_modes_beneficiaries_external_form_link",
+                 "insertion_service"."mobilization_modes_beneficiaries_external_form_link_text",
+                 "insertion_service"."mobilization_modes_beneficiaries_other",
+                 "insertion_service"."mobilization_modes_professionals_external_form_link",
+                 "insertion_service"."mobilization_modes_professionals_external_form_link_text",
+                 "insertion_service"."mobilization_modes_professionals_other",
+                 "insertion_service"."credentials",
+                 "insertion_service"."credentials_documents",
+                 "insertion_service"."credentials_online_form",
+                 "insertion_service"."opening_hours",
+                 "insertion_service"."opening_hours_text",
+                 "insertion_service"."contact_full_name",
+                 "insertion_service"."contact_email",
+                 "insertion_service"."contact_phone",
+                 "insertion_service"."contact_is_public",
+                 "insertion_service"."is_orientable_with_form",
+                 "insertion_service"."average_orientation_response_delay_days",
+                 "insertion_service"."dora_synced_at",
+                 "insertion_service"."updated_on",
+                 "insertion_service"."created_at",
+                 "insertion_service"."updated_at",
+                 "insertion_genericreferenceitem"."id",
+                 "insertion_genericreferenceitem"."source",
+                 "insertion_genericreferenceitem"."kind",
+                 "insertion_genericreferenceitem"."value",
+                 "insertion_genericreferenceitem"."label",
+                 "insertion_genericreferenceitem"."description",
+                 "insertion_genericreferenceitem"."created_at",
+                 "insertion_genericreferenceitem"."updated_at"
+          FROM "insertion_service"
+          LEFT OUTER JOIN "insertion_genericreferenceitem" ON ("insertion_service"."kind_id" = "insertion_genericreferenceitem"."id")
+          WHERE "insertion_service"."structure_id" IN (%s)
+          ORDER BY "insertion_service"."name" ASC
+        ''',
+      }),
+    ]),
+  })
+# ---
+# name: test_card_view_contact_modal_contains_structure_coordinates
+  '''
+  <div aria-labelledby="structure-contact-modal-label" aria-modal="true" class="modal fade" id="structure-contact-modal" role="dialog" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+              <div class="modal-header">
+                  <h3 class="modal-title" id="structure-contact-modal-label">
+                      Coordonnées de contact
+                  </h3>
+                  <button aria-label="Fermer" class="btn-close" data-bs-dismiss="modal" type="button">
+                  </button>
+              </div>
+              <div class="modal-body">
+                  <div class="d-flex">
+                      <i aria-hidden="true" class="ri-map-pin-2-line me-2">
+                      </i>
+                      <address class="m-0">
+                          10 rue de la Paix, 75002 Paris
+                      </address>
+                  </div>
+                  <hr class="my-3"/>
+                  <ul class="list-unstyled mb-0">
+                      <li>
+                          <i aria-hidden="true" class="ri-mail-line fw-normal me-2">
+                          </i>
+                          <a aria-label="Contact par mail" class="text-break" href="mailto:contact@structure.test">
+                              contact@structure.test
+                          </a>
+                          <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="contact@structure.test" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="copier-email-contact" type="button">
+                              <i aria-hidden="true" class="ri-file-copy-line fw-normal">
+                              </i>
+                              <span class="visually-hidden">
+                                  Copier l’adresse e-mail
+                              </span>
+                          </button>
+                      </li>
+                      <li>
+                          <i aria-hidden="true" class="ri-phone-line fw-normal me-2">
+                          </i>
+                          01 02 03 04 05
+                          <button class="btn-link fw-medium ms-1" data-bs-placement="top" data-bs-title="Copié !" data-bs-toggle="tooltip" data-bs-trigger="manual" data-it-clipboard-button="copy" data-it-copy-to-clipboard="+33102030405" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="copier-email-contact" type="button">
+                              <i aria-hidden="true" class="ri-file-copy-line fw-normal">
+                              </i>
+                              <span class="visually-hidden">
+                                  Copier
+                              </span>
+                          </button>
+                      </li>
+                      <li>
+                          <i aria-hidden="true" class="ri-global-line fw-normal me-2">
+                          </i>
+                          <a aria-label="Voir le site web de la structure (ouverture dans un nouvel onglet)" class="btn-link fw-medium has-external-link" data-matomo-action="clic" data-matomo-category="fiche-structure" data-matomo-event="true" data-matomo-option="lien-site-web" href="https://structure.test" rel="noopener noreferrer" target="_blank">
+                              https://structure.test
+                          </a>
+                      </li>
+                  </ul>
+              </div>
+              <div class="modal-footer">
+                  <button class="btn btn-primary" data-bs-dismiss="modal" type="button">
+                      Terminer
+                  </button>
+              </div>
+          </div>
+      </div>
+  </div>
+  
+  '''
+# ---

--- a/tests/www/structures_views/test_views.py
+++ b/tests/www/structures_views/test_views.py
@@ -1,0 +1,69 @@
+from django.conf import settings
+from django.urls import reverse
+from itoutils.django.testing import assertSnapshotQueries
+from pytest_django.asserts import assertContains, assertNotContains, assertTemplateUsed
+
+from itou.insertion.models import SOURCE_DORA_VALUE, GenericReferenceItemKind, GenericReferenceItemSource
+from tests.insertion.factories import GenericReferenceItemFactory, StructureFactory
+from tests.utils.testing import parse_response_to_soup, pretty_indented
+
+
+def test_card_view_anonymous_renders_description_tab(client, snapshot):
+    structure = StructureFactory(
+        name="Structure test",
+        description="Description de test",
+        source=GenericReferenceItemFactory(
+            source=GenericReferenceItemSource.DATA_INCLUSION,
+            kind=GenericReferenceItemKind.SOURCE,
+            value=SOURCE_DORA_VALUE,
+        ),
+        source_link=f"{settings.DORA_WWW_BASE_URL}/structures/structure-test",
+    )
+    with assertSnapshotQueries(snapshot):
+        response = client.get(reverse("insertion_views:structure_card", kwargs={"structure_uid": structure.uid}))
+
+    assert response.context["structure"] == structure
+    assertTemplateUsed(response, "insertion/structure_card.html")
+    assertContains(response, "Structure test")
+    assertContains(response, "Présentation de la structure")
+    assertContains(response, "Description de test")
+    assertContains(
+        response,
+        f'<link rel="canonical" href="{settings.DORA_WWW_BASE_URL}/structures/structure-test">',
+        html=True,
+    )
+
+
+def test_card_view_non_dora_source_has_no_canonical(client):
+    structure = StructureFactory(
+        source=GenericReferenceItemFactory(
+            source=GenericReferenceItemSource.DATA_INCLUSION,
+            kind=GenericReferenceItemKind.SOURCE,
+            value="other",
+        ),
+        source_link="https://example.com/structures/structure-test",
+    )
+    response = client.get(reverse("insertion_views:structure_card", kwargs={"structure_uid": structure.uid}))
+
+    assertNotContains(response, 'rel="canonical"', html=True)
+
+
+def test_card_view_not_found(client):
+    response = client.get(reverse("insertion_views:structure_card", kwargs={"structure_uid": "unknown-uid"}))
+
+    assert response.status_code == 404
+
+
+def test_card_view_contact_modal_contains_structure_coordinates(client, snapshot):
+    structure = StructureFactory(
+        email="contact@structure.test",
+        phone="+33102030405",
+        address_line_1="10 rue de la Paix",
+        post_code="75002",
+        city="Paris",
+        website="https://structure.test",
+    )
+    response = client.get(reverse("insertion_views:structure_card", kwargs={"structure_uid": structure.uid}))
+
+    modal = parse_response_to_soup(response, selector="#structure-contact-modal")
+    assert pretty_indented(modal) == snapshot


### PR DESCRIPTION

## :thinking: Pourquoi ?

Ajout d'une page de visualisation d'une structure d'insertion.

## :cake: Comment ?

Implémentation basée sur un [design Figma](https://www.figma.com/design/xcU6Mp4qiijbpTdwV416ON/MER---Prescripteur?node-id=2079-2964&p=f&t=xZEHtdAdbEPSVKU6-0).

:warning: Pour le moment, on n'implémente que l'affichage de la description. Les onglets et la liste des services sera implémentée une fois la fiche service implémentée.

- Mutualisation de la fonction de formatage d'adresse sur une ligne ;
- Conversion des numéros de téléphone français au format E.164 (+33...) vers le format national (0...) ;
- Création de la vue dans `itou/www/insertion_views/views.py` ;
- Création du gabarit `itou/templates/insertion/structure_card.html`.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

1. Importer les données des offres d'insertion avec la commande `import_structures_and_services` ;
2. Aller sur la page d'une structure, par exemple : http://localhost:8000/insertion/structure/soliguide--9997/card.

Exemples de page structure sur la recette jetable :
- https://c1-review-ggounot-fiche-structure.cleverapps.io/insertion/structure/soliguide--9997/card

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
