### PR TITLE
Tech : Utilisation de `@dry_runnable` pour `sync_romes_and_appellations` et `sync_ft_organizations`

### DIFF
--- a/itou/jobs/management/commands/sync_romes_and_appellations.py
+++ b/itou/jobs/management/commands/sync_romes_and_appellations.py
@@ -1,4 +1,5 @@
 from django.utils import timezone
+from itoutils.django.commands import dry_runnable
 
 from itou.jobs.models import Appellation, Rome
 from itou.utils.apis import pe_api_enums
@@ -28,11 +29,14 @@ class Command(BaseCommand):
     enough to not setup the whole process of keeping track of outdated objects in the sync, etc.
     """
 
+    ATOMIC_HANDLE = True
+
     help = "Synchronizes ROMEs and Appellations from the PE API"
 
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
+    @dry_runnable
     def handle(self, *, wet_run, **options):
         now = timezone.now()
 
@@ -43,29 +47,27 @@ class Command(BaseCommand):
         for item in yield_sync_diff(romes_data, "code", Rome.objects.all(), "code", [("libelle", "name")]):
             self.logger.info(item.label)
 
-        if wet_run:
-            romes = [pe_data_to_rome(item, now) for item in romes_data]
-            Rome.objects.bulk_create(
-                romes,
-                batch_size=BULK_CREATE_BATCH_SIZE,
-                update_conflicts=True,
-                update_fields=("name", "updated_at"),
-                unique_fields=("code",),
-            )
-            self.logger.info("len=%d ROME entries have been created or updated.", len(romes))
+        romes = [pe_data_to_rome(item, now) for item in romes_data]
+        Rome.objects.bulk_create(
+            romes,
+            batch_size=BULK_CREATE_BATCH_SIZE,
+            update_conflicts=True,
+            update_fields=("name", "updated_at"),
+            unique_fields=("code",),
+        )
+        self.logger.info("len=%d ROME entries have been created or updated.", len(romes))
 
         for item in yield_sync_diff(
             appellations_data, "code", Appellation.objects.all(), "code", [("libelle", "name")]
         ):
             self.logger.info(item.label)
 
-        if wet_run:
-            appellations = [pe_data_to_appellation(item, now) for item in appellations_data]
-            Appellation.objects.bulk_create(
-                appellations,
-                batch_size=BULK_CREATE_BATCH_SIZE,
-                update_conflicts=True,
-                update_fields=("name", "updated_at", "rome_id"),
-                unique_fields=("code",),
-            )
-            self.logger.info("len=%d Appellation entries have been created or updated.", len(appellations))
+        appellations = [pe_data_to_appellation(item, now) for item in appellations_data]
+        Appellation.objects.bulk_create(
+            appellations,
+            batch_size=BULK_CREATE_BATCH_SIZE,
+            update_conflicts=True,
+            update_fields=("name", "updated_at", "rome_id"),
+            unique_fields=("code",),
+        )
+        self.logger.info("len=%d Appellation entries have been created or updated.", len(appellations))

--- a/itou/prescribers/management/commands/sync_ft_organizations.py
+++ b/itou/prescribers/management/commands/sync_ft_organizations.py
@@ -1,5 +1,6 @@
 from django.db import IntegrityError, transaction
 from django.db.models import Q
+from itoutils.django.commands import dry_runnable
 
 from itou.cities.models import City
 from itou.common_apps.address.models import BAN_API_RELIANCE_SCORE, lat_lon_to_coords
@@ -76,7 +77,7 @@ class Command(BaseCommand):
         parser.add_argument("action", choices=["update-information", "fix-empty-safir"])
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 
-    def fix_empty_safir(self, data, *, wet_run=False):
+    def fix_empty_safir(self, data):
         data_by_siret = {datum["siret"]: datum for datum in data if datum.get("siret")}
         for organization in PrescriberOrganization.objects.filter(
             Q(code_safir_pole_emploi="") | Q(code_safir_pole_emploi=None),
@@ -86,14 +87,13 @@ class Command(BaseCommand):
             self.stdout.write(f"Organization={organization.pk} doesn't have a safir code")
             organization.code_safir_pole_emploi = data_by_siret[organization.siret]["codeSafir"]
             self.stdout.write(f"Set safir={organization.code_safir_pole_emploi} for organization={organization} ")
-            if wet_run:
-                try:
-                    with transaction.atomic():
-                        organization.save(update_fields={"code_safir_pole_emploi"})
-                except IntegrityError:
-                    self.stdout.write(f"ERR: safir={organization.code_safir_pole_emploi} already used")
+            try:
+                with transaction.atomic():
+                    organization.save(update_fields={"code_safir_pole_emploi"})
+            except IntegrityError:
+                self.stdout.write(f"ERR: safir={organization.code_safir_pole_emploi} already used")
 
-    def update_information(self, data, *, wet_run=False):
+    def update_information(self, data):
         qs = PrescriberOrganization.objects.filter(kind=PrescriberOrganizationKind.FT).exclude(
             Q(code_safir_pole_emploi="") | Q(code_safir_pole_emploi=None)
         )
@@ -134,17 +134,16 @@ class Command(BaseCommand):
                     authorization_status=PrescriberAuthorizationStatus.VALIDATED,
                 )
                 fill_organization_from_api_data(obj, siret, item.raw)
-                if wet_run:
-                    obj.save()
+                obj.save()
             elif item.kind == DiffItemKind.EDITION:
                 fill_organization_from_api_data(item.db_obj, siret, item.raw)
-                if wet_run:
-                    item.db_obj.save()
+                item.db_obj.save()
 
+    @dry_runnable
     def handle(self, *, action, wet_run=False, **options):
         data = pole_emploi_partenaire_api_client().agences()
         match action:
             case "fix-empty-safir":
-                self.fix_empty_safir(data, wet_run=wet_run)
+                self.fix_empty_safir(data)
             case "update-information":
-                self.update_information(data, wet_run=wet_run)
+                self.update_information(data)

--- a/itou/prescribers/management/commands/sync_ft_organizations.py
+++ b/itou/prescribers/management/commands/sync_ft_organizations.py
@@ -29,10 +29,6 @@ def address_from_api_data(data):
     return data["adressePrincipale"].get("ligne4")
 
 
-def address_extra_from_api_data(data):
-    return data["adressePrincipale"].get("ligne3", "")
-
-
 def post_code_from_api_data(data):
     return data["adressePrincipale"].get("bureauDistributeur")
 
@@ -57,7 +53,6 @@ def fill_organization_from_api_data(obj, siret, data):
     obj.email = email_from_api_data(data)
     # Address
     obj.address_line_1 = address_from_api_data(data)
-    obj.address_line_2 = address_extra_from_api_data(data)
     obj.post_code = post_code_from_api_data(data)
     # Geolocation
     obj.coords = coordinates_from_api_data(data)
@@ -103,7 +98,6 @@ class Command(BaseCommand):
             (phone_from_api_data, "phone"),
             (email_from_api_data, "email"),
             (address_from_api_data, "address_line_1"),
-            (address_extra_from_api_data, "address_line_2"),
             (post_code_from_api_data, "post_code"),
             (coordinates_from_api_data, "coords"),
             (insee_city_from_api_data, "insee_city"),

--- a/tests/jobs/management/__snapshots__/test_sync_romes_and_appellations.ambr
+++ b/tests/jobs/management/__snapshots__/test_sync_romes_and_appellations.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: test_sync_rome_appellation[logs]
+  list([
+    'HTTP Request: POST https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire "HTTP/1.1 200 OK"',
+    'HTTP Request: GET https://pe.fake/offresdemploi/v2/referentiel/metiers "HTTP/1.1 200 OK"',
+    'HTTP Request: GET https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code) "HTTP/1.1 200 OK"',
+    'count=1 label=Rome had the same key in collection and queryset',
+    '\tCHANGED name=Patisserie changed to value=Pâtisserie avec accent',
+    'count=1 label=Rome added by collection',
+    '\tADDED {"code": "MET01", "libelle": "Edition"}',
+    'count=2 label=Rome removed by collection',
+    '\tREMOVED Métiers du corps (B001)',
+    '\tREMOVED Arts de la table (F002)',
+    'len=2 ROME entries have been created or updated.',
+    'count=2 label=Appellation had the same key in collection and queryset',
+    '\tCHANGED name=Entraîneur sportif changed to value=Entraîneur sportif avéré',
+    "\tCHANGED name=Chef cuistot d'élite changed to value=Chef cuistor d'élite",
+    'count=1 label=Appellation added by collection',
+    '\tADDED {"code": "JOB32", "libelle": "Ecriveur de bouquins", "metier": {"code": "MET01"}}',
+    'count=0 label=Appellation removed by collection',
+    'len=3 Appellation entries have been created or updated.',
+  ])
+# ---

--- a/tests/jobs/management/test_sync_romes_and_appellations.py
+++ b/tests/jobs/management/test_sync_romes_and_appellations.py
@@ -12,7 +12,7 @@ from itou.jobs.models import Appellation, Rome
         "SECRET": "pe-secret",
     }
 )
-def test_sync_rome_appellation(caplog, respx_mock):
+def test_sync_rome_appellation(caplog, respx_mock, snapshot):
     respx_mock.post("https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire").respond(
         200, json={"token_type": "foo", "access_token": "batman", "expires_in": 3600}
     )
@@ -43,29 +43,7 @@ def test_sync_rome_appellation(caplog, respx_mock):
     appellation0.save()
     appellation1.save()
     management.call_command("sync_romes_and_appellations", wet_run=True)
-    assert caplog.messages[:-1] == [
-        'HTTP Request: POST https://auth.fr/connexion/oauth2/access_token?realm=%2Fpartenaire "HTTP/1.1 200 OK"',
-        'HTTP Request: GET https://pe.fake/offresdemploi/v2/referentiel/metiers "HTTP/1.1 200 OK"',
-        (
-            "HTTP Request: GET https://pe.fake/rome-metiers/v1/metiers/appellation?champs=code,libelle,metier(code) "
-            '"HTTP/1.1 200 OK"'
-        ),
-        "count=1 label=Rome had the same key in collection and queryset",
-        "\tCHANGED name=Patisserie changed to value=Pâtisserie avec accent",
-        "count=1 label=Rome added by collection",
-        '\tADDED {"code": "MET01", "libelle": "Edition"}',
-        "count=2 label=Rome removed by collection",
-        "\tREMOVED Métiers du corps (B001)",
-        "\tREMOVED Arts de la table (F002)",  # not really removed though by our command, see docstring
-        "len=2 ROME entries have been created or updated.",
-        "count=2 label=Appellation had the same key in collection and queryset",
-        "\tCHANGED name=Entraîneur sportif changed to value=Entraîneur sportif avéré",
-        "\tCHANGED name=Chef cuistot d'élite changed to value=Chef cuistor d'élite",
-        "count=1 label=Appellation added by collection",
-        '\tADDED {"code": "JOB32", "libelle": "Ecriveur de bouquins", "metier": {"code": "MET01"}}',
-        "count=0 label=Appellation removed by collection",
-        "len=3 Appellation entries have been created or updated.",
-    ]
+    assert caplog.messages[:-1] == snapshot(name="logs")
     caplog.messages[-1].startswith(
         "Management command itou.jobs.management.commands.sync_romes_and_appellations succeeded in"
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Travail préparatoire à leur conversion vers le nouvel utilitaire de synchronisation et que c'est pas plus mal en soi :).