### PR TITLE
forms: Fix typography in "Par exemple" tooltips

### DIFF
--- a/itou/common_apps/address/forms.py
+++ b/itou/common_apps/address/forms.py
@@ -11,11 +11,11 @@ from itou.utils.widgets import JobSeekerAddressAutocompleteWidget
 
 
 class JobSeekerAddressForm(forms.ModelForm):
-    address_line_1 = forms.CharField(label="Adresse", help_text=("Par exemple: 102 Quai de Jemmapes"))
+    address_line_1 = forms.CharField(label="Adresse", help_text="Par exemple : 102 Quai de Jemmapes")
     address_line_2 = forms.CharField(
-        label="Complément d'adresse", required=False, help_text=("Par exemple: Appartement 16")
+        label="Complément d'adresse", required=False, help_text="Par exemple : Appartement 16"
     )
-    post_code = forms.CharField(label="Code postal", help_text=("Par exemple: 75010"))
+    post_code = forms.CharField(label="Code postal", help_text="Par exemple : 75010")
     insee_code = forms.CharField(widget=forms.HiddenInput(), required=False)
     ban_api_resolved_address = forms.CharField(widget=forms.HiddenInput(), required=False)
     fill_mode = forms.CharField(widget=forms.HiddenInput(), required=False)

--- a/itou/www/job_seekers_views/forms.py
+++ b/itou/www/job_seekers_views/forms.py
@@ -207,7 +207,7 @@ class JobSeekerExistsForm(forms.Form):
 
     email = forms.EmailField(
         label="Adresse e-mail personnelle du candidat",
-        help_text=("Par exemple: julie@example.com"),
+        help_text="Par exemple : julie@example.com",
         widget=forms.EmailInput(attrs={"autocomplete": "off"}),
     )
 
@@ -419,7 +419,7 @@ class NirModificationRequestForm(forms.ModelForm):
         required=True,
         strip=True,
         validators=[validate_nir],
-        help_text="Par exemple: 2 69 05 49 588 157 80",
+        help_text="Par exemple : 2 69 05 49 588 157 80",
     )
 
     rationale = forms.CharField(


### PR DESCRIPTION
Un double-point devrait être précédé d'une espace insécable.