### PR TITLE
Admin: Raccourcir le nom de la colonne liée au dernier accompagnateur connu dans les assignations candidats

### DIFF
--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -1176,7 +1176,7 @@ class JobSeekerAssignmentAdmin(ItouModelAdmin):
         "assigned_to_unknown_advisor",
     ]
     list_display_links = ("job_seeker_display",)
-    list_filter = ("last_action_kind",)
+    list_filter = ("last_action_kind", "assigned_to_unknown_advisor")
     search_fields = (
         "job_seeker__first_name",
         "job_seeker__last_name",

--- a/itou/users/migrations/0048_jobseekerassignment_assigned_to_unknown_advisor.py
+++ b/itou/users/migrations/0048_jobseekerassignment_assigned_to_unknown_advisor.py
@@ -12,9 +12,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="jobseekerassignment",
             name="assigned_to_unknown_advisor",
-            field=models.BooleanField(
-                default=False, verbose_name="assigné à un accompagnateur non référencé sur le service"
-            ),
+            field=models.BooleanField(default=False, verbose_name="accompagnateur désigné inconnu"),
         ),
         migrations.AddConstraint(
             model_name="jobseekerassignment",

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -1645,7 +1645,7 @@ class JobSeekerAssignment(models.Model):
         default=ActionKind.CREATE,
     )
     assigned_to_unknown_advisor = models.BooleanField(
-        verbose_name="assigné à un accompagnateur non référencé sur le service",
+        verbose_name="accompagnateur désigné inconnu",
         default=False,
     )
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parce qu'il prend trop de place.