### PR TITLE
Tech : Désactiver la transaction et le _trigger context_ pour `upload_data_to_pilotage`

### DIFF
--- a/itou/metabase/management/commands/upload_data_to_pilotage.py
+++ b/itou/metabase/management/commands/upload_data_to_pilotage.py
@@ -20,6 +20,9 @@ from itou.utils.storage.s3 import pilotage_s3_client
 class Command(BaseCommand):
     help = "Upload FluxIAE to S3 for sharing."
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     FILENAME_PREFIX = "fluxIAE_ITOU_"
     DATASTORE_DIRECTORY = "flux-iae/"
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

[LES-EMPLOIS-PROD-Y5](https://inclusion.sentry.io/issues/117264181/)

Cette commande ne touche pas à la DB et ne fait que copier un fichier de S3 à S3.
