### PR TITLE
API: Bloquer les demandes de token par des utilisateurs n'utilisant pas ProConnect 

### DIFF
--- a/itou/api/token_auth/views.py
+++ b/itou/api/token_auth/views.py
@@ -3,9 +3,11 @@ import logging
 from rest_framework import serializers
 from rest_framework.authtoken import views as drf_authtoken_views
 from rest_framework.authtoken.models import Token
+from rest_framework.authtoken.serializers import AuthTokenSerializer
 from rest_framework.response import Response
 
 from itou.api import AUTH_TOKEN_EXPLANATION_TEXT
+from itou.users.enums import IdentityProvider
 from itou.utils.auth import LoginNotRequiredMixin
 
 
@@ -15,7 +17,19 @@ logger = logging.getLogger(__name__)
 TOKEN_ID_STR = "__token__"
 
 
+class ItouAuthTokenSerializer(AuthTokenSerializer):
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+        user = attrs["user"]
+        if user.has_sso_provider and user.identity_provider != IdentityProvider.INCLUSION_CONNECT:
+            msg = "Ce compte ne peut pas se connecter avec un username et mot de passe."
+            raise serializers.ValidationError(msg, code="authorization")
+        return attrs
+
+
 class ObtainAuthToken(LoginNotRequiredMixin, drf_authtoken_views.ObtainAuthToken):
+    serializer_class = ItouAuthTokenSerializer
+
     def post(self, request, *args, **kwargs):
         if request.data.get("username") == TOKEN_ID_STR:
             password = request.data.get("password")
@@ -36,9 +50,9 @@ class ObtainAuthToken(LoginNotRequiredMixin, drf_authtoken_views.ObtainAuthToken
 
 
 ObtainAuthToken.__doc__ = f"""\
-**Route majoritairement utilisée pour les comptes n’ayant pas activé ProConnect.**
+**Route utilisée pour les comptes n’ayant pas activé ProConnect.**
 
-Si vous avez activé ProConnect pour votre compte, vous pouvez obtenir un jeton d’accès aux
+Si vous avez activé ProConnect pour votre compte, vous devez obtenir un jeton d’accès aux
 APIs depuis un **compte administrateur de la structure** de la manière suivante :
 
 {AUTH_TOKEN_EXPLANATION_TEXT}

--- a/tests/api/employee_record_api/tests.py
+++ b/tests/api/employee_record_api/tests.py
@@ -3,14 +3,16 @@ from django.urls import reverse
 from django.utils import timezone
 from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertContains
+from rest_framework.authtoken.models import Token
 
+from itou.api.token_auth.views import TOKEN_ID_STR
 from itou.employee_record.enums import Status
 from itou.employee_record.models import EmployeeRecord
 from itou.utils.mocks.address_format import mock_get_geocoding_data
 from tests.companies.factories import CompanyMembershipFactory
 from tests.employee_record.factories import EmployeeRecordUpdateNotificationFactory, EmployeeRecordWithProfileFactory
 from tests.job_applications.factories import JobApplicationFactory
-from tests.users.factories import DEFAULT_PASSWORD, HASHED_DEFAULT_PASSWORD, EmployerFactory
+from tests.users.factories import HASHED_DEFAULT_PASSWORD, EmployerFactory
 
 
 class TestEmployeeRecordAPIPermissions:
@@ -33,7 +35,8 @@ class TestEmployeeRecordAPIPermissions:
         """
         Standard use-case: using external API client with token auth
         """
-        data = {"username": self.user.email, "password": DEFAULT_PASSWORD}
+        token = Token.objects.create(user=self.user)
+        data = {"username": TOKEN_ID_STR, "password": token.key}
         response = api_client.post(self.token_url, data, format="json")
         assert response.status_code == 200
 
@@ -47,7 +50,8 @@ class TestEmployeeRecordAPIPermissions:
         assert response.status_code == 200
 
     def test_permissions_ko_with_token(self, api_client):
-        data = {"username": self.unauthorized_user.email, "password": DEFAULT_PASSWORD}
+        token = Token.objects.create(user=self.unauthorized_user)
+        data = {"username": TOKEN_ID_STR, "password": token.key}
         response = api_client.post(self.token_url, data, format="json")
         assert response.status_code == 200
 

--- a/tests/api/token_auth/tests.py
+++ b/tests/api/token_auth/tests.py
@@ -1,18 +1,30 @@
+import pytest
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
 
+from itou.users.enums import IdentityProvider
 from tests.users.factories import DEFAULT_PASSWORD, EmployerFactory
 
 
-def test_token_auth_with_login_password(client):
-    user = EmployerFactory(with_password=True)
-    assert Token.objects.count() == 0
-
-    url = reverse("v1:token-auth")
-    response = client.post(url, data={"username": user.email, "password": DEFAULT_PASSWORD})
-
-    token = Token.objects.get()
-    assert response.json() == {"token": token.key}
+@pytest.mark.parametrize(
+    "identity_provider,expects_creation",
+    [
+        (IdentityProvider.DJANGO, True),
+        (IdentityProvider.INCLUSION_CONNECT, True),
+        (IdentityProvider.PRO_CONNECT, False),
+    ],
+    ids=["django", "inclusion_connect", "pro_connect"],
+)
+def test_token_auth_with_login_password(client, identity_provider, expects_creation):
+    user = EmployerFactory(with_password=True, identity_provider=identity_provider)
+    assert not Token.objects.exists()
+    response = client.post(reverse("v1:token-auth"), data={"username": user.email, "password": DEFAULT_PASSWORD})
+    if expects_creation:
+        token = Token.objects.get()
+        assert response.json() == {"token": token.key}
+    else:
+        assert response.status_code == 400
+        assert not Token.objects.exists()
 
 
 def test_token_auth_with_token(client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Empêcher ces utilisateurs d'utiliser un ancien mot de passe.

Cela ne règle pas encore la question de la durée de vie des tokens générés.  

J'ai 2 propositions, je pense que la seconde est plus adaptée car plus globale
1) on bidouille au niveau du serializer de la vue `ObtainAuthToken`
2) on répond `False` à `user.check_password()` s'il doit utiliser un SSO


EDIT: la seconde solution ne permet pas de se connecter aux comptes de démo utilisant ProConnect.
On va rester sur la bidouille sur `ObtainAuthToken`

## :cake: Comment ? <!-- optionnel -->

> _Décrivez en quelques mots la solution retenue et mise en oeuvre, les difficultés ou problèmes rencontrés. Attirez l'attention sur les décisions d'architecture ou de conception importantes._

## :rotating_light: À vérifier

- [ ] Mettre à jour le CHANGELOG_breaking_changes.md ?
- [ ] Ajouter l'étiquette « Bug » ?

## :desert_island: Comment tester ?

> _Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. Si vous disposez d'une recette jetable, mettre l'URL pour tester dans cette partie._

## :computer: Captures d'écran <!-- optionnel -->

<!--
# Catégories changelog

 +-------------------------|--------------------------+
| API                      | Notifications            |
| Accessibilité            | Page d’accueil           |
| Admin                    | PASS IAE                 |
| Annexes financières      | Performances             |
| Candidature              | Pilotage                 |
| Connexion                | Prescripteur             |
| Contrôle a posteriori    | Profil salarié           |
| Demandes de prolongation | Recherche employeur      |
| Demandeur d’emploi       | Recherche fiche de poste |
| Employeur                | Recherche prescripteur   |
| Fiche de poste           | Stabilité                |
| Fiche entreprise         | Statistiques             |
| Fiches salarié           | Tableau de bord          |
| GEIQ                     | Tech                     |
| Inscription              | Vie privée               |
| Interface                |                          |
+--------------------------|--------------------------+
-->
