### PR TITLE
Tech : Désactivation de `AUTO_TRIGGER_CONTEXT` pour les commandes n'utilisant pas de transaction globale

### DIFF
--- a/itou/analytics/management/commands/collect_analytics_data.py
+++ b/itou/analytics/management/commands/collect_analytics_data.py
@@ -11,6 +11,10 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    # Transaction is handled manually for each datum.
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
 

--- a/itou/employee_record/common_management.py
+++ b/itou/employee_record/common_management.py
@@ -28,6 +28,9 @@ class EmployeeRecordTransferCommand(BaseCommand):
     # The file naming scheme also disallows creating more than one file in the same seconds.
     MAX_UPLOADED_FILES = 1
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         """Subclasses have a preflight option to check for serialization errors."""
         parser.add_argument(

--- a/itou/gps/management/commands/archive_old_gps_memberships.py
+++ b/itou/gps/management/commands/archive_old_gps_memberships.py
@@ -13,11 +13,11 @@ CHUNK_SIZE = 10_000
 
 
 class Command(BaseCommand):
-    """
-    End old FollowUpMemberships
-    """
-
     help = "End old FollowUpMemberships"
+
+    # Transaction is handled manually for each batch of objects.
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
 
     def handle(self, **options):
         two_years_ago = timezone.now() - relativedelta(years=2)

--- a/itou/metabase/management/commands/fetch_riae_contracts.py
+++ b/itou/metabase/management/commands/fetch_riae_contracts.py
@@ -74,7 +74,6 @@ class Command(BaseCommand):
             )
             contracts = client.fetch_dataset_results(client.build_dataset_query(database=2, query=query))
 
-    @transaction.atomic()
     def _write_contract(self, contracts):
         return len(
             Contract.objects.bulk_create(
@@ -165,8 +164,9 @@ class Command(BaseCommand):
             except Exception:
                 self.logger.exception("Failed to upsert Contract")
 
-        synced += self._write_contract(contracts)
+        with transaction.atomic():
+            synced += self._write_contract(contracts)
+            # Remove old contracts not updated : they don't exist in metabase anymore
+            Contract.objects.filter(updated_at__lte=run_time).delete()
 
-        # Remove old contracts not updated : they don't exist in metabase anymore
-        Contract.objects.filter(updated_at__lte=run_time).delete()
         self.logger.info(f"Synced {synced} Contracts")

--- a/itou/metabase/management/commands/fetch_riae_contracts.py
+++ b/itou/metabase/management/commands/fetch_riae_contracts.py
@@ -13,6 +13,9 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def _get_riae_contracts_data(self):
         client = Client(settings.METABASE_SITE_URL)
         QUERY_LIMIT = 100_000  # Limit to <100MB data in ram (estimated with pympler.asizeof.asizeof)

--- a/itou/nexus/management/commands/populate_metabase_nexus.py
+++ b/itou/nexus/management/commands/populate_metabase_nexus.py
@@ -119,6 +119,9 @@ def log_retry_attempt(retry_state):
 class Command(BaseCommand):
     help = "Populate nexus metabase database."
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def populate_users(self):
         queryset = User.objects.filter(
             is_active=True, kind__in=UserKind.professionals(), email__isnull=False

--- a/itou/scripts/management/commands/redact_zendesk_attachments.py
+++ b/itou/scripts/management/commands/redact_zendesk_attachments.py
@@ -60,6 +60,9 @@ class ZendeskClient:
 class Command(BaseCommand):
     help = "Remove all attachments from solved tickets after a week"
 
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def handle(self, **options):
         zendesk_client = ZendeskClient()
 

--- a/itou/users/management/commands/send_users_to_brevo.py
+++ b/itou/users/management/commands/send_users_to_brevo.py
@@ -60,6 +60,9 @@ def job_seeker_serializer(user):
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(

--- a/tests/nexus/__snapshots__/tests_management_commands.ambr
+++ b/tests/nexus/__snapshots__/tests_management_commands.ambr
@@ -1,20 +1,8 @@
 # serializer version: 1
 # name: test_populate_metabase_nexus[SQL queries]
   dict({
-    'num_queries': 6,
+    'num_queries': 5,
     'queries': list([
-      dict({
-        'origin': list([
-          '_set_context_connection_wrapper[utils/triggers/__init__.py]',
-          'populate_table[nexus/management/commands/populate_metabase_nexus.py]',
-          'Command.populate_users[nexus/management/commands/populate_metabase_nexus.py]',
-          'Command.handle[nexus/management/commands/populate_metabase_nexus.py]',
-          'Command.execute[utils/command.py]',
-          'Command.execute[itoutils/django/commands.py]',
-          'Command.execute[itoutils/django/commands.py]',
-        ]),
-        'sql': "SELECT set_config('itou.context', %s, TRUE)",
-      }),
       dict({
         'origin': list([
           'populate_table[nexus/management/commands/populate_metabase_nexus.py]',


### PR DESCRIPTION
Par défaut, on a `ATOMIC_HANDLE = False` et `AUTO_TRIGGER_CONTEXT = True`. Ces valeurs sont incompatibles et provoquent [ce log d'erreur](https://github.com/gip-inclusion/les-emplois/blob/706d23ad779a072283fda52623d5d2261052dba1/itou/utils/triggers/__init__.py#L60-L64).

Il faut donc définir surcharger `AUTO_TRIGGER_CONTEXT = False`. Et comme il est prévu de modifier la valeur par défaut de `ATOMIC_HANDLE` en True, autant être explicite pour ces commandes et définir `ATOMIC_HANDLE = False`.

**Attention :** cette PR contient un commit un peu différent, sauras-tu le retrouver ? (Si tu n'es pas joueur : cf. mon commentaire de revue de PR.)