### PR TITLE
Tech: arrêter de créer des objets `NotificationSettings` lors de la consultation de certaines pages de l'admin

### DIFF
--- a/itou/communications/models.py
+++ b/itou/communications/models.py
@@ -104,20 +104,23 @@ class NotificationSettings(models.Model):
             return f"Paramètres de notification de {self.user.get_full_name()} ({self.structure})"
         return f"Paramètres de notification de {self.user.get_full_name()}"
 
-    @staticmethod
-    def get_or_create(user, structure=None):
+    @classmethod
+    def get_filter_kwargs(cls, user, structure=None):
         if structure is None:
             structure_type = None
             structure_pk = None
         else:
             structure_type = ContentType.objects.get_for_model(structure)
             structure_pk = structure.pk
+        return {
+            "user": user,
+            "structure_type": structure_type,
+            "structure_pk": structure_pk,
+        }
 
-        notification_settings, created = NotificationSettings.objects.get_or_create(
-            user=user,
-            structure_type=structure_type,
-            structure_pk=structure_pk,
-        )
+    @classmethod
+    def get_or_create(cls, user, structure=None):
+        notification_settings, created = cls.objects.get_or_create(**cls.get_filter_kwargs(user, structure=structure))
         return notification_settings, created
 
     @property

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -76,14 +76,17 @@ class DisabledNotificationsMixin:
     @admin.display(description="Notifications désactivées")
     def disabled_notifications(self, obj):
         if isinstance(obj, CompanyMembership):
-            notification_settings, _ = NotificationSettings.get_or_create(obj.user, obj.company)
+            structure = obj.company
         elif isinstance(obj, PrescriberMembership):
-            notification_settings, _ = NotificationSettings.get_or_create(obj.user, obj.organization)
+            structure = obj.organization
         else:
-            notification_settings, _ = NotificationSettings.get_or_create(obj.user)
+            structure = None
 
-        disabled_notifications = notification_settings.disabled_notifications_names
-        if disabled_notifications:
+        notification_settings = NotificationSettings.objects.filter(
+            **NotificationSettings.get_filter_kwargs(obj.user, structure=structure)
+        ).first()
+
+        if notification_settings and (disabled_notifications := notification_settings.disabled_notifications_names):
             return mark_safe(
                 "<ul class='inline'>"
                 + "".join([f"<li>{notification}</<li>" for notification in disabled_notifications])


### PR DESCRIPTION
## :thinking: Pourquoi ?

C'est assez inattendu (même si cela simplifiait un peu le code :sweat_smile: ).

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
