### PR TITLE
Tech : Configuration d'une période de "cooldown" pour Dependabot (pour les paquets Python)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/requirements/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+    cooldown:
+      default-days: 5
     commit-message:
       prefix: "requirement"
       prefix-development: "dev requirement"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce que je suis un boulet et que je n'ai fait que la moitié du boulot dans le commit cc954330a046b417b6624a668, qui ne change que la configuration des actions GitHub...