### PR TITLE
API : Documenter que `lien_cv` est déprécié dans l'API candidats

### DIFF
--- a/itou/api/applicants_api/views.py
+++ b/itou/api/applicants_api/views.py
@@ -79,6 +79,9 @@ la ou les structure(s) sélectionnée(s).
 Les candidats sont triés par date de création dans la base des emplois de l'inclusion,
 du plus récent au plus ancien.
 
+**Note** : la clé `lien_cv` est dépréciée et associée à une valeur vide. Elle est conservée pour
+des raisons de compatibilité.
+
 # Permissions
 
 L'utilisation de cette API nécessite un jeton d'autorisation (`token`) :


### PR DESCRIPTION
## :thinking: Pourquoi ?

J'ai à plusieurs reprises dû expliquer cela, l'info n'étant pas dans la documentation.

(et j'ai promis cette modification à un utilisateur de l'API)
