### PR TITLE
Tests : Correction de bagottage possible en ne générant plus de codes postaux invalides pour la Corse

### DIFF
--- a/itou/cities/models.py
+++ b/itou/cities/models.py
@@ -17,8 +17,6 @@ class EditionModeChoices(models.TextChoices):
 class City(models.Model):
     """French cities with their geocoding data, synchronized via the sync_cities script regularly."""
 
-    DEPARTMENT_CHOICES = DEPARTMENTS.items()
-
     name = models.CharField(verbose_name="ville", max_length=255, db_index=True)
     normalized_name = models.GeneratedField(
         expression=Replace(Lower(SlylyImmutableUnaccent("name")), Value("-"), Value(" ")),
@@ -27,7 +25,7 @@ class City(models.Model):
         db_persist=True,
     )
     slug = models.SlugField(verbose_name="slug", max_length=255, unique=True)
-    department = models.CharField(verbose_name="département", choices=DEPARTMENT_CHOICES, max_length=3, db_index=True)
+    department = models.CharField(verbose_name="département", choices=DEPARTMENTS.items(), max_length=3, db_index=True)
 
     # Note that post codes and insee codes have a n-to-n relationship.
     # One insee code can have several post codes but the inverse is also true e.g. zip code 33360 has six insee codes.

--- a/itou/common_apps/address/models.py
+++ b/itou/common_apps/address/models.py
@@ -135,8 +135,6 @@ class AddressMixin(models.Model):
     # instead implement a way for the user to confirm it directly (semi-auto selection in the form for instance)
     BAN_API_LEGACY_RELIANCE_SCORE = 0.4
 
-    DEPARTMENT_CHOICES = DEPARTMENTS.items()
-
     address_line_1 = models.CharField(verbose_name="adresse", max_length=255, blank=True)
     address_line_2 = models.CharField(
         verbose_name="complément d'adresse",
@@ -153,7 +151,7 @@ class AddressMixin(models.Model):
     city = models.CharField(verbose_name="ville", max_length=255, blank=True)
     department = models.CharField(
         verbose_name="département",
-        choices=DEPARTMENT_CHOICES,
+        choices=DEPARTMENTS.items(),
         max_length=3,
         blank=True,
         db_index=True,

--- a/itou/utils/faker_providers.py
+++ b/itou/utils/faker_providers.py
@@ -24,3 +24,10 @@ class ItouProvider(BaseProvider):
         return Point(
             [float(coord) for coord in self.generator.format("local_latlng", country_code="FR", coords_only=True)]
         )
+
+    def postalcode(self) -> str:
+        while True:
+            postcode = self.generator.format("postcode")
+            if postcode.startswith("20") and postcode[:3] not in {"200", "201", "202", "204", "206", "207"}:
+                continue
+            return postcode


### PR DESCRIPTION
## :thinking: Pourquoi ?

Vu avec ce test : `pytest -v --randomly-seed=2634371339 tests/www/job_seekers_views/test_search_services.py::test_search_services_no_city[True-list_view]`

Le changement sur `DEPARTMENT_CHOICES` n'a rien à voir avec la choucroute mais autant s'en débarrasser.