### PR TITLE
Interface: Appliquer les nouvelles règles aux pages de détails

### DIFF
--- a/itou/templates/apply/includes/appointments.html
+++ b/itou/templates/apply/includes/appointments.html
@@ -6,7 +6,7 @@
 {% endif %}
 
 {% if participations %}
-    <h3>Rendez-vous</h3>
+    <h2>Rendez-vous</h2>
     <div class="table-responsive mt-3 mt-md-4">
         <table id="rdvi-appointments" class="table table-hover">
             <caption class="visually-hidden">Liste des rendez-vous</caption>

--- a/itou/templates/apply/includes/invitation_requests.html
+++ b/itou/templates/apply/includes/invitation_requests.html
@@ -1,8 +1,11 @@
 <div id="rdvi-invitation-requests" class="mb-6">
-    <div class="d-flex justify-content-between mb-3">
-        <h3 class="mb-0">Invitations envoyées</h3>
-        {% include "apply/includes/buttons/rdv_insertion_invite.html" with csrf_token=csrf_token job_application=job_application for_detail=True only %}
+    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+        <h2 class="mb-0">Invitations envoyées</h2>
+        <div class="d-flex flex-column flex-md-row gap-2">
+            {% include "apply/includes/buttons/rdv_insertion_invite.html" with csrf_token=csrf_token job_application=job_application for_detail=True only %}
+        </div>
     </div>
+
     {% if invitation_requests %}
         <div class="table-responsive mt-3 mt-md-4">
             <table class="table table-hover">

--- a/itou/templates/apply/includes/job_application_answers.html
+++ b/itou/templates/apply/includes/job_application_answers.html
@@ -2,7 +2,7 @@
 {% load matomo %}
 
 {% if job_application.answer or job_application.state.is_refused %}
-    <div class="c-box mb-4">
+    <div class="c-box mb-3 mb-md-4">
         <h3>Réponse de l'employeur</h3>
         <ul class="list-data mb-3">
             {% if job_application.refusal_reason %}

--- a/itou/templates/apply/includes/job_seeker_info.html
+++ b/itou/templates/apply/includes/job_seeker_info.html
@@ -9,17 +9,23 @@
         <h3 class="mb-0">Informations personnelles</h3>
     </div>
     <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-        <a href="{% if can_edit_personal_information %}{% url 'dashboard:edit_job_seeker_info' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}{% if job_application %}&from_application={{ job_application.pk }}{% endif %}{% endif %}"
-           class="btn btn-ico btn-outline-primary{% if not can_edit_personal_information %} disabled{% endif %}"
-           {% if with_matomo_event %}{% matomo_event "salaries" "clic" "edit_jobseeker_infos" %}{% endif %}
-           aria-label="Modifier les informations personnelles de {{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }}">
-            <i class="ri-pencil-line fw-medium" aria-hidden="true"></i>
-            <span>Modifier</span>
-        </a>
-        {% if not can_edit_personal_information %}
-            <button type="button" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.">
-                <i class="ri-information-line ri-xl text-info ms-1" aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations."></i>
-            </button>
+        {% if can_edit_personal_information %}
+            <a href="{% url 'dashboard:edit_job_seeker_info' job_seeker_public_id=job_seeker.public_id %}?back_url={{ request.get_full_path|urlencode }}{% if job_application %}&from_application={{ job_application.pk }}{% endif %}"
+               class="btn btn-ico btn-outline-primary"
+               {% if with_matomo_event %}{% matomo_event "salaries" "clic" "edit_jobseeker_infos" %}{% endif %}
+               aria-label="Modifier les informations personnelles de {{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }}">
+                <i class="ri-pencil-line fw-medium" aria-hidden="true"></i>
+                <span>Modifier</span>
+            </a>
+        {% else %}
+            <span tabindex="0"
+                  class="btn btn-ico btn-outline-primary disabled"
+                  data-bs-toggle="tooltip"
+                  data-bs-placement="top"
+                  data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations.">
+                <i class="ri-pencil-line fw-medium" aria-hidden="true"></i>
+                <span>Modifier</span>
+            </span>
         {% endif %}
     </div>
 </div>

--- a/itou/templates/apply/process_details.html
+++ b/itou/templates/apply/process_details.html
@@ -59,8 +59,8 @@
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="informations" role="tabpanel" aria-labelledby="informations-tab">
                     <div class="s-section__row row">
-                        <div class="s-section__col col-12 col-xxl-12 order-2 order-xxl-1">
-                            <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                        <div class="s-section__col col-12 col-xxl-12 order-1 order-xxl-1">
+                            <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                                 <h2 class="mb-0">Informations générales</h2>
                                 <div class="d-flex flex-column flex-md-row gap-2" id="copy_public_id">
                                     {% include "includes/job_seekers/copy_public_id.html" with public_id=job_application.job_seeker.public_id only %}
@@ -91,7 +91,7 @@
 
                                 {# Prior actions info #}
                                 {% if job_application.can_have_prior_action and job_application.prior_actions.all %}
-                                    <hr>
+                                    <hr class="my-4">
                                     <h3>Action préalable à l'embauche</h3>
                                     {% for prior_action in job_application.prior_actions.all %}
                                         {% include "apply/includes/job_application_prior_action.html" with job_application=job_application prior_action=prior_action add_prior_action_form=None hide_final_hr=forloop.last with_oob_state_update=False %}
@@ -105,7 +105,7 @@
                             {# Job seeker referent ------------------------------------------------------------------------- #}
                             {% include "gps/includes/membership_referent.html" with job_seeker=job_application.job_seeker %}
                         </div>
-                        <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-3">
+                        <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
                             {% block sidebar %}
                                 {% if request.from_prescriber %}
                                     <div class="c-box mb-4">
@@ -124,7 +124,7 @@
                 {% if participations %}
                     <div class="tab-pane fade" id="appointments" role="tabpanel" aria-labelledby="appointments-tab">
                         <div class="s-section__row row">
-                            <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                            <div class="s-section__col col-12">
                                 {# Appointments ------------------------------------------------- #}
                                 {% include "apply/includes/appointments.html" with job_application=job_application %}
                             </div>
@@ -133,7 +133,7 @@
                 {% endif %}
                 <div class="tab-pane fade" id="historique" role="tabpanel" aria-labelledby="historique-tab">
                     <div class="s-section__row row">
-                        <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                        <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                             <h2>Historique des modifications</h2>
                             {# History ------------------------------------------------------ #}
                             {% include "apply/includes/transition_logs.html" with job_application=job_application transition_logs=transition_logs %}

--- a/itou/templates/apply/process_details_company.html
+++ b/itou/templates/apply/process_details_company.html
@@ -79,8 +79,8 @@
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="informations" role="tabpanel" aria-labelledby="informations-tab">
                     <div class="s-section__row row">
-                        <div class="s-section__col col-12 col-xxl-12 order-2 order-xxl-1">
-                            <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                        <div class="s-section__col col-12 col-xxl-12 order-1 order-xxl-1">
+                            <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                                 <h2 class="mb-0">Informations générales</h2>
                                 <div class="d-flex flex-column flex-md-row gap-2" id="copy_public_id">
                                     {% include "includes/job_seekers/copy_public_id.html" with public_id=job_application.job_seeker.public_id only %}
@@ -115,7 +115,7 @@
                                 {# Prior actions info #}
                                 {% if job_application.can_have_prior_action %}
                                     {% if job_application.prior_actions.all or job_application.can_change_prior_actions %}
-                                        <hr>
+                                        <hr class="my-4">
                                         <h3>Action préalable à l'embauche</h3>
                                         {% for prior_action in job_application.prior_actions.all %}
                                             {% include "apply/includes/job_application_prior_action.html" with job_application=job_application prior_action=prior_action add_prior_action_form=None hide_final_hr=forloop.last with_oob_state_update=False %}
@@ -136,7 +136,7 @@
                                 {% include "gps/includes/membership_referent.html" with job_seeker=job_application.job_seeker %}
                             {% endif %}
                         </div>
-                        <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2">
+                        <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
                             {% block sidebar %}
                                 {{ block.super }}
                                 {% include "apply/includes/job_application_add_comment.html" with location="sidebar" job_application=job_application form=add_comment_form request=request csrf_token=csrf_token only %}
@@ -149,7 +149,7 @@
                 {% if job_application.upcoming_participations_count or request.current_organization.rdv_solidarites_id %}
                     <div class="tab-pane fade" id="appointments" role="tabpanel" aria-labelledby="appointments-tab">
                         <div class="s-section__row row">
-                            <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                            <div class="s-section__col col-12">
                                 {# Appointments ------------------------------------------------- #}
                                 {% include "apply/includes/appointments.html" with job_application=job_application %}
                             </div>
@@ -159,7 +159,7 @@
 
                 <div class="tab-pane fade" id="comments" role="tabpanel" aria-labelledby="comments-tab">
                     <div class="s-section__row row">
-                        <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                        <div class="col-12 col-xxl-8 col-xxxl-9">
                             {# Comments ------------------------------------------------------ #}
                             <h2>Commentaires</h2>
                             {% include "apply/includes/job_application_add_comment.html" with location="tab" job_application=job_application form=add_comment_form request=request csrf_token=csrf_token only %}
@@ -170,7 +170,7 @@
 
                 <div class="tab-pane fade" id="historique" role="tabpanel" aria-labelledby="historique-tab">
                     <div class="s-section__row row">
-                        <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                        <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                             <h2>Historique des modifications</h2>
                             {# History ------------------------------------------------------ #}
                             {% include "apply/includes/transition_logs.html" with job_application=job_application transition_logs=transition_logs %}

--- a/itou/templates/companies/overview.html
+++ b/itou/templates/companies/overview.html
@@ -46,7 +46,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
                     <div class="tab-content">
-                        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3 mb-lg-4">
+                        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
                             <h2 class="mb-0">Présentation</h2>
                             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur la structure">
                                 <a class="btn btn-outline-primary btn-ico"
@@ -67,15 +67,16 @@
                             <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
                                 <div class="c-box h-100 {% if not company.description and not company.provided_support %}d-flex align-items-center justify-content-center{% endif %}">
                                     {% if company.description %}
-                                        <article class="mb-3 mb-md-5">
-                                            <h3 class="mb-2">Son activité</h3>
+                                        <article>
+                                            <h3>Son activité</h3>
                                             {{ company.description|markdownify }}
                                         </article>
                                     {% endif %}
 
                                     {% if company.provided_support %}
+                                        <hr class="my-4">
                                         <article>
-                                            <h3 class="mb-2">L'accompagnement proposé</h3>
+                                            <h3>L'accompagnement proposé</h3>
                                             {{ company.provided_support|markdownify }}
                                         </article>
                                     {% endif %}

--- a/itou/templates/employee_record/includes/employee_record_summary.html
+++ b/itou/templates/employee_record/includes/employee_record_summary.html
@@ -63,7 +63,7 @@
 
         <hr class="my-4">
         <h2 class="h3">Situation du {{ request.current_organization|worker_denomination }}</h2>
-        <ul class="mb-0">
+        <ul class="mb-0 fs-sm">
             <li>{{ profile.get_education_level_display }}</li>
             {% if profile.low_level_in_french %}<li>Maîtrise de la langue française inférieure au niveau A1</li>{% endif %}
             {% if profile.pole_emploi_since %}
@@ -113,14 +113,14 @@
 
         <hr class="my-4">
         <h2 class="h3">Annexe financière</h2>
-        <p class="mb-0">
+        <p class="mb-0 fs-sm">
             {% if employee_record.financial_annex %}
                 {{ employee_record.financial_annex.number }} ({{ employee_record.financial_annex.get_state_display|lower }})
             {% else %}
                 Aucune annexe financière n’a été sélectionnée.
             {% endif %}
         </p>
-        <p>
+        <p class="mb-0 fs-sm">
             L’annexe financière n’est pas transmise à l’Extranet IAE 2.0 de l’ASP.
             Elle est destinée uniquement aux logiciels de gestion des salariés.
             {% if in_form_step %}Si vous n’en utilisez pas, vous pouvez laisser cette étape vide.{% endif %}

--- a/itou/templates/employees/detail.html
+++ b/itou/templates/employees/detail.html
@@ -25,10 +25,9 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                    <h2 class="visually-hidden">Informations du salarié : {{ job_seeker.get_inverted_full_name }}</h2>
                     {# Job seeker info ------------------------------------------------------------------------- #}
                     <div class="c-box mb-3 mb-md-4">
-                        <h2>Informations du salarié</h2>
-                        <hr>
                         {% include "apply/includes/job_seeker_info.html" with job_seeker=job_seeker job_application=job_application with_matomo_event=True can_view_personal_information=can_view_personal_information can_edit_personal_information=can_edit_personal_information request=request csrf_token=csrf_token only %}
                     </div>
 
@@ -79,7 +78,7 @@
                                         Rechercher une immersion
                                     </a>
                                 </p>
-                                <p>
+                                <p class="mb-0">
                                     <a href="{{ immersion_convention_url }}" class="btn-link has-external-link" rel="noopener" target="_blank" aria-label="Initier une convention (ouverture dans un nouvel onglet)">
                                         Initier une convention
                                     </a>

--- a/itou/templates/gps/group_beneficiary.html
+++ b/itou/templates/gps/group_beneficiary.html
@@ -8,7 +8,7 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                         <h2 class="mb-0">Informations</h2>
                         {% if can_edit_personal_information %}
                             <a href="{% url 'dashboard:edit_job_seeker_info' job_seeker_public_id=group.beneficiary.public_id %}?back_url={{ request.get_full_path|urlencode }}"

--- a/itou/templates/gps/group_contribution.html
+++ b/itou/templates/gps/group_contribution.html
@@ -5,7 +5,7 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12">
-                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                         <h2 class="mb-0">Mon intervention</h2>
                         <a href="{% url "gps:group_edition" group.pk %}?back_url={{ back_url|urlencode }}" class="btn btn-ico btn-primary">
                             <i class="ri-pencil-line" aria-hidden="true"></i>
@@ -31,18 +31,23 @@
                                 {% if membership.ended_at %}
                                     <strong>{{ membership.ended_at|date:"F Y" }}</strong>
                                 {% else %}
-                                    <span class="text-disabled">(accompagnement en cours)</span>
+                                    <i class="text-disabled">(accompagnement en cours)</i>
                                 {% endif %}
                             </li>
                         </ul>
                     </div>
                     <div class="c-box mb-3 mb-md-4">
-                        <h3 class="mb-0">Motif de l’intervention</h3>
-                        {% if membership.reason %}
-                            <strong>{{ membership.reason }}</strong>
-                        {% else %}
-                            <i class="text-disabled">Non renseigné</i>
-                        {% endif %}
+                        <h3>Motif de l’intervention</h3>
+                        <ul class="list-data">
+                            <li>
+                                <small>Motif</small>
+                                {% if membership.reason %}
+                                    <strong>{{ membership.reason }}</strong>
+                                {% else %}
+                                    <i class="text-disabled">Non renseigné</i>
+                                {% endif %}
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>

--- a/itou/templates/gps/group_list.html
+++ b/itou/templates/gps/group_list.html
@@ -38,6 +38,13 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="col-12">
+                    <h2>
+                        {% if active_memberships %}
+                            En cours d’accompagnement
+                        {% else %}
+                            Historique
+                        {% endif %}
+                    </h2>
                     {% component_info c_info__summary=c_info__summary extra_classes="mb-3 mb-md-4" %}
                         {% fragment as c_info__summary %}
                             Retrouvez la liste de vos bénéficiaires et les coordonnées des professionnels qui interviennent dans leur parcours

--- a/itou/templates/gps/group_memberships.html
+++ b/itou/templates/gps/group_memberships.html
@@ -9,7 +9,7 @@
         <div class="s-section__container container">
             <div class="row">
                 <div class="col-12" id="gps_intervenants">
-                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                    <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                         <h2 class="mb-0">Intervenants</h2>
                     </div>
                     <form id="display-contact-info-form">

--- a/itou/templates/gps/includes/membership_referent.html
+++ b/itou/templates/gps/includes/membership_referent.html
@@ -134,10 +134,8 @@
             {% endif %}
         {% endwith %}
     {% else %}
-        <div id="card-no-referent" class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3">
-            <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                <i>L’accompagnateur de {{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }} n’est pas connu de nos services</i>
-            </div>
+        <div id="card-no-referent" class="fs-sm">
+            <i>L’accompagnateur de {{ job_seeker.get_inverted_full_name|mask_unless:can_view_personal_information }} n’est pas connu de nos services</i>
         </div>
     {% endif %}
 </div>

--- a/itou/templates/job_seekers_views/list.html
+++ b/itou/templates/job_seekers_views/list.html
@@ -55,6 +55,17 @@
     {% include "job_seekers_views/includes/job_seekers_filters/offcanvas.html" with filters_counter=filters_counter filters_form=filters_form list_organization=list_organization order=order request=request only %}
     <section class="s-section">
         <div class="s-section__container container">
+            <div class="s-section__row row">
+                <div class="col-12">
+                    <h2>
+                        {% if list_organization %}
+                            Tous les candidats de la structure
+                        {% else %}
+                            Mes candidats
+                        {% endif %}
+                    </h2>
+                </div>
+            </div>
             {% if list_organization %}
                 {% url 'job_seekers_views:list_organization' as url_list %}
             {% else %}

--- a/itou/templates/prescribers/overview.html
+++ b/itou/templates/prescribers/overview.html
@@ -34,7 +34,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12">
                     <div class="tab-content">
-                        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3 mb-lg-4">
+                        <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center justify-content-lg-between mb-3">
                             <h2 class="mb-0">Présentation</h2>
                             <div class="d-flex flex-column flex-md-row gap-2 justify-content-md-end" role="group" aria-label="Actions sur l'organisation">
                                 <a class="btn {% if can_edit %}btn-outline-primary{% else %}btn-primary{% endif %} btn-ico"
@@ -57,7 +57,7 @@
                             <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
                                 <div class="c-box h-100 {% if not organization.description %}d-flex align-items-center justify-content-center{% endif %}">
                                     {% if organization.description %}
-                                        <article class="mb-3 mb-lg-5">
+                                        <article>
                                             <h3>Son activité</h3>
                                             {{ organization.description|markdownify }}
                                         </article>

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -2449,6 +2449,9 @@
           <div class="s-section__container container">
               <div class="s-section__row row">
                   <div class="col-12">
+                      <h2>
+                          En cours d’accompagnement
+                      </h2>
                       <div class="c-info mb-3 mb-md-4">
                           <span class="c-info__summary">
                               Retrouvez la liste de vos bénéficiaires et les coordonnées des professionnels qui interviennent dans leur parcours

--- a/tests/gps/__snapshots__/test_views.ambr
+++ b/tests/gps/__snapshots__/test_views.ambr
@@ -65,7 +65,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Informations
                           </h2>
@@ -160,7 +160,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Informations
                           </h2>
@@ -305,7 +305,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Informations
                           </h2>
@@ -457,7 +457,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Informations
                           </h2>
@@ -629,7 +629,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Informations
                           </h2>
@@ -817,7 +817,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Mon intervention
                           </h2>
@@ -862,12 +862,19 @@
                           </ul>
                       </div>
                       <div class="c-box mb-3 mb-md-4">
-                          <h3 class="mb-0">
+                          <h3>
                               Motif de l’intervention
                           </h3>
-                          <strong>
-                              parce que
-                          </strong>
+                          <ul class="list-data">
+                              <li>
+                                  <small>
+                                      Motif
+                                  </small>
+                                  <strong>
+                                      parce que
+                                  </strong>
+                              </li>
+                          </ul>
                       </div>
                   </div>
               </div>
@@ -943,7 +950,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Mon intervention
                           </h2>
@@ -981,19 +988,26 @@
                                   <small>
                                       Date de fin
                                   </small>
-                                  <span class="text-disabled">
+                                  <i class="text-disabled">
                                       (accompagnement en cours)
-                                  </span>
+                                  </i>
                               </li>
                           </ul>
                       </div>
                       <div class="c-box mb-3 mb-md-4">
-                          <h3 class="mb-0">
+                          <h3>
                               Motif de l’intervention
                           </h3>
-                          <i class="text-disabled">
-                              Non renseigné
-                          </i>
+                          <ul class="list-data">
+                              <li>
+                                  <small>
+                                      Motif
+                                  </small>
+                                  <i class="text-disabled">
+                                      Non renseigné
+                                  </i>
+                              </li>
+                          </ul>
                       </div>
                   </div>
               </div>
@@ -1504,7 +1518,7 @@
           <div class="s-section__container container">
               <div class="row">
                   <div class="col-12" id="gps_intervenants">
-                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                           <h2 class="mb-0">
                               Intervenants
                           </h2>

--- a/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
+++ b/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
@@ -2435,29 +2435,31 @@
 # name: TestRdvInsertionInvitationRequestsList.test_invitations_requests_listing[employer-apply:details_for_company-True]
   '''
   <div class="mb-6" id="rdvi-invitation-requests">
-      <div class="d-flex justify-content-between mb-3">
-          <h3 class="mb-0">
+      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+          <h2 class="mb-0">
               Invitations envoyées
-          </h3>
-          <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
-              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-              <button aria-label="Proposer un rendez-vous à HENRY Jacques" class="btn btn-secondary btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
-                  <div class="stable-text">
-                      <i aria-hidden="true" class="ri-mail-send-line fw-medium">
-                      </i>
-                      <span>
-                          Proposer un rendez-vous
-                      </span>
-                  </div>
-                  <div class="loading-text">
-                      <span aria-hidden="true" class="spinner-border spinner-border-sm">
-                      </span>
-                      <span role="status">
-                          Envoi en cours
-                      </span>
-                  </div>
-              </button>
-          </form>
+          </h2>
+          <div class="d-flex flex-column flex-md-row gap-2">
+              <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
+                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                  <button aria-label="Proposer un rendez-vous à HENRY Jacques" class="btn btn-secondary btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
+                      <div class="stable-text">
+                          <i aria-hidden="true" class="ri-mail-send-line fw-medium">
+                          </i>
+                          <span>
+                              Proposer un rendez-vous
+                          </span>
+                      </div>
+                      <div class="loading-text">
+                          <span aria-hidden="true" class="spinner-border spinner-border-sm">
+                          </span>
+                          <span role="status">
+                              Envoi en cours
+                          </span>
+                      </div>
+                  </button>
+              </form>
+          </div>
       </div>
       <p>
           Aucune invitation en attente de réponse actuellement
@@ -2469,29 +2471,31 @@
 # name: TestRdvInsertionInvitationRequestsList.test_invite_response_includes_updated_invitation_requests_listing_for_employer[existing_invitation_requests]
   '''
   <div class="mb-6" id="rdvi-invitation-requests">
-      <div class="d-flex justify-content-between mb-3">
-          <h3 class="mb-0">
+      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+          <h2 class="mb-0">
               Invitations envoyées
-          </h3>
-          <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
-              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-              <button aria-label="Proposer un rendez-vous à HENRY Jacques" class="btn btn-secondary btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
-                  <div class="stable-text">
-                      <i aria-hidden="true" class="ri-mail-send-line fw-medium">
-                      </i>
-                      <span>
-                          Proposer un rendez-vous
-                      </span>
-                  </div>
-                  <div class="loading-text">
-                      <span aria-hidden="true" class="spinner-border spinner-border-sm">
-                      </span>
-                      <span role="status">
-                          Envoi en cours
-                      </span>
-                  </div>
-              </button>
-          </form>
+          </h2>
+          <div class="d-flex flex-column flex-md-row gap-2">
+              <form class="d-inline-flex" hx-post="/apply/11111111-1111-1111-1111-111111111111/rdv_insertion_invite_for_detail" hx-swap="outerHTML" hx-target="#rdvi-invitation-requests">
+                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                  <button aria-label="Proposer un rendez-vous à HENRY Jacques" class="btn btn-secondary btn-ico w-100 w-md-auto" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="proposer-rdv">
+                      <div class="stable-text">
+                          <i aria-hidden="true" class="ri-mail-send-line fw-medium">
+                          </i>
+                          <span>
+                              Proposer un rendez-vous
+                          </span>
+                      </div>
+                      <div class="loading-text">
+                          <span aria-hidden="true" class="spinner-border spinner-border-sm">
+                          </span>
+                          <span role="status">
+                              Envoi en cours
+                          </span>
+                      </div>
+                  </button>
+              </form>
+          </div>
       </div>
       <p>
           Aucune invitation en attente de réponse actuellement
@@ -2503,17 +2507,19 @@
 # name: TestRdvInsertionInvitationRequestsList.test_invite_response_includes_updated_invitation_requests_listing_for_employer[updated_invitation_requests]
   '''
   <div class="mb-6" id="rdvi-invitation-requests">
-      <div class="d-flex justify-content-between mb-3">
-          <h3 class="mb-0">
+      <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
+          <h2 class="mb-0">
               Invitations envoyées
-          </h3>
-          <span class="text-success text-center flex-grow-1 flex-md-grow-0" role="status">
-              <i aria-hidden="true" class="ri-check-line ri-xl fw-medium">
-              </i>
-              Invitation envoyée
-              <i aria-label="Une relance sera envoyée 3 jours après. Vous pourrez renvoyer une invitation sous 10J." class="ri-error-warning-line" data-bs-html="true" data-bs-placement="left" data-bs-title="Une relance sera envoyée 3 jours après. <br> Vous pourrez renvoyer une invitation sous 10J." data-bs-toggle="tooltip" role="button" tabindex="0">
-              </i>
-          </span>
+          </h2>
+          <div class="d-flex flex-column flex-md-row gap-2">
+              <span class="text-success text-center flex-grow-1 flex-md-grow-0" role="status">
+                  <i aria-hidden="true" class="ri-check-line ri-xl fw-medium">
+                  </i>
+                  Invitation envoyée
+                  <i aria-label="Une relance sera envoyée 3 jours après. Vous pourrez renvoyer une invitation sous 10J." class="ri-error-warning-line" data-bs-html="true" data-bs-placement="left" data-bs-title="Une relance sera envoyée 3 jours après. <br> Vous pourrez renvoyer une invitation sous 10J." data-bs-toggle="tooltip" role="button" tabindex="0">
+                  </i>
+              </span>
+          </div>
       </div>
       <div class="table-responsive mt-3 mt-md-4">
           <table class="table table-hover">

--- a/tests/www/apply/__snapshots__/test_process_comments.ambr
+++ b/tests/www/apply/__snapshots__/test_process_comments.ambr
@@ -143,8 +143,8 @@
               <div class="tab-content">
                   <div aria-labelledby="informations-tab" class="tab-pane fade show active" id="informations" role="tabpanel">
                       <div class="s-section__row row">
-                          <div class="s-section__col col-12 col-xxl-12 order-2 order-xxl-1">
-                              <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3 mb-md-4">
+                          <div class="s-section__col col-12 col-xxl-12 order-1 order-xxl-1">
+                              <div class="d-flex flex-column flex-md-row gap-3 align-items-md-center justify-content-md-between mb-3">
                                   <h2 class="mb-0">
                                       Informations générales
                                   </h2>
@@ -398,7 +398,7 @@
                                       </li>
                                   </ul>
                               </div>
-                              <div class="c-box mb-4">
+                              <div class="c-box mb-3 mb-md-4">
                                   <h3>
                                       Réponse de l'employeur
                                   </h3>
@@ -423,16 +423,14 @@
                                           </h3>
                                       </div>
                                   </div>
-                                  <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                      <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                          <i>
-                                              L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                          </i>
-                                      </div>
+                                  <div class="fs-sm" id="card-no-referent">
+                                      <i>
+                                          L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                      </i>
                                   </div>
                               </div>
                           </div>
-                          <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2">
+                          <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-2 order-xxl-3">
                               <div class="c-box c-box--note mb-3 mb-md-4" id="comments-add-sidebar">
                                   <form class="js-prevent-multiple-submit" hx-indicator="#comments-add-sidebar" hx-post="/apply/11111111-1111-1111-1111-111111111111/siae/comment" hx-swap="outerHTML" hx-target="#comments-add-sidebar" hx-vals='{"location": "sidebar"}'>
                                       <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
@@ -550,7 +548,7 @@
                   </div>
                   <div aria-labelledby="comments-tab" class="tab-pane fade" id="comments" role="tabpanel">
                       <div class="s-section__row row">
-                          <div class="col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                          <div class="col-12 col-xxl-8 col-xxxl-9">
                               <h2>
                                   Commentaires
                               </h2>
@@ -767,7 +765,7 @@
                   </div>
                   <div aria-labelledby="historique-tab" class="tab-pane fade" id="historique" role="tabpanel">
                       <div class="s-section__row row">
-                          <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                          <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                               <h2>
                                   Historique des modifications
                               </h2>

--- a/tests/www/apply/__snapshots__/test_process_comments.ambr
+++ b/tests/www/apply/__snapshots__/test_process_comments.ambr
@@ -168,17 +168,13 @@
                                           </h3>
                                       </div>
                                       <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                          <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                          <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                               <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                               </i>
                                               <span>
                                                   Modifier
                                               </span>
-                                          </a>
-                                          <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                              <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                              </i>
-                                          </button>
+                                          </span>
                                       </div>
                                   </div>
                                   <ul class="list-data mb-3">

--- a/tests/www/companies_views/test_overview.py
+++ b/tests/www/companies_views/test_overview.py
@@ -19,6 +19,6 @@ def test_overview(client, description, provided_support):
     client.force_login(company.members.get())
     response = client.get(reverse("companies_views:overview"))
     assertion = assertContains if description else assertNotContains
-    assertion(response, '<h3 class="mb-2">Son activité</h3>')
+    assertion(response, "<h3>Son activité</h3>")
     assertion = assertContains if provided_support else assertNotContains
-    assertion(response, '<h3 class="mb-2">L\'accompagnement proposé</h3>')
+    assertion(response, "<h3>L'accompagnement proposé</h3>")

--- a/tests/www/employee_record_views/__snapshots__/test_summary.ambr
+++ b/tests/www/employee_record_views/__snapshots__/test_summary.ambr
@@ -460,7 +460,7 @@
           <h2 class="h3">
               Situation du salarié
           </h2>
-          <ul class="mb-0">
+          <ul class="mb-0 fs-sm">
               <li>
                   Troisième cycle ou école d'ingénieur
               </li>
@@ -514,10 +514,10 @@
           <h2 class="h3">
               Annexe financière
           </h2>
-          <p class="mb-0">
+          <p class="mb-0 fs-sm">
               Aucune annexe financière n’a été sélectionnée.
           </p>
-          <p>
+          <p class="mb-0 fs-sm">
               L’annexe financière n’est pas transmise à l’Extranet IAE 2.0 de l’ASP.
               Elle est destinée uniquement aux logiciels de gestion des salariés.
           </p>

--- a/tests/www/employees_views/__snapshots__/test_detail.ambr
+++ b/tests/www/employees_views/__snapshots__/test_detail.ambr
@@ -1898,7 +1898,7 @@
                   Rechercher une immersion
               </a>
           </p>
-          <p>
+          <p class="mb-0">
               <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
                   Initier une convention
               </a>
@@ -1928,7 +1928,7 @@
                   Rechercher une immersion
               </a>
           </p>
-          <p>
+          <p class="mb-0">
               <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
                   Initier une convention
               </a>
@@ -1960,7 +1960,7 @@
                   Rechercher une immersion
               </a>
           </p>
-          <p>
+          <p class="mb-0">
               <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
                   Initier une convention
               </a>
@@ -1990,7 +1990,7 @@
                   Rechercher une immersion
               </a>
           </p>
-          <p>
+          <p class="mb-0">
               <a aria-label="Initier une convention (ouverture dans un nouvel onglet)" class="btn-link has-external-link" href="https://staging.immersion-facile.beta.gouv.fr/initier-convention?mtm_campaign=les-emplois-recherche-immersion&mtm_kwd=les-emplois-recherche-immersion" rel="noopener" target="_blank">
                   Initier une convention
               </a>

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -279,17 +279,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -577,17 +573,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -869,17 +861,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -1113,17 +1101,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -1457,17 +1441,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -4264,17 +4244,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -4587,17 +4563,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -4869,17 +4841,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -5096,17 +5064,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -5395,17 +5359,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -5677,17 +5637,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -5914,17 +5870,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">
@@ -7255,17 +7207,13 @@
                                                   </h3>
                                               </div>
                                               <div class="col-12 col-sm-auto mt-2 mt-sm-0 d-flex align-items-center">
-                                                  <a aria-label="Modifier les informations personnelles de DOE Jane" class="btn btn-ico btn-outline-primary disabled" data-matomo-action="clic" data-matomo-category="salaries" data-matomo-event="true" data-matomo-option="edit_jobseeker_infos" href="">
+                                                  <span class="btn btn-ico btn-outline-primary disabled" data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" tabindex="0">
                                                       <i aria-hidden="true" class="ri-pencil-line fw-medium">
                                                       </i>
                                                       <span>
                                                           Modifier
                                                       </span>
-                                                  </a>
-                                                  <button data-bs-placement="top" data-bs-title="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." data-bs-toggle="tooltip" type="button">
-                                                      <i aria-label="Ce candidat a pris le contrôle de son compte utilisateur. Vous ne pouvez pas modifier ses informations." class="ri-information-line ri-xl text-info ms-1">
-                                                      </i>
-                                                  </button>
+                                                  </span>
                                               </div>
                                           </div>
                                           <ul class="list-data mb-3">

--- a/tests/www/job_seekers_views/__snapshots__/test_details.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_details.ambr
@@ -479,12 +479,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -756,12 +754,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -1002,12 +998,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -1348,12 +1342,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -4480,12 +4472,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -4781,12 +4771,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -5010,12 +4998,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -5294,12 +5280,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -5595,12 +5579,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -5824,12 +5806,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -6063,12 +6043,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>
@@ -7456,12 +7434,10 @@
                                                   </h3>
                                               </div>
                                           </div>
-                                          <div class="d-flex flex-column flex-md-row gap-2 align-items-center gap-md-3" id="card-no-referent">
-                                              <div class="flex-md-grow-1 mt-2 mb-2 mb-md-0">
-                                                  <i>
-                                                      L’accompagnateur de DOE Jane n’est pas connu de nos services
-                                                  </i>
-                                              </div>
+                                          <div class="fs-sm" id="card-no-referent">
+                                              <i>
+                                                  L’accompagnateur de DOE Jane n’est pas connu de nos services
+                                              </i>
                                           </div>
                                       </div>
                                   </div>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -159,6 +159,13 @@
       </div>
       <section class="s-section">
           <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="col-12">
+                      <h2>
+                          Tous les candidats de la structure
+                      </h2>
+                  </div>
+              </div>
               <form hx-get="/job-seekers/list-organization" hx-include="#id_job_seeker,#id_organization_members" hx-indicator="#job-seekers-section" hx-push-url="true" hx-swap="outerHTML" hx-target="#job-seekers-section" hx-trigger="change from:#id_order, change delay:.5s, change from:#id_job_seeker delay:.5s, change from:#id_organization_members delay:.5s">
                   <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                       <div class="col-12">
@@ -457,6 +464,13 @@
       </div>
       <section class="s-section">
           <div class="s-section__container container">
+              <div class="s-section__row row">
+                  <div class="col-12">
+                      <h2>
+                          Mes candidats
+                      </h2>
+                  </div>
+              </div>
               <form hx-get="/job-seekers/list" hx-include="#id_job_seeker" hx-indicator="#job-seekers-section" hx-push-url="true" hx-swap="outerHTML" hx-target="#job-seekers-section" hx-trigger="change from:#id_order, change delay:.5s, change from:#id_job_seeker delay:.5s">
                   <div class="s-section__row row selection-indicator" data-emplois-elements-visibility-on-selection="hidden">
                       <div class="col-12">


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcqu'on a mis [ça a plat](https://www.notion.so/gip-inclusion/UX-UI-Lister-les-cas-red-finir-les-r-gles-ux-ui-des-titres-sous-titres-s-parateurs-puis-harmonise-2a05f321b60480ffbcaeff022cd5fda3?v=2715f321b60480088826000c5284ddfc&source=copy_link)

## :cake: Comment ? <!-- optionnel -->
En respectant les nouvelles [règles écrites](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-box-detail--docs#regles-dintegration)


## :computer: Captures d'écran <!-- optionnel -->
En passant, correction de ce [bouton disabled avec tooltip](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/components-tooltips--docs) pour une meilleure a11y
<img width="428" height="163" alt="capture 2026-04-30 à 11 13 05" src="https://github.com/user-attachments/assets/58432e2f-f3f5-411a-89e4-e749f9ca7017" />

<img width="458" height="185" alt="capture 2026-04-30 à 11 12 25" src="https://github.com/user-attachments/assets/e9bcb981-3e82-4c49-99c0-374f679f2618" />
