### PR TITLE
Tech: appel de `update_companies_job_app_score` en `--wet-run` dans les taches planifiées

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -5,7 +5,7 @@
   "*/20 7-18 * * MON-FRI $ROOT/clevercloud/run_management_command.sh anonymize_jobseekers --wet-run",
 
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_ft_offers --wet-run",
-  "5 * * * * $ROOT/clevercloud/run_management_command.sh update_companies_job_app_score",
+  "5 * * * * $ROOT/clevercloud/run_management_command.sh update_companies_job_app_score --wet-run",
   "10 * * * * $ROOT/clevercloud/run_management_command.sh pe_certify_users --wet-run",
   "15 * * * * $ROOT/clevercloud/run_management_command.sh sanitize_employee_records",
   "30 * * * * $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",


### PR DESCRIPTION
## :thinking: Pourquoi ?

Je l'ai retrouvé dans mon espace de travail, loin du [commit](https://github.com/gip-inclusion/les-emplois/commit/aea4b27b6c3817113407f92eb6d61e7d11fb59bd) auquel il était destiné :disappointed: 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
