### PR TITLE
Tableau de bord: Bandeau d’info webinaire

### DIFF
--- a/itou/templates/approvals/list.html
+++ b/itou/templates/approvals/list.html
@@ -42,6 +42,22 @@
                 <div class="col-12">
                     <div class="tab-content">
                         <h2 class="mb-3 mb-md-4">Salariés et PASS IAE</h2>
+                        {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible=True extra_classes="mb-3" %}
+                            {% fragment as title %}
+                                Webinaire thématique
+                            {% endfragment %}
+                            {% fragment as content %}
+                                <p class="mb-0">
+                                    1 heure pour tout comprendre sur le PASS IAE : simplifiez la gestion de vos PASS IAE (étapes clés, bonnes pratiques et réponses à vos questions en direct).
+                                </p>
+                            {% endfragment %}
+                            {% fragment as call_to_action %}
+                                <a class="btn btn-sm btn-primary has-external-link"
+                                   target="_blank"
+                                   rel="noopener"
+                                   href="https://tally.so/r/b55KY0?event_id=gestion-du-pass-iae-2026-06-16-1777898236003&titre_event=Gestion%20du%20PASS%20IAE&date_event=16%20Juin%202026%20-%2014h00">Je m'inscris</a>
+                            {% endfragment %}
+                        {% endcomponent_alert %}
                         {% include "includes/mon_recap_banner.html" with request=request mon_recap_banner_departments=mon_recap_banner_departments only %}
                         <form hx-get="{% url 'approvals:list' %}"
                               hx-trigger="change delay:.5s, change from:#id_job_seeker"

--- a/itou/templates/dashboard/dashboard.html
+++ b/itou/templates/dashboard/dashboard.html
@@ -131,6 +131,23 @@
             {% endfragment %}
         {% endcomponent_alert %}
     {% endif %}
+
+    {% if request.from_authorized_prescriber %}
+        {% component_alert title=title content=content call_to_action=call_to_action variant="info" dismissible=True extra_classes="mb-3" %}
+            {% fragment as title %}
+                Webinaire thématique
+            {% endfragment %}
+            {% fragment as content %}
+                <p class="mb-0">1 heure pour améliorer vos candidatures et faciliter leur traitement par les SIAE.</p>
+            {% endfragment %}
+            {% fragment as call_to_action %}
+                <a class="btn btn-sm btn-primary has-external-link"
+                   target="_blank"
+                   rel="noopener"
+                   href="https://tally.so/r/b55KY0?event_id=orientation-vers-l-iae-2026-06-18-1777898055204&titre_event=Orientation%20vers%20l%E2%80%99IAE&date_event=18%20Juin%202026%20-%2010h00">Je m'inscris</a>
+            {% endfragment %}
+        {% endcomponent_alert %}
+    {% endif %}
 {% endblock %}
 
 {% block title_extra %}


### PR DESCRIPTION
## :thinking: Pourquoi ?

https://www.notion.so/gip-inclusion/Bandeau-d-info-webinaire-sur-la-page-salari-s-et-PASS-IAE-34c5f321b60480c8a91be193ed08cc37


## :rotating_light: Attention
Date de publication du bandeau : du 19 mai 2026 jusqu’au 15 juin 2026



## :computer: Captures d'écran <!-- optionnel -->
Bandeau pour les SIAE 

<img width="1243" height="665" alt="capture 2026-05-07 à 10 37 30" src="https://github.com/user-attachments/assets/95a77a41-4254-436f-82b1-dd171c752ed0" />

---

Bandeau pour les prescripteurs habilités

<img width="1630" height="578" alt="capture 2026-05-07 à 10 43 17" src="https://github.com/user-attachments/assets/7d452ca9-137d-4bb8-a226-2cecf7fa9ed2" />
