### PR TITLE
Tech : Ajout d'infos sur l'objet édité dans l'admin

### DIFF
--- a/itou/approvals/admin.py
+++ b/itou/approvals/admin.py
@@ -414,6 +414,9 @@ class ApprovalAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelA
             return get_organization_view_link(company, display_attr="display_name")
         return self.get_empty_value_display()
 
+    def get_change_view_title(self, obj) -> str:
+        return f"Modifier le PASS IAE {obj.number} · {obj._meta.object_name}(pk={obj.pk})"
+
 
 class IsInProgressFilter(admin.SimpleListFilter):
     title = "En cours"

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -259,6 +259,9 @@ class CompanyAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, OrganizationAdmin):
             return False
         return super().has_change_permission(request, obj)
 
+    def get_change_view_title(self, obj) -> str:
+        return f"Modifier l’entreprise {obj.name} · {obj._meta.object_name}(pk={obj.pk})"
+
     @admin.display(description="Liste des PASS IAE pour cette entreprise")
     def approvals_list(self, obj):
         if obj.pk is None:

--- a/itou/prescribers/admin.py
+++ b/itou/prescribers/admin.py
@@ -260,6 +260,9 @@ class PrescriberOrganizationAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, Organiz
 
         return super().response_change(request, obj)
 
+    def get_change_view_title(self, obj) -> str:
+        return f"Modifier l’organisation prescriptrice {obj.name} · {obj._meta.object_name}(pk={obj.pk})"
+
     @admin.display(boolean=True, description="Habilitation")
     def is_authorized(self, obj):
         return obj.is_authorized

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -655,6 +655,9 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
             ),
         ] + urls
 
+    def get_change_view_title(self, obj) -> str:
+        return f"Modifier l’utilisateur {obj.get_full_name()} · {obj._meta.object_name}(pk={obj.pk})"
+
     def deactivate_view(self, request, user_pk):
         if not self.has_change_permission(request):
             raise PermissionDenied
@@ -1122,6 +1125,12 @@ class JobSeekerProfileAdmin(DisabledNotificationsMixin, InconsistencyCheckMixin,
             if is_france_travail_id_format(search_term):
                 search_fields.append("pole_emploi_id__iexact")
         return search_fields
+
+    def get_change_view_title(self, obj) -> str:
+        return (
+            f"Modifier le profil demandeur d’emploi de {obj.user.get_full_name()} · "
+            f"{obj._meta.object_name}(pk={obj.pk})"
+        )
 
 
 class EmailAddressWithRemarkAdmin(ItouModelMixin, EmailAddressAdmin):

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -13,6 +13,7 @@ from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils.html import format_html, format_html_join
+from django.utils.text import capfirst
 
 from itou.utils.models import PkSupportRemark, UUIDSupportRemark
 from itou.utils.templatetags.str_filters import pluralizefr
@@ -183,8 +184,12 @@ class ItouModelMixin:
             )
 
     def render_change_form(self, request, context, add=False, change=False, form_url="", obj=None):
-        if obj is not None and hasattr(obj, "display_with_pii"):
-            context["subtitle"] = obj.display_with_pii
+        if obj is not None:
+            # Set the title of the page when editing an object, using the overridable `get_change_view_title` method.
+            if self.has_change_permission(request, obj):
+                context["title"] = self.get_change_view_title(obj)
+            if hasattr(obj, "display_with_pii"):
+                context["subtitle"] = obj.display_with_pii
         return super().render_change_form(request, context, add=add, change=change, form_url=form_url, obj=obj)
 
     def _get_queryset_with_relations(self, request):
@@ -236,6 +241,9 @@ class ItouModelMixin:
             if field_name in fields_with_pii:
                 new_list[i] = f"{field_name}_display_with_pii"
         return tuple(new_list)
+
+    def get_change_view_title(self, obj) -> str:
+        return f"Modifier l’objet {capfirst(obj._meta.verbose_name)} · {obj._meta.object_name}(pk={obj.pk})"
 
     def change_view(self, request, object_id, form_url="", extra_context=None):
         # Make sure this view has the trigger context available


### PR DESCRIPTION
## :thinking: Pourquoi ?

Afin de retrouver plus rapidement une page de l'admin via l'historique du navigateur. Utile pour les objets auxquels on revient souvent (ex : comptes à détourner) lorsqu'on développe, etc.

C'est plus pratique d'y accéder sans avoir à repasser par la recherche à chaque fois. Dans la mesure où toutes les pages restent de toute façon dans l'historique.

Détails ajoutées pour les modèles suivants :
- Organization
- PrescriberOrganization
- User

Il y en a peut-être d'autres pour lesquels ce serait utile.

(Tech ? Interface ? ~~Peut-être Interface vu que ça doit bien faire péter quelques tests/shanpshots.~~)

## :cake: Comment ?

Méthode `change_view` de l'admin, exemple :
```python
def change_view(self, request, object_id, form_url="", extra_context=None):
    extra_context = extra_context or {}
    obj = self.get_object(request, object_id)
    if obj:
        extra_context["title"] = f"Modifier l'entreprise {obj.name} (pk={obj.pk})"
    return super().change_view(request, object_id, form_url, extra_context)
```

Je pensais qu'on arrivait à changer seulement le titre de la page HTML rien qu'avec `change_view`, mais en fait non. C'est un peu vilain de voir le `(pk=123)` apparaître aussi dans le `<h1>` de la page, on peut éventuellement le retirer, mais c'est pratique pour ceux qui s'en souviennent (plutôt que d'avoir à taper un nom), ça peut servir de détrompeur (local/recette/prod) et puis j'avais pas envie de trop bidouiller.

## :desert_island: Comment tester ?

.

## :computer: Captures d'écran <!-- optionnel -->

Le titre de la page (qui apparaît dans l'onglet du navigateur) sera donc par exemple : `Modifier l'entreprise Les moulins de l'immobilier (pk=3855) | Les emplois de l'inclusion`

Et dans l'admin on a :

AVANT :

<img width="911" height="384" alt="Capture d’écran 2026-04-27 à 11 48 47" src="https://github.com/user-attachments/assets/e694ea02-1bf6-474a-8236-5eb9c45a406e" />
<img width="595" height="316" alt="Capture d’écran 2026-04-27 à 11 52 49" src="https://github.com/user-attachments/assets/8aeb2fc6-3726-4427-88b4-7b68dcb96c9a" />


APRÈS :

<img width="858" height="385" alt="Capture d’écran 2026-04-27 à 11 49 28" src="https://github.com/user-attachments/assets/250e9252-1abb-4b39-9d62-f265bbb96212" />
<img width="755" height="302" alt="Capture d’écran 2026-04-27 à 11 53 42" src="https://github.com/user-attachments/assets/028d9d37-994f-47c0-bd96-7c0e9ce66694" />
