### PR TITLE
Tech: alerte la déclaration d'un contexte en dehors d'une transaction

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -91,6 +91,9 @@ def log_retry_attempt(retry_state):
 class Command(BaseCommand):
     help = "Populate metabase database."
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Order in the dict is the order in which the function are going to be called, hence referential data on top

--- a/itou/metabase/management/commands/populate_metabase_matomo.py
+++ b/itou/metabase/management/commands/populate_metabase_matomo.py
@@ -133,6 +133,9 @@ class MatomoFetchOptions:
 class Command(BaseCommand):
     help = "Fetches dashboards from matomo and inserts them monday by monday in Metabase in its raw version"
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
         parser.add_argument("--pool-size", dest="pool_size", type=int, default=2)

--- a/itou/utils/command.py
+++ b/itou/utils/command.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 
 from django.core.management import base
@@ -7,8 +8,13 @@ from itou.utils import triggers
 
 
 class TriggerContextMixin:
+    AUTO_TRIGGER_CONTEXT = True
+
+    def get_trigger_context(self):
+        return {"user": os.getenv("CC_USER_ID"), "run_uid": get_current_command_info().run_uid}
+
     def execute(self, *args, **kwargs):
-        with triggers.context(user=os.getenv("CC_USER_ID"), run_uid=get_current_command_info().run_uid):
+        with triggers.context(**self.get_trigger_context()) if self.AUTO_TRIGGER_CONTEXT else contextlib.nullcontext():
             return super().execute(*args, **kwargs)
 
 

--- a/itou/utils/triggers/__init__.py
+++ b/itou/utils/triggers/__init__.py
@@ -1,20 +1,34 @@
 import contextlib
 import functools
 import json
+import logging
 import operator
 import threading
 from typing import Any
 
+from django.conf import settings
 from django.db import connection, models
 from pgtrigger import Condition, core
+
+from itou.utils.enums import ItouEnvironment
+
+
+logger = logging.getLogger(__name__)
 
 
 _context = threading.local()
 
 
-def _set_context_connection_wrapper(execute, *args, **kwargs):
+def _set_context_connection_wrapper(execute, sql, params, many, context):
     context_is_outdated = getattr(_context, "last_data_set", None) != _context.data
     if context_is_outdated:
+        if not context["connection"].in_atomic_block:
+            # This should not happen since set_config is called with is_local=true
+            error_msg = "Trying to define a context outside a transaction"
+            if settings.ITOU_ENVIRONMENT in [ItouEnvironment.DEV, ItouEnvironment.TEST]:
+                raise RuntimeError(error_msg)
+            else:
+                logger.error(error_msg)  # Notify issue to sentry
         # Ideally we should set the last data *after* the completion of the query, but
         # doing it here prevent the connection wrapper to be called recursively without exit
         # condition or any other kind of synchronization because of the `set_config()` query.
@@ -25,7 +39,7 @@ def _set_context_connection_wrapper(execute, *args, **kwargs):
                 [json.dumps(_context.data)],
             )
 
-    return execute(*args, **kwargs)
+    return execute(sql, params, many, context)
 
 
 @contextlib.contextmanager

--- a/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
@@ -1,20 +1,8 @@
 # serializer version: 1
 # name: test_populate_analytics
   dict({
-    'num_queries': 36,
+    'num_queries': 35,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_analytics[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -471,20 +459,8 @@
 # ---
 # name: test_populate_approvals
   dict({
-    'num_queries': 27,
+    'num_queries': 26,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_approvals[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -871,20 +847,8 @@
 # ---
 # name: test_populate_companies
   dict({
-    'num_queries': 62,
+    'num_queries': 61,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_companies[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -1824,20 +1788,8 @@
 # ---
 # name: test_populate_criteria
   dict({
-    'num_queries': 15,
+    'num_queries': 14,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_criteria[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -2028,21 +1980,8 @@
 # ---
 # name: test_populate_enums
   dict({
-    'num_queries': 36,
+    'num_queries': 35,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'create_table[metabase/db.py]',
-          'store_df[metabase/dataframes.py]',
-          'Command.populate_enums[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'create_table[metabase/db.py]',
@@ -2483,20 +2422,8 @@
 # ---
 # name: test_populate_evaluated_criteria
   dict({
-    'num_queries': 17,
+    'num_queries': 16,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_evaluated_criteria[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -2715,20 +2642,8 @@
 # ---
 # name: test_populate_evaluated_job_applications
   dict({
-    'num_queries': 16,
+    'num_queries': 15,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_evaluated_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -2941,20 +2856,8 @@
 # ---
 # name: test_populate_evaluated_siaes
   dict({
-    'num_queries': 19,
+    'num_queries': 18,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_evaluated_siaes[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -3223,20 +3126,8 @@
 # ---
 # name: test_populate_evaluation_campaigns
   dict({
-    'num_queries': 17,
+    'num_queries': 16,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_evaluation_campaigns[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -3454,20 +3345,8 @@
 # ---
 # name: test_populate_gps_groups
   dict({
-    'num_queries': 17,
+    'num_queries': 16,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_gps_groups[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -3685,20 +3564,8 @@
 # ---
 # name: test_populate_gps_memberships
   dict({
-    'num_queries': 20,
+    'num_queries': 19,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_gps_memberships[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -3979,20 +3846,8 @@
 # ---
 # name: test_populate_institutions
   dict({
-    'num_queries': 17,
+    'num_queries': 16,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_institutions[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -4214,20 +4069,8 @@
 # ---
 # name: test_populate_job_applications
   dict({
-    'num_queries': 43,
+    'num_queries': 42,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_job_applications[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -4837,20 +4680,8 @@
 # ---
 # name: test_populate_job_applications.1
   dict({
-    'num_queries': 13,
+    'num_queries': 12,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_selected_jobs[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -5050,20 +4881,8 @@
 # ---
 # name: test_populate_job_descriptions
   dict({
-    'num_queries': 27,
+    'num_queries': 26,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_job_descriptions[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -5506,20 +5325,8 @@
 # ---
 # name: test_populate_job_seekers
   dict({
-    'num_queries': 74,
+    'num_queries': 73,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'get_table[metabase/tables/job_seekers.py]',
-          'Command.populate_job_seekers[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'get_table[metabase/tables/job_seekers.py]',
@@ -6556,20 +6363,8 @@
 # ---
 # name: test_populate_memberships
   dict({
-    'num_queries': 22,
+    'num_queries': 21,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_memberships[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -6902,20 +6697,8 @@
 # ---
 # name: test_populate_organizations
   dict({
-    'num_queries': 41,
+    'num_queries': 40,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_organizations[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -7626,20 +7409,8 @@
 # ---
 # name: test_populate_prolongation_requests
   dict({
-    'num_queries': 27,
+    'num_queries': 26,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_prolongation_requests[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -8018,20 +7789,8 @@
 # ---
 # name: test_populate_prolongations
   dict({
-    'num_queries': 22,
+    'num_queries': 21,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_prolongations[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -8314,20 +8073,8 @@
 # ---
 # name: test_populate_suspensions
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_suspensions[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',
@@ -8557,20 +8304,8 @@
 # ---
 # name: test_populate_users
   dict({
-    'num_queries': 18,
+    'num_queries': 17,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[metabase/db.py]',
-          'Command.populate_users[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_emplois.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[metabase/db.py]',

--- a/tests/metabase/management/__snapshots__/test_populate_metabase_matomo.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_matomo.ambr
@@ -75,20 +75,8 @@
 # ---
 # name: test_matomo_populate_public[SQL queries]
   dict({
-    'num_queries': 4,
+    'num_queries': 3,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'create_table[metabase/db.py]',
-          'update_table_at_date[metabase/management/commands/populate_metabase_matomo.py]',
-          'Command.handle[metabase/management/commands/populate_metabase_matomo.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'create_table[metabase/db.py]',


### PR DESCRIPTION
## :thinking: Pourquoi ?

Car on utilise [set_config()](https://www.postgresql.org/docs/17/functions-admin.html#FUNCTIONS-ADMIN-SET) avec `is_local=true` (_If is_local is true, the new value will only apply during the current transaction_).

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
