### PR TITLE
Tech: amélioration de la détection des contextes à mettre à jour hors-transaction

### DIFF
--- a/itou/utils/triggers/__init__.py
+++ b/itou/utils/triggers/__init__.py
@@ -21,6 +21,11 @@ _context = threading.local()
 
 def _set_context_connection_wrapper(execute, sql, params, many, context):
     context_is_outdated = getattr(_context, "last_data_set", None) != _context.data
+    if context_is_outdated and not context["connection"].in_atomic_block and _context.data is None:
+        # If we aren't in a transaction then the context has already been flushed so we don't need
+        # to call `set_config()` to empty it as `None` is the default sentinel value for `_context.data`.
+        _context.last_data_set = None
+        context_is_outdated = False
     if context_is_outdated:
         if not context["connection"].in_atomic_block:
             # This should not happen since set_config is called with is_local=true


### PR DESCRIPTION
## :thinking: Pourquoi ?

Si l'on n'est plus dans une transaction, le contexte a été automatiquement nettoyé (car `set_config` est appelé avec local=true).
Donc les données que l'on souhaitait mettre était `None`, on n'a plus rien à faire.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
