### PR TITLE
Interface: ajout d’une mention de décision dans les bilans d'éxécutions

### DIFF
--- a/itou/templates/geiq_assessments/email/assessment_review_for_geiq_body.txt
+++ b/itou/templates/geiq_assessments/email/assessment_review_for_geiq_body.txt
@@ -15,7 +15,10 @@ Références du dossier :
 {% for conventionned_institution in conventionned_institutions %}{{ conventionned_institution }}{% if not forloop.last %}; {% endif %}{% endfor %}
 {% endwith %}
 
-Récapitulatif de la décision enregistrée par la {{ assessment.reviewed_by_institution.name }} :
+Vous trouverez ci-dessous le récapitulatif de la décision enregistrée par la {{ assessment.reviewed_by_institution.name }}.
+
+IMPORTANT : Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
+Seul le courrier officiel émis par la {{ assessment.reviewed_by_institution.name }} pourra confirmer de manière définitive le montant accordé.
 
 Montant total accordé : {{ assessment.granted_amount|format_int_euros }}
 Montant du premier versement déjà réalisé : {{ assessment.advance_amount|format_int_euros }}

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -35,13 +35,13 @@
         {% fragment as c_title__cta %}
             {% if can_invalidate %}
                 {% if assessment.decision_validated_at %}
-                    <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#invalidate_modal">
+                    <button type="button" class="btn btn-lg btn-outline-primary" data-bs-toggle="modal" data-bs-target="#invalidate_modal">
                         Modifier la sélection
                     </button>
                 {% else %}
                     <form method="post">
                         {% csrf_token %}
-                        <button class="btn btn-outline-primary" name="action" value="{{ ContractsAction.INVALIDATE }}">
+                        <button class="btn btn-lg btn-outline-primary" name="action" value="{{ ContractsAction.INVALIDATE }}">
                             Modifier la sélection
                         </button>
                     </form>

--- a/itou/templates/geiq_assessments_views/assessment_details_for_geiq.html
+++ b/itou/templates/geiq_assessments_views/assessment_details_for_geiq.html
@@ -43,26 +43,33 @@
                         </div>
                     {% endif %}
                     <div class="c-box mb-3 mb-md-4">
-                        <h4>Informations générales</h4>
-                        <h5>Structures concernées par la convention</h5>
-                        <ul>
+                        <h3>Informations générales</h3>
+                        <strong>Structures concernées par la convention</strong>
+                        <br>
+                        <ul class="mb-0">
                             {% for antenna_name in assessment.label_antenna_names %}<li>{{ antenna_name }}</li>{% endfor %}
                         </ul>
                         {% for institution_link in assessment.institution_links.all %}
-                            {% if institution_link.with_convention %}
-                                {% if institution_link.institution.kind == InstitutionKind.DDETS_GEIQ %}
-                                    <h5>Contact(s) DDETS</h5>
-                                {% elif institution_link.institution.kind == InstitutionKind.DREETS_GEIQ %}
-                                    <h5>Contact(s) DREETS</h5>
-                                {% else %}
-                                    <h5>Contact(s) {{ institution_link.institution.kind }}</h5>
+                            {% with institution_link.institution.active_members.all as institution_members %}
+                                {% if institution_link.with_convention and institution_members %}
+                                    <hr class="my-3">
+                                    {% if institution_link.institution.kind == InstitutionKind.DDETS_GEIQ %}
+                                        <strong>Contact(s) DDETS</strong>
+                                        <br>
+                                    {% elif institution_link.institution.kind == InstitutionKind.DREETS_GEIQ %}
+                                        <strong>Contact(s) DREETS</strong>
+                                        <br>
+                                    {% else %}
+                                        <strong>Contact(s) {{ institution_link.institution.kind }}</strong>
+                                        <br>
+                                    {% endif %}
+                                    <ul class="mb-0">
+                                        {% for member in institution_members %}
+                                            {% if member.email != PILOTAGE_INSTITUTION_EMAIL_CONTACT %}<li>{{ member.email }}</li>{% endif %}
+                                        {% endfor %}
+                                    </ul>
                                 {% endif %}
-                                <ul>
-                                    {% for member in institution_link.institution.active_members.all %}
-                                        {% if member.email != PILOTAGE_INSTITUTION_EMAIL_CONTACT %}<li>{{ member.email }}</li>{% endif %}
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
+                            {% endwith %}
                         {% endfor %}
                     </div>
                 </div>

--- a/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
+++ b/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
@@ -293,15 +293,21 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
                     </div>
                     <div class="modal-body">
-                        La validation entraînera l’envoi d'un email au GEIQ indiquant le montant accordé : {{ assessment.granted_amount|format_int_euros }}.
-                        <br>
-                        {% if assessment.granted_amount > assessment.advance_amount %}
-                            Cette décision implique la mise en place d’un prochain versement de {{ abs_balance_amount|format_int_euros }} au GEIQ, conformément aux modalités habituelles.
-                        {% elif assessment.granted_amount == assessment.advance_amount %}
-                            Cette décision n'entraîne aucun versement complémentaire, la totalité ayant déjà été réglée lors du premier versement.
-                        {% else %}
-                            Cette décision implique la mise en place d’un ordre de reversement de {{ abs_balance_amount|format_int_euros }} adressé au GEIQ, conformément aux modalités habituelles.
-                        {% endif %}
+                        <p>
+                            La validation entraînera l’envoi d'un email au GEIQ indiquant le montant accordé : {{ assessment.granted_amount|format_int_euros }}.
+                            <br>
+                            {% if assessment.granted_amount > assessment.advance_amount %}
+                                Cette décision implique la mise en place d’un prochain versement de {{ abs_balance_amount|format_int_euros }} au GEIQ, conformément aux modalités habituelles.
+                            {% elif assessment.granted_amount == assessment.advance_amount %}
+                                Cette décision n'entraîne aucun versement complémentaire, la totalité ayant déjà été réglée lors du premier versement.
+                            {% else %}
+                                Cette décision implique la mise en place d’un ordre de reversement de {{ abs_balance_amount|format_int_euros }} adressé au GEIQ, conformément aux modalités habituelles.
+                            {% endif %}
+                        </p>
+                        <p class="mb-0">
+                            Le GEIQ sera informé que la décision concernant le montant total accordé reste soumise à validation financière.
+                            <strong>Seul le courrier officiel émis par vos services pourra confirmer de manière définitive le montant accordé.</strong>
+                        </p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-sm btn-link" data-bs-dismiss="modal">Annuler</button>

--- a/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
+++ b/itou/templates/geiq_assessments_views/assessment_details_for_institution.html
@@ -262,12 +262,13 @@
                     {% endif %}
                     <div class="c-box mb-3 mb-md-4">
                         <h4>Informations générales</h4>
-                        <h5>Structures concernées par la convention</h5>
-                        <ul>
+                        <strong>Structures concernées par la convention</strong>
+                        <ul class="mb-0">
                             {% for antenna_name in assessment.label_antenna_names %}<li>{{ antenna_name }}</li>{% endfor %}
                         </ul>
-                        <h5>Contact(s) GEIQ</h5>
-                        <ul>
+                        <hr class="my-3">
+                        <strong>Contact(s) GEIQ</strong>
+                        <ul class="mb-0">
                             <li>{{ assessment.created_by.get_full_name }} - {{ assessment.created_by.email }}</li>
                             {% if assessment.submitted_by and assessment.submitted_by != assessment.created_by %}
                                 <li>{{ assessment.submitted_by.get_full_name }} - {{ assessment.submitted_by.email }}</li>

--- a/itou/templates/geiq_assessments_views/assessment_print.html
+++ b/itou/templates/geiq_assessments_views/assessment_print.html
@@ -53,7 +53,10 @@
                     </dd>
                 </div>
             </dl>
-            <p class="small">Ces données ont été calculées suite à la sélection que vous avez effectuée.</p>
+            <p class="fs-sm">Ces données ont été calculées suite à la sélection que vous avez effectuée.</p>
+            <p class="fs-sm">
+                Le GEIQ est informé que la décision concernant le montant total accordé reste soumise à validation financière. <strong>Seul le courrier officiel émis par vos services pourra confirmer de manière définitive le montant accordé</strong>.
+            </p>
         </section>
 
         <section class="mt-5">

--- a/itou/templates/geiq_assessments_views/assessment_result.html
+++ b/itou/templates/geiq_assessments_views/assessment_result.html
@@ -9,6 +9,14 @@
             <div class="row">
                 <div class="col-12">
                     <h2>Résultat</h2>
+                    {% component_alert content=content variant="info" icon=False extra_classes="mb-3" %}
+                        {% fragment as content %}
+                            <p class="mb-0">
+                                Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
+                                Seul le courrier officiel émis par la {{ assessment.reviewed_by_institution.name }} pourra confirmer de manière définitive le montant accordé.
+                            </p>
+                        {% endfragment %}
+                    {% endcomponent_alert %}
                     <div class="c-box c-box--summary mb-3 mb-md-4">
                         <div class="c-box--summary__header">
                             <h3 class="m-0">Décision</h3>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -258,9 +258,10 @@
   
                       
                       <div class="c-box mb-3 mb-md-4">
-                          <h4>Informations générales</h4>
-                          <h5>Structures concernées par la convention</h5>
-                          <ul>
+                          <h3>Informations générales</h3>
+                          <strong>Structures concernées par la convention</strong>
+                          <br/>
+                          <ul class="mb-0">
                               <li>Siège (12)</li><li>Une antenne (12)</li>
                           </ul>
                           
@@ -885,8 +886,8 @@
       }),
       dict({
         'origin': list([
-          'ForNode[geiq_assessments_views/assessment_details_for_geiq.html]',
           'IfNode[geiq_assessments_views/assessment_details_for_geiq.html]',
+          'WithNode[geiq_assessments_views/assessment_details_for_geiq.html]',
           'ForNode[geiq_assessments_views/assessment_details_for_geiq.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/_assessment_base_for_geiq.html]',
@@ -945,8 +946,8 @@
       }),
       dict({
         'origin': list([
-          'ForNode[geiq_assessments_views/assessment_details_for_geiq.html]',
           'IfNode[geiq_assessments_views/assessment_details_for_geiq.html]',
+          'WithNode[geiq_assessments_views/assessment_details_for_geiq.html]',
           'ForNode[geiq_assessments_views/assessment_details_for_geiq.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[geiq_assessments_views/_assessment_base_for_geiq.html]',
@@ -1235,32 +1236,41 @@
   
                       
                       <div class="c-box mb-3 mb-md-4">
-                          <h4>Informations générales</h4>
-                          <h5>Structures concernées par la convention</h5>
-                          <ul>
+                          <h3>Informations générales</h3>
+                          <strong>Structures concernées par la convention</strong>
+                          <br/>
+                          <ul class="mb-0">
                               <li>Siège (12)</li><li>Une antenne (12)</li>
                           </ul>
                           
                               
                                   
-                                      <h5>Contact(s) DDETS</h5>
+                                      <hr class="my-3"/>
+                                      
+                                          <strong>Contact(s) DDETS</strong>
+                                          <br/>
+                                      
+                                      <ul class="mb-0">
+                                          
+                                              <li>paul@dd.ets</li>
+                                          
+                                      </ul>
                                   
-                                  <ul>
-                                      
-                                          <li>paul@dd.ets</li>
-                                      
-                                  </ul>
                               
                           
                               
                                   
-                                      <h5>Contact(s) DREETS</h5>
+                                      <hr class="my-3"/>
+                                      
+                                          <strong>Contact(s) DREETS</strong>
+                                          <br/>
+                                      
+                                      <ul class="mb-0">
+                                          
+                                              <li>paul@dre.ets</li>
+                                          
+                                      </ul>
                                   
-                                  <ul>
-                                      
-                                          <li>paul@dre.ets</li>
-                                      
-                                  </ul>
                               
                           
                       </div>
@@ -1556,13 +1566,14 @@
                       </div>
                   </div>
                   <div class="c-box mb-3 mb-md-4">
-                      <h4>
+                      <h3>
                           Informations générales
-                      </h4>
-                      <h5>
+                      </h3>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <br/>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (12)
                           </li>
@@ -1570,10 +1581,12 @@
                               Une autre antenne (23)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) DDETS
-                      </h5>
-                      <ul>
+                      </strong>
+                      <br/>
+                      <ul class="mb-0">
                           <li>
                               paul@dd.ets
                           </li>
@@ -2323,9 +2336,10 @@
   
                       
                       <div class="c-box mb-3 mb-md-4">
-                          <h4>Informations générales</h4>
-                          <h5>Structures concernées par la convention</h5>
-                          <ul>
+                          <h3>Informations générales</h3>
+                          <strong>Structures concernées par la convention</strong>
+                          <br/>
+                          <ul class="mb-0">
                               <li>Siège (12)</li><li>Une antenne (12)</li>
                           </ul>
                           
@@ -2552,9 +2566,10 @@
   
                       
                       <div class="c-box mb-3 mb-md-4">
-                          <h4>Informations générales</h4>
-                          <h5>Structures concernées par la convention</h5>
-                          <ul>
+                          <h3>Informations générales</h3>
+                          <strong>Structures concernées par la convention</strong>
+                          <br/>
+                          <ul class="mb-0">
                               <li>Siège (12)</li><li>Une antenne (12)</li>
                           </ul>
                           

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_geiq.ambr
@@ -1773,6 +1773,29 @@
               <div class="row">
                   <div class="col-12">
                       <h2>Résultat</h2>
+                      
+  
+  
+  
+  
+  
+      
+      
+      
+      <div class="alert alert-info mb-3" role="status">
+          
+          
+              
+              
+                              <p class="mb-0">
+                                  Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
+                                  Seul le courrier officiel émis par la DREETS Bretagne pourra confirmer de manière définitive le montant accordé.
+                              </p>
+                          
+          
+      </div>
+  
+  
                       <div class="c-box c-box--summary mb-3 mb-md-4">
                           <div class="c-box--summary__header">
                               <h3 class="m-0">Décision</h3>
@@ -1887,6 +1910,29 @@
               <div class="row">
                   <div class="col-12">
                       <h2>Résultat</h2>
+                      
+  
+  
+  
+  
+  
+      
+      
+      
+      <div class="alert alert-info mb-3" role="status">
+          
+          
+              
+              
+                              <p class="mb-0">
+                                  Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
+                                  Seul le courrier officiel émis par la DREETS Bretagne pourra confirmer de manière définitive le montant accordé.
+                              </p>
+                          
+          
+      </div>
+  
+  
                       <div class="c-box c-box--summary mb-3 mb-md-4">
                           <div class="c-box--summary__header">
                               <h3 class="m-0">Décision</h3>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -39,7 +39,10 @@
   Institution référente sélectionnée par le GEIQ :
   DDETS 29
   
-  Récapitulatif de la décision enregistrée par la DDETS 29 :
+  Vous trouverez ci-dessous le récapitulatif de la décision enregistrée par la DDETS 29.
+  
+  IMPORTANT : Cette information est communiquée à titre indicatif à la suite du contrôle effectué. La décision concernant le montant total accordé reste soumise à validation financière.
+  Seul le courrier officiel émis par la DDETS 29 pourra confirmer de manière définitive le montant accordé.
   
   Montant total accordé : 80 000 €
   Montant du premier versement déjà réalisé : 50 000 €
@@ -2281,8 +2284,15 @@
                       </dd>
                   </div>
               </dl>
-              <p class="small">
+              <p class="fs-sm">
                   Ces données ont été calculées suite à la sélection que vous avez effectuée.
+              </p>
+              <p class="fs-sm">
+                  Le GEIQ est informé que la décision concernant le montant total accordé reste soumise à validation financière.
+                  <strong>
+                      Seul le courrier officiel émis par vos services pourra confirmer de manière définitive le montant accordé
+                  </strong>
+                  .
               </p>
           </section>
           <section class="mt-5">

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_institution.ambr
@@ -349,18 +349,19 @@
                       <h4>
                           Informations générales
                       </h4>
-                      <h5>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (29)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) GEIQ
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Jean DUPONT - jean.dupont@example.com
                           </li>
@@ -404,18 +405,19 @@
                       <h4>
                           Informations générales
                       </h4>
-                      <h5>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (29)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) GEIQ
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Jean DUPONT - jean.dupont@example.com
                           </li>
@@ -710,18 +712,19 @@
                       <h4>
                           Informations générales
                       </h4>
-                      <h5>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (29)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) GEIQ
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Jean DUPONT - jean.dupont@example.com
                           </li>
@@ -1024,18 +1027,19 @@
                       <h4>
                           Informations générales
                       </h4>
-                      <h5>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (29)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) GEIQ
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Jean DUPONT - jean.dupont@example.com
                           </li>
@@ -1340,18 +1344,19 @@
                       <h4>
                           Informations générales
                       </h4>
-                      <h5>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (29)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) GEIQ
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Jean DUPONT - jean.dupont@example.com
                           </li>
@@ -1647,18 +1652,19 @@
                       <h4>
                           Informations générales
                       </h4>
-                      <h5>
+                      <strong>
                           Structures concernées par la convention
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Une antenne (29)
                           </li>
                       </ul>
-                      <h5>
+                      <hr class="my-3"/>
+                      <strong>
                           Contact(s) GEIQ
-                      </h5>
-                      <ul>
+                      </strong>
+                      <ul class="mb-0">
                           <li>
                               Jean DUPONT - jean.dupont@example.com
                           </li>

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -1412,7 +1412,9 @@ class TestAssessmentResult:
 
     def test_access(self, client, settings, snapshot):
         membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
-        dreets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DREETS_GEIQ)
+        dreets_membership = InstitutionMembershipFactory(
+            institution__kind=InstitutionKind.DREETS_GEIQ, institution__name="DREETS Bretagne"
+        )
         settings.GEIQ_ASSESSMENT_CAMPAIGN_POSTCODE_PREFIXES = [membership.company.post_code[:2]]
         assessment = AssessmentFactory(
             id=uuid.UUID("00000000-1111-2222-3333-444444444444"),


### PR DESCRIPTION
## :thinking: Pourquoi ?
Certaines DDETS (retours région BFC) ne souhaitent pas que les GEIQ reçoivent une notification détaillée de la décision car elles doivent suivre un protocole interne avant de pouvoir l’officialiser (accord DGFip)

Afin de ne pas chambouler tous les parcours (bouton, modales, onglet, notif…) , on va partir sur l’ajout d’une mention qui indique aux GEIQ que le montant accordé est donné à titre indicatif et que le résultat définitif sera communiqué dans un courrier officiel.

https://www.notion.so/gip-inclusion/Ajout-d-une-mention-dans-les-notifs-et-crans-de-d-cision-pour-indiquer-que-le-montant-accord-est-d-3575f321b604808cbafdcc5afcc373b8?d=3585f321b60480ffb935001c162b0eb0#3585f321b60480c08344fedebfe24004

En bonus 🎁 
- ajustement UI de la box "Informations générales" en sidebar
- correction de la taille d'un bouton dans la zone de titre de page
