### PR TITLE
Tech: utilisation d'un seul `AUTHENTICATION_BACKENDS`

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -364,10 +364,7 @@ DJANGO_DATADOG_LOGGER_EXTRA_INCLUDE = re.compile(
 
 AUTH_USER_MODEL = "users.User"
 
-AUTHENTICATION_BACKENDS = (
-    "django.contrib.auth.backends.ModelBackend",
-    "allauth.account.auth_backends.AuthenticationBackend",
-)
+AUTHENTICATION_BACKENDS = ("allauth.account.auth_backends.AuthenticationBackend",)
 
 SILENCED_SYSTEM_CHECKS = ["slippers.E001"]  # We register the components differently
 

--- a/itou/openid_connect/france_connect/views.py
+++ b/itou/openid_connect/france_connect/views.py
@@ -216,9 +216,7 @@ def france_connect_callback(request):
 
     init_user_nir_from_session(request, user)
 
-    # Because we have more than one Authentication backend in our settings, we need to specify
-    # the one we want to use in login
-    login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+    login(request, user)
     # Keep token_data["id_token"] to logout from FC
     request.session[constants.FRANCE_CONNECT_SESSION_TOKEN] = token_data["id_token"]
     request.session[constants.FRANCE_CONNECT_SESSION_STATE] = state

--- a/itou/openid_connect/pe_connect/views.py
+++ b/itou/openid_connect/pe_connect/views.py
@@ -196,9 +196,7 @@ def pe_connect_callback(request):
         # Async via Huey
         huey_import_user_pe_data(user, access_token, latest_pe_data_import)
 
-    # Because we have more than one Authentication backend in our settings, we need to specify
-    # the one we want to use in login
-    login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+    login(request, user)
     # Keep token_data["id_token"] to logout from PEAMU
     request.session[constants.PE_CONNECT_SESSION_TOKEN] = token_data["id_token"]
     request.session[constants.PE_CONNECT_SESSION_STATE] = state

--- a/itou/openid_connect/pro_connect/views.py
+++ b/itou/openid_connect/pro_connect/views.py
@@ -390,9 +390,7 @@ def pro_connect_callback(request):
                 },
             )
 
-    # Because we have more than one Authentication backend in our settings, we need to specify
-    # the one we want to use in login
-    login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+    login(request, user)
 
     # reattach prescriber session
     if prescriber_session_data := pro_connect_state.data.get("prescriber_session_data"):

--- a/itou/www/signup/views.py
+++ b/itou/www/signup/views.py
@@ -78,7 +78,7 @@ class ItouPasswordResetFromKeyView(PasswordResetFromKeyView):
             # clear any pre-existing session and login the user
             self.request.session.clear()
             self.reset_user.emailaddress_set.filter(email=self.reset_user.email).update(verified=True)
-            login(self.request, self.reset_user, backend="django.contrib.auth.backends.ModelBackend")
+            login(self.request, self.reset_user)
             return reverse("welcoming_tour:index")
         return super().get_success_url()
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Tous nos utilisateurs se loggent avec leur email ce qui indique que seul celui de allauth est utilisé (et vu que `User.USERNAME_FIELD == "username"`).

Autant clarifier la situation.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
