### PR TITLE
Vie privée : modification de logs qui affichaient des NIR

### DIFF
--- a/itou/approvals/models.py
+++ b/itou/approvals/models.py
@@ -967,7 +967,7 @@ class Approval(PENotificationMixin, CommonApprovalMixin):
                 self.user.jobseeker_profile.birthdate,
             ]
         ):
-            self.pe_log_err("had an invalid user={} nir={}", self.user, self.user.jobseeker_profile.nir)
+            self.pe_log_err("had an invalid user={}", self.user)
             # we save those as pending since the cron will ignore those cases anyway and thus has
             # no chance to block itself.
             return self.pe_save_pending(

--- a/itou/users/management/commands/deduplicate_job_seekers.py
+++ b/itou/users/management/commands/deduplicate_job_seekers.py
@@ -128,7 +128,6 @@ class Command(XlsxExportMixin, DeprecatedLoggerMixin, BaseCommand):
                 self.HARD_DUPLICATES_COUNT,
                 len(duplicates),
                 duplicate.email,
-                duplicate.jobseeker_profile.nir,
                 duplicate.jobseeker_profile.birthdate,
                 approval.number if approval else "",
                 approval.start_at.strftime("%d/%m/%Y") if approval else "",
@@ -158,7 +157,6 @@ class Command(XlsxExportMixin, DeprecatedLoggerMixin, BaseCommand):
                 self.NIR_DUPLICATES_COUNT,
                 len(duplicates),
                 duplicate.email,
-                duplicate.nir,
             ]
 
             # Debug info (when verbosity >= 1).

--- a/itou/www/invitations_views/helpers.py
+++ b/itou/www/invitations_views/helpers.py
@@ -5,7 +5,7 @@ from itou.invitations.models import EmployerInvitation, LaborInspectorInvitation
 from itou.users.enums import UserKind
 
 
-def handle_prescriber_intivation(invitation, request):
+def handle_prescriber_invitation(invitation, request):
     if not invitation.guest_can_join_organization(request):
         raise PermissionDenied()
 
@@ -53,7 +53,7 @@ def accept_all_pending_invitations(request):
         return False
 
     MAPPING = {
-        UserKind.PRESCRIBER: (PrescriberWithOrgInvitation, handle_prescriber_intivation),
+        UserKind.PRESCRIBER: (PrescriberWithOrgInvitation, handle_prescriber_invitation),
         UserKind.EMPLOYER: (EmployerInvitation, handle_employer_invitation),
         UserKind.LABOR_INSPECTOR: (LaborInspectorInvitation, handle_labor_inspector_invitation),
     }

--- a/itou/www/invitations_views/views.py
+++ b/itou/www/invitations_views/views.py
@@ -35,7 +35,7 @@ from itou.www.invitations_views.forms import (
 from itou.www.invitations_views.helpers import (
     handle_employer_invitation,
     handle_labor_inspector_invitation,
-    handle_prescriber_intivation,
+    handle_prescriber_invitation,
 )
 from itou.www.signup import forms as signup_forms
 
@@ -231,7 +231,7 @@ class InvitePrescriberView(BaseInviteUserView):
 @bypass_terms_acceptance
 def join_prescriber_organization(request, invitation_id):
     invitation = get_object_or_404(PrescriberWithOrgInvitation, pk=invitation_id)
-    handle_prescriber_intivation(invitation, request)
+    handle_prescriber_invitation(invitation, request)
     request.session[global_constants.ITOU_SESSION_CURRENT_ORGANIZATION_KEY] = (
         invitation.organization.organization_switch_key
     )

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -681,7 +681,7 @@ class SearchByEmailForSenderView(JobSeekerForSenderBaseView):
                         nir,
                     )
                     messages.warning(request, msg)
-                    logger.exception("step_job_seeker: error when saving job_seeker=%s nir=%s", job_seeker, nir)
+                    logger.exception("step_job_seeker: error when saving job_seeker=%s", job_seeker)
                 else:
                     if self.is_gps:
                         gps_utils.add_beneficiary(request, job_seeker, created=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

- Suppression de lignes qui faisaient apparaître des NIR en clair dans les logs,
- Correction d'une typo sans rapport.