### PR TITLE
Accessibilité: Correction de certains en-têtes de tableaux

### DIFF
--- a/itou/templates/apply/includes/appointments.html
+++ b/itou/templates/apply/includes/appointments.html
@@ -15,7 +15,9 @@
                     <th scope="col">Statut</th>
                     <th scope="col">Date et heure</th>
                     <th scope="col">Motif</th>
-                    <th scope="col" class="text-end w-50px"></th>
+                    <th scope="col" class="text-end w-50px">
+                        <span class="visually-hidden">Actions possibles sur les rendez-vous</span>
+                    </th>
                 </tr>
             </thead>
             <tbody>

--- a/itou/templates/apply/includes/list_table.html
+++ b/itou/templates/apply/includes/list_table.html
@@ -22,7 +22,9 @@
                 <th scope="col" class="text-nowrap">Critères administratifs</th>
                 <th scope="col">Statut éligibilité</th>
             {% endif %}
-            <th scope="col" class="text-end w-50px"></th>
+            <th scope="col" class="text-end w-50px">
+                <span class="visually-hidden">Actions possibles sur les candidatures</span>
+            </th>
         </tr>
     </thead>
     <tbody>

--- a/itou/templates/apply/list_of_available_exports.html
+++ b/itou/templates/apply/list_of_available_exports.html
@@ -80,7 +80,9 @@
                                     <tr>
                                         <th scope="col">Contenu du fichier</th>
                                         <th scope="col">Nombre de candidatures</th>
-                                        <th scope="col" class="text-end w-50px"></th>
+                                        <th scope="col" class="text-end w-50px">
+                                            <span class="visually-hidden">Actions possibles sur les candidatures</span>
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/itou/templates/approvals/details.html
+++ b/itou/templates/approvals/details.html
@@ -53,7 +53,9 @@
                                             <th scope="col">Jusqu’au</th>
                                             <th scope="col">Motif</th>
                                             <th scope="col">Émetteur</th>
-                                            <th scope="col" class="text-end w-100px"></th>
+                                            <th scope="col" class="text-end w-100px">
+                                                <span class="visually-hidden">Actions possibles sur les suspensions</span>
+                                            </th>
                                         </tr>
                                     </thead>
                                     <tbody>

--- a/itou/templates/approvals/includes/list_table.html
+++ b/itou/templates/approvals/includes/list_table.html
@@ -19,7 +19,9 @@
                    tabindex="0">
                 </i>
             </th>
-            <th scope="col" class="text-end w-50px"></th>
+            <th scope="col" class="text-end w-50px">
+                <span class="visually-hidden">Actions possibles sur les salariés et PASS IAE</span>
+            </th>
         </tr>
     </thead>
     <tbody>

--- a/itou/templates/approvals/prolongation_requests/list.html
+++ b/itou/templates/approvals/prolongation_requests/list.html
@@ -56,7 +56,9 @@
                                             </button>
                                         </th>
                                         <th scope="col">Statut</th>
-                                        <th scope="col" class="text-end w-50px"></th>
+                                        <th scope="col" class="text-end w-50px">
+                                            <span class="visually-hidden">Actions possibles sur les prolongations de PASS IAE</span>
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/itou/templates/companies/job_description_list.html
+++ b/itou/templates/companies/job_description_list.html
@@ -83,7 +83,9 @@
                                         <th scope="col">Nbre de postes</th>
                                         <th scope="col">Statut</th>
                                         <th scope="col">Mise à jour</th>
-                                        <th scope="col" class="text-end w-100px"></th>
+                                        <th scope="col" class="text-end w-100px">
+                                            <span class="visually-hidden">Actions possibles sur les métiers exercés</span>
+                                        </th>
                                     </tr>
                                 </thead>
                                 <tbody>

--- a/itou/templates/includes/members.html
+++ b/itou/templates/includes/members.html
@@ -20,7 +20,11 @@
                     <th scope="col">Nom Prénom</th>
                     <th scope="col">Email</th>
                     <th scope="col">Date d'inscription</th>
-                    {% if user in active_admin_members %}<th scope="col" class="text-end w-50px"></th>{% endif %}
+                    {% if user in active_admin_members %}
+                        <th scope="col" class="text-end w-50px">
+                            <span class="visually-hidden">Actions possibles sur les collaborateurs</span>
+                        </th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>

--- a/itou/templates/job_seekers_views/includes/list_results.html
+++ b/itou/templates/job_seekers_views/includes/list_results.html
@@ -24,6 +24,7 @@
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.JOB_APPLICATIONS_NB_ASC name="Nombre de candidatures" only %}
                         {% include 'common/tables/th_with_sort.html' with order=order ascending_value=order.LAST_UPDATED_AT_ASC name="Dernière action" only %}
                         <th scope="col" class="text-end {% if request.current_organization.is_authorized %}w-100px{% else %}w-50px{% endif %}">
+                            <span class="visually-hidden">Actions possibles sur les candidats</span>
                         </th>
                     </tr>
                 </thead>

--- a/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
+++ b/tests/www/apply/__snapshots__/test_detail_rdv_insertion.ambr
@@ -17,6 +17,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -126,6 +129,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -235,6 +241,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -344,6 +353,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -535,6 +547,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -726,6 +741,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -917,6 +935,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -1354,6 +1375,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>
@@ -1791,6 +1815,9 @@
                   Motif
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les rendez-vous
+                  </span>
               </th>
           </tr>
       </thead>

--- a/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_job_seeker.ambr
@@ -1553,6 +1553,9 @@
                           Émetteur
                       </th>
                       <th class="text-end w-50px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les candidatures
+                          </span>
                       </th>
                   </tr>
               </thead>

--- a/tests/www/apply/__snapshots__/test_list_for_siae.ambr
+++ b/tests/www/apply/__snapshots__/test_list_for_siae.ambr
@@ -7458,6 +7458,9 @@
                   Nombre de candidatures
               </th>
               <th class="text-end w-50px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les candidatures
+                  </span>
               </th>
           </tr>
       </thead>
@@ -9548,6 +9551,9 @@
                               Statut éligibilité
                           </th>
                           <th class="text-end w-50px" scope="col">
+                              <span class="visually-hidden">
+                                  Actions possibles sur les candidatures
+                              </span>
                           </th>
                       </tr>
                   </thead>
@@ -9846,6 +9852,9 @@
                               Statut éligibilité
                           </th>
                           <th class="text-end w-50px" scope="col">
+                              <span class="visually-hidden">
+                                  Actions possibles sur les candidatures
+                              </span>
                           </th>
                       </tr>
                   </thead>

--- a/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
+++ b/tests/www/apply/__snapshots__/test_list_prescriptions.ambr
@@ -9032,6 +9032,9 @@
                           Statut éligibilité
                       </th>
                       <th class="text-end w-50px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les candidatures
+                          </span>
                       </th>
                   </tr>
               </thead>
@@ -10647,6 +10650,9 @@
                           Statut éligibilité
                       </th>
                       <th class="text-end w-50px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les candidatures
+                          </span>
                       </th>
                   </tr>
               </thead>

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -5343,6 +5343,9 @@
                           Émetteur
                       </th>
                       <th class="text-end w-100px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les suspensions
+                          </span>
                       </th>
                   </tr>
               </thead>
@@ -5463,6 +5466,9 @@
                           Émetteur
                       </th>
                       <th class="text-end w-100px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les suspensions
+                          </span>
                       </th>
                   </tr>
               </thead>
@@ -5563,6 +5569,9 @@
                           Émetteur
                       </th>
                       <th class="text-end w-100px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les suspensions
+                          </span>
                       </th>
                   </tr>
               </thead>

--- a/tests/www/approvals_views/__snapshots__/test_list.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_list.ambr
@@ -2192,6 +2192,9 @@
                           </i>
                       </th>
                       <th class="text-end w-50px" scope="col">
+                          <span class="visually-hidden">
+                              Actions possibles sur les salariés et PASS IAE
+                          </span>
                       </th>
                   </tr>
               </thead>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -1172,6 +1172,9 @@
                                       Statut
                                   </th>
                                   <th class="text-end w-50px" scope="col">
+                                      <span class="visually-hidden">
+                                          Actions possibles sur les prolongations de PASS IAE
+                                      </span>
                                   </th>
                               </tr>
                           </thead>
@@ -1783,6 +1786,9 @@
                                       Statut
                                   </th>
                                   <th class="text-end w-50px" scope="col">
+                                      <span class="visually-hidden">
+                                          Actions possibles sur les prolongations de PASS IAE
+                                      </span>
                                   </th>
                               </tr>
                           </thead>

--- a/tests/www/companies_views/__snapshots__/test_members_views.ambr
+++ b/tests/www/companies_views/__snapshots__/test_members_views.ambr
@@ -106,6 +106,9 @@
                                           Date d'inscription
                                       </th>
                                       <th class="text-end w-50px" scope="col">
+                                          <span class="visually-hidden">
+                                              Actions possibles sur les collaborateurs
+                                          </span>
                                       </th>
                                   </tr>
                               </thead>

--- a/tests/www/institutions_views/__snapshots__/test_views.ambr
+++ b/tests/www/institutions_views/__snapshots__/test_views.ambr
@@ -81,6 +81,9 @@
                                           Date d'inscription
                                       </th>
                                       <th class="text-end w-50px" scope="col">
+                                          <span class="visually-hidden">
+                                              Actions possibles sur les collaborateurs
+                                          </span>
                                       </th>
                                   </tr>
                               </thead>

--- a/tests/www/job_seekers_views/__snapshots__/test_list.ambr
+++ b/tests/www/job_seekers_views/__snapshots__/test_list.ambr
@@ -1668,6 +1668,9 @@
                   </button>
               </th>
               <th class="text-end w-100px" scope="col">
+                  <span class="visually-hidden">
+                      Actions possibles sur les candidats
+                  </span>
               </th>
           </tr>
       </thead>

--- a/tests/www/prescribers_views/__snapshots__/test_members.ambr
+++ b/tests/www/prescribers_views/__snapshots__/test_members.ambr
@@ -84,6 +84,9 @@
                                           Date d'inscription
                                       </th>
                                       <th class="text-end w-50px" scope="col">
+                                          <span class="visually-hidden">
+                                              Actions possibles sur les collaborateurs
+                                          </span>
                                       </th>
                                   </tr>
                               </thead>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Pour corriger une erreur remontée par les tests d'accessibilité de storybook. (Pas d'en-tête de cellules de tableau vide)
