### PR TITLE
Tech: utilisation de `@dry_runnable` dans la commande `resolve_insee_cities`

### DIFF
--- a/itou/cities/management/commands/resolve_insee_cities.py
+++ b/itou/cities/management/commands/resolve_insee_cities.py
@@ -15,6 +15,7 @@ that we can ask the users to fix it.
 """
 
 from django.core.management.base import CommandError
+from itoutils.django.commands import dry_runnable
 
 from itou.common_apps.address.models import BAN_API_RELIANCE_SCORE, resolve_insee_city
 from itou.companies.models import Company
@@ -25,6 +26,8 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
     # Keep the running duration low (<10s), no matter the size of the table.
     # After the initial "migration" this command will only take care of the eventual
     # address changes, so probably very few objects at a time.
@@ -46,7 +49,8 @@ class Command(BaseCommand):
             required=True,
         )
 
-    def handle(self, wet_run, mode, **options):
+    @dry_runnable
+    def handle(self, mode, **options):
         if mode == "companies":
             queryset = Company.objects.active()
             model = Company
@@ -82,18 +86,17 @@ class Command(BaseCommand):
                 self.logger.warning(f"Failed to find matching city for {item.city=} {item.post_code=}")
                 item.geocoding_score = 0  # reset the score to not see them again next run of the cron
                 failed_items.append(item)
-        if wet_run:
-            model.objects.bulk_update(
-                updated_items,
-                ["insee_city"],
-                batch_size=self.BATCH_UPDATE_SIZE,
-            )
-            model.objects.bulk_update(
-                failed_items,
-                ["geocoding_score"],
-                batch_size=self.BATCH_UPDATE_SIZE,
-            )
-            self.logger.info(
-                f"count={len(updated_items)} {model_name} updated and "
-                f"err_count={len(failed_items)} {model_name} without a resolution."
-            )
+        model.objects.bulk_update(
+            updated_items,
+            ["insee_city"],
+            batch_size=self.BATCH_UPDATE_SIZE,
+        )
+        model.objects.bulk_update(
+            failed_items,
+            ["geocoding_score"],
+            batch_size=self.BATCH_UPDATE_SIZE,
+        )
+        self.logger.info(
+            f"count={len(updated_items)} {model_name} updated and "
+            f"err_count={len(failed_items)} {model_name} without a resolution."
+        )

--- a/tests/cities/__snapshots__/tests.ambr
+++ b/tests/cities/__snapshots__/tests.ambr
@@ -1,4 +1,13 @@
 # serializer version: 1
+# name: test_resolve_insee_cities[dry_run]
+  list([
+    'Command launched with wet_run=False',
+    "Failed to find matching city for item.city='ERAND' item.post_code='44350'",
+    "Failed to find matching city for item.city='Guérande' item.post_code='54350'",
+    'count=1 JobSeeker updated and err_count=2 JobSeeker without a resolution.',
+    'Setting transaction to be rollback as wet_run=False',
+  ])
+# ---
 # name: test_resolve_insee_cities[first_pass]
   list([
     "Failed to find matching city for item.city='ERAND' item.post_code='44350'",

--- a/tests/cities/tests.py
+++ b/tests/cities/tests.py
@@ -393,12 +393,23 @@ def test_resolve_insee_cities(caplog, snapshot):
     user = JobSeekerFactory(city="GUERAND", post_code="44350", geocoding_score=0.9)
     non_resolved_user_1 = JobSeekerFactory(city="Guérande", post_code="54350", geocoding_score=0.9)
     non_resolved_user_2 = JobSeekerFactory(city="ERAND", post_code="44350", geocoding_score=0.9)
+
+    # Dry run
+    call_command("resolve_insee_cities", wet_run=False, mode="job_seekers")
+    assert caplog.messages[:-1] == snapshot(name="dry_run")
+    assert caplog.messages[-1].startswith(
+        "Management command itou.cities.management.commands.resolve_insee_cities succeeded in "
+    )
+    user.refresh_from_db()
+    assert user.insee_city is None
+    caplog.clear()
+
+    # Wet run
     call_command("resolve_insee_cities", wet_run=True, mode="job_seekers")
     assert caplog.messages[:-1] == snapshot(name="first_pass")
     assert caplog.messages[-1].startswith(
         "Management command itou.cities.management.commands.resolve_insee_cities succeeded in "
     )
-
     user.refresh_from_db()
     assert user.insee_city == guerande
     non_resolved_user_1.refresh_from_db()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter l'erreur https://inclusion.sentry.io/issues/112922284/ et migrer une commande de plus à `@dry_runnable` qui devrait être le comportement par défaut de nos commandes.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
