### PR TITLE
Tech: arrêter de créer des objets NotificationSettings lors de la consultation de certaines pages de l'admin - partie 2

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -392,9 +392,11 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
     def disabled_notifications(self, obj):
         if obj.is_professional:
             return "Voir pour chaque structure ci-dessous"
-        notification_settings, _ = NotificationSettings.get_or_create(obj)
-        disabled_notifications = notification_settings.disabled_notifications_names
-        if disabled_notifications:
+        notification_settings = NotificationSettings.objects.filter(
+            **NotificationSettings.get_filter_kwargs(obj.user, structure=None)
+        ).first()
+
+        if notification_settings and (disabled_notifications := notification_settings.disabled_notifications_names):
             return mark_safe(
                 "<ul class='inline'>"
                 + "".join([f"<li>{notification}</<li>" for notification in disabled_notifications])


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce que j'ai oublié cette partie dans #7950.

Normalement c'est bon maintenant :see_no_evil: 

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
