### PR TITLE
Candidature : Correction d'un bug sur les candidatures avec critères certifiés mais sans date de début de contrat

### DIFF
--- a/itou/utils/templatetags/badges.py
+++ b/itou/utils/templatetags/badges.py
@@ -132,7 +132,8 @@ def criterion_certification_badge(selected_criterion, job_application):
             if job_application and job_application.state == JobApplicationState.ACCEPTED:
                 template = (
                     "eligibility/includes/badge_certified.html"
-                    if job_application.hiring_start_at in selected_criterion.certification_period
+                    if job_application.hiring_start_at
+                    and job_application.hiring_start_at in selected_criterion.certification_period
                     else "eligibility/includes/badge_not_certified.html"
                 )
             else:

--- a/tests/utils/test_templatetags.py
+++ b/tests/utils/test_templatetags.py
@@ -232,6 +232,19 @@ class TestCriterionCertificationBadge:
             NOT_CERTIFIED_BADGE_HTML,
         )
 
+    def test_accepted_job_app_without_hiring_start_at(self):
+        """This happens for job applications imported together with PE approvals (origin="pe_approval")"""
+        criterion = IAESelectedAdministrativeCriteriaFactory(criteria_certified=True)
+        job_application = JobApplicationFactory(
+            sent_by_prescriber_alone=True,
+            hiring_start_at=None,
+            state=JobApplicationState.ACCEPTED,
+        )
+        assertHTMLEqual(
+            criterion_certification_badge(criterion, job_application),
+            NOT_CERTIFIED_BADGE_HTML,
+        )
+
     def test_certified_complete_eligibility_diagnosis_duration(self):
         criterion = IAESelectedAdministrativeCriteriaFactory(criteria_certified=True)
         job_application = JobApplicationFactory(


### PR DESCRIPTION
## :thinking: Pourquoi ?

Vu sur Sentry : https://inclusion.sentry.io/issues/116485304/


Cela peut se produire quand un candidat a des critères certifiables, et qu'on visite une de ses candidatures acceptées qui n'a pas de `hiring_start_at` (candidatures liées à l'import des agréments Pôle Emploi par exemple).

<details>
<summary>Stack trace</summary>

```
Traceback (most recent call last):
  File "django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 198, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "contextlib.py", line 85, in inner
    return func(*args, **kwds)
  File "itou/utils/auth.py", line 27, in _check_request_view_wrapper
    return view_func(request, *args, **kwargs)
  File "itou/www/apply/views/process_views.py", line 263, in details_for_company
    return render(request, template_name, context)
  File "django/shortcuts.py", line 25, in render
    content = loader.render_to_string(template_name, context, request, using=using)
  File "django/template/loader.py", line 62, in render_to_string
    return template.render(context, request)
  File "django/template/backends/django.py", line 107, in render
    return self.template.render(context)
  File "django/template/base.py", line 174, in render
    return self._render(context)
  File "django/template/base.py", line 166, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/loader_tags.py", line 160, in render
    return compiled_parent._render(context)
  File "django/template/base.py", line 166, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/loader_tags.py", line 160, in render
    return compiled_parent._render(context)
  File "django/template/base.py", line 166, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/loader_tags.py", line 66, in render
    result = block.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 333, in render
    return nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/loader_tags.py", line 211, in render
    return template.render(context)
  File "django/template/base.py", line 176, in render
    return self._render(context)
  File "django/template/base.py", line 166, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 333, in render
    return nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 333, in render
    return nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/loader_tags.py", line 209, in render
    return template.render(context.new(values))
  File "django/template/base.py", line 176, in render
    return self._render(context)
  File "django/template/base.py", line 166, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 581, in render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 333, in render
    return nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 249, in render
    nodelist.append(node.render_annotated(context))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/loader_tags.py", line 209, in render
    return template.render(context.new(values))
  File "django/template/base.py", line 176, in render
    return self._render(context)
  File "django/template/base.py", line 166, in _render
    return self.nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/defaulttags.py", line 333, in render
    return nodelist.render(context)
  File "django/template/base.py", line 1091, in render
    return SafeString("".join([node.render_annotated(context) for node in self]))
  File "django/template/base.py", line 1052, in render_annotated
    return self.render(context)
  File "django/template/library.py", line 325, in render
    output = self.func(*resolved_args, **resolved_kwargs)
  File "itou/utils/templatetags/badges.py", line 135, in criterion_certification_badge
    if job_application.hiring_start_at in selected_criterion.certification_period
  File "psycopg/types/range.py", line 186, in __contains__
    if x < self._lower:  # type: ignore[operator]
TypeError: '<' not supported between instances of 'NoneType' and 'datetime.date'
```

</details>