### PR TITLE
Interface: Redesign notification lors du hijack/détournement

### DIFF
--- a/itou/static/js/hijack_hide.js
+++ b/itou/static/js/hijack_hide.js
@@ -1,6 +1,16 @@
 "use strict";
-$(document).ready(() => {
-  $(document).on("click", "#hide-btn", function(){
-    document.getElementById('djhj').style.display = 'none'
+
+function ready(fn) {
+  if (document.readyState !== 'loading') {
+    fn();
+  } else {
+    document.addEventListener('DOMContentLoaded', fn);
+  }
+}
+
+ready(() => {
+  const hideButton = document.getElementById("hide-btn")
+  hideButton.addEventListener("click", function (event) {
+    document.getElementById("djhj").style.display = "none"
   })
-})
+});

--- a/itou/templates/hijack/notification.html
+++ b/itou/templates/hijack/notification.html
@@ -1,21 +1,26 @@
 {% load i18n %}
 {% load static %}
 <!-- hijack/notification.html -->
-<link rel="stylesheet" href="{% static 'hijack/hijack.css' %}" media="screen">
-<div class="djhj" id="djhj">
-    <div class="djhj-notification">
-        <div class="djhj-message">
-            {% blocktrans trimmed with user=request.user %}
-                You are currently working on behalf of <em>{{ user }}</em>.
-            {% endblocktrans %}
-        </div>
-        <form action="{% url 'hijack:release' %}" method="post" class="djhj-actions">
+<div id="djhj" class="position-fixed z-3 bottom-0 start-50 translate-middle-x shadow mb-3">
+    <div class="alert bg-warning-lightest border-1 border-warning mb-0">
+        <p class="text-warning">
+            Connecté en tant que
+            <b>{{ user.first_name }} {{ user.last_name|upper }}</b>, <em>{{ user.kind }}</em>, pk=<span class="font-monospace">{{ user.pk }}</span>
+        </p>
+        <form action="{% url 'hijack:release' %}" method="post" class="text-end">
             {% csrf_token %}
             <input type="hidden" name="next" value="{{ request.path }}">
-            <button id="hide-btn" class="djhj-button" type="button">{% trans 'hide' %}</button>
-            <button class="djhj-button">{% trans 'release' %}</button>
+            <div class="btn-group btn-group-action btn-group-sm align-items-end" role="group" aria-label="Actions rapides">
+                <button class="btn btn-ico btn-warning" type="submit">
+                    <i class="ri-logout-circle-r-line" aria-hidden="true"></i>
+                    <span>{% trans 'release'|title %}</span>
+                </button>
+                <button class="btn btn-ico-only btn-warning" type="button" id="hide-btn" aria-label="{% trans 'hide'|title %}">
+                    <i class="ri-close-fill" aria-hidden="true"></i>
+                    <span class="visually-hidden">{% trans 'hide'|title %}</span>
+                </button>
+            </div>
         </form>
     </div>
 </div>
-
 <script src="{% static "js/hijack_hide.js" %}"></script>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La boîte de notification par défaut de Django Hijack est triste et prend beaucoup d'espace en hauteur pour finalement n'afficher pas grand-chose d'indispensable à l'exception des boutons `Hide` et `Release`.


## :cake: Comment ?

- Modification du [template pour la notification](https://django-hijack.readthedocs.io/en/latest/customization/#notification-layout) `itou/templates/hijack/notification.html` et ajout d'un fichier CSS.
	- Affichage des prénom et nom de l'utilisateur dont on détourne le compte, en plus du type et de la `pk`.
	- Icônes pour les deux boutons, dont l'ordre est inversé, afin de mettre la croix (`Hide`) à droite, par convention. J'apprends au passage qu'on se sert de [Remix Icon](https://remixicon.com/) (?).
	- Hauteur réduite.
	- Texte raccourci. Seulement pour le français car des traductions existent dans Django Hijack, donc au cas où. M'enfin on pourrait bien ne laisser que le français, je suppose.
- Modification de `itou/static/js/hijack_hide.js` afin que la fermeture de la notification ne nécessite plus jQuery.
	- Rend a priori possible de cacher la notification aussi sur les templates qui héritent de `base_printable.html` (qui ne charge pas jQuery).
	- A-t-on même vraiment besoin d'un script externe ?


## 🤨 Pistes d'amélioration

1. Je réalise qu'on utilise en fait des alertes sur le site, donc la notification, même si elle est en survol, peut passer pour un élément classique de l'UI ce qui atténue un peu l'effet _alerte_. Je pense que la notification doit être visuellement assez distincte du reste de la page, voire bizarre, et toujours visible (position `fixed`), légèrement gênante, afin que l'utilisateur qui détourne un compte ait toujours à l'esprit qu'il a (potentiellement) de grandes responsabilités.
<img width="806" height="285" alt="Capture d’écran 2026-04-10 à 12 53 01" src="https://github.com/user-attachments/assets/11e9b2f0-ccfa-467a-b497-6fc9a28da2fe" />


2. Ajouter un badge `PROD` ou `DEV` afin de rappeler que le détournement a lieu en production, pour plus de sécurité ?

Mon inspiration (??) étant :
<img width="546" height="62" alt="Capture d’écran 2026-04-10 à 12 51 46" src="https://github.com/user-attachments/assets/98cf6f0a-8fbe-4263-a102-b6f525809aea" />

3. Les tooltips au survol des icônes n'apparaissent pas lorsqu'on se trouve sur l'accueil (`dashboard`).

4. On pourrait garder la couleur rouge du bandeau de changement de compte. D'ailleurs j'aime bien l'idée d'en faire un bandeau, mais toujours afin de rendre la notification un peu _dérangeante_, c'est peut-être mieux qu'elle reste fixée en survol sur la page (alors le bandeau se cache automatiquement lorsqu'on scroll).

## :computer: Captures d'écran <!-- optionnel -->

AVANT :
<img width="594" height="167" alt="Capture d’écran 2026-04-10 à 12 27 56" src="https://github.com/user-attachments/assets/c3b77484-8af4-49d5-89e5-9d97b3b92e1c" />

APRÈS :
<img width="564" height="105" alt="Capture d’écran 2026-04-10 à 12 29 02" src="https://github.com/user-attachments/assets/0e745a32-2cf0-48ba-883d-fd1544c30065" />
