### PR TITLE
Tech : Suppression de l'erreur "Too many missing emails" dans le script d'import des GEIQ

### DIFF
--- a/itou/companies/management/commands/import_geiq.py
+++ b/itou/companies/management/commands/import_geiq.py
@@ -150,8 +150,6 @@ class Command(BaseCommand):
         self.stdout.write("Done.")
 
         warning_messages = []
-        if info_stats["rows_with_empty_email"] > 20:
-            warning_messages.append(f"Too many missing emails: {info_stats['rows_with_empty_email']}")
         if info_stats["not_created_because_of_missing_email"]:
             warning_messages.append(
                 f"Structure(s) not created because of a missing email: "


### PR DESCRIPTION
For already existing GEIQs, we don't care if email addresses are missing (the script does _not_ update the e-mail address of existing GEIQs). A missing email address is only relevant for _new_ GEIQ, which is handled by the "not_created_because_of_missing_email" stats key.

[cf. discussion Slack]