### PR TITLE
Fiche salarie: amélioration des cas de NIR/NTT manquant pour les envois en modification des dates du PASS IAE

### DIFF
--- a/itou/employee_record/serializers.py
+++ b/itou/employee_record/serializers.py
@@ -89,6 +89,17 @@ class _StaticPersonSerializer(_PersonSerializer):
     def get_civilite(self, obj: EmployeeRecord) -> str:
         return super().get_civilite(obj) or Title.M.value
 
+    def get_salarieNIR(self, obj: EmployeeRecord) -> str:
+        if salarieNir := super().get_salarieNIR(obj):
+            return salarieNir
+        # Provide a valid NTT for update notification
+        ntt_parts = ["1" if self.get_civilite(obj) == Title.M.value else "2"]
+        ntt_parts.append("130030133")  # PDI SIREN
+        # With asp_uid being 30 characters long, it matches perfectly the 40-char max length
+        # constraint of NTT
+        ntt_parts.append(obj.job_application.job_seeker.jobseeker_profile.asp_uid)
+        return "".join(ntt_parts)
+
 
 class _AddressSerializer(serializers.Serializer):
     # Source object is a job seeker
@@ -355,7 +366,11 @@ class EmployeeRecordUpdateNotificationSerializer(serializers.Serializer):
                 for field in {"birth_country"}
             ]
         )
-        if is_missing_required_fields:
+        # Also check if a NIR/NTT is missing
+        if is_missing_required_fields or (
+            is_ntt_required(obj.employee_record.job_application.job_seeker.jobseeker_profile.nir)
+            and not obj.employee_record.ntt
+        ):
             return _StaticPersonSerializer(obj.employee_record).data
         return _PersonSerializer(obj.employee_record).data
 

--- a/tests/employee_record/__snapshots__/test_serializers.ambr
+++ b/tests/employee_record/__snapshots__/test_serializers.ambr
@@ -1552,6 +1552,48 @@
     'codetypevoie': 'AV',
   })
 # ---
+# name: test_update_notification_use_static_serializers_on_missing_fields[nir--personnePhysique]
+  ReturnDict({
+    'civilite': 'MME',
+    'codeComInsee': dict({
+      'codeComInsee': None,
+      'codeDpt': '099',
+    }),
+    'codeGroupePays': '3',
+    'codeInseePays': '102',
+    'dateNaissance': '01/01/1990',
+    'idItou': 'a08dbdb523633cfc59dfdb297307a1',
+    'nomNaissance': None,
+    'nomUsage': 'DOE',
+    'passDateDeb': '01/01/2000',
+    'passDateFin': '01/01/3000',
+    'passIae': '999999999999',
+    'prenom': 'JANE',
+    'salarieNIR': '2130030133a08dbdb523633cfc59dfdb297307a1',
+    'sufPassIae': None,
+  })
+# ---
+# name: test_update_notification_use_static_serializers_on_missing_ntt_field
+  ReturnDict({
+    'civilite': 'MME',
+    'codeComInsee': dict({
+      'codeComInsee': None,
+      'codeDpt': '099',
+    }),
+    'codeGroupePays': '3',
+    'codeInseePays': '102',
+    'dateNaissance': '01/01/1990',
+    'idItou': 'a08dbdb523633cfc59dfdb297307a1',
+    'nomNaissance': None,
+    'nomUsage': 'DOE',
+    'passDateDeb': '01/01/2000',
+    'passDateFin': '01/01/3000',
+    'passIae': '999999999999',
+    'prenom': 'JANE',
+    'salarieNIR': '2130030133a08dbdb523633cfc59dfdb297307a1',
+    'sufPassIae': None,
+  })
+# ---
 # name: test_update_notification_use_static_serializers_on_missing_pole_emploi_since_fields
   ReturnDict({
     'cotisationsTI': None,

--- a/tests/employee_record/test_serializers.py
+++ b/tests/employee_record/test_serializers.py
@@ -254,6 +254,7 @@ class TestEmployeeRecordUpdateNotificationSerializer:
         ("hexa_post_code", "", "adresse"),
         ("hexa_commune", None, "adresse"),
         ("education_level", "", "situationSalarie"),
+        ("nir", "", "personnePhysique"),
     ],
 )
 def test_update_notification_use_static_serializers_on_missing_fields(snapshot, field, value, key):
@@ -266,6 +267,18 @@ def test_update_notification_use_static_serializers_on_missing_fields(snapshot, 
 
     data = EmployeeRecordUpdateNotificationSerializer(notification).data
     assert data[key] == snapshot()
+
+
+def test_update_notification_use_static_serializers_on_missing_ntt_field(snapshot):
+    notification = EmployeeRecordUpdateNotificationFactory(
+        employee_record__job_application__for_snapshot=True,
+        # such NIR starting with an 8 requires a NTT
+        employee_record__job_application__job_seeker__jobseeker_profile__nir="890012345678901",
+        employee_record__ntt=None,
+    )
+
+    data = EmployeeRecordUpdateNotificationSerializer(notification).data
+    assert data["personnePhysique"] == snapshot()
 
 
 def test_update_notification_use_static_serializers_on_missing_pole_emploi_since_fields(snapshot):

--- a/tests/employee_record/test_transfer_employee_records_updates.py
+++ b/tests/employee_record/test_transfer_employee_records_updates.py
@@ -81,6 +81,8 @@ def test_preflight_with_error(snapshot, command, caplog):
         ready_for_transfer=True,
         employee_record__approval_number="",
         employee_record__job_application__approval=None,
+        # Make sure a missing NTT does not change the error message
+        employee_record__job_application__job_seeker__jobseeker_profile__with_classic_nir=True,
         # Data used by the snapshot
         pk=42,
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sinon, les fiches salarie envoyées sans NIR/NTT mais qui nécessitent d'être renvoyées pour modification (suite à une modification de la date de fin du PASS IAE) finissent avec une erreur 3501 et empêchent donc la mise à jour de la date de fin de PASS coté ASP.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
