### PR TITLE
Tech: ajout de `ATOMIC_HANDLE = True` sur les commandes utilisant `@dry_runnable`

### DIFF
--- a/itou/archive/management/commands/anonymize_cancelled_approvals.py
+++ b/itou/archive/management/commands/anonymize_cancelled_approvals.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.db import transaction
 from django.utils import timezone
 from itoutils.django.commands import dry_runnable
 from sentry_sdk.crons import monitor
@@ -24,6 +23,8 @@ def anonymized_cancelled_approval(obj):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
@@ -44,7 +45,6 @@ class Command(BaseCommand):
         },
     )
     @dry_runnable
-    @transaction.atomic
     def handle(self, *args, wet_run, **options):
         if settings.SUSPEND_ANONYMIZE_CANCELLED_APPROVALS:
             self.logger.info("Anonymizing cancelled approvals is suspended, exiting command")

--- a/itou/archive/management/commands/anonymize_jobseekers.py
+++ b/itou/archive/management/commands/anonymize_jobseekers.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
-from django.db import transaction
 from django.db.models import Count, F, Max, Min, OuterRef, Q, Subquery, Sum
 from django.utils import timezone
 from itoutils.django.commands import dry_runnable
@@ -155,6 +154,8 @@ def anonymized_eligibility_diagnosis(obj):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
@@ -185,7 +186,6 @@ class Command(BaseCommand):
 
         self.logger.info("Reset notified job seekers with recent activity: %s", reset_users_count)
 
-    @transaction.atomic
     def archive_jobseekers_after_grace_period(self):
         now = timezone.now()
         grace_period_since = now - GRACE_PERIOD

--- a/itou/archive/management/commands/anonymize_professionals.py
+++ b/itou/archive/management/commands/anonymize_professionals.py
@@ -1,7 +1,6 @@
 from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
-from django.db import transaction
 from django.db.models import Exists, F, OuterRef, Prefetch, Q
 from django.utils import timezone
 from itoutils.django.commands import dry_runnable
@@ -25,6 +24,8 @@ BATCH_SIZE = 200
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
@@ -52,7 +53,6 @@ class Command(BaseCommand):
 
         self.logger.info("Reset notified professionals with recent activity: %s", reset_users_count)
 
-    @transaction.atomic
     def anonymize_professionals_after_grace_period(self):
         now = timezone.now()
         grace_period_since = now - GRACE_PERIOD

--- a/itou/archive/management/commands/remove_unknown_emails_from_brevo.py
+++ b/itou/archive/management/commands/remove_unknown_emails_from_brevo.py
@@ -23,6 +23,8 @@ def modified_before(contact, cutoff_date):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(

--- a/itou/companies/management/commands/move_company_data.py
+++ b/itou/companies/management/commands/move_company_data.py
@@ -33,6 +33,7 @@ HELP_TEXT = """
 
 class Command(BaseCommand):
     help = HELP_TEXT
+    ATOMIC_HANDLE = True
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/itou/users/management/commands/delete_old_nir_modification_requests.py
+++ b/itou/users/management/commands/delete_old_nir_modification_requests.py
@@ -9,6 +9,8 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 

--- a/itou/users/management/commands/pe_certify_users.py
+++ b/itou/users/management/commands/pe_certify_users.py
@@ -27,6 +27,8 @@ RETRY_DELAY = datetime.timedelta(days=7)
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", action="store_true", dest="wet_run")
         # default chunk size is chosen to be 200 so that the cron lasts about 3 minutes.

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -946,6 +946,14 @@
     'queries': list([
       dict({
         'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+          'Command.execute[itoutils/django/commands.py]',
+          'Command.execute[itoutils/django/commands.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
           '_set_context_connection_wrapper[utils/triggers/__init__.py]',
           'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -983,17 +991,6 @@
                  AND "users_user"."last_login" >= ("users_user"."upcoming_deletion_notified_at")
                  AND "users_user"."upcoming_deletion_notified_at" IS NOT NULL)
         ''',
-      }),
-      dict({
-        'origin': list([
-          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
-          'Command.handle[archive/management/commands/anonymize_professionals.py]',
-          'wrapper[itoutils/django/commands.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': 'SAVEPOINT "<snapshot>"',
       }),
       dict({
         'origin': list([
@@ -3408,7 +3405,6 @@
       dict({
         'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-          'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
           'Command.execute[utils/command.py]',
           'Command.execute[itoutils/django/commands.py]',
@@ -3419,8 +3415,6 @@
       dict({
         'origin': list([
           'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
-          'wrapper[itoutils/django/commands.py]',
-          'Command.execute[utils/command.py]',
           'Command.execute[itoutils/django/commands.py]',
           'Command.execute[itoutils/django/commands.py]',
         ]),


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cela corrigera le message "Trying to define a context outside a transaction" (cf https://inclusion.sentry.io/issues/112922284/) et sera bientôt nécessaire pour utiliser le décorateur `@dry_runnable` (cf https://github.com/gip-inclusion/itoutils/pull/85).


## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
