### PR TITLE
GEIQ : La DDETS peut corriger sa décision quand la DREETS lui renvoie pour correction

### DIFF
--- a/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
+++ b/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
@@ -198,8 +198,13 @@
                             </div>
                             <div class="c-box--summary__footer">
                                 <div class="d-flex justify-content-end">
-                                    {% if assessment.decision_validated_at %}
+                                    {% if assessment.final_reviewed_at %}
                                         <a class="btn btn-primary btn-block btn-ico w-100 w-md-auto" href="{% url "geiq_assessments_views:assessment_print" pk=assessment.pk %}" rel="noopener" target="_blank">
+                                            <i class="ri-eye-line fw-medium" aria-hidden="true"></i>
+                                            <span>Consulter la décision</span>
+                                        </a>
+                                    {% elif assessment.reviewed_at %}
+                                        <a class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto" href="{% url "geiq_assessments_views:assessment_review" pk=assessment.pk %}">
                                             <i class="ri-eye-line fw-medium" aria-hidden="true"></i>
                                             <span>Consulter la décision</span>
                                         </a>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -623,12 +623,8 @@
                       </div>
                       <div class="c-box--summary__footer">
                           <div class="d-flex justify-content-end">
-                              <a class="btn btn-primary btn-block btn-ico w-100 w-md-auto" href="/geiq-assessments/institution/00000000-1111-2222-3333-444444444444/print" rel="noopener" target="_blank">
-                                  <i aria-hidden="true" class="ri-eye-line fw-medium">
-                                  </i>
-                                  <span>
-                                      Consulter la décision
-                                  </span>
+                              <a class="btn btn-primary btn-block w-100 w-md-auto" href="/geiq-assessments/institution/00000000-1111-2222-3333-444444444444/review">
+                                  Saisir la décision
                               </a>
                           </div>
                       </div>
@@ -1566,7 +1562,7 @@
                       </div>
                       <div class="c-box--summary__footer">
                           <div class="d-flex justify-content-end">
-                              <a class="btn btn-primary btn-block btn-ico w-100 w-md-auto" href="/geiq-assessments/institution/00000000-1111-2222-3333-444444444444/print" rel="noopener" target="_blank">
+                              <a class="btn btn-outline-primary btn-block btn-ico w-100 w-md-auto" href="/geiq-assessments/institution/00000000-1111-2222-3333-444444444444/review">
                                   <i aria-hidden="true" class="ri-eye-line fw-medium">
                                   </i>
                                   <span>


### PR DESCRIPTION
## :thinking: Pourquoi ?

La vue imprimable ne doit être affichée que lorsque le bilan est validé (`final_review`).
([carte Notion](https://www.notion.so/gip-inclusion/ETQ-DDETS-DREETS-je-peux-imprimer-ma-page-de-d-cision-du-bilan-d-ex-cution-3205f321b60480ba9827f153d062c9b6))

J'ai un peu modifié les boutons aussi, pour n'avoir *Saisir la décision* que quand on peut vraiment la saisir (et sinon, c'est *Consulter la décision*)


---

Avant : 

<img width="1222" height="959" alt="image" src="https://github.com/user-attachments/assets/a982af35-aade-42b5-9217-9bd868d8d081" />


Après : 

<img width="1222" height="959" alt="image" src="https://github.com/user-attachments/assets/15937d13-72ca-4e74-a40b-aff3ecd114d1" />

<img width="1222" height="959" alt="image" src="https://github.com/user-attachments/assets/aa45218e-2016-4203-86ce-90bd5e8da71f" />

<img width="1222" height="959" alt="image" src="https://github.com/user-attachments/assets/472e258c-f552-4f5e-88d1-2d784f61fb16" />

