### PR TITLE
Tech: passer `archive_job_applications ` en `dry_runnable`

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -39,7 +39,7 @@
   "0 12 * * * $ROOT/clevercloud/run_management_command.sh evaluation_campaign_notify",
   "30 20 * * * $ROOT/clevercloud/run_management_command.sh populate_metabase_emplois --mode all",
   "5 23 * * * $ROOT/clevercloud/run_management_command.sh archive_employee_records --wet-run",
-  "20 23 * * * $ROOT/clevercloud/run_management_command.sh archive_job_applications",
+  "20 23 * * * $ROOT/clevercloud/run_management_command.sh archive_job_applications --wet-run",
   "40 23 * * * $ROOT/clevercloud/run_management_command.sh archive_old_gps_memberships",
   "55 23 * * * $ROOT/clevercloud/run_management_command.sh purge_orphaned_support_remarks --wet-run",
 

--- a/itou/job_applications/management/commands/archive_job_applications.py
+++ b/itou/job_applications/management/commands/archive_job_applications.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.template.defaultfilters import pluralize
 from django.utils import timezone
+from itoutils.django.commands import dry_runnable
 
 from itou.job_applications.enums import ARCHIVABLE_JOB_APPLICATION_STATES
 from itou.job_applications.models import JobApplication
@@ -9,6 +10,10 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--wet-run", dest="wet_run", action="store_true")
+
+    @dry_runnable
     def handle(self, **options):
         now = timezone.now()
         count = JobApplication.objects.filter(

--- a/tests/job_applications/test_archive_job_applications.py
+++ b/tests/job_applications/test_archive_job_applications.py
@@ -35,8 +35,27 @@ def test_archive(caplog):
         updated_at=cutoff + datetime.timedelta(hours=1),
     )
 
-    call_command("archive_job_applications")
+    already_archived_count = JobApplication.objects.exclude(archived_at=None).count()
+    expected_log = f"Archived {len(ARCHIVABLE_JOB_APPLICATION_STATES)} job applications"
 
+    # Dry run
+    call_command("archive_job_applications")
+    assert caplog.messages[:-1] == [
+        "Command launched with wet_run=False",
+        expected_log,
+        "Setting transaction to be rollback as wet_run=False",
+    ]
+    assert caplog.messages[-1].startswith(
+        "Management command itou.job_applications.management.commands.archive_job_applications succeeded in"
+    )
+    assert JobApplication.objects.exclude(archived_at=None).count() == already_archived_count
+
+    # Wet run
+    caplog.clear()
+    call_command("archive_job_applications", wet_run=True)
+    assert JobApplication.objects.exclude(archived_at=None).count() == already_archived_count + len(
+        ARCHIVABLE_JOB_APPLICATION_STATES
+    )
     assertQuerySetEqual(
         JobApplication.objects.exclude(archived_at=None),
         [
@@ -51,7 +70,7 @@ def test_archive(caplog):
         ],
         ordered=False,
     )
-    assert caplog.messages[:-1] == [f"Archived {len(ARCHIVABLE_JOB_APPLICATION_STATES)} job applications"]
+    assert caplog.messages[:-1] == [expected_log]
     assert caplog.messages[-1].startswith(
         "Management command itou.job_applications.management.commands.archive_job_applications succeeded in"
     )


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour éviter https://inclusion.sentry.io/issues/112922284/events/46b5f9b32ad9415ca4f234e054917bda/?project=4508410589020240&query=is%3Aunresolved&referrer=next-event et au passage pouvoir lancer la commande en dry-run.

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
