### PR TITLE
Candidature: Permettre au professionnel de revenir sur la page de recherche après avoir postulé pour un candidat

### DIFF
--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -94,7 +94,14 @@
                                 </div>
                                 <div class="c-box--results__footer">
                                     <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
-                                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                        {% partialdef btn-group inline %}
+                                            {% if request.from_prescriber and search_url %}
+                                                <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "job_seekers_views:details" job_application.job_seeker.public_id %}">Voir le profil candidat</a>
+                                                <a class="btn btn-primary btn-block w-100 w-md-auto" href={{ search_url }}>Revenir à la recherche pour ce candidat</a>
+                                            {% else %}
+                                                <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                            {% endif %}
+                                        {% endpartialdef %}
                                     </div>
                                 </div>
                             </div>
@@ -123,7 +130,7 @@
                             </div>
                         {% endif %}
                     {% else %}
-                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                        {% partial btn-group %}
                     {% endif %}
                 </div>
             </div>

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -102,6 +102,9 @@
                                                     <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
                                                 {% endif %}
                                                 <a class="btn btn-primary btn-block w-100 w-md-auto" href={{ search_url }}>Revenir à la recherche pour ce candidat</a>
+                                            {% elif auto_prescription_process %}
+                                                <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                                <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href={% url "apply:details_for_company" job_application_id=job_application.id %}>Voir la candidature</a>
                                             {% else %}
                                                 <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
                                             {% endif %}

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -95,8 +95,12 @@
                                 <div class="c-box--results__footer">
                                     <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
                                         {% partialdef btn-group inline %}
-                                            {% if request.from_prescriber and search_url %}
-                                                <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "job_seekers_views:details" job_application.job_seeker.public_id %}">Voir le profil candidat</a>
+                                            {% if search_url %}
+                                                {% if request.from_prescriber %}
+                                                    <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "job_seekers_views:details" job_application.job_seeker.public_id %}">Voir le profil candidat</a>
+                                                {% elif request.from_employer %}
+                                                    <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                                {% endif %}
                                                 <a class="btn btn-primary btn-block w-100 w-md-auto" href={{ search_url }}>Revenir à la recherche pour ce candidat</a>
                                             {% else %}
                                                 <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -42,56 +42,66 @@
                             </b>
                         </p>
                         <div id="informations" {% if form.is_bound %}class="d-none"{% endif %} data-swap-element-with=".c-form">
-                            <div class="card c-card c-card--noshadow border-bottom p-3">
-                                <div class="card-header d-flex flex-row align-items-center">
-                                    <h2 class="mb-0 flex-grow-1">{{ job_application.job_seeker.get_inverted_full_name }}</h2>
+                            <div class="c-box c-box--results has-links-inside">
+                                <div class="c-box--results__header d-flex flex-row align-items-center">
+                                    <h3 class="mb-0 flex-grow-1">{{ job_application.job_seeker.get_inverted_full_name }}</h3>
                                     {% if request.user.is_job_seeker %}
-                                        <a class="btn btn-outline-primary btn-ico btn-sm" href="{% url 'dashboard:edit_user_info' %}">
-                                            <i class="ri-pencil-line" aria-hidden="true"></i>
-                                            <span>Modifier</span>
-                                        </a>
+                                        <a class="btn btn-primary btn-block w-100 w-md-auto" href="{% url 'dashboard:edit_user_info' %}">Modifier</a>
                                     {% elif can_edit_personal_information %}
-                                        <span class="btn btn-outline-primary btn-ico btn-sm" data-swap-element="#informations">
-                                            <i class="ri-pencil-line" aria-hidden="true"></i>
-                                            <span>Modifier</span>
-                                        </span>
+                                        <span class="btn btn-primary btn-block w-100 w-md-auto" data-swap-element="#informations">Modifier</span>
                                     {% endif %}
                                 </div>
-                                <div class="card-body">
-                                    <hr>
-                                    <p>
-                                        <span class="text-muted">Adresse</span>
-                                        <br />
-                                        <b>{{ job_application.job_seeker.address_on_one_line|default:"Non renseigné" }}</b>
-                                        <br />
-                                    </p>
-                                    <hr>
-                                    <p>
-                                        <span class="text-muted">N&deg; de téléphone</span>
-                                        <br />
-                                        {% if job_application.job_seeker.phone %}
-                                            <b>{{ job_application.job_seeker.phone|format_phone }}</b>
-                                        {% elif request.user.is_job_seeker %}
-                                            <b>Non renseigné</b>
-                                            <p class="text-warning fst-italic">
-                                                L’ajout du numéro de téléphone permet à l’employeur de vous contacter plus facilement.
-                                            </p>
-                                        {% else %}
-                                            <b>Non renseigné</b>
-                                            <p class="text-warning fst-italic">L’ajout du numéro de téléphone facilitera la prise de contact avec le candidat.</p>
-                                        {% endif %}
-                                    </p>
+                                <hr class="m-0">
+                                <div class="c-box--results__body">
+                                    <ul class="list-data">
+                                        <li>
+                                            <small>Adresse</small>
+                                            {% if job_application.job_seeker.address_on_one_line %}
+                                                <address>{{ job_application.job_seeker.address_on_one_line }}</address>
+                                            {% else %}
+                                                <i class="text-disabled">Non renseigné</i>
+                                            {% endif %}
+                                        </li>
+                                        <li>
+                                            {% if job_application.job_seeker.phone %}
+                                                <small>N&deg; de téléphone</small>
+                                                <strong>{{ job_application.job_seeker.phone|format_phone }}</strong>
+                                            {% elif request.user.is_job_seeker %}
+                                                <small>
+                                                    N&deg; de téléphone
+                                                    <i class="ri-information-line text-info"
+                                                       data-bs-toggle="tooltip"
+                                                       data-bs-title="L’ajout du numéro de téléphone permet à l’employeur de vous contacter plus facilement."
+                                                       aria-label="L’ajout du numéro de téléphone permet à l’employeur de vous contacter plus facilement."
+                                                       role="button"
+                                                       tabindex="0"></i>
+                                                </small>
+                                                <i class="text-disabled">Non renseigné</i>
+                                            {% else %}
+                                                <small>
+                                                    N&deg; de téléphone
+                                                    <i class="ri-information-line text-info"
+                                                       data-bs-toggle="tooltip"
+                                                       data-bs-title="L’ajout du numéro de téléphone facilitera la prise de contact avec le candidat."
+                                                       aria-label="L’ajout du numéro de téléphone facilitera la prise de contact avec le candidat."
+                                                       role="button"
+                                                       tabindex="0"></i>
+                                                </small>
+                                                <i class="text-disabled">Non renseigné</i>
+                                            {% endif %}
+                                        </li>
+                                    </ul>
                                 </div>
-                            </div>
-                            <div class="form-row align-items-center justify-content-end gx-3 mt-3">
-                                <div class="form-group col-6 col-lg-auto">
-                                    <a class="btn btn-primary btn-block" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                <div class="c-box--results__footer">
+                                    <div class="d-flex flex-column flex-md-row justify-content-md-end gap-3">
+                                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                         {% if not request.user.is_job_seeker %}
                             <div class="c-form c-card--noshadow border-bottom {% if not form.is_bound %}d-none{% endif %}" data-swap-element-with="#informations">
-                                <h2 class="h3 mb-5">{{ job_application.job_seeker.get_inverted_full_name }}</h2>
+                                <h3>{{ job_application.job_seeker.get_inverted_full_name }}</h3>
 
                                 <form method="post">
                                     {% csrf_token %}
@@ -113,11 +123,7 @@
                             </div>
                         {% endif %}
                     {% else %}
-                        <div class="form-row align-items-center justify-content-end gx-3 mt-3">
-                            <div class="form-group col-6 col-lg-auto">
-                                <a class="btn btn-primary btn-block" href="{% url "dashboard:index" %}">Tableau de bord</a>
-                            </div>
-                        </div>
+                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{% url "dashboard:index" %}">Tableau de bord</a>
                     {% endif %}
                 </div>
             </div>
@@ -131,7 +137,6 @@
     {{ form.media.js }}
     {% if request.from_employer or request.from_prescriber %}
         <script async src="{{ TALLY_URL }}/widgets/embed.js"></script>
-        <script src='{% static "js/nps_popup.js" %}' data-delaypopup="false" data-userkind="{% if request.from_employer %}employeur{% else %}prescripteur{% endif %}" data-page="depot-candidature">
-        </script>
+        <script src='{% static "js/nps_popup.js" %}' data-delaypopup="false" data-userkind="{% if request.from_employer %}employeur{% else %}prescripteur{% endif %}" data-page="depot-candidature"></script>
     {% endif %}
 {% endblock %}

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -14,6 +14,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
 from django.views.generic import TemplateView, View
+from itoutils.urls import add_url_params
 
 from itou.approvals.models import Approval
 from itou.companies.enums import CompanyKind
@@ -30,7 +31,7 @@ from itou.utils.constants import ITOU_DIAGNOSTIC_URL
 from itou.utils.perms.utils import can_edit_personal_information, can_view_personal_information
 from itou.utils.session import SessionNamespace, SessionNamespaceException
 from itou.utils.templatetags.str_filters import mask_unless
-from itou.utils.urls import get_safe_url
+from itou.utils.urls import get_safe_url, get_url_param_value
 from itou.utils.views import with_triggers_context
 from itou.www.apply.forms import ApplicationJobsForm, SubmitJobApplicationForm
 from itou.www.apply.views import constants as apply_view_constants
@@ -161,6 +162,15 @@ class StartViewForSubmit(ApplicationPermissionMixin, View):
     def get_reset_url(self):
         return self.reset_url
 
+    def get_search_url(self):
+        search_views = ["search:employers_results", "search:job_descriptions_results"]
+
+        # If the user decides to view the details of a job description or of a company beforehand,
+        # the search results url will be present inside the reset_url as a back_url parameter.
+        search_url = get_url_param_value(self.reset_url, "back_url") or self.reset_url
+
+        return search_url if any(reverse(view) in search_url for view in search_views) else None
+
     def init_job_seeker_session(self, request):
         job_seeker_session = SessionNamespace.create(
             request.session,
@@ -197,6 +207,9 @@ class StartViewForSubmit(ApplicationPermissionMixin, View):
 
             if job_seeker:
                 session_data["job_seeker_public_id"] = str(job_seeker.public_id)
+
+            if search_url := self.get_search_url():
+                session_data["search_url"] = search_url
 
         self.apply_session = initialize_apply_session(request, session_data)
 
@@ -615,9 +628,18 @@ class ApplicationResumeView(CheckApplySessionMixin, ApplicationBaseView):
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.form = self.form_class(**self.get_form_kwargs())
+        self.search_url = self.apply_session.get("search_url", default=None)
+
+    def get_search_url(self):
+        # If we apply for a job seeker with his NIR, his public id will be missing from the url and will have to be
+        # typed in again once we go back to the search results.
+        if self.search_url and (job_seeker_public_id := str(self.job_seeker.public_id)) not in self.search_url:
+            return add_url_params(self.search_url, {"job_seeker_public_id": job_seeker_public_id})
+        return self.search_url
 
     def get_next_url(self, job_application):
-        return reverse("apply:application_end", kwargs={"application_pk": job_application.pk})
+        next_url = reverse("apply:application_end", kwargs={"application_pk": job_application.pk})
+        return add_url_params(next_url, {"search_url": self.get_search_url()})
 
     def form_valid(self):
         # Fill the job application with the required information
@@ -733,6 +755,10 @@ class ApplicationEndView(TemplateView):
         self.form = CreateOrUpdateJobSeekerStep2Form(
             instance=self.job_application.job_seeker, data=request.POST or None
         )
+        self.search_url = get_safe_url(request, "search_url")
+
+    def get_search_url(self):
+        return self.search_url
 
     def post(self, request, *args, **kwargs):
         if not can_edit_personal_information(self.request, self.job_application.job_seeker):
@@ -740,16 +766,23 @@ class ApplicationEndView(TemplateView):
         if self.form.is_valid():
             self.form.save()
             # Redirect to the same page, so we don't have a POST method
-            return HttpResponseRedirect(request.path_info)
+            url = add_url_params(request.path_info, {"search_url": self.get_search_url()})
+            return HttpResponseRedirect(url)
         return self.render_to_response(self.get_context_data(**kwargs))
 
     def get_context_data(self, **kwargs):
         if self.request.from_employer and self.company == self.request.current_organization:
             page_title = "Auto-prescription enregistrée"
             matomo_custom_title = "Auto-prescription enregistrée"
+            search_url = None
         else:
             page_title = "Candidature envoyée"
             matomo_custom_title = "Candidature soumise"
+            search_url = self.get_search_url()
+
+        reset_url = reverse("apply:application_end", kwargs={"application_pk": self.job_application.pk})
+        reset_url = add_url_params(reset_url, {"search_url": search_url})
+
         return super().get_context_data(**kwargs) | {
             "job_application": self.job_application,
             "form": self.form,
@@ -759,7 +792,8 @@ class ApplicationEndView(TemplateView):
             "can_view_personal_information": can_view_personal_information(
                 self.request, self.job_application.job_seeker
             ),
-            "reset_url": reverse("apply:application_end", kwargs={"application_pk": self.job_application.pk}),
+            "reset_url": reset_url,
+            "search_url": search_url,
             "page_title": page_title,
             "matomo_custom_title": matomo_custom_title,
         }

--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -771,7 +771,8 @@ class ApplicationEndView(TemplateView):
         return self.render_to_response(self.get_context_data(**kwargs))
 
     def get_context_data(self, **kwargs):
-        if self.request.from_employer and self.company == self.request.current_organization:
+        auto_prescription_process = self.request.from_employer and self.company == self.request.current_organization
+        if auto_prescription_process:
             page_title = "Auto-prescription enregistrée"
             matomo_custom_title = "Auto-prescription enregistrée"
             search_url = None
@@ -796,6 +797,7 @@ class ApplicationEndView(TemplateView):
             "search_url": search_url,
             "page_title": page_title,
             "matomo_custom_title": matomo_custom_title,
+            "auto_prescription_process": auto_prescription_process,
         }
 
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3457,11 +3457,16 @@ class TestApplicationView:
         else:
             dashboard_url = reverse("dashboard:index")
             if is_auto_prescription:
+                job_application_url = reverse(
+                    "apply:details_for_company", kwargs={"job_application_id": job_application.id}
+                )
                 assertContains(
                     response,
                     f"""
                         <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{dashboard_url}">
                         Tableau de bord</a>
+                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{job_application_url}">
+                        Voir la candidature</a>
                     """,
                     html=True,
                 )

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3355,33 +3355,24 @@ class TestApplicationEndView:
 
     def test_wo_phone_number_as_job_seeker(self, client):
         application = JobApplicationFactory(sent_by_job_seeker=True, job_seeker__phone="")
-        expected_html = (
-            '<p class="text-warning fst-italic">L’ajout du numéro de téléphone permet à l’employeur de vous '
-            "contacter plus facilement.</p>"
-        )
+        expected_text = "L’ajout du numéro de téléphone permet à l’employeur de vous contacter plus facilement."
         client.force_login(application.job_seeker)
         response = client.get(reverse("apply:application_end", kwargs={"application_pk": application.pk}))
-        assertContains(response, expected_html, html=True)
+        assertContains(response, expected_text)
 
     def test_wo_phone_number_as_employer(self, client):
         application = JobApplicationFactory(sent_by_another_employer=True, job_seeker__phone="")
-        expected_html = (
-            '<p class="text-warning fst-italic">L’ajout du numéro de téléphone facilitera '
-            "la prise de contact avec le candidat.</p>"
-        )
+        expected_text = "L’ajout du numéro de téléphone facilitera la prise de contact avec le candidat."
         client.force_login(application.sender)
         response = client.get(reverse("apply:application_end", kwargs={"application_pk": application.pk}))
-        assertContains(response, expected_html, html=True)
+        assertContains(response, expected_text)
 
     def test_wo_phone_number_as_prescriber(self, client):
         application = JobApplicationFactory(sent_by_authorized_prescriber=True, job_seeker__phone="")
-        expected_html = (
-            '<p class="text-warning fst-italic">L’ajout du numéro de téléphone facilitera '
-            "la prise de contact avec le candidat.</p>"
-        )
+        expected_text = "L’ajout du numéro de téléphone facilitera la prise de contact avec le candidat."
         client.force_login(application.sender)
         response = client.get(reverse("apply:application_end", kwargs={"application_pk": application.pk}))
-        assertContains(response, expected_html, html=True)
+        assertContains(response, expected_text)
 
     def test_not_sender(self, client):
         application = JobApplicationFactory(sent_by_prescriber_alone=True)

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from django.utils import timezone
 from freezegun import freeze_time
 from itoutils.django.testing import assertSnapshotQueries
+from itoutils.urls import add_url_params
 from pytest_django.asserts import (
     assertContains,
     assertMessages,
@@ -3301,6 +3302,163 @@ class TestApplicationView:
         assert AdministrativeCriteriaKind.FLE in prefilled_criteria
         assert response.context["form"].initial["level_1_2"] is True  # ASS criterion
         assert response.context["form"].initial["level_2_17"] is True  # FLE / low_level_in_french criterion
+
+    @pytest.mark.parametrize("is_prescriber", [True, False])
+    @pytest.mark.parametrize("search_from_job_seeker_profile", [True, False])
+    @pytest.mark.parametrize("apply_from_card", [True, False])
+    def test_application_end_displayed_buttons(
+        self, client, is_prescriber, search_from_job_seeker_profile, apply_from_card
+    ):
+        geispolsheim = create_city_geispolsheim()
+        geispolsheim_company = CompanyFactory(
+            romes=("N1101", "N1105"),
+            department="67",
+            coords=geispolsheim.coords,
+            post_code="67118",
+            kind=CompanyKind.AI,
+            with_membership=True,
+            with_jobs=True,
+        )
+        JobDescriptionFactory(company=geispolsheim_company, location=geispolsheim)
+        user = (
+            PrescriberFactory(membership__organization__authorized=True)
+            if is_prescriber
+            else EmployerFactory(membership=True)
+        )
+        job_seeker = JobSeekerFactory(
+            jobseeker_profile__birthdate=datetime.date(1990, 12, 1),
+            jobseeker_profile__pole_emploi_id="1234567A",
+            created_by=PrescriberFactory(),
+        )
+
+        client.force_login(user)
+
+        # Step search company
+        # ----------------------------------------------------------------------
+
+        search_params = dict()
+        if search_from_job_seeker_profile:
+            search_params |= {"job_seeker_public_id": job_seeker.public_id}
+        next_url = add_url_params(reverse("search:employers_results"), search_params)
+        response = client.get(next_url)
+
+        # Add filters to search
+        search_params |= {
+            "city": geispolsheim.slug,
+            "distance": 50,
+            "kinds": geispolsheim_company.kind,
+            "department": geispolsheim.department,
+        }
+        search_url = add_url_params(reverse("search:employers_results"), search_params)
+        response = client.get(search_url)
+
+        back_url = search_url
+        url_params = {"back_url": back_url} | (
+            {"job_seeker_public_id": job_seeker.public_id} if search_from_job_seeker_profile else {}
+        )
+
+        # Optional step: visit company card
+        # ----------------------------------------------------------------------
+
+        if apply_from_card:
+            company_card_url = add_url_params(geispolsheim_company.get_card_url(), url_params)
+            url_params["back_url"] = company_card_url
+
+        # Step apply to company
+        # ----------------------------------------------------------------------
+
+        apply_company_url = add_url_params(
+            reverse("apply:start", kwargs={"company_pk": geispolsheim_company.pk}), url_params
+        )
+        response = client.get(apply_company_url, follow=True)
+        apply_session_name = get_session_name(client.session, APPLY_SESSION_KIND)
+        next_url = reverse("apply:application_jobs", kwargs={"session_uuid": apply_session_name})
+
+        if not search_from_job_seeker_profile:
+            job_seeker_session_name = get_session_name(client.session, JobSeekerSessionKinds.GET_OR_CREATE)
+            nir_url = reverse(
+                "job_seekers_views:check_nir_for_sender", kwargs={"session_uuid": job_seeker_session_name}
+            )
+            assertRedirects(response, nir_url)
+
+            response = client.post(nir_url, data={"nir": job_seeker.jobseeker_profile.nir, "confirm": 1}, follow=True)
+
+        assertRedirects(response, next_url)
+
+        # Step apply to job
+        # ----------------------------------------------------------------------
+
+        response = client.get(next_url)
+        assert response.status_code == 200
+
+        selected_job = geispolsheim_company.job_description_through.first()
+        response = client.post(next_url, data={"selected_jobs": [selected_job.pk]})
+
+        assert client.session[apply_session_name] == {
+            "company_pk": geispolsheim_company.pk,
+            "selected_jobs": [selected_job.pk],
+            "reset_url": url_params["back_url"],
+            "search_url": search_url,
+            "job_seeker_public_id": str(job_seeker.public_id),
+        }
+
+        if is_prescriber:
+            next_url = reverse("apply:application_iae_eligibility", kwargs={"session_uuid": apply_session_name})
+            assertRedirects(response, next_url)
+
+            # Step application's eligibility
+            # ----------------------------------------------------------------------
+            # job seeker is getting RSA
+            response = client.post(next_url, {"level_1_1": True})
+
+        next_url = reverse("apply:application_resume", kwargs={"session_uuid": apply_session_name})
+        assertRedirects(response, next_url)
+
+        # Step application's resume.
+        # ----------------------------------------------------------------------
+
+        response = client.post(
+            next_url,
+            data={
+                "message": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            },
+        )
+
+        job_application = JobApplication.objects.get()
+
+        # Before redirecting, add the job seeker public id to the search url if missing
+        if not search_from_job_seeker_profile:
+            search_url = add_url_params(search_url, {"job_seeker_public_id": job_seeker.public_id})
+
+        # Check if search url is present in redirection
+        next_url = add_url_params(
+            reverse("apply:application_end", kwargs={"application_pk": job_application.pk}), {"search_url": search_url}
+        )
+        assertRedirects(response, next_url)
+        response = client.get(next_url)
+
+        if is_prescriber:
+            job_seeker_profile_url = reverse("job_seekers_views:details", kwargs={"public_id": job_seeker.public_id})
+            assertContains(
+                response,
+                f"""
+                    <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{job_seeker_profile_url}">
+                    Voir le profil candidat</a>
+                    <a class="btn btn-primary btn-block w-100 w-md-auto" href={search_url}>
+                    Revenir à la recherche pour ce candidat</a>
+                """,
+                html=True,
+            )
+        else:
+            dashboard_url = reverse("dashboard:index")
+            assertContains(
+                response,
+                f"""
+                    <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{dashboard_url}">
+                    Tableau de bord</a>
+                """,
+                html=True,
+            )
 
 
 class TestApplicationEndView:

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3303,11 +3303,18 @@ class TestApplicationView:
         assert response.context["form"].initial["level_1_2"] is True  # ASS criterion
         assert response.context["form"].initial["level_2_17"] is True  # FLE / low_level_in_french criterion
 
-    @pytest.mark.parametrize("is_prescriber", [True, False])
+    @pytest.mark.parametrize(
+        "user_factory",
+        [
+            pytest.param(partial(PrescriberFactory, membership__organization__authorized=True), id="prescriber"),
+            pytest.param(partial(EmployerFactory, membership=True), id="employer"),
+            pytest.param(None, id="auto_prescripting_employer"),
+        ],
+    )
     @pytest.mark.parametrize("search_from_job_seeker_profile", [True, False])
     @pytest.mark.parametrize("apply_from_card", [True, False])
     def test_application_end_displayed_buttons(
-        self, client, is_prescriber, search_from_job_seeker_profile, apply_from_card
+        self, client, user_factory, search_from_job_seeker_profile, apply_from_card
     ):
         geispolsheim = create_city_geispolsheim()
         geispolsheim_company = CompanyFactory(
@@ -3320,16 +3327,14 @@ class TestApplicationView:
             with_jobs=True,
         )
         JobDescriptionFactory(company=geispolsheim_company, location=geispolsheim)
-        user = (
-            PrescriberFactory(membership__organization__authorized=True)
-            if is_prescriber
-            else EmployerFactory(membership=True)
-        )
+        user = user_factory and user_factory() or geispolsheim_company.members.first()
         job_seeker = JobSeekerFactory(
             jobseeker_profile__birthdate=datetime.date(1990, 12, 1),
             jobseeker_profile__pole_emploi_id="1234567A",
             created_by=PrescriberFactory(),
         )
+        is_prescriber = user_factory and user_factory.func is PrescriberFactory
+        is_auto_prescription = user_factory is None
 
         client.force_login(user)
 
@@ -3451,14 +3456,26 @@ class TestApplicationView:
             )
         else:
             dashboard_url = reverse("dashboard:index")
-            assertContains(
-                response,
-                f"""
-                    <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{dashboard_url}">
-                    Tableau de bord</a>
-                """,
-                html=True,
-            )
+            if is_auto_prescription:
+                assertContains(
+                    response,
+                    f"""
+                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{dashboard_url}">
+                        Tableau de bord</a>
+                    """,
+                    html=True,
+                )
+            else:
+                assertContains(
+                    response,
+                    f"""
+                        <a class="btn btn-outline-primary btn-block w-100 w-md-auto" href="{dashboard_url}">
+                        Tableau de bord</a>
+                        <a class="btn btn-primary btn-block w-100 w-md-auto" href={search_url}>
+                        Revenir à la recherche pour ce candidat</a>
+                    """,
+                    html=True,
+                )
 
 
 class TestApplicationEndView:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Plutôt que de reprendre sa recherche de zéro pour un même candidat, un professionnel peut désormais retourner directement sur la page de recherche filtrée depuis laquelle il a postulé pour un candidat.
Lors d'une auto-prescription, un employeur peut  désormais directement accéder à la candidature qu'il vient d'enregistrer.
[Carte Notion](https://www.notion.so/gip-inclusion/ETQ-professionnel-qui-a-postul-pour-un-candidat-je-peux-retourner-sur-la-page-de-recherche-filtr-e--3285f321b60480dd802efc27c15eea58)

## :computer: Captures d'écran <!-- optionnel -->

**Prescripteur :**

<img width="1211" height="538" alt="prescriber" src="https://github.com/user-attachments/assets/6996b894-2b47-4a74-a743-2392049ec9b9" />

**Employeur :**

<img width="1213" height="596" alt="employer_other_company" src="https://github.com/user-attachments/assets/dda32e9f-bfe3-4563-8a74-0ba412877f2b" />

**Employeur (auto-prescription):**

<img width="1219" height="539" alt="employer_auto_prescription" src="https://github.com/user-attachments/assets/2ab20b05-67af-43a2-b8b0-4968ba1b065b" />

(Ma souris a saboté cette dernière capture d'écran en survolant le bouton "Voir la candidature" sans mon consentement et a été châtiée en conséquence)