### PR TITLE
GEIQ: Déselection par défaut des contrats sans aide potentielle

### DIFF
--- a/itou/geiq_assessments/sync.py
+++ b/itou/geiq_assessments/sync.py
@@ -247,7 +247,8 @@ def sync_employee_and_contracts(assessment):
             year=assessment.campaign.year,
         )
         contract.allowance_requested = (
-            contract.nb_days_in_campaign_year > geiq_assessments_models.MIN_DAYS_IN_YEAR_FOR_ALLOWANCE
+            contract.employee.allowance_amount
+            and contract.nb_days_in_campaign_year > geiq_assessments_models.MIN_DAYS_IN_YEAR_FOR_ALLOWANCE
         )
 
         return contract

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -67,7 +67,7 @@
                         <p>
                             Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
                             <br>
-                            Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                            Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
                         </p>
                         <p class="mb-0">
                             L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.

--- a/tests/geiq/test_sync.py
+++ b/tests/geiq/test_sync.py
@@ -44,7 +44,7 @@ def test_sync_employee_and_contracts(caplog, label_settings, mocker):
         salarie__montant_aide=814,
         antenne={"id": 0, "name": "Un Joli GEIQ"},
         date_debut="2023-01-15:00:00+01:00",
-        date_fin="2023-01-31:00:00+01:00",
+        date_fin="2023-01-31:00:00+01:00",  # Contract duration is less than 3 months
         date_fin_contrat="2023-01-31:00:00+01:00",
     )
     prequal_of_contract = SalariePreQualificationLabelDataFactory(
@@ -58,10 +58,17 @@ def test_sync_employee_and_contracts(caplog, label_settings, mocker):
         date_fin="2023-01-31:00:00+01:00",
         date_fin_contrat="2022-01-31:00:00+01:00",
     )
+    contract_without_allowance = SalarieContratLabelDataFactory(
+        salarie__geiq_id=assessment.label_geiq_id,
+        salarie__montant_aide=0,
+        antenne={"id": 0, "name": "Un Joli GEIQ"},
+        date_debut="2023-01-01T00:00:00+01:00",
+        date_fin="2024-01-31:00:00+01:00",
+    )
 
     def _fake_get_all_contracts(self, geiq_id, date_fin=None):
         assert geiq_id == assessment.label_geiq_id
-        return [dict(contract), dict(contract_with_prequal), dict(contract_of_antenna)]
+        return [dict(c) for c in (contract, contract_with_prequal, contract_of_antenna, contract_without_allowance)]
 
     def _fake_get_all_prequalifications(self, geiq_id):
         assert geiq_id == assessment.label_geiq_id
@@ -85,7 +92,7 @@ def test_sync_employee_and_contracts(caplog, label_settings, mocker):
     mocker.patch.object(geiq_label.LabelApiClient, "get_taux_geiq", _fake_get_taux_geiq)
     sync.sync_employee_and_contracts(assessment)
     employees = models.Employee.objects.order_by("label_id")
-    assert len(employees) == 2
+    assert len(employees) == 3
     assert prequal_only["salarie"]["id"] not in {employee.label_id for employee in employees}
     assert contract_ending_before_2023["salarie"]["id"] not in {employee.label_id for employee in employees}
     assert contract["salarie"]["id"] == employees[0].label_id
@@ -101,17 +108,21 @@ def test_sync_employee_and_contracts(caplog, label_settings, mocker):
     assert contract1.nb_days_in_campaign_year == 17
     assert contract1.allowance_requested is False  # Since less than 90 days
     assert contract1.allowance_granted is False
+    assert employees[2].allowance_amount == 0
+    contract2 = employees[2].contracts.first()
+    assert contract2.allowance_requested is False  # Since no potential allowance
+    assert contract2.allowance_granted is False
 
     assessment.refresh_from_db()
     assert assessment.contracts_synced_at is not None
     assert assessment.label_rates == FAKE_LABEL_RATES
-    assert assessment.employee_nb == 2
+    assert assessment.employee_nb == 3
 
     assert caplog.messages == [
-        "Label sync will create nb=2 type=employé",
+        "Label sync will create nb=3 type=employé",
         "Label sync will update nb=0 type=employé",
         "Label sync will delete nb=0 type=employé",
-        "Label sync will create nb=2 type=contrat",
+        "Label sync will create nb=3 type=contrat",
         "Label sync will update nb=0 type=contrat",
         "Label sync will delete nb=0 type=contrat",
         "Label sync will create nb=1 type=préqualification",

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -1316,7 +1316,7 @@
                   <p>
                       Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
                       <br/>
-                      Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                      Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
                   </p>
                   <p class="mb-0">
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
@@ -1527,7 +1527,7 @@
                   <p>
                       Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
                       <br/>
-                      Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                      Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
                   </p>
                   <p class="mb-0">
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
@@ -1764,7 +1764,7 @@
                   <p>
                       Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
                       <br/>
-                      Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                      Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
                   </p>
                   <p class="mb-0">
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.


### PR DESCRIPTION
## :thinking: Pourquoi ?

À l'import d'un bilan GEIQ employeur, les contrats pour lesquels l'aide potentielle est nulle ne doivent plus être sélectionnés par défaut.

[[Carte Notion](https://www.notion.so/gip-inclusion/Bilan-geiq-suite-l-import-d-cocher-automatiquement-le-contrat-si-l-aide-potentielle-est-0-33c5f321b60480b680fdc9f30053337a?source=copy_link)]

## :cake: Comment ?

Complétion de `contract.allowance_requested` dans `sync.py` :
```
        contract.allowance_requested = (
            contract.employee.allowance_amount
            and contract.nb_days_in_campaign_year > geiq_assessments_models.MIN_DAYS_IN_YEAR_FOR_ALLOWANCE
        )
```

Et modification de l'indication donnée en haut de page :

AVANT :
> Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite. 

APRÈS :
> Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.

## :desert_island: Comment tester ?

Après création et import d'un nouveau bilan, dans le détail / sélection des contrats, s'assurer qu'aucun contrat dont l'aide potentielle est nulle OU dont la durée est inférieure à 3 mois n'est sélectionné par défaut.

## :computer: Captures d'écran <!-- optionnel -->

APRÈS :
<img width="872" height="648" alt="Capture d’écran 2026-04-20 à 12 35 44" src="https://github.com/user-attachments/assets/28aa8313-1c4a-4695-a13c-ac9a1081a85f" />