### PR TITLE
Tech : Gérer les communes déléguées dans `sync_ft_offers` + simplification de la gestion des arrondissements

### DIFF
--- a/itou/companies/management/commands/sync_ft_offers.py
+++ b/itou/companies/management/commands/sync_ft_offers.py
@@ -62,17 +62,8 @@ def pe_offer_to_job_description(data, logger):
         logger.warning(f"no job URL in raw offer, skipping {source_id=}")
         return None
 
-    code_postal = int(data["lieuTravail"]["codePostal"])
-    # FIXME(vperron): This makes the PEC jobs have a less accurate position on our site than they had before.
-    # This should and could be removed as soon as the cities sync project has been completed.
-    if 75001 <= code_postal <= 75020:
-        city = City.objects.get(code_insee="75056")
-    elif 69001 <= code_postal <= 69009:
-        city = City.objects.get(code_insee="69123")
-    elif 13001 <= code_postal <= 13016:
-        city = City.objects.get(code_insee="13055")
-    else:
-        city = City.objects.get(code_insee=data["lieuTravail"]["commune"])
+    city = City.objects.get(code_insee=data["lieuTravail"]["commune"])
+
     source_tags = []
     if data["natureContrat"] == pe_api_enums.NATURE_CONTRATS[pe_api_enums.NATURE_CONTRAT_PEC]:
         source_tags.append(JobSourceTag.FT_PEC_OFFER.value)

--- a/itou/companies/management/commands/sync_ft_offers.py
+++ b/itou/companies/management/commands/sync_ft_offers.py
@@ -62,7 +62,21 @@ def pe_offer_to_job_description(data, logger):
         logger.warning(f"no job URL in raw offer, skipping {source_id=}")
         return None
 
-    city = City.objects.get(code_insee=data["lieuTravail"]["commune"])
+    try:
+        city = City.objects.get(code_insee=data["lieuTravail"]["commune"])
+    except City.DoesNotExist:
+        try:
+            # It may be the INSEE code of a "commune déléguée", which
+            # we do not store in City. Try the postal code as a
+            # fallback.
+            city = City.objects.get(post_codes__contains=[data["lieuTravail"]["codePostal"]])
+        except City.DoesNotExist:
+            logger.error(
+                "Could not find city with insee_code=%s or postal_code=%s",
+                data["lieuTravail"]["commune"],
+                data["lieuTravail"]["codePostal"],
+            )
+            return None
 
     source_tags = []
     if data["natureContrat"] == pe_api_enums.NATURE_CONTRATS[pe_api_enums.NATURE_CONTRAT_PEC]:

--- a/tests/companies/test_sync_ft_offers.py
+++ b/tests/companies/test_sync_ft_offers.py
@@ -1,9 +1,13 @@
+import copy
+import logging
+
 import pytest
 from django.core import management
 from django.test import override_settings
 
 from itou.cities.models import City
 from itou.companies.enums import POLE_EMPLOI_SIRET
+from itou.companies.management.commands.sync_ft_offers import pe_offer_to_job_description
 from itou.companies.models import JobDescription
 from itou.jobs.models import Appellation, Rome
 from itou.utils.apis import pe_api_enums
@@ -174,3 +178,34 @@ def test_sync_ft_offers(caplog, respx_mock):
         "successfully deleted count=1 PE job offers",
     ]
     assert JobDescription.objects.count() == 1
+
+
+class TestPeOfferToJobDescription:
+    def setup_method(self):
+        rome = Rome.objects.create(code="I1304")
+        Appellation.objects.create(
+            code=rome.code,
+            name="Technicien / Technicienne de maintenance industrielle",
+            rome=rome,
+        )
+
+    @property
+    def base_offer_data(self):
+        d = copy.deepcopy(API_OFFRES_RESPONSE_OK[0])
+        d["natureContrat"] = pe_api_enums.NATURE_CONTRATS[pe_api_enums.NATURE_CONTRAT_PEC]
+        return d
+
+    def test_pe_offer_to_job_description_basic_insee_code_lookup(self):
+        city = City.objects.create(
+            slug="slug",
+            department="39",
+            name="SAINT-CLAUDE",
+            post_codes=["ignored"],
+            code_insee="39478",
+        )
+        offer = self.base_offer_data
+        offer["lieuTravail"]["commune"] = "39478"
+
+        job_description = pe_offer_to_job_description(offer, logging.getLogger())
+
+        assert job_description.location == city

--- a/tests/companies/test_sync_ft_offers.py
+++ b/tests/companies/test_sync_ft_offers.py
@@ -209,3 +209,26 @@ class TestPeOfferToJobDescription:
         job_description = pe_offer_to_job_description(offer, logging.getLogger())
 
         assert job_description.location == city
+
+    def test_pe_offer_to_job_description_basic_postal_code_fallback(self):
+        city = City.objects.create(
+            slug="slug",
+            department="74",
+            name="ANNECY",
+            post_codes=["74000", "74370", "74600", "74940", "74960"],
+            code_insee="74010",
+        )
+        offer = self.base_offer_data
+        offer["lieuTravail"] = {
+            "codePostal": "74960",
+            # This is the INSEE code of Cran-Gevrier, a "commune
+            # déléguée", which we do not store.
+            "commune": "74093",
+            "latitude": 45.90795,
+            "libelle": "74 - ANNECY",
+            "longitude": 6.106588,
+        }
+
+        job_description = pe_offer_to_job_description(offer, logging.getLogger())
+
+        assert job_description.location == city


### PR DESCRIPTION
2 commits : 

1. On supprime la gestion spécifique des arrondissements de Paris, Marseille et Lyon. Le code devait dater du temps où on n'avait pas les arrondissements dans le modèle `City`, mais c'est désormais le cas. Donc on peut se baser sur le code INSEE pour retrouver la bonne instance de `City` correspondant à l'arrondissement.

2. On peut apparemment recevoir le code INSEE d'une [commune déléguée](https://fr.wikipedia.org/wiki/Commune_nouvelle#Communes_d%C3%A9l%C3%A9gu%C3%A9es). Par exemple ([ici dans Sentry](https://inclusion.sentry.io/issues/117642884)), 74093 pour Cran-Gevrier (qui fait partie d'Annecy). Or on ne stocke pas ces communes dans le modèle `City`. Contournement simple : si le code INSEE est inconnu, regarder le code postal. En l'occurrence, on trouverait Annecy, ce qui est le mieux qu'on puisse récupérer ici.