### PR TITLE
Tests : Correction d'un test bagottant

### DIFF
--- a/tests/employee_record/test_models.py
+++ b/tests/employee_record/test_models.py
@@ -191,7 +191,7 @@ class TestEmployeeRecordModel:
         """
         How to find employee records given their ASP batch file name and line number ?
         """
-        employee_record = EmployeeRecordFactory(with_batch_information=True)
+        employee_record = EmployeeRecordFactory(with_batch_information=True, __sequence=1)
 
         assert EmployeeRecord.objects.find_by_batch("X", employee_record.asp_batch_line_number).count() == 0
         assert EmployeeRecord.objects.find_by_batch(employee_record.asp_batch_file, 0).count() == 0


### PR DESCRIPTION

## :thinking: Pourquoi ?
L'exécution de test_find_by_batch seul échouait systématiquement : la
valeur asp_batch_line_number est une séquence qui commence à 0.

Selon l'ordre des autres tests, il échouait également parfois.

https://github.com/gip-inclusion/les-emplois/actions/runs/24709547136/job/72270574352

