### PR TITLE
Tech : Désactivation de AUTO_TRIGGER_CONTEXT pour les commandes n'utilisant pas de transaction globale (2ème vague)

### DIFF
--- a/itou/job_applications/management/commands/archive_job_applications.py
+++ b/itou/job_applications/management/commands/archive_job_applications.py
@@ -9,6 +9,9 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def handle(self, **options):
         now = timezone.now()
         count = JobApplication.objects.filter(


### PR DESCRIPTION
The global transaction was already disabled (ATOMIC_HANDLE is False by
default), but we needed to override `AUTO_TRIGGER_CONTEXT` (which is
True by default).

---

Idem #7982, il en manquait (je m'étais basé sur les erreurs Sentry des 2 derniers jours).
