### PR TITLE
Tech: Ajouter l'accompagnateur du candidat au groupe de suivi s'il n'en fait pas partie

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -672,6 +672,10 @@ class ApplicationResumeView(CheckApplySessionMixin, ApplicationBaseView):
                 assigned_to_unknown_advisor,
             )
 
+            # Add advisor to GPS as well
+            if advisor := (professional is not self.request.user and professional):
+                FollowUpGroup.objects.follow_beneficiary(self.job_seeker, advisor)
+
         # Send notifications
         company_recipients = job_application.to_company.active_members.all()
         for employer in company_recipients:

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -479,6 +479,7 @@ class TestApply:
 
         if with_known_advisor:
             assert assignment.professional == other_user
+            assert assignment.job_seeker.follow_up_group.referent.member == other_user
         else:
             assert assignment.professional == user
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

On ajoute l'utilisateur qui réalise la démarche de candidature (ou autre) pour le candidat à son GPS, mais pas l'accompagnateur qu'il désigne, ce qui entraîne un champ régulièrement vide.