### PR TITLE
Interface: Ajout du champ "Dernier accompagnateur connu" au tableau de suivi de l'espace "Candidats"

### DIFF
--- a/itou/gps/models.py
+++ b/itou/gps/models.py
@@ -110,7 +110,9 @@ class FollowUpGroup(models.Model):
     # until follow up groups are replaced in favor of job seeker assignments
     @property
     def referent(self):
-        if last_advisor := self.beneficiary.last_advisor:
+        last_advisor, _ = self.beneficiary.last_advisor_with_org
+        if last_advisor:
+            last_advisor, _ = self.beneficiary.last_advisor_with_org
             return self.memberships.filter(member=last_advisor.id).first()
         return None
 

--- a/itou/job_applications/models.py
+++ b/itou/job_applications/models.py
@@ -1385,7 +1385,7 @@ class JobApplication(xwf_models.WorkflowEnabled, models.Model):
             self.sender,
             self.sender_prescriber_organization or self.sender_company,
             job_application=self,
-            advisor=self.job_seeker.last_advisor,
+            advisor=self.job_seeker.last_advisor_with_org[0],
         )
 
     @property

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -21,6 +21,7 @@
                     <tr>
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.FULL_NAME_ASC name="Nom Prénom" only %}
                         <th scope="col">Situation IAE</th>
+                        <th scope="col">Dernier accompagnateur connu</th>
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.JOB_APPLICATIONS_NB_ASC name="Nombre de candidatures" only %}
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.LAST_UPDATED_AT_ASC name="Dernière action" only %}
                         <th scope="col" class="text-end {% if request.current_organization.is_authorized %}w-100px{% else %}w-50px{% endif %}">
@@ -39,6 +40,9 @@
                             </td>
                             <td>
                                 {% include "eligibility/includes/iae/eligibility_badge.html" with job_seeker=job_seeker eligibility_diagnosis=job_seeker.valid_eligibility_diagnosis force_valid_approval=False badge_size="badge-xs" only %}
+                            </td>
+                            <td>
+                                {{ job_seeker.last_advisor_with_org.0.get_inverted_full_name|default:"Non précisé" }} ({{ job_seeker.last_advisor_with_org.1.name|default:"Non précisé" }})
                             </td>
                             <td>{{ job_seeker.job_applications_nb }}</td>
                             <td>{{ job_seeker.last_updated_at|date:"d/m/Y" }}</td>

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -740,9 +740,17 @@ class User(AbstractUser, AddressMixin, AbstractFieldsHistoryModel):
         return self.terms_accepted_at < get_latest_terms_datetime()
 
     @cached_property
+    def last_assignment(self):
+        assignments = self.job_seeker_assignments.all()
+        if assignments:
+            last_assignment = sorted(assignments, key=lambda j: j.updated_at, reverse=True)[0]
+            return last_assignment
+        return None
+
+    @property
     def last_advisor(self):
-        if last_assignment := self.job_seeker_assignments.order_by("-updated_at").first():
-            return None if last_assignment.assigned_to_unknown_advisor else last_assignment.professional
+        if self.last_assignment and not self.last_assignment.assigned_to_unknown_advisor:
+            return self.last_assignment.professional
         return None
 
 

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -748,12 +748,6 @@ class User(AbstractUser, AddressMixin, AbstractFieldsHistoryModel):
         return None
 
     @property
-    def last_advisor(self):
-        if self.last_assignment and not self.last_assignment.assigned_to_unknown_advisor:
-            return self.last_assignment.professional
-        return None
-
-    @property
     def last_advisor_with_org(self):
         if self.last_assignment:
             professional = (

--- a/itou/users/models.py
+++ b/itou/users/models.py
@@ -753,6 +753,16 @@ class User(AbstractUser, AddressMixin, AbstractFieldsHistoryModel):
             return self.last_assignment.professional
         return None
 
+    @property
+    def last_advisor_with_org(self):
+        if self.last_assignment:
+            professional = (
+                None if self.last_assignment.assigned_to_unknown_advisor else self.last_assignment.professional
+            )
+            organization = self.last_assignment.prescriber_organization or self.last_assignment.company
+            return professional, organization
+        return None, None
+
 
 def get_allauth_account_user_display(user):
     return user.email

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -8,6 +8,7 @@ from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.db.models import Count, DateTimeField, Exists, IntegerField, Max, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Coalesce, Concat, Lower
+from django.db.models.query import Prefetch
 from django.forms import ValidationError
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -310,7 +311,19 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         order = JobSeekerOrder(request.GET.get("order"))
     except ValueError:
         order = JobSeekerOrder.LAST_UPDATED_AT_DESC
-    queryset = queryset.order_by(*order.order_by).select_related("jobseeker_profile").prefetch_related("approvals")
+    queryset = (
+        queryset.order_by(*order.order_by)
+        .select_related("jobseeker_profile")
+        .prefetch_related(
+            "approvals",
+            Prefetch(
+                "job_seeker_assignments",
+                queryset=JobSeekerAssignment.objects.select_related(
+                    "professional", "prescriber_organization", "company"
+                ).order_by("-updated_at"),
+            ),
+        )
+    )
 
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_SMALL)
     for job_seeker in page_obj:

--- a/itou/www/job_seekers_views/views.py
+++ b/itou/www/job_seekers_views/views.py
@@ -285,19 +285,14 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         ),
         output_field=IntegerField(),
     )
-    queryset = (
-        User.objects.filter(kind=UserKind.JOB_SEEKER, pk__in=job_seekers_ids)
-        .select_related("jobseeker_profile")
-        .prefetch_related("approvals")
-        .annotate(
-            full_name=Concat(Lower("last_name"), Value(" "), Lower("first_name")),
-            job_applications_nb=Coalesce(subquery_count, 0),
-            last_updated_at=subquery_last_action_at,
-            valid_eligibility_diagnosis=subquery_diagnosis,
-            application_sent_by=ArrayAgg(
-                "job_applications__sender", distinct=True, filter=Q(job_applications__sender__isnull=False)
-            ),
-        )
+    queryset = User.objects.filter(kind=UserKind.JOB_SEEKER, pk__in=job_seekers_ids).annotate(
+        full_name=Concat(Lower("last_name"), Value(" "), Lower("first_name")),
+        job_applications_nb=Coalesce(subquery_count, 0),
+        last_updated_at=subquery_last_action_at,
+        valid_eligibility_diagnosis=subquery_diagnosis,
+        application_sent_by=ArrayAgg(
+            "job_applications__sender", distinct=True, filter=Q(job_applications__sender__isnull=False)
+        ),
     )
 
     form = FilterForm(
@@ -315,7 +310,7 @@ def list_job_seekers(request, template_name="job_seekers_views/list.html", list_
         order = JobSeekerOrder(request.GET.get("order"))
     except ValueError:
         order = JobSeekerOrder.LAST_UPDATED_AT_DESC
-    queryset = queryset.order_by(*order.order_by)
+    queryset = queryset.order_by(*order.order_by).select_related("jobseeker_profile").prefetch_related("approvals")
 
     page_obj = pager(queryset, request.GET.get("page"), items_per_page=settings.PAGE_SIZE_SMALL)
     for job_seeker in page_obj:

--- a/tests/job_applications/tests.py
+++ b/tests/job_applications/tests.py
@@ -1323,7 +1323,7 @@ class TestJobApplicationNotifications:
         if with_unknown_advisor:
             assert "Non référencé" in email.body
         else:
-            assert job_application.job_seeker.last_advisor.get_full_name() in email.body
+            assert job_application.job_seeker.last_advisor_with_org[0].get_full_name() in email.body
         if is_authorized_prescriber:
             assert job_application.sender_prescriber_organization.accept_survey_url in email.body
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1015,37 +1015,6 @@ class TestLastAssignment:
         job_seeker_assignment = JobSeekerAssignmentFactory(job_seeker=job_seeker)
         assert job_seeker.last_assignment == job_seeker_assignment
 
-    def test_no_last_advisor(self):
-        job_seeker = JobSeekerFactory()
-        assert job_seeker.last_assignment is None
-        assert job_seeker.last_advisor is None
-
-    def test_unknown_advisor(self):
-        job_seeker_assignment = JobSeekerAssignmentFactory(
-            assigned_to_unknown_advisor=True, prescriber_organization=PrescriberOrganizationFactory()
-        )
-        job_seeker = job_seeker_assignment.job_seeker
-        assert job_seeker.last_assignment == job_seeker_assignment
-        assert job_seeker.last_advisor is None
-
-    def test_last_advisor(self):
-        updated_at = datetime.datetime(2026, 1, 1, 1, 1, 11, tzinfo=datetime.UTC)
-        job_seeker_assignment = JobSeekerAssignmentFactory(
-            prescriber_organization=PrescriberOrganizationFactory(), updated_at=updated_at
-        )
-
-        job_seeker = job_seeker_assignment.job_seeker
-
-        assert job_seeker.last_assignment == job_seeker_assignment
-        assert job_seeker.last_advisor == job_seeker_assignment.professional
-
-        updated_at = datetime.datetime(2026, 4, 21, 12, 12, 11, tzinfo=datetime.UTC)
-        job_seeker_assignment_2 = JobSeekerAssignmentFactory(updated_at=updated_at, job_seeker=job_seeker)
-
-        del job_seeker.last_assignment  # clear cache to retrieve accurate value
-        assert job_seeker.last_assignment == job_seeker_assignment_2
-        assert job_seeker.last_advisor == job_seeker_assignment_2.professional
-
     def test_no_last_advisor_with_org(self):
         job_seeker = JobSeekerFactory()
         assert job_seeker.last_assignment is None

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -4,6 +4,7 @@ import json
 import random
 import re
 import uuid
+from functools import partial
 from operator import attrgetter
 from unittest import mock
 
@@ -1044,6 +1045,80 @@ class TestLastAssignment:
         del job_seeker.last_assignment  # clear cache to retrieve accurate value
         assert job_seeker.last_assignment == job_seeker_assignment_2
         assert job_seeker.last_advisor == job_seeker_assignment_2.professional
+
+    def test_no_last_advisor_with_org(self):
+        job_seeker = JobSeekerFactory()
+        assert job_seeker.last_assignment is None
+        assert job_seeker.last_advisor_with_org == (None, None)
+
+    @pytest.mark.parametrize(
+        "org_factory,job_seeker_assignment_factory",
+        [
+            pytest.param(
+                PrescriberOrganizationFactory,
+                lambda org: partial(JobSeekerAssignmentFactory, prescriber_organization=org),
+                id="unknown_prescriber_advisor",
+            ),
+            pytest.param(
+                CompanyFactory,
+                lambda company: partial(JobSeekerAssignmentFactory, company=company),
+                id="unknown_employer_advisor",
+            ),
+        ],
+    )
+    def test_unknown_advisor_with_org(self, org_factory, job_seeker_assignment_factory):
+        org = org_factory()
+        job_seeker_assignment = job_seeker_assignment_factory(org)(assigned_to_unknown_advisor=True)
+        job_seeker = job_seeker_assignment.job_seeker
+        last_advisor, last_advisor_org = job_seeker.last_advisor_with_org
+        assert job_seeker.last_assignment == job_seeker_assignment
+        assert last_advisor is None
+        assert last_advisor_org == org
+
+    def test_last_advisor_without_org(self):
+        job_seeker_assignment = JobSeekerAssignmentFactory()
+        job_seeker = job_seeker_assignment.job_seeker
+        last_advisor, last_advisor_org = job_seeker.last_advisor_with_org
+        assert job_seeker.last_assignment == job_seeker_assignment
+        assert last_advisor == job_seeker_assignment.professional
+        assert last_advisor_org is None
+
+    @pytest.mark.parametrize(
+        "org_factory,job_seeker_assignment_factory",
+        [
+            pytest.param(
+                PrescriberOrganizationFactory,
+                lambda org: partial(JobSeekerAssignmentFactory, prescriber_organization=org),
+                id="last_advisor_is_prescriber",
+            ),
+            pytest.param(
+                CompanyFactory,
+                lambda company: partial(JobSeekerAssignmentFactory, company=company),
+                id="last_advisor_is_employer",
+            ),
+        ],
+    )
+    def test_last_advisor_with_org(self, org_factory, job_seeker_assignment_factory):
+        updated_at = datetime.datetime(2026, 1, 1, 1, 1, 11, tzinfo=datetime.UTC)
+        org_1 = org_factory()
+        job_seeker_assignment_1 = job_seeker_assignment_factory(org_1)(updated_at=updated_at)
+
+        job_seeker = job_seeker_assignment_1.job_seeker
+
+        last_advisor, last_advisor_org = job_seeker.last_advisor_with_org
+        assert job_seeker.last_assignment == job_seeker_assignment_1
+        assert last_advisor == job_seeker_assignment_1.professional
+        assert last_advisor_org == org_1
+
+        updated_at = datetime.datetime(2026, 4, 21, 12, 12, 11, tzinfo=datetime.UTC)
+        org_2 = org_factory()
+        job_seeker_assignment_2 = job_seeker_assignment_factory(org_2)(updated_at=updated_at, job_seeker=job_seeker)
+
+        del job_seeker.last_assignment  # clear cache to retrieve accurate value
+        last_advisor, last_advisor_org = job_seeker.last_advisor_with_org
+        assert job_seeker.last_assignment == job_seeker_assignment_2
+        assert last_advisor == job_seeker_assignment_2.professional
+        assert last_advisor_org == org_2
 
 
 @pytest.mark.parametrize("initial_asp_uid", ("000000000000000000000000000000", ""))

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -1004,9 +1004,19 @@ class TestLatestApproval:
         )
 
 
-class TestLastAdvisor:
+class TestLastAssignment:
+    def test_no_last_assignment(self):
+        job_seeker = JobSeekerFactory()
+        assert job_seeker.last_assignment is None
+
+    def test_last_assignment(self):
+        job_seeker = JobSeekerFactory()
+        job_seeker_assignment = JobSeekerAssignmentFactory(job_seeker=job_seeker)
+        assert job_seeker.last_assignment == job_seeker_assignment
+
     def test_no_last_advisor(self):
         job_seeker = JobSeekerFactory()
+        assert job_seeker.last_assignment is None
         assert job_seeker.last_advisor is None
 
     def test_unknown_advisor(self):
@@ -1014,19 +1024,25 @@ class TestLastAdvisor:
             assigned_to_unknown_advisor=True, prescriber_organization=PrescriberOrganizationFactory()
         )
         job_seeker = job_seeker_assignment.job_seeker
+        assert job_seeker.last_assignment == job_seeker_assignment
         assert job_seeker.last_advisor is None
 
     def test_last_advisor(self):
         updated_at = datetime.datetime(2026, 1, 1, 1, 1, 11, tzinfo=datetime.UTC)
         job_seeker_assignment = JobSeekerAssignmentFactory(
-            prescriber_organization=PrescriberOrganizationFactory(),
-            updated_at=updated_at,
-            assigned_to_unknown_advisor=True,
+            prescriber_organization=PrescriberOrganizationFactory(), updated_at=updated_at
         )
+
         job_seeker = job_seeker_assignment.job_seeker
+
+        assert job_seeker.last_assignment == job_seeker_assignment
+        assert job_seeker.last_advisor == job_seeker_assignment.professional
+
         updated_at = datetime.datetime(2026, 4, 21, 12, 12, 11, tzinfo=datetime.UTC)
         job_seeker_assignment_2 = JobSeekerAssignmentFactory(updated_at=updated_at, job_seeker=job_seeker)
 
+        del job_seeker.last_assignment  # clear cache to retrieve accurate value
+        assert job_seeker.last_assignment == job_seeker_assignment_2
         assert job_seeker.last_advisor == job_seeker_assignment_2.professional
 
 

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -619,7 +619,7 @@
 # ---
 # name: test_multiple.1
   dict({
-    'num_queries': 22,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -1007,58 +1007,9 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
-                 "users_jobseekerprofile"."fields_history",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."ft_gps_id",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."are_allocation_since",
-                 "users_jobseekerprofile"."activity_bonus_since",
-                 "users_jobseekerprofile"."cape_freelance",
-                 "users_jobseekerprofile"."cesa_freelance",
-                 "users_jobseekerprofile"."actor_met_for_business_creation",
-                 "users_jobseekerprofile"."mean_monthly_income_before_process",
-                 "users_jobseekerprofile"."eiti_contributions",
-                 "users_jobseekerprofile"."ase_exit",
-                 "users_jobseekerprofile"."isolated_parent",
-                 "users_jobseekerprofile"."housing_issue",
-                 "users_jobseekerprofile"."refugee",
-                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
-                 "users_jobseekerprofile"."low_level_in_french",
-                 "users_jobseekerprofile"."mobility_issue",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
-                 "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."is_not_stalled_anymore"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -1067,46 +1018,9 @@
           GROUP BY "users_user"."id",
                    38,
                    39,
-                   41,
-                   "users_jobseekerprofile"."user_id"
+                   41
           ORDER BY "users_user"."last_name" ASC,
                    "users_user"."first_name" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
-          'FilterForm.__init__[www/job_seekers_views/forms.py]',
-          'list_job_seekers[www/job_seekers_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
-                                                   %s,
-                                                   %s)
-          ORDER BY "approvals_approval"."created_at" DESC
         ''',
       }),
       dict({
@@ -1185,58 +1099,9 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
-                 "users_jobseekerprofile"."fields_history",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."ft_gps_id",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."are_allocation_since",
-                 "users_jobseekerprofile"."activity_bonus_since",
-                 "users_jobseekerprofile"."cape_freelance",
-                 "users_jobseekerprofile"."cesa_freelance",
-                 "users_jobseekerprofile"."actor_met_for_business_creation",
-                 "users_jobseekerprofile"."mean_monthly_income_before_process",
-                 "users_jobseekerprofile"."eiti_contributions",
-                 "users_jobseekerprofile"."ase_exit",
-                 "users_jobseekerprofile"."isolated_parent",
-                 "users_jobseekerprofile"."housing_issue",
-                 "users_jobseekerprofile"."refugee",
-                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
-                 "users_jobseekerprofile"."low_level_in_french",
-                 "users_jobseekerprofile"."mobility_issue",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
-                 "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."is_not_stalled_anymore"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -1245,45 +1110,8 @@
           GROUP BY "users_user"."id",
                    38,
                    39,
-                   41,
-                   "users_jobseekerprofile"."user_id"
+                   41
           ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'FilterForm._get_choices_for_organization_members[www/job_seekers_views/forms.py]',
-          'FilterForm.__init__[www/job_seekers_views/forms.py]',
-          'list_job_seekers[www/job_seekers_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
-                                                   %s,
-                                                   %s)
-          ORDER BY "approvals_approval"."created_at" DESC
         ''',
       }),
       dict({
@@ -1860,7 +1688,7 @@
 # ---
 # name: test_multiple_with_job_seekers_created_by_organization.1
   dict({
-    'num_queries': 21,
+    'num_queries': 19,
     'queries': list([
       dict({
         'origin': list([
@@ -2246,58 +2074,9 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
-                 "users_jobseekerprofile"."fields_history",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."ft_gps_id",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."are_allocation_since",
-                 "users_jobseekerprofile"."activity_bonus_since",
-                 "users_jobseekerprofile"."cape_freelance",
-                 "users_jobseekerprofile"."cesa_freelance",
-                 "users_jobseekerprofile"."actor_met_for_business_creation",
-                 "users_jobseekerprofile"."mean_monthly_income_before_process",
-                 "users_jobseekerprofile"."eiti_contributions",
-                 "users_jobseekerprofile"."ase_exit",
-                 "users_jobseekerprofile"."isolated_parent",
-                 "users_jobseekerprofile"."housing_issue",
-                 "users_jobseekerprofile"."refugee",
-                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
-                 "users_jobseekerprofile"."low_level_in_french",
-                 "users_jobseekerprofile"."mobility_issue",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
-                 "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."is_not_stalled_anymore"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -2305,45 +2084,9 @@
           GROUP BY "users_user"."id",
                    38,
                    39,
-                   41,
-                   "users_jobseekerprofile"."user_id"
+                   41
           ORDER BY "users_user"."last_name" ASC,
                    "users_user"."first_name" ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'FilterForm._get_choices_for_job_seeker[www/job_seekers_views/forms.py]',
-          'FilterForm.__init__[www/job_seekers_views/forms.py]',
-          'list_job_seekers[www/job_seekers_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
-                                                   %s)
-          ORDER BY "approvals_approval"."created_at" DESC
         ''',
       }),
       dict({
@@ -2421,58 +2164,9 @@
              ORDER BY U0."created_at" DESC
              LIMIT 1) AS "valid_eligibility_diagnosis",
                  ARRAY_AGG(DISTINCT "job_applications_jobapplication"."sender_id") FILTER (
-                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by",
-                 "users_jobseekerprofile"."fields_history",
-                 "users_jobseekerprofile"."user_id",
-                 "users_jobseekerprofile"."birthdate",
-                 "users_jobseekerprofile"."birth_place_id",
-                 "users_jobseekerprofile"."birth_country_id",
-                 "users_jobseekerprofile"."nir",
-                 "users_jobseekerprofile"."lack_of_nir_reason",
-                 "users_jobseekerprofile"."pole_emploi_id",
-                 "users_jobseekerprofile"."lack_of_pole_emploi_id_reason",
-                 "users_jobseekerprofile"."ft_gps_id",
-                 "users_jobseekerprofile"."asp_uid",
-                 "users_jobseekerprofile"."education_level",
-                 "users_jobseekerprofile"."resourceless",
-                 "users_jobseekerprofile"."rqth_employee",
-                 "users_jobseekerprofile"."oeth_employee",
-                 "users_jobseekerprofile"."pole_emploi_since",
-                 "users_jobseekerprofile"."unemployed_since",
-                 "users_jobseekerprofile"."has_rsa_allocation",
-                 "users_jobseekerprofile"."rsa_allocation_since",
-                 "users_jobseekerprofile"."ass_allocation_since",
-                 "users_jobseekerprofile"."aah_allocation_since",
-                 "users_jobseekerprofile"."are_allocation_since",
-                 "users_jobseekerprofile"."activity_bonus_since",
-                 "users_jobseekerprofile"."cape_freelance",
-                 "users_jobseekerprofile"."cesa_freelance",
-                 "users_jobseekerprofile"."actor_met_for_business_creation",
-                 "users_jobseekerprofile"."mean_monthly_income_before_process",
-                 "users_jobseekerprofile"."eiti_contributions",
-                 "users_jobseekerprofile"."ase_exit",
-                 "users_jobseekerprofile"."isolated_parent",
-                 "users_jobseekerprofile"."housing_issue",
-                 "users_jobseekerprofile"."refugee",
-                 "users_jobseekerprofile"."detention_exit_or_ppsmj",
-                 "users_jobseekerprofile"."low_level_in_french",
-                 "users_jobseekerprofile"."mobility_issue",
-                 "users_jobseekerprofile"."hexa_lane_number",
-                 "users_jobseekerprofile"."hexa_std_extension",
-                 "users_jobseekerprofile"."hexa_non_std_extension",
-                 "users_jobseekerprofile"."hexa_lane_type",
-                 "users_jobseekerprofile"."hexa_lane_name",
-                 "users_jobseekerprofile"."hexa_additional_address",
-                 "users_jobseekerprofile"."hexa_post_code",
-                 "users_jobseekerprofile"."hexa_commune_id",
-                 "users_jobseekerprofile"."pe_obfuscated_nir",
-                 "users_jobseekerprofile"."pe_last_certification_attempt_at",
-                 "users_jobseekerprofile"."created_by_prescriber_organization_id",
-                 "users_jobseekerprofile"."is_stalled",
-                 "users_jobseekerprofile"."is_not_stalled_anymore"
+                                                                                           WHERE "job_applications_jobapplication"."sender_id" IS NOT NULL) AS "application_sent_by"
           FROM "users_user"
           LEFT OUTER JOIN "job_applications_jobapplication" ON ("users_user"."id" = "job_applications_jobapplication"."job_seeker_id")
-          LEFT OUTER JOIN "users_jobseekerprofile" ON ("users_user"."id" = "users_jobseekerprofile"."user_id")
           WHERE ("users_user"."kind" = %s
                  AND "users_user"."id" IN (%s,
                                            %s,
@@ -2480,44 +2174,8 @@
           GROUP BY "users_user"."id",
                    38,
                    39,
-                   41,
-                   "users_jobseekerprofile"."user_id"
+                   41
           ORDER BY RANDOM() ASC
-        ''',
-      }),
-      dict({
-        'origin': list([
-          'FilterForm._get_choices_for_organization_members[www/job_seekers_views/forms.py]',
-          'FilterForm.__init__[www/job_seekers_views/forms.py]',
-          'list_job_seekers[www/job_seekers_views/views.py]',
-          '_check_request_view_wrapper[utils/auth.py]',
-          'wrapper[utils/readonly.py]',
-        ]),
-        'sql': '''
-          SELECT "approvals_approval"."id",
-                 "approvals_approval"."start_at",
-                 "approvals_approval"."end_at",
-                 "approvals_approval"."created_at",
-                 "approvals_approval"."number",
-                 "approvals_approval"."pe_notification_status",
-                 "approvals_approval"."pe_notification_time",
-                 "approvals_approval"."pe_notification_endpoint",
-                 "approvals_approval"."pe_notification_exit_code",
-                 "approvals_approval"."user_id",
-                 "approvals_approval"."created_by_id",
-                 "approvals_approval"."origin",
-                 "approvals_approval"."eligibility_diagnosis_id",
-                 "approvals_approval"."updated_at",
-                 "approvals_approval"."origin_siae_siret",
-                 "approvals_approval"."origin_siae_kind",
-                 "approvals_approval"."origin_sender_kind",
-                 "approvals_approval"."origin_prescriber_organization_kind",
-                 "approvals_approval"."public_id"
-          FROM "approvals_approval"
-          WHERE "approvals_approval"."user_id" IN (%s,
-                                                   %s,
-                                                   %s)
-          ORDER BY "approvals_approval"."created_at" DESC
         ''',
       }),
       dict({

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -619,7 +619,7 @@
 # ---
 # name: test_multiple.1
   dict({
-    'num_queries': 20,
+    'num_queries': 21,
     'queries': list([
       dict({
         'origin': list([
@@ -1397,6 +1397,137 @@
       }),
       dict({
         'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s,
+                                                                %s,
+                                                                %s,
+                                                                %s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'IfNode[job_seekers_views/list.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[job_seekers_views/list.html]',
@@ -1485,6 +1616,9 @@
               <th scope="col">
                   Situation IAE
               </th>
+              <th scope="col">
+                  Dernier accompagnateur connu
+              </th>
               <th aria-sort="none" scope="col">
                   <button data-emplois-setter-target="#id_order" data-emplois-setter-value="job_applications_nb" type="button">
                       Nombre de candidatures
@@ -1517,6 +1651,9 @@
                   </span>
               </td>
               <td>
+                  DERAY Odile (Pres. Org.)
+              </td>
+              <td>
                   1
               </td>
               <td>
@@ -1543,48 +1680,6 @@
           </tr>
           <tr>
               <td>
-                  <a class="btn-link" href="/job-seekers/details/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list">
-                      XERUS Charlotte
-                  </a>
-              </td>
-              <td>
-                  <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
-                      <i aria-hidden="true" class="ri-pass-valid-line">
-                      </i>
-                      PASS IAE valide
-                  </span>
-              </td>
-              <td>
-                  1
-              </td>
-              <td>
-                  30/08/2024
-              </td>
-              <td class="text-end w-100px">
-                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
-                      <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
-                      </i>
-                  </a>
-                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
-                      <i aria-hidden="true" class="ri-more-2-fill">
-                      </i>
-                  </button>
-                  <div aria-labelledby="dropdown_2_action_menu" class="dropdown-menu">
-                      <form action="/job-seekers/switch_stalled_status/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list" method="post">
-                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                          <input name="is_not_stalled_anymore" type="hidden" value="0"/>
-                          <button class="dropdown-item" type="submit">
-                              Le candidat est sans solution
-                          </button>
-                      </form>
-                      <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&back_url=%2Fjob-seekers%2Flist&city=brest-29">
-                          Orienter vers un service d’insertion
-                      </a>
-                  </div>
-              </td>
-          </tr>
-          <tr>
-              <td>
                   <a class="btn-link" href="/job-seekers/details/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list">
                       YGREC Bernard
                   </a>
@@ -1601,6 +1696,9 @@
                   </span>
               </td>
               <td>
+                  DERAY Odile (Pres. Org.)
+              </td>
+              <td>
                   1
               </td>
               <td>
@@ -1611,11 +1709,11 @@
                       <i aria-label="Postuler pour YGREC Bernard" class="ri-draft-line">
                       </i>
                   </a>
-                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
                       <i aria-hidden="true" class="ri-more-2-fill">
                       </i>
                   </button>
-                  <div aria-labelledby="dropdown_3_action_menu" class="dropdown-menu">
+                  <div aria-labelledby="dropdown_2_action_menu" class="dropdown-menu">
                       <a class="dropdown-item" href="/eligibility/update/iae/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list">
                           Valider son éligibilité IAE
                       </a>
@@ -1627,6 +1725,51 @@
                           </button>
                       </form>
                       <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&back_url=%2Fjob-seekers%2Flist&city=brest-29">
+                          Orienter vers un service d’insertion
+                      </a>
+                  </div>
+              </td>
+          </tr>
+          <tr>
+              <td>
+                  <a class="btn-link" href="/job-seekers/details/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list">
+                      XERUS Charlotte
+                  </a>
+              </td>
+              <td>
+                  <span class="badge badge-xs rounded-pill bg-success-lighter text-success">
+                      <i aria-hidden="true" class="ri-pass-valid-line">
+                      </i>
+                      PASS IAE valide
+                  </span>
+              </td>
+              <td>
+                  Non précisé (ACME Inc.)
+              </td>
+              <td>
+                  1
+              </td>
+              <td>
+                  28/08/2024
+              </td>
+              <td class="text-end w-100px">
+                  <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
+                      <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
+                      </i>
+                  </a>
+                  <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
+                      <i aria-hidden="true" class="ri-more-2-fill">
+                      </i>
+                  </button>
+                  <div aria-labelledby="dropdown_3_action_menu" class="dropdown-menu">
+                      <form action="/job-seekers/switch_stalled_status/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list" method="post">
+                          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                          <input name="is_not_stalled_anymore" type="hidden" value="0"/>
+                          <button class="dropdown-item" type="submit">
+                              Le candidat est sans solution
+                          </button>
+                      </form>
+                      <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&back_url=%2Fjob-seekers%2Flist&city=brest-29">
                           Orienter vers un service d’insertion
                       </a>
                   </div>
@@ -1650,10 +1793,13 @@
                   </span>
               </td>
               <td>
+                  BIALÈS Patrick (Pres. Org.)
+              </td>
+              <td>
                   2
               </td>
               <td>
-                  30/08/2024
+                  28/08/2024
               </td>
               <td class="text-end w-100px">
                   <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&city=brest-29">
@@ -1688,7 +1834,7 @@
 # ---
 # name: test_multiple_with_job_seekers_created_by_organization.1
   dict({
-    'num_queries': 19,
+    'num_queries': 20,
     'queries': list([
       dict({
         'origin': list([
@@ -2458,6 +2604,136 @@
       }),
       dict({
         'origin': list([
+          'list_job_seekers[www/job_seekers_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+          'wrapper[utils/readonly.py]',
+        ]),
+        'sql': '''
+          SELECT "users_jobseekerassignment"."id",
+                 "users_jobseekerassignment"."created_at",
+                 "users_jobseekerassignment"."updated_at",
+                 "users_jobseekerassignment"."job_seeker_id",
+                 "users_jobseekerassignment"."professional_id",
+                 "users_jobseekerassignment"."prescriber_organization_id",
+                 "users_jobseekerassignment"."company_id",
+                 "users_jobseekerassignment"."last_action_kind",
+                 "users_jobseekerassignment"."assigned_to_unknown_advisor",
+                 T3."id",
+                 T3."password",
+                 T3."last_login",
+                 T3."is_superuser",
+                 T3."username",
+                 T3."first_name",
+                 T3."last_name",
+                 T3."is_staff",
+                 T3."is_active",
+                 T3."date_joined",
+                 T3."fields_history",
+                 T3."address_line_1",
+                 T3."address_line_2",
+                 T3."post_code",
+                 T3."city",
+                 T3."department",
+                 T3."coords",
+                 T3."geocoding_score",
+                 T3."geocoding_updated_at",
+                 T3."ban_api_resolved_address",
+                 T3."insee_city_id",
+                 T3."title",
+                 T3."full_name_search_vector",
+                 T3."email",
+                 T3."phone",
+                 T3."kind",
+                 T3."identity_provider",
+                 T3."has_completed_welcoming_tour",
+                 T3."created_by_id",
+                 T3."external_data_source_history",
+                 T3."last_checked_at",
+                 T3."terms_accepted_at",
+                 T3."public_id",
+                 T3."address_filled_at",
+                 T3."first_login",
+                 T3."upcoming_deletion_notified_at",
+                 T3."allow_next_sso_sub_update",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized",
+                 "companies_company"."id",
+                 "companies_company"."fields_history",
+                 "companies_company"."address_line_1",
+                 "companies_company"."address_line_2",
+                 "companies_company"."post_code",
+                 "companies_company"."city",
+                 "companies_company"."department",
+                 "companies_company"."coords",
+                 "companies_company"."geocoding_score",
+                 "companies_company"."geocoding_updated_at",
+                 "companies_company"."ban_api_resolved_address",
+                 "companies_company"."insee_city_id",
+                 "companies_company"."name",
+                 "companies_company"."created_at",
+                 "companies_company"."updated_at",
+                 "companies_company"."uid",
+                 "companies_company"."active_members_email_reminder_last_sent_at",
+                 "companies_company"."automatic_geocoding_update",
+                 "companies_company"."siret",
+                 "companies_company"."naf",
+                 "companies_company"."kind",
+                 "companies_company"."brand",
+                 "companies_company"."phone",
+                 "companies_company"."email",
+                 "companies_company"."auth_email",
+                 "companies_company"."website",
+                 "companies_company"."description",
+                 "companies_company"."provided_support",
+                 "companies_company"."source",
+                 "companies_company"."created_by_id",
+                 "companies_company"."block_job_applications",
+                 "companies_company"."job_applications_blocked_at",
+                 "companies_company"."spontaneous_applications_open_since",
+                 "companies_company"."convention_id",
+                 "companies_company"."job_app_score",
+                 "companies_company"."is_searchable",
+                 "companies_company"."rdv_solidarites_id"
+          FROM "users_jobseekerassignment"
+          INNER JOIN "users_user" T3 ON ("users_jobseekerassignment"."professional_id" = T3."id")
+          LEFT OUTER JOIN "prescribers_prescriberorganization" ON ("users_jobseekerassignment"."prescriber_organization_id" = "prescribers_prescriberorganization"."id")
+          LEFT OUTER JOIN "companies_company" ON ("users_jobseekerassignment"."company_id" = "companies_company"."id")
+          WHERE "users_jobseekerassignment"."job_seeker_id" IN (%s,
+                                                                %s,
+                                                                %s)
+          ORDER BY "users_jobseekerassignment"."updated_at" DESC
+        ''',
+      }),
+      dict({
+        'origin': list([
           'IfNode[job_seekers_views/list.html]',
           'BlockNode[layout/base.html]',
           'ExtendsNode[job_seekers_views/list.html]',
@@ -2508,44 +2784,6 @@
   <tbody>
       <tr>
           <td>
-              <a class="btn-link" href="/job-seekers/details/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list-organization">
-                  XERUS Charlotte
-              </a>
-          </td>
-          <td>
-              <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
-                  <i aria-hidden="true" class="ri-error-warning-line">
-                  </i>
-                  Éligibilité IAE à valider
-              </span>
-          </td>
-          <td>
-              0
-          </td>
-          <td>
-              30/08/2024
-          </td>
-          <td class="text-end w-100px">
-              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
-                  <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
-                  </i>
-              </a>
-              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_1_action_menu" type="button">
-                  <i aria-hidden="true" class="ri-more-2-fill">
-                  </i>
-              </button>
-              <div aria-labelledby="dropdown_1_action_menu" class="dropdown-menu">
-                  <a class="dropdown-item" href="/eligibility/update/iae/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list-organization">
-                      Valider son éligibilité IAE
-                  </a>
-                  <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&back_url=%2Fjob-seekers%2Flist-organization&city=brest-29" id="introjs-orienter-vers-service-insertion">
-                      Orienter vers un service d’insertion
-                  </a>
-              </div>
-          </td>
-      </tr>
-      <tr>
-          <td>
               <a class="btn-link" href="/job-seekers/details/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list-organization">
                   YGREC Bernard
               </a>
@@ -2558,6 +2796,9 @@
               </span>
           </td>
           <td>
+              Non précisé (Pres. Org.)
+          </td>
+          <td>
               0
           </td>
           <td>
@@ -2568,15 +2809,15 @@
                   <i aria-label="Postuler pour YGREC Bernard" class="ri-draft-line">
                   </i>
               </a>
-              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
+              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_1_action_menu" type="button">
                   <i aria-hidden="true" class="ri-more-2-fill">
                   </i>
               </button>
-              <div aria-labelledby="dropdown_2_action_menu" class="dropdown-menu">
+              <div aria-labelledby="dropdown_1_action_menu" class="dropdown-menu">
                   <a class="dropdown-item" href="/eligibility/update/iae/22222222-2222-2222-2222-222222222222?back_url=/job-seekers/list-organization">
                       Valider son éligibilité IAE
                   </a>
-                  <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&back_url=%2Fjob-seekers%2Flist-organization&city=brest-29">
+                  <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=22222222-2222-2222-2222-222222222222&back_url=%2Fjob-seekers%2Flist-organization&city=brest-29" id="introjs-orienter-vers-service-insertion">
                       Orienter vers un service d’insertion
                   </a>
               </div>
@@ -2596,14 +2837,58 @@
               </span>
           </td>
           <td>
+              GRAVIER Emile (Pres. Org.)
+          </td>
+          <td>
               0
           </td>
           <td>
-              30/08/2024
+              29/08/2024
           </td>
           <td class="text-end w-100px">
               <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&city=brest-29">
                   <i aria-label="Postuler pour ZORRO Alain" class="ri-draft-line">
+                  </i>
+              </a>
+              <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_2_action_menu" type="button">
+                  <i aria-hidden="true" class="ri-more-2-fill">
+                  </i>
+              </button>
+              <div aria-labelledby="dropdown_2_action_menu" class="dropdown-menu">
+                  <a class="dropdown-item" href="/eligibility/update/iae/11111111-1111-1111-1111-111111111111?back_url=/job-seekers/list-organization">
+                      Mettre à jour son éligibilité IAE
+                  </a>
+                  <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&back_url=%2Fjob-seekers%2Flist-organization&city=brest-29">
+                      Orienter vers un service d’insertion
+                  </a>
+              </div>
+          </td>
+      </tr>
+      <tr>
+          <td>
+              <a class="btn-link" href="/job-seekers/details/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list-organization">
+                  XERUS Charlotte
+              </a>
+          </td>
+          <td>
+              <span class="badge badge-xs rounded-pill bg-warning-lighter text-warning">
+                  <i aria-hidden="true" class="ri-error-warning-line">
+                  </i>
+                  Éligibilité IAE à valider
+              </span>
+          </td>
+          <td>
+              Non précisé (ACME Inc.)
+          </td>
+          <td>
+              0
+          </td>
+          <td>
+              31/08/2022
+          </td>
+          <td class="text-end w-100px">
+              <a class="btn btn-sm btn-link btn-ico-only" data-bs-title="Postuler pour ce candidat" data-bs-toggle="tooltip" data-matomo-action="clic" data-matomo-category="candidature" data-matomo-event="true" data-matomo-option="postuler-pour-ce-candidat" href="/search/employers/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&city=brest-29">
+                  <i aria-label="Postuler pour XERUS Charlotte" class="ri-draft-line">
                   </i>
               </a>
               <button aria-expanded="false" aria-haspopup="true" aria-label="Plus d'actions" class="btn btn-sm btn-link btn-ico-only" data-bs-toggle="dropdown" id="dropdown_3_action_menu" type="button">
@@ -2611,10 +2896,10 @@
                   </i>
               </button>
               <div aria-labelledby="dropdown_3_action_menu" class="dropdown-menu">
-                  <a class="dropdown-item" href="/eligibility/update/iae/11111111-1111-1111-1111-111111111111?back_url=/job-seekers/list-organization">
-                      Mettre à jour son éligibilité IAE
+                  <a class="dropdown-item" href="/eligibility/update/iae/33333333-3333-3333-3333-333333333333?back_url=/job-seekers/list-organization">
+                      Valider son éligibilité IAE
                   </a>
-                  <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=11111111-1111-1111-1111-111111111111&back_url=%2Fjob-seekers%2Flist-organization&city=brest-29">
+                  <a class="dropdown-item" data-matomo-action="clic" data-matomo-category="candidat" data-matomo-event="true" data-matomo-option="services-search-from-list" href="/search/services/results?job_seeker_public_id=33333333-3333-3333-3333-333333333333&back_url=%2Fjob-seekers%2Flist-organization&city=brest-29">
                       Orienter vers un service d’insertion
                   </a>
               </div>

--- a/tests/www/job_seekers_views/test_list.py
+++ b/tests/www/job_seekers_views/test_list.py
@@ -17,7 +17,7 @@ from itou.users.enums import ActionKind
 from itou.users.models import JobSeekerAssignment, User, UserKind
 from itou.utils.templatetags.str_filters import mask_unless
 from tests.approvals.factories import ApprovalFactory
-from tests.companies.factories import CompanyFactory
+from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
 from tests.eligibility.factories import GEIQEligibilityDiagnosisFactory, IAEEligibilityDiagnosisFactory
 from tests.job_applications.factories import JobApplicationFactory
 from tests.prescribers.factories import (
@@ -25,7 +25,12 @@ from tests.prescribers.factories import (
     PrescriberOrganizationFactory,
     PrescriberOrganizationWith2MembershipFactory,
 )
-from tests.users.factories import JobSeekerFactory, LaborInspectorFactory, PrescriberFactory
+from tests.users.factories import (
+    JobSeekerAssignmentFactory,
+    JobSeekerFactory,
+    LaborInspectorFactory,
+    PrescriberFactory,
+)
 from tests.utils.htmx.testing import assertSoupEqual, update_page_with_htmx
 from tests.utils.testing import PAGINATION_PAGE_ONE_MARKUP, parse_response_to_soup, pretty_indented
 from tests.www.apply.test_submit import fake_session_initialization
@@ -76,6 +81,16 @@ def assert_update_eligibility(response, can_update):
     assert_function = assertContains if can_update else assertNotContains
     assert_function(response, "Mettre à jour son éligibilité IAE")
     assert_function(response, "Valider son éligibilité IAE")
+
+
+def assert_contains_last_advisor(response, job_seeker_assignment):
+    if job_seeker_assignment.assigned_to_unknown_advisor:
+        last_advisor_name = "Non précisé"
+    else:
+        last_advisor_name = job_seeker_assignment.professional.get_inverted_full_name()
+    last_advisor_org = job_seeker_assignment.prescriber_organization or job_seeker_assignment.company
+    last_advisor_org_name = (last_advisor_org and last_advisor_org.name) or "Non précisé"
+    assertContains(response, f"{last_advisor_name} ({last_advisor_org_name})")
 
 
 @pytest.mark.parametrize("url", [reverse("job_seekers_views:list"), reverse("job_seekers_views:list_organization")])
@@ -164,6 +179,13 @@ def test_multiple(client, snapshot):
     url = reverse("job_seekers_views:list")
 
     # App with diagnosis but without approval
+    organization = PrescriberOrganizationFactory(for_snapshot=True, authorized=True)
+    prescriber = PrescriberMembershipFactory(
+        user__first_name="Odile", user__last_name="Deray", organization=organization
+    ).user
+    other_prescriber = PrescriberMembershipFactory(
+        user__first_name="Patrick", user__last_name="Bialès", organization=organization
+    ).user
     job_app = JobApplicationFactory(
         job_seeker__first_name="Alain",
         job_seeker__last_name="Zorro",
@@ -172,17 +194,32 @@ def test_multiple(client, snapshot):
         job_seeker__city="Brest",
         job_seeker__jobseeker_profile__is_stalled=True,
         sent_by_authorized_prescriber=True,
-        with_job_seeker_assignment=True,
+        sender=prescriber,
+        sender_prescriber_organization=organization,
         updated_at=timezone.now() - datetime.timedelta(days=1),
         with_iae_eligibility_diagnosis=True,
     )
-    prescriber = job_app.sender
+    job_seeker_assignment = JobSeekerAssignmentFactory(
+        job_seeker=job_app.job_seeker,
+        professional=other_prescriber,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.APPLY,
+        updated_at=timezone.now() - datetime.timedelta(days=1),
+    )
+
     # Other app for the same job seeker
     JobApplicationFactory(
         sent_by_prescriber_alone=True,
         sender=prescriber,
+        sender_prescriber_organization=organization,
         job_seeker=job_app.job_seeker,
-        with_job_seeker_assignment=True,
+        updated_at=timezone.now() - datetime.timedelta(days=2),
+    )
+    JobSeekerAssignmentFactory(
+        job_seeker=job_app.job_seeker,
+        professional=prescriber,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.APPLY,
         updated_at=timezone.now() - datetime.timedelta(days=2),
     )
     # Other app without diagnosis
@@ -195,7 +232,13 @@ def test_multiple(client, snapshot):
         job_seeker__post_code="29200",
         job_seeker__city="Brest",
         job_seeker__jobseeker_profile__is_stalled=True,
-        with_job_seeker_assignment=True,
+        sender_prescriber_organization=organization,
+    )
+    job_seeker_assignment2 = JobSeekerAssignmentFactory(
+        job_seeker=job_app2.job_seeker,
+        professional=prescriber,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.APPLY,
     )
     # Other app with approval
     job_app3 = JobApplicationFactory(
@@ -209,13 +252,32 @@ def test_multiple(client, snapshot):
         job_seeker__jobseeker_profile__is_stalled=True,
         job_seeker__jobseeker_profile__is_not_stalled_anymore=True,
         with_approval=True,
-        with_job_seeker_assignment=True,
+        sender_prescriber_organization=organization,
+    )
+    JobSeekerAssignmentFactory(
+        job_seeker=job_app3.job_seeker,
+        professional=prescriber,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.APPLY,
+        updated_at=timezone.now() - datetime.timedelta(days=2),
+    )
+
+    company = CompanyFactory(for_snapshot=True)
+    employer = CompanyMembershipFactory(company=company).user
+    job_seeker_assignment3 = JobSeekerAssignmentFactory(
+        job_seeker=job_app3.job_seeker,
+        professional=employer,
+        company=company,
+        last_action_kind=ActionKind.ACCEPT,
+        assigned_to_unknown_advisor=True,
+        updated_at=timezone.now() - datetime.timedelta(days=1),
     )
 
     # Other app without address/city
     job_app4 = JobApplicationFactory(
         sent_by_prescriber_alone=True,
         sender=prescriber,
+        sender_prescriber_organization=organization,
         job_seeker__first_name="David",
         job_seeker__last_name="Waterford",
         job_seeker__public_id="44444444-4444-4444-4444-444444444444",
@@ -245,6 +307,9 @@ def test_multiple(client, snapshot):
         # Address is in search URL
         for i, application in enumerate([job_app, job_app2, job_app3]):
             assert_contains_button_apply_for(response, application.job_seeker, with_city=True)
+
+        for assignment in [job_seeker_assignment, job_seeker_assignment2, job_seeker_assignment3]:
+            assert_contains_last_advisor(response, job_seeker_assignment)
 
         # Job seeker does not have an address, so it is not in the URL
         assert_contains_button_apply_for(response, job_app4.job_seeker, with_city=False)
@@ -278,8 +343,13 @@ def test_pagination(client):
 def test_multiple_with_job_seekers_created_by_organization(client, snapshot):
     url_user = reverse("job_seekers_views:list")
     url_organization = reverse("job_seekers_views:list_organization")
-    organization = PrescriberOrganizationWith2MembershipFactory(authorized=True)
-    [prescriber, other_prescriber] = organization.members.all()
+    organization = PrescriberOrganizationFactory(for_snapshot=True, authorized=True)
+    prescriber = PrescriberMembershipFactory(
+        user__first_name="Emile", user__last_name="Gravier", organization=organization
+    ).user
+    other_prescriber = PrescriberMembershipFactory(
+        user__first_name="Jean-Paul", user__last_name="Martoni", organization=organization
+    ).user
 
     # Job seeker created by this prescriber
     alain = JobSeekerFactory(
@@ -290,7 +360,6 @@ def test_multiple_with_job_seekers_created_by_organization(client, snapshot):
         city="Brest",
         created_by=prescriber,
         jobseeker_profile__created_by_prescriber_organization=organization,
-        with_job_seeker_assignment=True,
     )
 
     # Job seeker created by another member of the organization
@@ -302,12 +371,21 @@ def test_multiple_with_job_seekers_created_by_organization(client, snapshot):
         city="Brest",
         created_by=other_prescriber,
         jobseeker_profile__created_by_prescriber_organization=organization,
-        with_job_seeker_assignment=True,
+    )
+    bernard_assignment = JobSeekerAssignmentFactory(
+        job_seeker=bernard,
+        professional=other_prescriber,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.APPLY,
+        assigned_to_unknown_advisor=True,
     )
 
     # Job seeker created by a member of the organization, but not in the organization anymore
     prescriber_not_in_org_anymore = PrescriberFactory(
-        membership__organization=organization, membership__is_active=False
+        first_name="Simon",
+        last_name="Jérémi",
+        membership__organization=organization,
+        membership__is_active=False,
     )
     charlotte = JobSeekerFactory(
         first_name="Charlotte",
@@ -317,7 +395,24 @@ def test_multiple_with_job_seekers_created_by_organization(client, snapshot):
         city="Brest",
         created_by=prescriber_not_in_org_anymore,
         jobseeker_profile__created_by_prescriber_organization=organization,
-        with_job_seeker_assignment=True,
+    )
+    JobSeekerAssignmentFactory(
+        job_seeker=charlotte,
+        professional=prescriber_not_in_org_anymore,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.CREATE,
+        updated_at=timezone.now() - datetime.timedelta(days=2 * 365),
+    )
+
+    company = CompanyFactory(for_snapshot=True)
+    employer = CompanyMembershipFactory(company=company, user__first_name="Serge", user__last_name="Karamazov").user
+    charlotte_assignment = JobSeekerAssignmentFactory(
+        job_seeker=charlotte,
+        professional=employer,
+        company=company,
+        last_action_kind=ActionKind.ACCEPT,
+        assigned_to_unknown_advisor=True,
+        updated_at=timezone.now() - datetime.timedelta(days=2),
     )
 
     # When applying for a job seeker already in the list, he's not shown twice
@@ -327,7 +422,13 @@ def test_multiple_with_job_seekers_created_by_organization(client, snapshot):
         sent_by_authorized_prescriber=True,
         updated_at=timezone.now() - datetime.timedelta(days=1),
         with_iae_eligibility_diagnosis=True,
-        with_job_seeker_assignment=True,
+    )
+    alain_assignment = JobSeekerAssignmentFactory(
+        job_seeker=alain,
+        professional=prescriber,
+        prescriber_organization=organization,
+        last_action_kind=ActionKind.APPLY,
+        updated_at=timezone.now() - datetime.timedelta(days=1),
     )
 
     # Job seeker created by the prescriber but for another organization; will not be shown
@@ -365,6 +466,9 @@ def test_multiple_with_job_seekers_created_by_organization(client, snapshot):
         for job_seeker in [alain, bernard, charlotte]:
             assert_contains_job_seeker(response, job_seeker, back_url=url_organization, with_personal_information=True)
             assert_contains_button_apply_for(response, job_seeker, with_city=True)
+
+        for assignment in [alain_assignment, bernard_assignment, charlotte_assignment]:
+            assert_contains_last_advisor(response, assignment)
 
         # Job seeker not displayed for the prescriber
         for job_seeker in [david, edouard]:


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement, le dernier accompagnateur connu d'un candidat n'est visible que depuis le profil de ce dernier.
Il est désormais également affiché dans le tableau de suivi de l'espace "Candidats" des prescripteurs.
[Carte Notion](https://www.notion.so/gip-inclusion/Ajout-d-un-nouveau-champ-Dernier-accompagnateur-connu-dans-l-espace-de-suivi-candidats-2e85f321b60480d68ea8ddb5f1cdd09b?v=2845f321b60480bd9ef6000c92a2d6ab)

## :cake: Comment ? <!-- optionnel -->

J'ai opté à l'origine pour récupérer le dernier accompagnateur (ou plutôt son id) et son organisation dans des subqueries séparées, et de récupérer l'objet utilisateur à partir de son id ensuite. C'est l'option qui générait le moins de requêtes tout en restant plutôt propre, mais je trouvais gênant de récupérer le dernier accompagnateur connu de 2 façons différentes : depuis la propriété `last_advisor` de `User` et dans une subquery ici.

J'ai remarqué que [le queryset](https://github.com/gip-inclusion/les-emplois/blob/main/itou/www/job_seekers_views/views.py#L289) n'avait pas immédiatement besoin de récupérer `jobseeker_profile` ou `approvals`. L'initialisation du `FilterForm` ne nécessite que les noms et prénoms des utilisateurs, et la méthode `filter` ne fait qu'ajouter des filtres au queryset, ce qui ne cause pas de problème même si on n'a pas prefetch les attributs sur lesquels on filtre puisque le queryset est lazy. Donc normalement, rien n'est cassé :crossed_fingers:

J'ai ajouté 2 nouvelles propriétés au modèle `User` : `last_assignment` qui renvoie la dernière assignation d'un utilisateur et `last_known_advisor_with_org_or_company` qui renvoie le dernier accompagnateur connu et son organisation/entreprise récupérés depuis `last_assignment`. La propriété `last_advisor` se repose désormais également sur `last_assignment`.

## :computer: Captures d'écran <!-- optionnel -->

<img width="1629" height="815" alt="Copie d&#39;écran_20260511_195816" src="https://github.com/user-attachments/assets/2e9f8105-3281-4d91-954c-d548f62d207f" />
