### PR TITLE
Tech: utilisation de `dry_runnable`  dans la commande `sanitize_employee_records`

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -7,7 +7,7 @@
   "5 * * * * $ROOT/clevercloud/run_management_command.sh sync_ft_offers --wet-run",
   "5 * * * * $ROOT/clevercloud/run_management_command.sh update_companies_job_app_score --wet-run",
   "10 * * * * $ROOT/clevercloud/run_management_command.sh pe_certify_users --wet-run",
-  "15 * * * * $ROOT/clevercloud/run_management_command.sh sanitize_employee_records",
+  "15 * * * * $ROOT/clevercloud/run_management_command.sh sanitize_employee_records --wet-run",
   "30 * * * * $ROOT/clevercloud/run_management_command.sh upload_data_to_pilotage asp_riae_shared_bucket/ --wet-run",
   "45 * * * * $ROOT/clevercloud/run_management_command.sh requeue_tasks",
   "0 * * * * $ROOT/clevercloud/run_management_command.sh resolve_insee_cities --wet-run --mode=companies",

--- a/itou/employee_record/management/commands/sanitize_employee_records.py
+++ b/itou/employee_record/management/commands/sanitize_employee_records.py
@@ -1,6 +1,6 @@
-import django.db.transaction as transaction
 import xworkflows
 from django.utils import timezone
+from itoutils.django.commands import dry_runnable
 
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
@@ -10,6 +10,8 @@ from itou.utils.command import BaseCommand
 class Command(BaseCommand):
     """Performs checks and fixes on known employee records glitches."""
 
+    ATOMIC_HANDLE = True
+
     # Limit to 10 as we shouldn't have more than that in nominal situations, but mainly because we are
     # limited by how much we can transfer: 1 file, 700 rows, every 2 hours on weekdays.
     # The command is executed every hour, so on Monday morning we will have more than 600 rows to send.
@@ -18,16 +20,11 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
 
-        parser.add_argument(
-            "--dry-run",
-            action="store_true",
-            dest="dry_run",
-            help="Just check and report, don't fix anything",
-        )
+        parser.add_argument("--wet-run", action="store_true", dest="wet_run")
 
     # Check and fix methods: add as many as needed.
 
-    def _check_approvals(self, dry_run):
+    def _check_approvals(self):
         # Report employee records with no approvals
         # (approvals can be deleted after processing)
 
@@ -38,14 +35,10 @@ class Command(BaseCommand):
 
         self.logger.info("found %d employee records with missing approval", count_no_approval)
         if count_no_approval:
-            if dry_run:
-                return
-
             delete_nb, _delete_info = no_approval.delete()
             self.logger.info("deleted %d/%d employee records with missing approval", delete_nb, count_no_approval)
 
-    @transaction.atomic()
-    def _check_missed_notifications(self, dry_run):
+    def _check_missed_notifications(self):
         self.stdout.write("* Checking missing employee records notifications:")
         employee_record_with_missing_notification = (
             EmployeeRecord.objects.missed_notifications()
@@ -65,25 +58,22 @@ class Command(BaseCommand):
         )
 
         unarchive_count = 0
-        if not dry_run:
-            for employee_record in employee_record_with_missing_notification[: self.MAX_MISSED_NOTIFICATIONS_CREATED]:
-                try:
-                    employee_record.unarchive()
-                except xworkflows.AbortTransition:
-                    self.logger.exception("Failed to unarchive employee_record=%s", employee_record)
-                else:
-                    unarchive_count += 1
+        for employee_record in employee_record_with_missing_notification[: self.MAX_MISSED_NOTIFICATIONS_CREATED]:
+            try:
+                employee_record.unarchive()
+            except xworkflows.AbortTransition:
+                self.logger.exception("Failed to unarchive employee_record=%s", employee_record)
+            else:
+                unarchive_count += 1
         self.logger.info(
             "%d/%d employee records were unarchived", unarchive_count, len(employee_record_with_missing_notification)
         )
 
-    def handle(self, *, dry_run, **options):
+    @dry_runnable
+    def handle(self, **options):
         self.logger.info("Checking employee records coherence before transferring to ASP")
 
-        if dry_run:
-            self.logger.info("DRY-RUN mode: not fixing, just reporting")
-
-        self._check_approvals(dry_run)
-        self._check_missed_notifications(dry_run)
+        self._check_approvals()
+        self._check_missed_notifications()
 
         self.logger.info("Employee records sanitizing done. Have a great day!")

--- a/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
+++ b/tests/employee_record/__snapshots__/test_sanitize_employee_records.ambr
@@ -1,16 +1,22 @@
 # serializer version: 1
 # name: test_missed_notifications
   list([
+    'Checking employee records coherence before transferring to ASP',
+    'found 0 employee records with missing approval',
     'found 1 missed employee records notifications',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
     '1/1 employee records were unarchived',
+    'Employee records sanitizing done. Have a great day!',
   ])
 # ---
 # name: test_missed_notifications_limit
   list([
+    'Checking employee records coherence before transferring to ASP',
+    'found 0 employee records with missing approval',
     'found 3 missed employee records notifications',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
     '[EMPLOYEE RECORD] performed transition EmployeeRecordWorkflow.unarchive_new (ARCHIVED -> NEW)',
     '2/3 employee records were unarchived',
+    'Employee records sanitizing done. Have a great day!',
   ])
 # ---

--- a/tests/employee_record/test_sanitize_employee_records.py
+++ b/tests/employee_record/test_sanitize_employee_records.py
@@ -15,15 +15,16 @@ def command_fixture():
     return sanitize_employee_records.Command(stdout=io.StringIO(), stderr=io.StringIO())
 
 
-def test_handle_dry_run_option(mocker, command, caplog):
+def test_handle_dry_run(mocker, command, caplog):
     mocker.patch.object(command, "_check_approvals")
     mocker.patch.object(command, "_check_missed_notifications")
 
-    command.handle(dry_run=True)
+    command.handle(wet_run=False)
     assert caplog.messages == [
+        "Command launched with wet_run=False",
         "Checking employee records coherence before transferring to ASP",
-        "DRY-RUN mode: not fixing, just reporting",
         "Employee records sanitizing done. Have a great day!",
+        "Setting transaction to be rollback as wet_run=False",
     ]
 
 
@@ -34,13 +35,18 @@ def test_missing_approvals(command, caplog):
     employee_record.job_application.approval = None
     employee_record.job_application.save()
 
-    command._check_approvals(dry_run=False)
+    command.handle(wet_run=True)
 
     assert models.EmployeeRecord.objects.count() == 0
     assert caplog.messages == [
+        "Checking employee records coherence before transferring to ASP",
         "found 1 employee records with missing approval",
         "deleted 1/1 employee records with missing approval",
+        "found 0 missed employee records notifications",
+        "0/0 employee records were unarchived",
+        "Employee records sanitizing done. Have a great day!",
     ]
+    assert not models.EmployeeRecord.objects.filter(pk=employee_record.pk).exists()
 
 
 def test_missed_notifications(command, faker, caplog, snapshot):
@@ -77,7 +83,7 @@ def test_missed_notifications(command, faker, caplog, snapshot):
     )
 
     # Various cases are now set up, finally check the behavior
-    command._check_missed_notifications(dry_run=False)
+    command.handle(wet_run=True)
     assert employee_record_before_approval.update_notifications.count() == 1
     employee_record_before_approval.refresh_from_db()
     assert employee_record_before_approval.status != Status.ARCHIVED
@@ -95,7 +101,7 @@ def test_missed_notifications_limit(faker, mocker, snapshot, command, caplog):
         ),
     )
 
-    command._check_missed_notifications(dry_run=False)
+    command.handle(wet_run=True)
 
     assert models.EmployeeRecordUpdateNotification.objects.count() == 2
     assert [re.sub(r"<EmployeeRecord: .+?>", "[EMPLOYEE RECORD]", msg) for msg in caplog.messages] == snapshot()


### PR DESCRIPTION
## :thinking: Pourquoi ?

Éviter l'erreur https://inclusion.sentry.io/issues/112922284/ et migrer une commande de plus à `@dry_runnable` qui devrait être le comportement par défaut de nos commandes.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
