### PR TITLE
Tech: correctif de l'erreur mentionnant des contextes définis en dehors de transaction

### DIFF
--- a/itou/antivirus/management/commands/scan_s3_files.py
+++ b/itou/antivirus/management/commands/scan_s3_files.py
@@ -25,6 +25,9 @@ class Command(BaseCommand):
     # interrupted, prefer frequent and quick iterations.
     BATCH_SIZE = 200
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def handle(self, *args, **options):
         now = timezone.now()
         files = File.objects.exclude(scan__clamav_completed_at__gt=now - relativedelta(months=1)).order_by(

--- a/itou/approvals/management/commands/send_approvals_to_pe.py
+++ b/itou/approvals/management/commands/send_approvals_to_pe.py
@@ -20,6 +20,9 @@ MAX_APPROVALS_PER_RUN = 140
 class Command(BaseCommand):
     help = "Regularly sends all 'pending' and 'should retry' approvals to PE"
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
         parser.add_argument("--delay", action="store", dest="delay", default=0, type=int, choices=range(0, 5))

--- a/itou/job_applications/management/commands/reject_job_applications_after_delay.py
+++ b/itou/job_applications/management/commands/reject_job_applications_after_delay.py
@@ -4,10 +4,14 @@ from django.template import loader
 
 from itou.job_applications.enums import RefusalReason
 from itou.job_applications.models import JobApplication
+from itou.utils import triggers
 from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         parser.add_argument("--limit", type=int, default=40)
 
@@ -24,7 +28,7 @@ class Command(BaseCommand):
         )[:limit]
 
         for job_seeker in job_seekers_with_their_rejectable_applications:
-            with transaction.atomic():
+            with transaction.atomic(), triggers.context(**self.get_trigger_context()):
                 job_seeker_applications = (
                     JobApplication.objects.filter(job_seeker_id=job_seeker["job_seeker"])
                     .automatically_rejectable_applications()

--- a/itou/tasks/management/commands/requeue_tasks.py
+++ b/itou/tasks/management/commands/requeue_tasks.py
@@ -13,6 +13,8 @@ from itou.utils.command import BaseCommand
 
 class Command(BaseCommand):
     ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     help = """\
     Queue Huey tasks that could not be scheduled.
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://inclusion.sentry.io/issues/112922284/

Retombées de 49158dc2f0723a2086328db86510eb2d51ce1582.

Le contexte est censé être défini dans une transaction mais dans la plupart des commandes il n'est pas nécessaire.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
