### PR TITLE
Admin : Correction de la vue des affectations candidat

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -1182,6 +1182,12 @@ class JobSeekerAssignmentAdmin(ItouModelAdmin):
         "company__name",
         "company__brand",
     )
+    raw_id_fields = (
+        "job_seeker",
+        "professional",
+        "prescriber_organization",
+        "company",
+    )
     ordering = ("-updated_at",)
 
     @admin.display(description="candidat")


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sans l'attribut `raw_id_fields`, Django tente de charger tous les utilisateurs et toutes les organisations dans la page.

C'est long.

## :computer: Captures d'écran <!-- optionnel -->
Avant :
<img width="1014" height="786" alt="image" src="https://github.com/user-attachments/assets/9207f683-67d7-4531-b2e9-dbbfc387586c" />

après : 
<img width="1014" height="786" alt="image" src="https://github.com/user-attachments/assets/458a06a4-8913-49ca-9628-925e1800de83" />

