### PR TITLE
Tech: définition du _context manager_ `triggers.connection_wrapper`

### DIFF
--- a/itou/utils/command.py
+++ b/itou/utils/command.py
@@ -2,7 +2,6 @@ import contextlib
 import os
 
 from django.core.management import base
-from django.db import connection
 from itoutils.django.commands import AtomicHandleMixin, LoggedCommandMixin, get_current_command_info
 
 from itou.utils import triggers
@@ -16,7 +15,7 @@ class TriggerContextMixin:
 
     def execute(self, *args, **kwargs):
         with (
-            connection.execute_wrapper(triggers._set_context_connection_wrapper),
+            triggers.connection_wrapper(),
             triggers.context(**self.get_trigger_context()) if self.AUTO_TRIGGER_CONTEXT else contextlib.nullcontext(),
         ):
             return super().execute(*args, **kwargs)

--- a/itou/utils/triggers/__init__.py
+++ b/itou/utils/triggers/__init__.py
@@ -47,6 +47,11 @@ def _set_context_connection_wrapper(execute, sql, params, many, context):
     return execute(sql, params, many, context)
 
 
+# This is a context manager ready to be used
+def connection_wrapper():
+    return connection.execute_wrapper(_set_context_connection_wrapper)
+
+
 @contextlib.contextmanager
 def context(*, replace_existing: bool = False, **kwargs):
     if not connection.in_atomic_block:

--- a/itou/utils/triggers/middleware.py
+++ b/itou/utils/triggers/middleware.py
@@ -1,11 +1,9 @@
-from django.db import connection
-
 from itou.utils import triggers
 
 
 def fields_history(get_response):
     def middleware(request):
-        with connection.execute_wrapper(triggers._set_context_connection_wrapper):
+        with triggers.connection_wrapper():
             return get_response(request)
 
     return middleware

--- a/tests/companies/test_models.py
+++ b/tests/companies/test_models.py
@@ -652,13 +652,12 @@ def test_jobdescription_is_active_field_history():
     ]
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_company_siret_field_history():
     company = CompanyFactory(siret="00000000000000")
     assert company.fields_history == []
 
     company.siret = "00000000000001"
-    with triggers.context():
+    with triggers.connection_wrapper(), triggers.context():
         company.save()
     company.refresh_from_db()
     assert normalize_fields_history(company.fields_history) == [
@@ -676,7 +675,7 @@ def test_company_siret_field_history():
     )
 
     company.siret = "00000000000002"
-    with triggers.context(company=company.pk):
+    with triggers.connection_wrapper(), triggers.context(company=company.pk):
         company.save()
     company.refresh_from_db()
     assert normalize_fields_history(company.fields_history) == [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,6 @@ from factory import Faker
 from paramiko import ServerInterface
 from slippers.templatetags.slippers import AttrsNode
 
-from itou.utils import triggers
-
 
 # Rewrite before importing itou code.
 pytest.register_assert_rewrite("tests.utils.test", "tests.utils.htmx.test")
@@ -799,9 +797,3 @@ def detect_missing_csrf_token():
 @pytest.fixture(autouse=True)
 def do_not_bypass_terms_acceptance(settings):
     settings.BYPASS_TERMS_ACCEPTANCE = False
-
-
-@pytest.fixture
-def with_connection_wrapper_set():
-    with connection.execute_wrapper(triggers._set_context_connection_wrapper):
-        yield

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1010,13 +1010,12 @@ def test_job_seeker_profile_asp_uid(initial_asp_uid):
     assert profile.asp_uid == initial_asp_uid or "08b4e9f755a688b554a6487d96d2a0"
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_job_seeker_profile_asp_uid_field_history():
     profile = JobSeekerProfileFactory(asp_uid="000000000000000000000000000000")
     assert profile.fields_history == []
 
     profile.asp_uid = "000000000000000000000000000001"
-    with triggers.context():
+    with triggers.connection_wrapper(), triggers.context():
         profile.save()
     profile.refresh_from_db()
     assert normalize_fields_history(profile.fields_history) == [
@@ -1032,7 +1031,7 @@ def test_job_seeker_profile_asp_uid_field_history():
     )
 
     profile.asp_uid = "000000000000000000000000000002"
-    with triggers.context(profile=profile.pk):
+    with triggers.connection_wrapper(), triggers.context(profile=profile.pk):
         profile.save()
     profile.refresh_from_db()
     assert normalize_fields_history(profile.fields_history) == [

--- a/tests/utils/test_triggers.py
+++ b/tests/utils/test_triggers.py
@@ -9,17 +9,15 @@ from itou.utils import triggers
 
 
 @pytest.mark.parametrize("context", [{}, {"key": "value"}], ids=["empty", "non-empty"])
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context(context):
-    with assertNumQueries(2):
+    with triggers.connection_wrapper(), assertNumQueries(2):
         with triggers.context(**context), connection.cursor() as cursor:
             cursor.execute("SELECT current_setting('itou.context')")
             assert cursor.fetchone() == (json.dumps(context),)
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_stacking():
-    with assertNumQueries(6), connection.cursor() as cursor:
+    with triggers.connection_wrapper(), assertNumQueries(6), connection.cursor() as cursor:
         context_1 = {"level": 1}
         with triggers.context(**context_1):
             cursor.execute("SELECT current_setting('itou.context')")
@@ -34,11 +32,10 @@ def test_context_stacking():
             assert cursor.fetchone() == (json.dumps(context_1),)
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_stacking_with_different_data():
     expected = {"uuid": str(uuid.uuid4()), "foo": "bar"}
     # 5 different contexts defined and queried: 10 queries
-    with assertNumQueries(10), connection.cursor() as cursor:
+    with triggers.connection_wrapper(), assertNumQueries(10), connection.cursor() as cursor:
         with triggers.context(**expected):
             cursor.execute("SELECT current_setting('itou.context')")
             assert cursor.fetchone() == (json.dumps(expected),)
@@ -61,10 +58,9 @@ def test_context_stacking_with_different_data():
             assert cursor.fetchone() == ("{}",)
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_stacking_with_same_data():
     expected = {"uuid": str(uuid.uuid4())}
-    with assertNumQueries(3), connection.cursor() as cursor:
+    with triggers.connection_wrapper(), assertNumQueries(3), connection.cursor() as cursor:
         with triggers.context(**expected):
             cursor.execute("SELECT current_setting('itou.context')")
             assert cursor.fetchone() == (json.dumps(expected),)
@@ -74,10 +70,9 @@ def test_context_stacking_with_same_data():
             assert cursor.fetchone() == (json.dumps(expected),)
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_consecutively_with_same_data():
     expected = {"uuid": str(uuid.uuid4())}
-    with assertNumQueries(4), connection.cursor() as cursor:
+    with triggers.connection_wrapper(), assertNumQueries(4), connection.cursor() as cursor:
         with triggers.context(**expected):
             cursor.execute("SELECT current_setting('itou.context')")
             assert cursor.fetchone() == (json.dumps(expected),)
@@ -88,10 +83,9 @@ def test_context_consecutively_with_same_data():
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_savepoint_rollback():
     expected = {"uuid": str(uuid.uuid4())}
-    with transaction.atomic(), assertNumQueries(7), connection.cursor() as cursor:
+    with transaction.atomic(), triggers.connection_wrapper(), assertNumQueries(7), connection.cursor() as cursor:
         savepoint_id = transaction.savepoint()
         with triggers.context(**expected):
             cursor.execute("SELECT current_setting('itou.context')")
@@ -106,25 +100,29 @@ def test_context_savepoint_rollback():
             assert cursor.fetchone() == (json.dumps(expected),)
 
 
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_laziness():
     expected = {"uuid": str(uuid.uuid4())}
-    with assertNumQueries(2), connection.cursor() as cursor:
+    with triggers.connection_wrapper(), assertNumQueries(2), connection.cursor() as cursor:
         with triggers.context(**{"uuid": str(uuid.uuid4())}), triggers.context(**expected):
             cursor.execute("SELECT current_setting('itou.context')")
             assert cursor.fetchone() == (json.dumps(expected),)
 
 
 @pytest.mark.django_db(transaction=True)
-@pytest.mark.usefixtures("with_connection_wrapper_set")
 def test_context_on_error():
-    with transaction.atomic(), connection.cursor() as cursor, pytest.raises(RuntimeError), triggers.context():
+    with (
+        transaction.atomic(),
+        triggers.connection_wrapper(),
+        connection.cursor() as cursor,
+        pytest.raises(RuntimeError),
+        triggers.context(),
+    ):
         cursor.execute("SELECT current_setting('itou.context')")
         assert cursor.fetchone() == ("{}",)
         raise RuntimeError("test")
     # Here itou.utils.triggers._context must have been reset
     # So that triggers.context() can be used again with the same context
-    with transaction.atomic(), connection.cursor() as cursor, triggers.context():
+    with transaction.atomic(), triggers.connection_wrapper(), connection.cursor() as cursor, triggers.context():
         cursor.execute("SELECT current_setting('itou.context')")
         assert cursor.fetchone() == ("{}",)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

`connection.execute_wrapper(triggers._set_context_connection_wrapper)` est long et pénible à taper.

Et utilisation dans les tests à la place de la fixture.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
