### PR TITLE
Interface : Correction d'un bug permettant d'avoir plusieurs organisations sélectionnées dans le menu de sélection d'organisation

### DIFF
--- a/itou/templates/layout/_organization_switcher_dropdown_menu.html
+++ b/itou/templates/layout/_organization_switcher_dropdown_menu.html
@@ -3,7 +3,9 @@
     <ul class="list-unstyled">
         {% for org in organizations %}
             <li>
-                <button class="dropdown-item dropdown-item__summary{% if org.pk == current_organization.pk %} active{% endif %}" name="organization_key" value="{{ org.organization_switch_key }}">
+                <button class="dropdown-item dropdown-item__summary{% if org.organization_switch_key == current_organization.organization_switch_key %} active{% endif %}"
+                        name="organization_key"
+                        value="{{ org.organization_switch_key }}">
                     <i class="{{ org.icon }}" aria-hidden="true"></i>
                     <span>{{ org.kind }}</span>
                     {% if org.display_name|length > 18 %}

--- a/tests/www/test_layout.py
+++ b/tests/www/test_layout.py
@@ -96,9 +96,12 @@ def test_navigation_authenticated(snapshot, client, user_factory):
 
 
 def test_nav_dropdown_with_multiple_org_types(snapshot, client):
-    user = PrescriberMembershipFactory(organization__for_snapshot=True, user__for_snapshot=True).user
-    CompanyMembershipFactory(company__for_snapshot=True, user=user)
-    InstitutionMembershipFactory(institution__name="1 Titus Ion", user=user)
+    # Force pks to be identical: only one menu entry should be `active`
+    user = PrescriberMembershipFactory(
+        organization__for_snapshot=True, user__for_snapshot=True, organization__pk=5001
+    ).user
+    CompanyMembershipFactory(company__for_snapshot=True, user=user, company__pk=5001)
+    InstitutionMembershipFactory(institution__name="1 Titus Ion", user=user, institution__pk=5001)
     client.force_login(user)
 
     response = client.get(reverse("home:hp"), follow=True)


### PR DESCRIPTION
## :thinking: Pourquoi ?

Dans le cadre de la fusion des types d'utilisateurs pro, un utilisateur peut être membre d'organisations de différents types.
On ne peut donc plus garantir que leur PK soit unique dans le menu de sélection d'organisation.

