### PR TITLE
GEIQ : précisions concernant les modalités d'obtention de l'aide

### DIFF
--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -65,13 +65,18 @@
                     {% if request.from_employer %}
                         <h2>Sélectionnez les contrats pour lesquels vous souhaitez obtenir une aide</h2>
                         <p>
-                            Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
-                            <br>
-                            Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
+                            Les contrats compris dans la période du 1er octobre de l’année {{ previous_campaign_year }} au 31 décembre de l’année {{ campaign_year }} sont importés ici depuis le site Label GEIQ.
+                        </p>
+                        <p>
+                            Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                        </p>
+                        <p>
+                            L’aide potentielle est calculée par le site Label GEIQ à partir de critères administratifs sélectionnés par le GEIQ.
+                            Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
                         </p>
                         <p class="mb-0">
-                            L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
-                            Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
+                            Sélectionnez les contrats pour lesquels vous sollicitez l’aide à l’accompagnement.
+                            Conformément à l’accord conclu entre la FFGEIQ et la DGEFP, les DDETS/DREETS en charge de votre dossier peuvent accéder à l’ensemble des contrats importés.
                         </p>
                     {% elif request.from_institution %}
                         <h2>Sélectionnez les contrats pour lesquels vous souhaitez accorder l’aide</h2>

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -596,6 +596,8 @@ def assessment_contracts_list(request, pk, template_name="geiq_assessments_views
         "assessment": assessment,
         "back_url": back_url,
         "contracts_page": contracts_page,
+        "campaign_year": assessment.campaign.year,
+        "previous_campaign_year": assessment.campaign.year - 1,
         "can_validate": can_validate,
         "can_invalidate": can_invalidate,
         "AssessmentContractDetailsTab": AssessmentContractDetailsTab,

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -4534,13 +4534,18 @@
                       Sélectionnez les contrats pour lesquels vous souhaitez obtenir une aide
                   </h2>
                   <p>
-                      Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
-                      <br/>
-                      Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
+                      Les contrats compris dans la période du 1er octobre de l’année 2023 au 31 décembre de l’année 2024 sont importés ici depuis le site Label GEIQ.
+                  </p>
+                  <p>
+                      Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                  </p>
+                  <p>
+                      L’aide potentielle est calculée par le site Label GEIQ à partir de critères administratifs sélectionnés par le GEIQ.
+                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
                   </p>
                   <p class="mb-0">
-                      L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
-                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
+                      Sélectionnez les contrats pour lesquels vous sollicitez l’aide à l’accompagnement.
+                              Conformément à l’accord conclu entre la FFGEIQ et la DGEFP, les DDETS/DREETS en charge de votre dossier peuvent accéder à l’ensemble des contrats importés.
                   </p>
               </div>
           </div>
@@ -4768,13 +4773,18 @@
                       Sélectionnez les contrats pour lesquels vous souhaitez obtenir une aide
                   </h2>
                   <p>
-                      Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
-                      <br/>
-                      Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
+                      Les contrats compris dans la période du 1er octobre de l’année 2023 au 31 décembre de l’année 2024 sont importés ici depuis le site Label GEIQ.
+                  </p>
+                  <p>
+                      Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                  </p>
+                  <p>
+                      L’aide potentielle est calculée par le site Label GEIQ à partir de critères administratifs sélectionnés par le GEIQ.
+                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
                   </p>
                   <p class="mb-0">
-                      L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
-                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
+                      Sélectionnez les contrats pour lesquels vous sollicitez l’aide à l’accompagnement.
+                              Conformément à l’accord conclu entre la FFGEIQ et la DGEFP, les DDETS/DREETS en charge de votre dossier peuvent accéder à l’ensemble des contrats importés.
                   </p>
               </div>
           </div>
@@ -5028,13 +5038,18 @@
                       Sélectionnez les contrats pour lesquels vous souhaitez obtenir une aide
                   </h2>
                   <p>
-                      Les contrats compris dans la période du 1er octobre de l’année N-2 au 31 décembre de l’année N-1 sont importés ici depuis Label.
-                      <br/>
-                      Par défaut, seuls les contrats éligibles à une aide et dont la durée est supérieure à 3 mois (90 jours) sont sélectionnés. Vous pouvez toutefois corriger cette sélection et inclure les contrats de votre choix au bilan.
+                      Les contrats compris dans la période du 1er octobre de l’année 2023 au 31 décembre de l’année 2024 sont importés ici depuis le site Label GEIQ.
+                  </p>
+                  <p>
+                      Par défaut, tous les contrats dont la durée est inférieure à 3 mois (90 jours) sont désélectionnés, vous pouvez toujours les sélectionner si la situation le nécessite.
+                  </p>
+                  <p>
+                      L’aide potentielle est calculée par le site Label GEIQ à partir de critères administratifs sélectionnés par le GEIQ.
+                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
                   </p>
                   <p class="mb-0">
-                      L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
-                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que vous souhaitez présenter à la DDETS et/ou DREETS.
+                      Sélectionnez les contrats pour lesquels vous sollicitez l’aide à l’accompagnement.
+                              Conformément à l’accord conclu entre la FFGEIQ et la DGEFP, les DDETS/DREETS en charge de votre dossier peuvent accéder à l’ensemble des contrats importés.
                   </p>
               </div>
           </div>

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -1522,6 +1522,19 @@ class TestAssessmentContractsListView:
         assert trigger_btn is not None
         assert trigger_btn.get("type") == "button"
 
+    def test_contracts_selection_instructions(self, client):
+        self.assessment.campaign.year = 2025
+        self.assessment.campaign.save(update_fields=("year",))
+
+        response = client.get(self.url)
+
+        assertContains(response, "Sélectionnez les contrats pour lesquels vous souhaitez obtenir une aide")
+        assertContains(
+            response,
+            "Les contrats compris dans la période du 1er octobre de l’année 2024 au 31 décembre de l’année 2025 "
+            "sont importés ici depuis le site Label GEIQ.",
+        )
+
     def test_contract_list_htmx_consistency(self, client):
         contract = EmployeeContractFactory(employee__assessment=self.assessment)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Sur l'écran de sélection des contrats d'un bilan d'exécution pour les GEIQ, le texte d'aide présentait les variables "N-1" et "N-2" de manière brute. Cette PR améliore cela, désormais on a un affichage dynamique des deux dernières années correspondantes à la campagne de bilan en cours. L'objectif est d'apporter plus de clarté pour l'employeur lors de la sélection de ses contrats importés depuis Label Geiq. [Carte Notion](https://www.notion.so/gip-inclusion/Modifier-le-texte-sur-l-cran-de-s-lection-des-contrats-BOOST-DEV-33c5f321b6048005b885f22de9eeda0c).

## :computer: Captures d'écran

<img width="3224" height="2367" alt="Screenshot from 2026-05-11 19-09-27" src="https://github.com/user-attachments/assets/f28df24b-f8e1-4333-bcef-b85e88b1e30f" />
