### PR TITLE
Tech : Corrections dans la commande de déplacement de données d'une entreprise à une autre

### DIFF
--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -27,6 +27,7 @@ class TransferField(TextChoices):
     MEMBERSHIPS = "memberships", "Utilisateurs membres"
     INVITATIONS = "invitations", "Invitations"
     PROLONGATIONS = "prolongations", "Prolongations déclarées"
+    PROLONGATION_REQUESTS = "demandes de prolongation", "Demandes de prolongation"
     SUSPENSIONS = "suspensions", "Suspensions déclarées"
     BRAND = "brand", models.Company._meta.get_field("brand").verbose_name.capitalize()
     DESCRIPTION = "description", models.Company._meta.get_field("description").verbose_name.capitalize()
@@ -100,6 +101,11 @@ TRANSFER_SPECS = {
                 "email", flat=True
             )
         ),
+    },
+    TransferField.PROLONGATION_REQUESTS: {
+        "related_model": approvals_models.ProlongationRequest,
+        "related_model_field": "declared_by_siae",
+        "iae_only": True,
     },
     TransferField.PROLONGATIONS: {
         "related_model": approvals_models.Prolongation,

--- a/itou/companies/transfer.py
+++ b/itou/companies/transfer.py
@@ -21,6 +21,7 @@ class TransferField(TextChoices):
     GEIQ_DIAG_CREATED = "geiq_diag_created", "Diagnostics GEIQ créés"
     JOB_APPLICATIONS_SENT = "job_applications_sent", "Candidatures envoyées"
     JOB_APPLICATIONS_RECEIVED = "job_applications_received", "Candidatures reçues"
+    JOB_APPLICATIONS_TRANSFERRED = "job_applications_transferred", "Candidatures transférées"
     JOB_SEEKER_ASSIGNMENTS = "job_seeker_assignments", "Affectations candidats"
     EMPLOYEE_RECORDS_CREATED = "employee_records_created", "Fiches salarié (transférées via les candidatures reçues)"
     JOB_DESCRIPTIONS = "job_descriptions", "Fiches de poste"
@@ -58,6 +59,10 @@ TRANSFER_SPECS = {
     TransferField.JOB_APPLICATIONS_RECEIVED: {
         "related_model": job_applications_models.JobApplication,
         "related_model_field": "to_company",
+    },
+    TransferField.JOB_APPLICATIONS_TRANSFERRED: {
+        "related_model": job_applications_models.JobApplication,
+        "related_model_field": "transferred_from_id",
     },
     TransferField.JOB_SEEKER_ASSIGNMENTS: {
         "related_model": users_models.JobSeekerAssignment,

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -218,6 +218,24 @@ class TestMoveCompanyData:
         request.refresh_from_db()
         assert request.declared_by_siae == company_to
 
+    def test_move_job_application_transferred_from(self):
+        company_from = companies_factories.CompanyFactory()
+        company_to = companies_factories.CompanyFactory()
+        job_application = JobApplicationFactory(
+            sent_by_employer=True,
+            transferred_from=company_from,
+        )
+
+        management.call_command(
+            "move_company_data",
+            from_id=company_from.pk,
+            to_id=company_to.pk,
+            wet_run=True,
+        )
+
+        job_application.refresh_from_db()
+        assert job_application.transferred_from == company_to
+
 
 def test_update_companies_job_app_score(caplog):
     company_1 = companies_factories.CompanyFactory()

--- a/tests/companies/test_management_commands.py
+++ b/tests/companies/test_management_commands.py
@@ -13,6 +13,7 @@ from itou.companies.enums import CompanyKind, CompanySource, JobSource
 from itou.companies.models import Company, JobDescription
 from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment
+from tests.approvals.factories import ProlongationRequestFactory
 from tests.cities.factories import create_city_guerande
 from tests.companies import factories as companies_factories
 from tests.eligibility import factories as eligibility_factories
@@ -201,6 +202,21 @@ class TestMoveCompanyData:
         assert updated_assignment_3_to_comp.created_at == assignment_3_to_comp.created_at
         assert updated_assignment_3_to_comp.updated_at == assignment_3.updated_at
         assert updated_assignment_3_to_comp.last_action_kind == ActionKind.APPLY
+
+    def test_move_prolongation_requests(self):
+        company_from = companies_factories.CompanyFactory()
+        company_to = companies_factories.CompanyFactory(subject_to_iae_rules=True)
+        request = ProlongationRequestFactory(declared_by_siae=company_from)
+
+        management.call_command(
+            "move_company_data",
+            from_id=company_from.pk,
+            to_id=company_to.pk,
+            wet_run=True,
+        )
+
+        request.refresh_from_db()
+        assert request.declared_by_siae == company_to
 
 
 def test_update_companies_job_app_score(caplog):


### PR DESCRIPTION
La commande `move_company_data` déplaçait les prolongations (et plein d'autres données liées à l'entreprise source), mais pas les _demandes_ de prolongation. (Vu dans le cadre de l'investigation sur les alertes levées par le script d'import des SIAE, qui rapportait [une SIAE](https://emplois.inclusion.beta.gouv.fr/admin/companies/company/10453/change/) sans données liées, hormis une demande de prolongation. Tout le reste des données avait été précédemment déplacé par `move_company_data`, d'après la SupportRemark.)

De plus, le champ `JobApplication.transferred_from` n'était pas non plus pris en compte. (Ce cas a aussi été vu dans le cadre de l'investigation sur les alertes levées par le script d'import des SIAE.)