### PR TITLE
Tech: djLint scanne à nouveau tous les fichiers

### DIFF
--- a/itou/templates/static/accessibility.html
+++ b/itou/templates/static/accessibility.html
@@ -57,7 +57,9 @@
                         <li>Python</li>
                     </ul>
                     <h3>Environnement de test</h3>
-                    <p>Les vérifications de restitution de contenus ont été réalisées sur la base de la combinaison fournie par la base de référence du RGAA, avec les versions suivantes&nbsp;:</p>
+                    <p>
+                        Les vérifications de restitution de contenus ont été réalisées sur la base de la combinaison fournie par la base de référence du RGAA, avec les versions suivantes&nbsp;:
+                    </p>
                     <ul>
                         <li>Sur Mobile iOS avec Safari et VoiceOver</li>
                         <li>Sur Ordinateur MacOS avec Safari et VoiceOver</li>
@@ -85,7 +87,9 @@
                         <li>Postuler pour un candidat sur "Paris" (en tant que "Prescripteur habilité")</li>
                     </ul>
                     <h2>Retour d’information et contact</h2>
-                    <p>Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de Les emplois de l'inclusion pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.</p>
+                    <p>
+                        Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable de Les emplois de l'inclusion pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+                    </p>
                     <ul>
                         <li>
                             <a href="{{ contact_form_url }}" target="_blank" rel="noreferrer noopener" class="has-external-link" aria-label="Formulaire de contact, ouverture dans une nouvelle fenêtre">Formulaire de contact</a>
@@ -106,7 +110,9 @@
                         </li>
                     </ul>
                     <h2>Voies de recours</h2>
-                    <p>Si vous constatez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits.</p>
+                    <p>
+                        Si vous constatez un défaut d’accessibilité vous empêchant d’accéder à un contenu ou une fonctionnalité du site, que vous nous le signalez et que vous ne parvenez pas à obtenir une réponse de notre part, vous êtes en droit de faire parvenir vos doléances ou une demande de saisine au Défenseur des droits.
+                    </p>
                     <p>Plusieurs moyens sont à votre disposition&nbsp;:</p>
                     <ul>
                         <li>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ ignore="H006,H014,H017,H023,H030,H031,T002,T003"
 custom_blocks="buttons,component_alert,component_alert_global,component_box_dashboard,component_box_nexus_activated_service,component_info,component_navinfo,component_title,endbuttons,fragment,partialdef"
 max_attribute_length=200
 preserve_blank_lines=true
-extend_exclude = "itou/static_collected,itou/templates/utils/widgets/duet_date_picker_widget.html,"
+extend_exclude = "itou/static_collected,itou/templates/utils/widgets/duet_date_picker_widget.html"
 format_css = true
 format_js = true
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

djLint ne scannait plus aucun fichier du projet et affichait simplement :
```
djlint --reformat itou
No files to check! 😢
```

## :cake: Comment ? <!-- optionnel -->

- Suppression de la virgule finale de l'option `extend_exclude` dans la [conf djLint](https://djlint.com/docs/configuration/) du `pyproject.toml`.
- Reformatage du template `itou/templates/static/accessibility.html` avec djLint.

Curieux de savoir pourquoi le template `itou/templates/utils/widgets/duet_date_picker_widget.html` est exclus.

APRÈS :
```
extend_exclude = "itou/static_collected,itou/templates/utils/widgets/duet_date_picker_widget.html"
```

## :computer: Captures d'écran <!-- optionnel -->

APRÈS :
```
$ make quality
ruff format --check config itou scripts tests
1233 files already formatted
ruff check config itou scripts tests
All checks passed!
djlint --lint --check itou

Checking and Linting 560/560 files ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 00:22    


0 files would be updated.
Linted 560 files, found 0 errors.

[...]
```