### PR TITLE
Tech: passage de `update_companies_job_app_score` en `dry_runnable`

### DIFF
--- a/itou/companies/management/commands/update_companies_job_app_score.py
+++ b/itou/companies/management/commands/update_companies_job_app_score.py
@@ -1,4 +1,5 @@
 from django.db.models import F, Q
+from itoutils.django.commands import dry_runnable
 
 from itou.companies import models
 from itou.utils.command import BaseCommand
@@ -7,6 +8,12 @@ from itou.utils.command import BaseCommand
 class Command(BaseCommand):
     help = """Update the company job_app_score"""
 
+    ATOMIC_HANDLE = True
+
+    def add_arguments(self, parser):
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+
+    @dry_runnable
     def handle(self, **options):
         nb_updated = (
             models.Company.objects.with_computed_job_app_score()

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -1,5 +1,4 @@
 import datetime
-import io
 import operator
 
 import pytest
@@ -225,7 +224,6 @@ def test_update_companies_job_app_score(caplog):
     caplog.clear()
 
     # Wet run now
-    stdout = io.StringIO()
     management.call_command("update_companies_job_app_score", wet_run=True)
     assert caplog.messages[0] == "Updated 2 companies"
 
@@ -244,7 +242,7 @@ def test_update_companies_job_app_score(caplog):
     for jd in company_2.job_description_through.all():
         jd.delete()
     caplog.clear()
-    management.call_command("update_companies_job_app_score", wet_run=True, stdout=stdout)
+    management.call_command("update_companies_job_app_score", wet_run=True)
     # company_2 changed
     assert caplog.messages[0] == "Updated 1 companies"
 

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -211,8 +211,22 @@ def test_update_companies_job_app_score(caplog):
     assert company_1.job_app_score == Company.MAX_DEFAULT_JOB_APP_SCORE
     assert company_2.job_app_score == Company.MAX_DEFAULT_JOB_APP_SCORE
 
+    # Dry run first
+    management.call_command("update_companies_job_app_score", wet_run=False)
+    assert caplog.messages[0] == "Command launched with wet_run=False"
+    assert caplog.messages[1] == "Updated 2 companies"
+
+    company_1.refresh_from_db()
+    company_2.refresh_from_db()
+
+    assert company_1.job_app_score == Company.MAX_DEFAULT_JOB_APP_SCORE
+    assert company_2.job_app_score == Company.MAX_DEFAULT_JOB_APP_SCORE
+
+    caplog.clear()
+
+    # Wet run now
     stdout = io.StringIO()
-    management.call_command("update_companies_job_app_score")
+    management.call_command("update_companies_job_app_score", wet_run=True)
     assert caplog.messages[0] == "Updated 2 companies"
 
     company_1.refresh_from_db()
@@ -230,7 +244,7 @@ def test_update_companies_job_app_score(caplog):
     for jd in company_2.job_description_through.all():
         jd.delete()
     caplog.clear()
-    management.call_command("update_companies_job_app_score", stdout=stdout)
+    management.call_command("update_companies_job_app_score", wet_run=True, stdout=stdout)
     # company_2 changed
     assert caplog.messages[0] == "Updated 1 companies"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour régler https://inclusion.sentry.io/issues/112922284 concernant cette commande et c'est le comportement (`dry_runnable`) que l'on souhaite par défaut sur toutes nos commandes.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
