### PR TITLE
Inscription: Les entreprises sans membre actif ne sont plus proposées lors la recherche via SIREN

### DIFF
--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -45,7 +45,7 @@
                         </form>
                     </div>
 
-                    {% if siren_form.cleaned_data and not companies_without_members and not companies_with_members %}
+                    {% if siren_form.cleaned_data and not companies_without_active_members and not companies_with_active_members %}
                         {% component_alert content=content variant="warning" extra_classes="mt-3 mt-md-4" %}
                             {% fragment as content %}
                                 <p class="mb-0">
@@ -92,9 +92,11 @@
                     {% endif %}
 
 
-                    {% if companies_without_members and company_select_form %}
+                    {% if companies_without_active_members and company_select_form %}
                         <div class="c-form mt-3 mt-md-5">
-                            <h3 class="mb-1">{{ companies_without_members|pluralizefr:"Entreprise disponible,Entreprises disponibles" }}</h3>
+                            <h3 class="mb-1">
+                                {{ companies_without_active_members|pluralizefr:"Entreprise disponible,Entreprises disponibles" }}
+                            </h3>
                             <p>Les données sont fournies par la DGEFP et l’extranet IAE 2.0 de l’ASP.</p>
 
                             <form method="post" class="js-prevent-multiple-submit">
@@ -111,17 +113,17 @@
                             label is to manually render the inputs.
                                 {% endcomment %}
                                 <ul class="list-group list-group-flush">
-                                    {% for siae in companies_without_members %}
+                                    {% for company in companies_without_active_members %}
                                         <li class="list-group-item list-group-item-action">
-                                            <input class="form-check-input me-1" type="radio" name="{{ company_select_form.siaes.html_name }}" value="{{ siae.pk }}" id="id_{{ company_select_form.siaes.html_name }}_{{ forloop.counter0 }}" required>
+                                            <input class="form-check-input me-1" type="radio" name="{{ company_select_form.siaes.html_name }}" value="{{ company.pk }}" id="id_{{ company_select_form.siaes.html_name }}_{{ forloop.counter0 }}" required>
                                             <label class="form-check-label" for="id_{{ company_select_form.siaes.html_name }}_{{ forloop.counter0 }}">
-                                                <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
+                                                <b>{{ company.siren }} {{ company.siret_nic }}</b> - {{ company.kind }}
                                                 <br>
-                                                {{ siae.display_name }}
+                                                {{ company.display_name }}
                                                 <br>
-                                                {{ siae.address_line_1 }},
-                                                {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
-                                                {{ siae.post_code }} {{ siae.city }}
+                                                {{ company.address_line_1 }},
+                                                {% if company.address_line_2 %}{{ company.address_line_2 }},{% endif %}
+                                                {{ company.post_code }} {{ company.city }}
                                             </label>
                                         </li>
                                     {% endfor %}
@@ -146,32 +148,32 @@
                     {% endif %}
 
 
-                    {% if companies_with_members %}
+                    {% if companies_with_active_members %}
                         <div class="c-form mt-3 mt-md-5">
-                            <h3 class="mb-1">{{ companies_with_members|pluralizefr:"Entreprise déjà inscrite,Entreprises déjà inscrites" }}</h3>
+                            <h3 class="mb-1">
+                                {{ companies_with_active_members|pluralizefr:"Entreprise déjà inscrite,Entreprises déjà inscrites" }}
+                            </h3>
                             <p>
-                                Par mesure de sécurité, seuls les membres déjà inscrits dans {{ companies_with_members|pluralizefr:"cette structure,ces structures" }} peuvent ajouter de nouveaux collaborateurs.
+                                Par mesure de sécurité, seuls les membres déjà inscrits dans {{ companies_with_active_members|pluralizefr:"cette structure,ces structures" }} peuvent ajouter de nouveaux collaborateurs.
                             </p>
 
                             <ul class="list-group list-group-flush">
-                                {% for siae in companies_with_members %}
+                                {% for company in companies_with_active_members %}
                                     <li class="list-group-item">
                                         <p class="mb-0">
-                                            <b>{{ siae.siren }} {{ siae.siret_nic }}</b> - {{ siae.kind }}
+                                            <b>{{ company.siren }} {{ company.siret_nic }}</b> - {{ company.kind }}
                                         </p>
                                         <p>
-                                            {{ siae.display_name }}
+                                            {{ company.display_name }}
                                             <br>
-                                            {{ siae.address_line_1 }},
-                                            {% if siae.address_line_2 %}{{ siae.address_line_2 }},{% endif %}
-                                            {{ siae.post_code }} {{ siae.city }}
+                                            {{ company.address_line_1 }},
+                                            {% if company.address_line_2 %}{{ company.address_line_2 }},{% endif %}
+                                            {{ company.post_code }} {{ company.city }}
                                         </p>
                                         <p class="mb-0">
-                                            {# note: memberships.first does not work, it does not take the prefetch into account. #}
-                                            {% with siae.memberships.all.0.user as admin %}
-                                                {# For security, display only the first char of the last name. #}
-                                                Pour rejoindre cette structure, <b>veuillez contacter {{ admin.get_truncated_full_name }}</b>
-                                            {% endwith %}
+                                            {# Memberships.first does not work, it does not take the prefetch into account. #}
+                                            {# For security, display only the first char of the last name. #}
+                                            Pour rejoindre cette structure, <b>veuillez contacter {{ company.memberships.all.0.user.get_truncated_full_name }}</b>
                                         </p>
                                     </li>
                                 {% endfor %}
@@ -180,7 +182,7 @@
                     {% endif %}
 
 
-                    {% if companies_without_members or companies_with_members %}
+                    {% if companies_without_active_members or companies_with_active_members %}
                         <div class="mt-3 mt-md-4 text-end">
                             <p>
                                 En cas de problème, <a href="{{ ITOU_HELP_CENTER_URL }}"  class="has-external-link" target="_blank" rel="noopener" aria-label="{{ ITOU_HELP_CENTER_URL }} (ouverture dans un nouvel onglet)">contactez-nous</a>.

--- a/itou/templates/signup/company_select.html
+++ b/itou/templates/signup/company_select.html
@@ -124,6 +124,10 @@
                                                 {{ company.address_line_1 }},
                                                 {% if company.address_line_2 %}{{ company.address_line_2 }},{% endif %}
                                                 {{ company.post_code }} {{ company.city }}
+                                                <br>
+                                                {% if not company.auth_email %}
+                                                    <i>Cette organisation n'a pas de membre. Si vous souhaitez la rejoindre, veuillez <a href="{% zendesk_form_url request=request %}" target="_blank" rel="noopener" class="has-external-link">contacter notre support technique</a>.</i>
+                                                {% endif %}
                                             </label>
                                         </li>
                                     {% endfor %}

--- a/itou/templates/signup/includes/prescriber_card.html
+++ b/itou/templates/signup/includes/prescriber_card.html
@@ -1,4 +1,5 @@
 {% load format_filters %}
+{% load support %}
 <div class="card my-4">
     <div class="card-body">
         <h3 class="h2 card-title">
@@ -32,7 +33,7 @@
                 </form>
             {% endwith %}
         {% else %}
-            <i>Cette organisation n'a pas de membre.</i>
+            <i>Cette organisation n'a pas de membre. Si vous souhaitez la rejoindre, veuillez <a href="{% zendesk_form_url request=request %}" target="_blank" rel="noopener" class="has-external-link">contacter notre support technique</a>.</i>
         {% endif %}
     </div>
 </div>

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -18,6 +18,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.http import urlencode
+from django.utils.safestring import mark_safe
 from django.views.decorators.http import require_POST
 from django.views.generic import FormView, TemplateView, View
 
@@ -32,7 +33,7 @@ from itou.utils.auth import LoginNotRequiredMixin
 from itou.utils.legal_terms import bypass_terms_acceptance
 from itou.utils.nav_history import get_prev_url_from_history, push_url_in_history
 from itou.utils.tokens import company_signup_token_generator
-from itou.utils.urls import get_safe_url
+from itou.utils.urls import get_safe_url, get_zendesk_form_url
 from itou.www.signup import forms
 from itou.www.signup.errors import JobSeekerSignupConflictModalResolver
 
@@ -291,16 +292,18 @@ def company_select(request, template_name="signup/company_select.html"):
         if not obfuscated_auth_email:
             messages.error(
                 request,
-                (
-                    "L'adresse e-mail de contact du correspondant de cette structure n'est pas renseignée ou "
-                    "incorrecte. Merci de contacter l’assistance pour continuer l'inscription."
+                mark_safe(
+                    "L’adresse e-mail de contact du gestionnaire de cette structure n’est pas renseignée. Merci de "
+                    f'<a href="{get_zendesk_form_url(request)}" target="_blank" rel="noopener" '
+                    'class="has-external-link">contacter notre support technique</a> afin de poursuivre votre'
+                    "inscription."
                 ),
             )
         else:
             company_selected.new_signup_activation_email_to_official_contact().send()
             message = (
                 f"Nous venons d'envoyer un e-mail à l'adresse {company_selected.obfuscated_auth_email} "
-                f"pour continuer votre inscription. Veuillez consulter votre boite "
+                f"pour poursuivre votre inscription. Veuillez consulter votre boite "
                 f"de réception."
             )
             messages.success(request, message)

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -12,6 +12,7 @@ from django.contrib.auth import REDIRECT_FIELD_NAME, login
 from django.contrib.auth.decorators import login_not_required
 from django.core.exceptions import PermissionDenied
 from django.db import Error, transaction
+from django.db.models import Exists, OuterRef, Prefetch
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -241,13 +242,18 @@ class ChooseMembershipKindView(FormView):
 
 def company_select(request, template_name="signup/company_select.html"):
     """
-    Entry point of the signup process for SIAEs which consists of 2 steps.
+    Entry point of the signup process for companies.
 
-    The user is asked to select an SIAE based on a selection that match a given SIREN number.
+    Registering user is asked to select a company from those matching a given SIREN number.
+    We distinguish between companies with and without active members because:
+    - if a company has no active member, one can register autonomously by selecting (in the form) the company to which
+    an email will be sent (cf. Company.auth_email).
+    - if a company has at least one active member, one can register only by reaching to another member of that company.
+    In the latter case, the template displays the first (admin if any) member of the company as its contact person.
     """
 
-    companies_without_members = None
-    companies_with_members = None
+    companies_without_active_members = None
+    companies_with_active_members = None
 
     next_url = get_safe_url(request, "next")
     data = request.GET.copy()
@@ -258,28 +264,26 @@ def company_select(request, template_name="signup/company_select.html"):
     siren_form = forms.CompanySearchBySirenForm(data=data or None)
     company_select_form = None
 
-    # The SIREN, when available, is always passed in the querystring.
+    # The SIREN, when available, is always passed as a URL parameter.
     if request.method in ["GET", "POST"] and siren_form.is_valid():
-        # Make sure to look only for active structures.
+        # We make admin members (if any) from the company appear at the beginning of the final QuerySet so the contact
+        # person is more likely to be an admin when displaying the results.
+        memberships_qs = CompanyMembership.objects.select_related("user").order_by("-is_admin", "joined_at")
         companies_for_siren = (
+            # Make sure to look only for active companies.
             Company.objects.active()
             .filter(siret__startswith=siren_form.cleaned_data["siren"])
             .exclude(kind__in=[CompanyKind.EA, CompanyKind.EATT])  # Dropping EA/EATT companies support
             .distinct("pk")
+            .annotate(has_active_members=Exists(CompanyMembership.objects.filter(company=OuterRef("pk"))))
+            # Prevents the template from reissuing a request for each member/user.
+            .prefetch_related(Prefetch("memberships", queryset=memberships_qs))
         )
-        # A user cannot join structures that already have members.
-        # Show these structures in the template to make that clear.
-        companies_with_members = (
-            companies_for_siren.exclude(members=None)
-            # the template directly displays the first membership's user "as the admin".
-            # that's why we only select SIAEs that have at least an active admin user.
-            # it should always be the case, but lets enforce it anyway.
-            .filter(memberships__is_admin=True, memberships__is_active=True, memberships__user__is_active=True)
-            # avoid the template issuing requests for every member and user.
-            .prefetch_related("memberships__user")
+        companies_without_active_members = companies_for_siren.filter(has_active_members=False)
+        companies_with_active_members = companies_for_siren.filter(has_active_members=True)
+        company_select_form = forms.CompanySiaeSelectForm(
+            data=request.POST or None, siaes=companies_without_active_members
         )
-        companies_without_members = companies_for_siren.filter(members=None)
-        company_select_form = forms.CompanySiaeSelectForm(data=request.POST or None, siaes=companies_without_members)
 
     if request.method == "POST" and company_select_form and company_select_form.is_valid():
         company_selected = company_select_form.cleaned_data["siaes"]
@@ -304,8 +308,8 @@ def company_select(request, template_name="signup/company_select.html"):
 
     context = {
         "next_url": next_url,
-        "companies_without_members": companies_without_members,
-        "companies_with_members": companies_with_members,
+        "companies_without_active_members": companies_without_active_members,
+        "companies_with_active_members": companies_with_active_members,
         "company_select_form": company_select_form,
         "siren_form": siren_form,
         "prev_url": reverse("signup:choose_pro_membership_kind"),

--- a/tests/www/signup/__snapshots__/test_employer.ambr
+++ b/tests/www/signup/__snapshots__/test_employer.ambr
@@ -1,7 +1,7 @@
 # serializer version: 1
 # name: TestCompanySignup.test_company_select_does_not_die_under_requests
   dict({
-    'num_queries': 14,
+    'num_queries': 13,
     'queries': list([
       dict({
         'origin': list([
@@ -225,9 +225,16 @@
                              "companies_company"."convention_id",
                              "companies_company"."job_app_score",
                              "companies_company"."is_searchable",
-                             "companies_company"."rdv_solidarites_id"
+                             "companies_company"."rdv_solidarites_id",
+                             EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_companymembership" U0
+             INNER JOIN "users_user" U1 ON (U0."user_id" = U1."id")
+             WHERE (U1."is_active"
+                    AND U0."is_active"
+                    AND U0."company_id" = ("companies_company"."id"))
+             LIMIT 1) AS "has_active_members"
           FROM "companies_company"
-          LEFT OUTER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
           WHERE (NOT ("companies_company"."siret" = %s)
                  AND ("companies_company"."kind" IN (%s,
                                                      %s,
@@ -245,7 +252,14 @@
                  AND "companies_company"."siret"::text LIKE %s
                  AND NOT ("companies_company"."kind" IN (%s,
                                                          %s))
-                 AND "companies_companymembership"."user_id" IS NULL)
+                 AND NOT EXISTS
+                   (SELECT %s AS "a"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U1 ON (U0."user_id" = U1."id")
+                    WHERE (U1."is_active"
+                           AND U0."is_active"
+                           AND U0."company_id" = ("companies_company"."id"))
+                    LIMIT 1))
         ''',
       }),
       dict({
@@ -291,10 +305,16 @@
                              "companies_company"."convention_id",
                              "companies_company"."job_app_score",
                              "companies_company"."is_searchable",
-                             "companies_company"."rdv_solidarites_id"
+                             "companies_company"."rdv_solidarites_id",
+                             EXISTS
+            (SELECT %s AS "a"
+             FROM "companies_companymembership" U0
+             INNER JOIN "users_user" U1 ON (U0."user_id" = U1."id")
+             WHERE (U1."is_active"
+                    AND U0."is_active"
+                    AND U0."company_id" = ("companies_company"."id"))
+             LIMIT 1) AS "has_active_members"
           FROM "companies_company"
-          INNER JOIN "companies_companymembership" ON ("companies_company"."id" = "companies_companymembership"."company_id")
-          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
           WHERE (NOT ("companies_company"."siret" = %s)
                  AND ("companies_company"."kind" IN (%s,
                                                      %s,
@@ -312,16 +332,14 @@
                  AND "companies_company"."siret"::text LIKE %s
                  AND NOT ("companies_company"."kind" IN (%s,
                                                          %s))
-                 AND NOT (EXISTS
-                            (SELECT %s AS "a"
-                             FROM "companies_company" U0
-                             LEFT OUTER JOIN "companies_companymembership" U1 ON (U0."id" = U1."company_id")
-                             WHERE (U1."user_id" IS NULL
-                                    AND U0."id" = ("companies_company"."id"))
-                             LIMIT 1))
-                 AND "companies_companymembership"."is_active"
-                 AND "companies_companymembership"."is_admin"
-                 AND "users_user"."is_active")
+                 AND EXISTS
+                   (SELECT %s AS "a"
+                    FROM "companies_companymembership" U0
+                    INNER JOIN "users_user" U1 ON (U0."user_id" = U1."id")
+                    WHERE (U1."is_active"
+                           AND U0."is_active"
+                           AND U0."company_id" = ("companies_company"."id"))
+                    LIMIT 1))
         ''',
       }),
       dict({
@@ -340,29 +358,8 @@
                  "companies_companymembership"."created_at",
                  "companies_companymembership"."updated_at",
                  "companies_companymembership"."company_id",
-                 "companies_companymembership"."updated_by_id"
-          FROM "companies_companymembership"
-          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
-          WHERE ("users_user"."is_active"
-                 AND "companies_companymembership"."is_active"
-                 AND "companies_companymembership"."company_id" IN (%s,
-                                                                    %s,
-                                                                    %s,
-                                                                    %s,
-                                                                    %s,
-                                                                    %s))
-          ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'IfNode[signup/company_select.html]',
-          'BlockNode[layout/base.html]',
-          'ExtendsNode[signup/company_select.html]',
-          'company_select[www/signup/views.py]',
-        ]),
-        'sql': '''
-          SELECT "users_user"."id",
+                 "companies_companymembership"."updated_by_id",
+                 "users_user"."id",
                  "users_user"."password",
                  "users_user"."last_login",
                  "users_user"."is_superuser",
@@ -398,8 +395,18 @@
                  "users_user"."first_login",
                  "users_user"."upcoming_deletion_notified_at",
                  "users_user"."allow_next_sso_sub_update"
-          FROM "users_user"
-          WHERE ("users_user"."id") IN ((%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s), (%s))
+          FROM "companies_companymembership"
+          INNER JOIN "users_user" ON ("companies_companymembership"."user_id" = "users_user"."id")
+          WHERE ("users_user"."is_active"
+                 AND "companies_companymembership"."is_active"
+                 AND "companies_companymembership"."company_id" IN (%s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s,
+                                                                    %s))
+          ORDER BY "companies_companymembership"."is_admin" DESC,
+                   "companies_companymembership"."joined_at" ASC
         ''',
       }),
       dict({

--- a/tests/www/signup/test_employer.py
+++ b/tests/www/signup/test_employer.py
@@ -13,7 +13,7 @@ from itoutils.urls import add_url_params
 from pytest_django.asserts import assertContains, assertMessages, assertNotContains, assertRedirects
 
 from itou.companies.enums import CompanyKind
-from itou.companies.models import Company
+from itou.companies.models import Company, CompanyMembership
 from itou.users.enums import KIND_EMPLOYER, IdentityProvider
 from itou.users.models import User
 from itou.utils import constants as global_constants
@@ -33,18 +33,38 @@ class TestCompanySignup:
             f"{admin_user.first_name.title()} {admin_user.last_name[0].upper()}.</b>"
         )
 
+    @pytest.mark.parametrize(
+        "scenario",
+        ["no_member", "no_active_member"],
+    )
     @freeze_time("2024-09-15 15:53:54")
-    def test_join_a_company_without_members(self, client, mailoutbox):
+    def test_join_an_company_without_active_members(self, client, mailoutbox, pro_connect, scenario):
         """
-        A user joins a company without members.
+        A user joins a company without active members.
+
+        There are two ways for a user to be an inactive member of a company:
+        - as a user (see AbstractUser.is_active).
+        - as a member of a company (see MembershipAbstract.is_active).
+
         """
         user = random_pro_user_factory(identity_provider=IdentityProvider.PRO_CONNECT)
         client.force_login(user)
 
         company = CompanyFactory(kind=CompanyKind.ETTI)
-        assert 0 == company.members.count()
-
+        company_active_members_qs = CompanyMembership.objects.filter(company=company.pk)
         url = reverse("signup:company_select")
+
+        if scenario == "no_member":
+            assert company.members.count() == 0
+        elif scenario == "no_active_member":
+            # Active member but we make the membership inactive.
+            CompanyMembershipFactory(company=company, is_active=False, user__is_active=True)
+            # Active membership but we make the member inactive.
+            CompanyMembershipFactory(company=company, is_active=True, user__is_active=False)
+            assert company.members.count() == 2
+
+        assert company_active_members_qs.count() == 0  # Make sure there is no active user.
+
         response = client.get(url)
         assert response.status_code == 200
 
@@ -78,7 +98,7 @@ class TestCompanySignup:
         user.refresh_from_db()
         assert user.is_active
         assert company.has_admin(user)
-        assert 1 == company.members.count()
+        assert company_active_members_qs.count() == 1  # Make sure there is one active user after registration.
 
         # No new sent email.
         assert len(mailoutbox) == 1
@@ -126,7 +146,7 @@ class TestCompanySignup:
         )
         assert len(mailoutbox) == 0
 
-    def test_join_a_company_with_member(self, client):
+    def test_join_company_with_active_member(self, client):
         user = random_pro_user_factory()
         client.force_login(user)
 
@@ -353,11 +373,25 @@ class TestCompanySignup:
     def test_ignores_inactive_members(self, client):
         user = random_pro_user_factory()
         client.force_login(user)
-
         company = CompanyFactory(siret="40219166200001", with_jobs=True, not_ea_eatt_kind=True)
-        membership = CompanyMembershipFactory.create(company=company, is_active=False)
+        membership_1 = CompanyMembershipFactory(company=company, is_active=False, user__is_active=True)
+        membership_2 = CompanyMembershipFactory(company=company, is_active=True, user__is_active=False)
         response = client.get(reverse("signup:company_select"), {"siren": "402191662"})
-        assertNotContains(response, self.to_join_msg(membership.user))
+        assertNotContains(response, self.to_join_msg(membership_1.user))
+        assertNotContains(response, self.to_join_msg(membership_2.user))
+
+    def test_admin_users_appears_first(self, client):
+        user = random_pro_user_factory()
+        client.force_login(user)
+        company = CompanyFactory(siret="40219166200001", not_ea_eatt_kind=True)
+        membership_1 = CompanyMembershipFactory(company=company, is_admin=False)
+        response = client.get(reverse("signup:company_select"), {"siren": company.siret[:9]})
+        assertContains(response, self.to_join_msg(membership_1.user))
+        membership_2 = CompanyMembershipFactory(company=company, is_admin=True)
+        assert company.memberships.count() == 2
+        response = client.get(reverse("signup:company_select"), {"siren": company.siret[:9]})
+        assertNotContains(response, self.to_join_msg(membership_1.user))
+        assertContains(response, self.to_join_msg(membership_2.user))
 
     def test_with_next_param(self, client):
         user = random_pro_user_factory()

--- a/tests/www/signup/test_employer.py
+++ b/tests/www/signup/test_employer.py
@@ -19,7 +19,7 @@ from itou.users.models import User
 from itou.utils import constants as global_constants
 from itou.utils.mocks.api_entreprise import ETABLISSEMENT_API_RESULT_MOCK, INSEE_API_RESULT_MOCK
 from itou.utils.mocks.geocoding import BAN_GEOCODING_API_RESULT_MOCK
-from itou.utils.urls import get_tally_form_url
+from itou.utils.urls import get_tally_form_url, get_zendesk_form_url
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
 from tests.users.factories import JobSeekerFactory, random_pro_user_factory
 from tests.utils.testing import accept_legal_terms, parse_response_to_soup, pretty_indented
@@ -138,8 +138,10 @@ class TestCompanySignup:
                 messages.Message(
                     messages.ERROR,
                     (
-                        "L'adresse e-mail de contact du correspondant de cette structure n'est pas renseignée ou "
-                        "incorrecte. Merci de contacter l’assistance pour continuer l'inscription."
+                        "L’adresse e-mail de contact du gestionnaire de cette structure n’est pas renseignée. Merci "
+                        f'de <a href="{get_zendesk_form_url(response.wsgi_request)}" target="_blank" rel="noopener" '
+                        'class="has-external-link">contacter notre support technique</a> afin de poursuivre votre'
+                        "inscription."
                     ),
                 )
             ],


### PR DESCRIPTION
## :thinking: Pourquoi ?

[[Carte Notion](https://www.notion.so/gip-inclusion/Permettre-de-rejoindre-une-entreprise-avec-uniquement-des-membres-inactifs-32d5f321b60480c0881be7fdd1328ac0?source=copy_link)]

Aujourd'hui, lorsqu'un employeur souhaite s'inscrire, la vue [`company_select`](https://github.com/gip-inclusion/les-emplois/blob/b58283c3b12f79ab3db8f92889b88c1f4a3d4c97/itou/www/signup/views.py#L207) chargée de lui proposer des structures à rejoindre ignore celles qui ne comportent que des membres inactifs.

Cette PR vise à régler ce souci en traitant/affichant une structures <ins>sans membre actif</ins> de la même façon qu'une structure <ins>sans membre</ins>, c'est-à-dire qu'une structure sans membre actif apparaîtra dans _Entreprises disponibles_ (i.e. on pourra rejoindre l'entreprise via l'`auth_email`).

## :cake: Comment ?

- Deux requêtes retournant les structures proposées.
	- On inclut désormais les admins dans la liste des utilisateurs mais en les affichant en premier.
	- Renommage des deux variables (dans la vue et dans le template) afin d'indiquer précisément quelles sont les structures retournées.

## :desert_island: Comment tester ?

[[Recette](https://c1-review-louisgavalda-fix-allow-joining-company-without-active.cleverapps.io/)]