### PR TITLE
Interface : Afficher l'icône du bon type devant l'organisation dans le menu de changement d'organisation (s'il y a plusieurs types)

### DIFF
--- a/itou/common_apps/organizations/models.py
+++ b/itou/common_apps/organizations/models.py
@@ -242,6 +242,16 @@ class OrganizationAbstract(models.Model):
     def organization_switch_key(self):
         return f"{self.ORGANIZATION_KIND.name}-{self.pk}"
 
+    @property
+    def icon(self):
+        match self.ORGANIZATION_KIND:
+            case OrganizationKind.PRESCRIBER_ORGANIZATION:
+                return "ri-home-smile-line"
+            case OrganizationKind.COMPANY:
+                return "ri-community-line"
+            case OrganizationKind.INSTITUTION:
+                return "ri-government-line"
+
 
 class MembershipQuerySet(models.QuerySet):
     @property

--- a/itou/templates/layout/_organization_switcher_dropdown_menu.html
+++ b/itou/templates/layout/_organization_switcher_dropdown_menu.html
@@ -4,7 +4,7 @@
         {% for org in organizations %}
             <li>
                 <button class="dropdown-item dropdown-item__summary{% if org.pk == current_organization.pk %} active{% endif %}" name="organization_key" value="{{ org.organization_switch_key }}">
-                    <i class="{{ icon }}" aria-hidden="true"></i>
+                    <i class="{{ org.icon }}" aria-hidden="true"></i>
                     <span>{{ org.kind }}</span>
                     {% if org.display_name|length > 18 %}
                         <strong data-bs-toggle="tooltip" data-bs-title="{{ org.display_name }}">{{ org.display_name }}</strong>

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -15,7 +15,7 @@
               <ul class="list-unstyled">
                   <li>
                       <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
-                          <i aria-hidden="true" class="ri-community-line">
+                          <i aria-hidden="true" class="ri-government-line">
                           </i>
                           <span>
                               DDETS IAE
@@ -39,7 +39,7 @@
                   </li>
                   <li>
                       <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
-                          <i aria-hidden="true" class="ri-community-line">
+                          <i aria-hidden="true" class="ri-home-smile-line">
                           </i>
                           <span>
                               FT
@@ -85,7 +85,7 @@
               <ul class="list-unstyled">
                   <li>
                       <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
-                          <i aria-hidden="true" class="ri-community-line">
+                          <i aria-hidden="true" class="ri-government-line">
                           </i>
                           <span>
                               DDETS IAE
@@ -109,7 +109,7 @@
                   </li>
                   <li>
                       <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
-                          <i aria-hidden="true" class="ri-community-line">
+                          <i aria-hidden="true" class="ri-home-smile-line">
                           </i>
                           <span>
                               FT

--- a/tests/www/__snapshots__/test_layout.ambr
+++ b/tests/www/__snapshots__/test_layout.ambr
@@ -1,4 +1,141 @@
 # serializer version: 1
+# name: test_nav_dropdown_with_multiple_org_types[multi organization structure switcher in nav]
+  '''
+  <li class="d-none d-lg-inline-block dropdown dropdown-organization">
+      <button aria-controls="switchOrganizationDropdown" aria-expanded="false" aria-haspopup="true" class="btn btn-outline-primary btn-ico bg-white dropdown-toggle" data-bs-toggle="dropdown" type="button">
+          <i aria-hidden="true" class="ri-community-line">
+          </i>
+          <span>
+              EI - ACME Inc.
+          </span>
+      </button>
+      <div class="dropdown-menu w-100" id="switchOrganizationDropdown">
+          <form action="/dashboard/switch-organization?next_url=/dashboard/" method="post">
+              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+              <ul class="list-unstyled">
+                  <li>
+                      <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <span>
+                              DDETS IAE
+                          </span>
+                          <strong>
+                              1 Titus Ion
+                          </strong>
+                      </button>
+                  </li>
+                  <li>
+                      <button class="dropdown-item dropdown-item__summary active" name="organization_key" value="ORGANIZATION_KEY">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <span>
+                              EI
+                          </span>
+                          <strong>
+                              ACME Inc.
+                          </strong>
+                      </button>
+                  </li>
+                  <li>
+                      <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <span>
+                              FT
+                          </span>
+                          <strong>
+                              Pres. Org.
+                          </strong>
+                      </button>
+                  </li>
+              </ul>
+          </form>
+          <a class="dropdown-item dropdown-item__summary is-last-sticky" href="/company/create-company">
+              <i aria-hidden="true" class="ri-add-line">
+              </i>
+              <span>
+                  Créer ou rejoindre
+              </span>
+              <strong>
+                  une nouvelle structure
+              </strong>
+          </a>
+      </div>
+  </li>
+  
+  '''
+# ---
+# name: test_nav_dropdown_with_multiple_org_types[multi organization structure switcher in offcanvas]
+  '''
+  <div class="dropdown dropdown-organization flex-grow-1 py-4">
+      <button aria-controls="switchOrganizationDropdownMobile" aria-expanded="false" aria-haspopup="true" class="dropdown-toggle dropdown-toggle__summary" data-bs-toggle="dropdown" type="button">
+          <i aria-hidden="true" class="ri-community-line">
+          </i>
+          <span>
+              EI
+          </span>
+          <strong>
+              ACME Inc.
+          </strong>
+      </button>
+      <div class="dropdown-menu" id="switchOrganizationDropdownMobile">
+          <form action="/dashboard/switch-organization?next_url=/dashboard/" method="post">
+              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+              <ul class="list-unstyled">
+                  <li>
+                      <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <span>
+                              DDETS IAE
+                          </span>
+                          <strong>
+                              1 Titus Ion
+                          </strong>
+                      </button>
+                  </li>
+                  <li>
+                      <button class="dropdown-item dropdown-item__summary active" name="organization_key" value="ORGANIZATION_KEY">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <span>
+                              EI
+                          </span>
+                          <strong>
+                              ACME Inc.
+                          </strong>
+                      </button>
+                  </li>
+                  <li>
+                      <button class="dropdown-item dropdown-item__summary" name="organization_key" value="ORGANIZATION_KEY">
+                          <i aria-hidden="true" class="ri-community-line">
+                          </i>
+                          <span>
+                              FT
+                          </span>
+                          <strong>
+                              Pres. Org.
+                          </strong>
+                      </button>
+                  </li>
+              </ul>
+          </form>
+          <a class="dropdown-item dropdown-item__summary is-last-sticky" href="/company/create-company">
+              <i aria-hidden="true" class="ri-add-line">
+              </i>
+              <span>
+                  Créer ou rejoindre
+              </span>
+              <strong>
+                  une nouvelle structure
+              </strong>
+          </a>
+      </div>
+  </div>
+  
+  '''
+# ---
 # name: test_navigation_authenticated[Employer][navigation]
   '''
   <div aria-label="Barre de navigation principale" class="offcanvas" id="offcanvasNav">

--- a/tests/www/test_layout.py
+++ b/tests/www/test_layout.py
@@ -6,10 +6,17 @@ from django.urls import reverse
 from itou.nexus.enums import Service
 from itou.nexus.models import ActivatedService
 from itou.users.enums import IdentityProvider
+from tests.companies.factories import CompanyMembershipFactory
+from tests.institutions.factories import InstitutionMembershipFactory
 from tests.nexus.factories import NexusUserFactory
 from tests.prescribers.factories import PrescriberMembershipFactory
 from tests.users.factories import EmployerFactory, JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
 from tests.utils.testing import parse_response_to_soup, pretty_indented, remove_static_hash
+
+
+def set_org_id_for_snapshot(soup):
+    for button in soup.find_all("button", {"name": "organization_key"}):
+        button["value"] = "ORGANIZATION_KEY"
 
 
 def test_navigation_not_authenticated(snapshot, client):
@@ -76,12 +83,6 @@ def test_navigation_authenticated(snapshot, client, user_factory):
     response = client.get(reverse("home:hp"), follow=True)
     soup = parse_response_to_soup(response)
 
-    def set_org_id_for_snapshot(soup):
-        organization_switcher_buttons = soup.find_all("button", {"class": "active", "name": "organization_key"})
-        if organization_switcher_buttons:
-            [organization_switcher_button] = organization_switcher_buttons
-            organization_switcher_button["value"] = "ORGANIZATION_KEY"
-
     [nav_primary] = soup.select("#nav-primary")
     set_org_id_for_snapshot(nav_primary)
     assert pretty_indented(nav_primary) == snapshot(name="user menu")
@@ -92,6 +93,24 @@ def test_navigation_authenticated(snapshot, client, user_factory):
             a_tags["href"] = remove_static_hash(a_tags["href"])  # Normalize href for CI
     set_org_id_for_snapshot(offcanvasNav)
     assert pretty_indented(offcanvasNav) == snapshot(name="navigation")
+
+
+def test_nav_dropdown_with_multiple_org_types(snapshot, client):
+    user = PrescriberMembershipFactory(organization__for_snapshot=True, user__for_snapshot=True).user
+    CompanyMembershipFactory(company__for_snapshot=True, user=user)
+    InstitutionMembershipFactory(institution__name="1 Titus Ion", user=user)
+    client.force_login(user)
+
+    response = client.get(reverse("home:hp"), follow=True)
+    soup = parse_response_to_soup(response)
+
+    [switcher_nav] = soup.select("li.dropdown-organization")
+    set_org_id_for_snapshot(switcher_nav)
+    assert pretty_indented(switcher_nav) == snapshot(name="multi organization structure switcher in nav")
+
+    [switcher_offcanvas] = soup.select("div.dropdown-organization")
+    set_org_id_for_snapshot(switcher_offcanvas)
+    assert pretty_indented(switcher_offcanvas) == snapshot(name="multi organization structure switcher in offcanvas")
 
 
 @pytest.mark.parametrize("case", ["disabled", "enabled_no_proconnect", "enabled", "enabled_all_activated"])
@@ -116,12 +135,6 @@ def test_nexus_dropdown(snapshot, client, case, pro_connect):
     client.force_login(user)
     response = client.get(reverse("home:hp"), follow=True)
     soup = parse_response_to_soup(response)
-
-    def set_org_id_for_snapshot(soup):
-        organization_switcher_buttons = soup.find_all("button", {"class": "active", "name": "organization_key"})
-        if organization_switcher_buttons:
-            [organization_switcher_button] = organization_switcher_buttons
-            organization_switcher_button["value"] = "ORGANIZATION_KEY"
 
     [offcanvasNav] = soup.select("#offcanvasNav")
     for a_tags in soup.find_all("a", attrs={"href": True}):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un utilisateur peut maintenant être membre d'organisations de plusieurs types. On ne peut plus utiliser le type de l'orga courante pour afficher toutes les autres.

## :cake: Comment ? <!-- optionnel -->

Une propriété dans `OrganizationAbstract` plutôt que de mettre plein de `{% if %}` dans le gabarit.

Utiliser `self.ORGANIZATION_KIND` plutôt que `isinstance(self, Company)` pour ne pas à avoir à gérer les imports cycliques.


---

Avant : 
<img width="332" height="389" alt="2026-04-22-181155_hyprshot" src="https://github.com/user-attachments/assets/a39ceeac-6d56-413e-8b84-920b22576e24" />


Après : 
<img width="320" height="386" alt="2026-04-22-181211_hyprshot" src="https://github.com/user-attachments/assets/ba0d0922-afa1-4c62-b542-4dd3854312cc" />
