### PR TITLE
Fiche salarié (et ailleurs) : Ignorer les "memberships" inactives

### DIFF
--- a/itou/gps/models.py
+++ b/itou/gps/models.py
@@ -197,8 +197,10 @@ class FollowUpGroupMembership(models.Model):
 
     @property
     def organization_name(self):
-        return next((org.name for org in self.member.prescriberorganization_set.all()), None) or next(
-            (company.display_name for company in self.member.company_set.all()), None
+        return next(
+            (org.name for org in self.member.prescriberorganization_set.filter(memberships__is_active=True)), None
+        ) or next(
+            (company.display_name for company in self.member.company_set.filter(memberships__is_active=True)), None
         )
 
     @property

--- a/tests/gps/test_models.py
+++ b/tests/gps/test_models.py
@@ -7,7 +7,9 @@ from pytest_django.asserts import assertQuerySetEqual
 
 from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
 from itou.www.gps.enums import EndReason
+from tests.companies.factories import CompanyMembershipFactory
 from tests.gps.factories import FollowUpGroupFactory, FollowUpGroupMembershipFactory
+from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.users.factories import (
     EmployerFactory,
     ItouStaffFactory,
@@ -147,6 +149,30 @@ class TestFollowBeneficiary:
 
         assert not FollowUpGroup.objects.exists()
         assert f"Cannot follow beneficiary with inactive user={user}" in caplog.messages
+
+
+class TestFollowUpGroupMembership:
+    def test_organization_name_with_company_membership(self):
+        # Inactive membership => None
+        company_mship = CompanyMembershipFactory(is_active=False)
+        group = FollowUpGroupMembershipFactory(member=company_mship.user)
+        assert group.organization_name is None
+
+        # Active membership => company name
+        company_mship.is_active = True
+        company_mship.save()
+        assert group.organization_name == company_mship.company.display_name
+
+    def test_organization_name_with_organization_membership(self):
+        # Inactive membership => None
+        prescriber_mship = PrescriberMembershipFactory(is_active=False)
+        group = FollowUpGroupMembershipFactory(member=prescriber_mship.user)
+        assert group.organization_name is None
+
+        # Active membership => prescriber organization name
+        prescriber_mship.is_active = True
+        prescriber_mship.save()
+        assert group.organization_name == prescriber_mship.organization.display_name
 
 
 @freeze_time("2025-02-13T16:44:42")


### PR DESCRIPTION
Problème vu dans le cadre du ticket Zendesk 47728.

La méthode `FollowUpGroupMembership.organization_name` renvoie une organisation ou une entreprise aléatoire, ce qui (évidemment) ne fonctionne pas toujours très bien lorsqu'un utilisateur est lié à plusieurs organisations ou entreprises. Elle sera remplacée par l'utilisation de `JobSeekerAssignment`.

En attendant, la méthode devrait ignorer les appartenances inactives aux organisations et aux entreprises.