### PR TITLE
Pilotage : les champs 'structure' de la la table Metabase 'pass_agréments' ne peuvent correspondre à une structure qui n'est pas une SIAE

### DIFF
--- a/itou/metabase/management/commands/populate_metabase_emplois.py
+++ b/itou/metabase/management/commands/populate_metabase_emplois.py
@@ -548,14 +548,7 @@ class Command(BaseCommand):
         }
         queryset = (
             Approval.objects.select_related("user")
-            .annotate(
-                last_hiring_company_pk=(
-                    JobApplication.objects.accepted()
-                    .filter(job_seeker=OuterRef("user"))
-                    .values("to_company")
-                    .order_by("-created_at")[:1]
-                )
-            )
+            .with_assigned_company()
             .only(
                 *only_fields,
                 "user_id",

--- a/itou/metabase/tables/approvals.py
+++ b/itou/metabase/tables/approvals.py
@@ -20,7 +20,7 @@ def get_companies_map():
 
 
 def get_company_from_approval(approval):
-    return get_companies_map().get(approval.last_hiring_company_pk)
+    return get_companies_map().get(approval.assigned_company)
 
 
 def get_approval_type(approval):

--- a/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
+++ b/tests/metabase/management/__snapshots__/test_populate_metabase_emplois.ambr
@@ -692,12 +692,35 @@
                  "approvals_approval"."user_id",
                  "approvals_approval"."origin",
           
-            (SELECT U0."to_company_id" AS "to_company"
-             FROM "job_applications_jobapplication" U0
-             WHERE (U0."state" = %s
-                    AND U0."job_seeker_id" = ("approvals_approval"."user_id"))
-             ORDER BY U0."created_at" DESC
-             LIMIT 1) AS "last_hiring_company_pk",
+            (SELECT V0."to_company_id" AS "to_company"
+             FROM "job_applications_jobapplication" V0
+             INNER JOIN "companies_company" V2 ON (V0."to_company_id" = V2."id")
+             WHERE (V0."state" = %s
+                    AND V0."job_seeker_id" = ("approvals_approval"."user_id")
+                    AND V2."kind" IN (%s,
+                                      %s,
+                                      %s,
+                                      %s,
+                                      %s))
+             ORDER BY CASE
+                          WHEN (V0."origin" = %s) THEN V0."hiring_start_at"
+                          WHEN (V0."origin" = %s) THEN V0."created_at"
+                          WHEN (V0."state" = %s) THEN COALESCE(
+                                                                 (SELECT U0."timestamp" AS "timestamp"
+                                                                  FROM "job_applications_jobapplicationtransitionlog" U0
+                                                                  WHERE (U0."job_application_id" = (V0."id")
+                                                                         AND U0."transition" = %s)
+                                                                  ORDER BY 1 DESC
+                                                                  LIMIT 1), V0."created_at")
+                          ELSE
+                                 (SELECT U0."timestamp" AS "timestamp"
+                                  FROM "job_applications_jobapplicationtransitionlog" U0
+                                  WHERE (U0."job_application_id" = (V0."id")
+                                         AND U0."transition" = %s)
+                                  ORDER BY 1 DESC
+                                  LIMIT 1)
+                      END DESC, V0."hiring_start_at" DESC
+             LIMIT 1) AS "assigned_company",
                  "users_user"."id",
                  "users_user"."password",
                  "users_user"."last_login",

--- a/tests/metabase/management/test_populate_metabase_emplois.py
+++ b/tests/metabase/management/test_populate_metabase_emplois.py
@@ -213,7 +213,7 @@ def test_populate_job_seekers(snapshot):
     user_3_selected_criteria.certification_period = InclusiveDateRange(datetime.date(2025, 3, 13))
     user_3_selected_criteria.save()
     # Older accepted job_application with no eligibility diagnosis
-    # Allow to check last_hiring_company_pk
+    # Allow to check assigned_company
     JobApplicationFactory(
         sent_by_prescriber_alone=True,
         job_seeker=user_3,
@@ -522,6 +522,28 @@ def test_populate_job_applications(snapshot):
 def test_populate_approvals(snapshot):
     approval = ApprovalFactory()
 
+    # create an older accepted job application at a SIAE
+    siae = CompanyFactory(kind=CompanyKind.EI, department="01")
+    JobApplicationFactory(
+        sent_by_job_seeker=True,
+        job_seeker=approval.user,
+        to_company=siae,
+        created_at=datetime.datetime(2023, 2, 5, tzinfo=datetime.UTC),
+        state=JobApplicationState.ACCEPTED,
+        approval=approval,
+    )
+
+    # create a more recent accepted job application at a GEIQ, which should be ignored
+    non_siae = CompanyFactory(kind=CompanyKind.GEIQ, department="02")
+    JobApplicationFactory(
+        sent_by_job_seeker=True,
+        job_seeker=approval.user,
+        to_company=non_siae,
+        created_at=datetime.datetime(2023, 2, 8, tzinfo=datetime.UTC),
+        state=JobApplicationState.ACCEPTED,
+        approval=approval,
+    )
+
     with assertSnapshotQueries(snapshot):
         management.call_command("populate_metabase_emplois", mode="approvals")
 
@@ -536,13 +558,13 @@ def test_populate_approvals(snapshot):
                 datetime.date(2025, 1, 31),
                 datetime.timedelta(days=729),
                 approval.user.id,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
+                siae.id,
+                siae.kind,
+                siae.siret,
+                siae.display_name,
+                "01",
+                "01 - Ain",
+                "Auvergne-Rhône-Alpes",
                 0,
                 hash_content(approval.number),
                 datetime.date(2023, 2, 2),


### PR DESCRIPTION
## :thinking: Pourquoi ?

[Demande de Yannick sur Slack](https://gip-inclusion.slack.com/archives/C01AQKD7MAN/p1777387603143019). L'annotation `last_hiring_company_pk` utilisée pour alimenter la table `pass_agréments` dans l'export Metabase ciblait la candidature acceptée la plus récente du candidat, sans vérifier le type de la structure. Ainsi, si un candidat avec un PASS IAE était embauché ultérieurement dans une structure non-SIAE (par exemple une Entreprise Adaptée), c'est cette dernière qui remontait à tort comme dernière structure de rattachement.

## :cake: Comment ?

J'ai modifié la méthode `populate_approvals` dans la commande `populate_metabase_emplois` pour que la sous-requête filtre explicitement sur les types de structures SIAE (`to_company__kind__in=CompanyKind.siae_kinds()`).
Un test a également été amélioré dans `test_populate_metabase_emplois.py` pour valider ce comportement de manière pérenne : on y simule une embauche dans une SIAE suivie d'une embauche dans une non-SIAE pour s'assurer que c'est bien la SIAE qui est retenue dans l'export.

## :desert_island: Comment tester ?

1. Lancer les tests unitaires pour valider le comportement :

   ```bash
   uv run pytest tests/metabase/management/test_populate_metabase_emplois.py -k test_populate_approvals
   ```
2. Vérifier localement l'export Metabase si la base de données de développement contient des candidats concernés :

   ```bash
   uv run manage.py populate_metabase_emplois --mode=approvals
   ```
Puis inspecter le résultat dans la table `pass_agréments` (la colonne type/nom de structure ne devrait afficher que des données relatives aux SIAE).