### PR TITLE
Admin : Ajout du numéro de téléphone dans le fichier d'export des prescripteurs et employeurs

### DIFF
--- a/itou/www/itou_staff_views/export_utils.py
+++ b/itou/www/itou_staff_views/export_utils.py
@@ -206,6 +206,7 @@ cta_export_spec = {
     "Structure - région": lambda membership: get_org(membership).region,
     "Utilisateur - prénom": lambda membership: membership.user.first_name,
     "Utilisateur - nom": lambda membership: membership.user.last_name,
+    "Utilisateur - téléphone": lambda membership: membership.user.phone,
     "Utilisateur - e-mail": lambda membership: membership.user.email,
     "Administrateur ?": lambda membership: "Oui" if membership.is_admin else "Non",
     "Utilisateur - date d'inscription": lambda membership: membership.user.date_joined.strftime("%d-%m-%Y"),

--- a/tests/www/itou_staff_views/__snapshots__/tests.ambr
+++ b/tests/www/itou_staff_views/__snapshots__/tests.ambr
@@ -265,9 +265,9 @@
 # ---
 # name: TestExportCTA.test_export[streaming content]
   '''
-  Utilisateur - type,Structure - type,Structure - nom,Structure - SIRET,Structure - adresse ligne 1,Structure - adresse ligne 2,Structure - code postal,Structure - ville,Structure - département,Structure - région,Utilisateur - prénom,Utilisateur - nom,Utilisateur - e-mail,Administrateur ?,Utilisateur - date d'inscription
-  Employeur,EI,ACME Inc.,012345678910,112 rue de la Croix-Nivert,,75015,Paris,75,Île-de-France,John,Doe,john.doe@test.local,Oui,17-05-2024
-  Orienteur,FT,Pres. Org.,012345678910,39 rue d'Artois,,75008,Paris,75,Île-de-France,Pierre,Dupont,pierre.dupont@test.local,Oui,17-05-2024
+  Utilisateur - type,Structure - type,Structure - nom,Structure - SIRET,Structure - adresse ligne 1,Structure - adresse ligne 2,Structure - code postal,Structure - ville,Structure - département,Structure - région,Utilisateur - prénom,Utilisateur - nom,Utilisateur - téléphone,Utilisateur - e-mail,Administrateur ?,Utilisateur - date d'inscription
+  Employeur,EI,ACME Inc.,012345678910,112 rue de la Croix-Nivert,,75015,Paris,75,Île-de-France,John,Doe,0606060606,john.doe@test.local,Oui,17-05-2024
+  Orienteur,FT,Pres. Org.,012345678910,39 rue d'Artois,,75008,Paris,75,Île-de-France,Pierre,Dupont,0612345678,pierre.dupont@test.local,Oui,17-05-2024
   
   '''
 # ---


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour répondre à [une demande](https://plateforme-inclusion.zendesk.com/agent/tickets/47262)  de la part d'une DDETS qui veut les noms, adresses et numéros des prescripteurs de son département.

## :cake: Comment ? <!-- optionnel -->

Ajout du phone de l'utilisateur dans le cta_export_spec.

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
