### PR TITLE
GEIQ : Permettre de justifier le refus d’aide pour un contrat (DDETS/DREETS)

### DIFF
--- a/itou/geiq_assessments/enums.py
+++ b/itou/geiq_assessments/enums.py
@@ -3,6 +3,22 @@ import enum
 from django.db import models
 
 
+class AssessmentContractDetailsTab(models.TextChoices):
+    EMPLOYEE = "employee", "Informations salarié"
+    CONTRACT = "contract", "Contrat"
+    SUPPORT_AND_TRAINING = "support-and-training", "Accompagnement et formation"
+    EXIT = "exit", "Sortie"
+    ALLOWANCE_REFUSAL_JUSTIFICATION = "refusal-justification", "Motif de refus"
+
+    @classmethod
+    def get_common_tabs(cls):
+        return [cls.EMPLOYEE, cls.CONTRACT, cls.SUPPORT_AND_TRAINING, cls.EXIT]
+
+    @classmethod
+    def get_institution_tabs(cls):
+        return cls.get_common_tabs() + [cls.ALLOWANCE_REFUSAL_JUSTIFICATION]
+
+
 class AssessmentState(models.TextChoices):
     NEW = "new", "À compléter"
     SUBMITTED = "submitted", "Envoyé"

--- a/itou/geiq_assessments/enums.py
+++ b/itou/geiq_assessments/enums.py
@@ -27,11 +27,24 @@ class AllowanceRefusalReason(models.TextChoices):
     ALLOWANCE_ALREADY_GRANTED = "allowance_already_granted", "Aide déjà attribuée"
     OTHER = "other", "Autre motif"
 
+    @classmethod
+    def get_description(cls, reason):
+        details = {
+            cls.UNCONFIRMED_ELIGIBILITY: "Le GEIQ n’a pas pu fournir les justificatifs nécessaires à "
+            "la confirmation de l’éligibilité du salarié.",
+            cls.ALLOWANCE_ALREADY_GRANTED: "Une aide a déjà été attribuée pour ce salarié.",
+            cls.OTHER: "Précisez le motif dans le champ de saisie ci-dessous.",
+        }
+        return details.get(reason)
+
 
 class InstitutionAction(enum.StrEnum):
     REVIEW = "review"
     ASK_FOR_INSTITUTION_FIX = "ask_for_institution_fix"
     ASK_FOR_GEIQ_FIX = "ask_for_geiq_fix"
+    REFUSE_ALLOWANCE = "refuse_allowance"
+    GRANT_ALLOWANCE = "grant_allowance"
+    ALLOWANCE_REFUSAL_JUSTIFICATION = "allowance_refusal_justification"
 
     # Make the Enum work in Django's templates
     # See :

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -55,7 +55,12 @@
     <section class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">
-                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
+                {% if request.from_institution %}
+                    <div class="s-section__col col-12 col-xxl-4 col-xxxl-3 order-1 order-xxl-2 mt-xxl-6">
+                        {% include "geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html" with contract=contract csrf_token=csrf_token active_tab=active_tab disabled=contract.employee.assessment.grants_selection_validated_at only %}
+                    </div>
+                {% endif %}
+                <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
                     <h2>{{ active_tab.label }}</h2>
                     {% if active_tab == AssessmentContractDetailsTab.EMPLOYEE %}
                         <div class="c-box mb-3 mb-md-4">
@@ -368,6 +373,8 @@
                                 </li>
                             </ul>
                         </div>
+                    {% elif request.from_institution and active_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %}
+                        {% include "geiq_assessments_views/includes/allowance_refusal_justification_form.html" with contract=contract csrf_token=csrf_token form=allowance_refusal_justification_form disabled=contract.employee.assessment.grants_selection_validated_at only %}
                     {% endif %}
                 </div>
             </div>

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -1,6 +1,7 @@
 {% extends "layout/base.html" %}
 {% load components %}
 {% load django_bootstrap5 %}
+{% load enums %}
 {% load format_filters %}
 {% load str_filters %}
 
@@ -26,6 +27,7 @@
 {% endblock %}
 
 {% block title_extra %}
+    {% enums "geiq_assessments" "AssessmentContractDetailsTab" as AssessmentContractDetailsTab %}
     {% if contract.employee.allowance_granted_previous_year %}
         {% component_alert content=content variant="warning" extra_classes="mb-0" %}
             {% fragment as content %}
@@ -52,6 +54,7 @@
 {% endblock %}
 
 {% block content %}
+    {% enums "geiq_assessments" "AssessmentContractDetailsTab" as AssessmentContractDetailsTab %}
     <section class="s-section">
         <div class="s-section__container container">
             <div class="s-section__row row">

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -35,9 +35,18 @@
     {% endif %}
     <ul class="s-tabs-01__nav nav nav-tabs mb-0" data-it-sliding-tabs="true">
         {% for tab in AssessmentContractDetailsTab %}
-            <li class="nav-item">
-                <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}</a>
-            </li>
+            {% if tab != AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION %}
+                <li class="nav-item">
+                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}
+                    </a>
+                </li>
+            {% elif tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION and request.from_institution and not contract.allowance_granted %}
+                <li class="nav-item">
+                    <a class="nav-link{% if active_tab == tab %} active{% endif %}" href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=tab.value %}">{{ tab.label }}
+                        {% if not contract.allowance_refusal_reason %}<i class="ri-error-warning-line ri-xl text-warning ms-2"></i>{% endif %}
+                    </a>
+                </li>
+            {% endif %}
         {% endfor %}
     </ul>
 {% endblock %}

--- a/itou/templates/geiq_assessments_views/assessment_contracts_details.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_details.html
@@ -20,8 +20,6 @@
         {% fragment as c_title__cta %}
             {% if request.from_employer %}
                 {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_requested csrf_token=csrf_token from_list=False editable=editable request=request only %}
-            {% elif request.from_institution %}
-                {% include "geiq_assessments_views/includes/contracts_switch.html" with contract=contract value=contract.allowance_granted csrf_token=csrf_token from_list=False editable=editable request=request only %}
             {% endif %}
         {% endfragment %}
     {% endcomponent_title %}

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -2,6 +2,7 @@
 {% load buttons_form %}
 {% load components %}
 {% load django_bootstrap5 %}
+{% load enums %}
 {% load format_filters %}
 {% load static %}
 {% load str_filters %}
@@ -155,6 +156,7 @@
                                             </tr>
                                         </thead>
                                         <tbody>
+                                            {% enums "geiq_assessments" "AssessmentContractDetailsTab" as AssessmentContractDetailsTab %}
                                             {% for contract in contracts_page %}
                                                 <tr>
                                                     <td>

--- a/itou/templates/geiq_assessments_views/assessment_contracts_list.html
+++ b/itou/templates/geiq_assessments_views/assessment_contracts_list.html
@@ -1,5 +1,4 @@
 {% extends "layout/base.html" %}
-{% load buttons_form %}
 {% load components %}
 {% load django_bootstrap5 %}
 {% load enums %}
@@ -85,6 +84,7 @@
                             L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
                             Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que le GEIQ souhaiterait vous soumettre.
                         </p>
+                        {% include "geiq_assessments_views/includes/contracts_list_justification_alert.html" with contracts_awaiting_justification_nb=stats.contracts_awaiting_justification_nb assessment=assessment request=request hx_swap_oob=False only %}
                     {% endif %}
                     {% if stats.with_allowance_granted_previous_year_nb %}
                         {% component_alert content=content variant="warning" custom_icon="ri-file-warning-line" extra_classes="mt-3 mb-0" %}
@@ -206,11 +206,7 @@
                     {% endpartialdef %}
 
                     {% if can_validate %}
-
-                        <form method="post" class="js-prevent-multiple-submit">
-                            {% csrf_token %}
-                            {% itou_buttons_form primary_label="Valider la sélection" primary_name="action" primary_value=ContractsAction.VALIDATE reset_url=back_url show_mandatory_fields_mention=False %}
-                        </form>
+                        {% include "geiq_assessments_views/includes/contracts_list_validate_button_form.html" with ContractsAction=ContractsAction back_url=back_url contracts_awaiting_justification_nb=stats.contracts_awaiting_justification_nb csrf_token=csrf_token request=request hx_swap_oob=False only %}
                     {% endif %}
                 </div>
             </div>

--- a/itou/templates/geiq_assessments_views/includes/allowance_refusal_justification_form.html
+++ b/itou/templates/geiq_assessments_views/includes/allowance_refusal_justification_form.html
@@ -1,0 +1,35 @@
+{% load buttons_form %}
+{% load django_bootstrap5 %}
+{% load enums %}
+{% enums "geiq_assessments" "InstitutionAction" as InstitutionAction %}
+<div class="c-form mb-3 mb-md-4">
+    <form method="post">
+        {% csrf_token %}
+        {% bootstrap_form_errors form type="all" %}
+        <h2 class="h3">{{ form.allowance_refusal_reason.label }} *</h2>
+        <input type="hidden" name="action" value="{{ InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION }}" />
+        {% for choice in form.allowance_refusal_reason %}
+            {# TODO(ewen): make a widget from this markup and better handle errors. #}
+            <div class="form-group">
+                <div class="form-check">
+                    <input id="{{ choice.id_for_label }}"
+                           class="form-check-input"
+                           type="radio"
+                           name="{{ choice.data.name }}"
+                           value="{{ choice.data.value }}"
+                           required
+                           {% if form.allowance_refusal_reason.field.disabled %}disabled{% endif %}
+                           aria-required="true"
+                           {% if choice.data.selected %}checked{% endif %}>
+                    <label class="form-check-label" for="{{ choice.id_for_label }}">
+                        <strong>{{ choice.data.label }}</strong>
+                        <br>
+                        <span class="text-muted">{{ choice.description }}</span>
+                    </label>
+                </div>
+            </div>
+        {% endfor %}
+        <div class="form-group">{% bootstrap_field form.allowance_refusal_details %}</div>
+        {% itou_buttons_form primary_label="Enregistrer" primary_disabled=disabled reset_url=None %}
+    </form>
+</div>

--- a/itou/templates/geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_grant_allowance_box_for_institution.html
@@ -1,0 +1,48 @@
+{% load enums %}
+{% enums "geiq_assessments" "InstitutionAction" as InstitutionAction %}
+<div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
+    {% if contract.allowance_granted %}
+        <h3>L’aide financière est accordée</h3>
+        <p>La demande d’aide est approuvée.</p>
+        <p>Vous pouvez refuser la demande pour ce contrat tant que le bilan n’a pas été validé.</p>
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-primary btn-block btn-lg btn-ico" name="action" value="{{ InstitutionAction.REFUSE_ALLOWANCE }}"{% if disabled %} disabled{% endif %}>
+                <i class="ri-close-line" aria-hidden="true"></i>
+                <span>Refuser l’aide</span>
+            </button>
+        </form>
+    {% else %}
+        <h3>L’aide financière n’est pas accordée</h3>
+        <p>La demande d’obtention de l’aide est refusée.</p>
+
+        {% if contract.allowance_refusal_reason %}
+            <p>Vous avez déjà motivé votre refus.</p>
+        {% else %}
+            <p>Vous devez obligatoirement justifier votre refus.</p>
+        {% endif %}
+
+        <p>
+            Vous avez la possibilité de modifier votre décision
+            {% if contract.allowance_refusal_reason %}ou le motif de refus{% endif %}
+            tant que le bilan n'a pas été validé.
+        </p>
+        {% if contract.allowance_refusal_reason %}
+            <p>Si vous décidez d’accorder l'aide, le motif et le commentaire de refus seront supprimés.</p>
+        {% endif %}
+
+        {% if active_tab != active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION %}
+            <a class="btn btn-outline-primary btn-block btn-lg mb-2{% if disabled %} disabled{% endif %}"
+               href="{% url "geiq_assessments_views:assessment_contracts_details" contract_pk=contract.pk tab=active_tab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}">
+                <span>{{ contract.allowance_refusal_reason|yesno:"Modifier le motif de refus,Justifier le refus" }}</span>
+            </a>
+        {% endif %}
+
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-primary btn-block btn-lg" name="action" value="{{ InstitutionAction.GRANT_ALLOWANCE }}"{% if disabled %} disabled{% endif %}>
+                <span>Accorder l’aide</span>
+            </button>
+        </form>
+    {% endif %}
+</div>

--- a/itou/templates/geiq_assessments_views/includes/contracts_list_justification_alert.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_list_justification_alert.html
@@ -1,0 +1,21 @@
+{% load components %}
+{% load str_filters %}
+<div id="alert-contracts-awaiting-justification"{% if hx_swap_oob %} hx-swap-oob="true"{% endif %}>
+    {% if request.from_institution and contracts_awaiting_justification_nb %}
+        {% component_alert title=title content=content call_to_action=call_to_action variant="warning" extra_classes="mt-3" %}
+            {% fragment as title %}
+                Refus à justifier
+            {% endfragment %}
+            {% fragment as content %}
+                <p class="mb-0">
+                    Vous devez encore motiver {{ contracts_awaiting_justification_nb|pluralizefr:"le,les" }} refus d’aide de {{ contracts_awaiting_justification_nb }} {{ contracts_awaiting_justification_nb|pluralizefr:"contrat,contrats" }}.
+                </p>
+            {% endfragment %}
+            {% fragment as call_to_action %}
+                <a type="button" class="btn btn-sm btn-primary" href="{% url "geiq_assessments_views:assessment_contracts_list" pk=assessment.pk %}?allowance_eligibility_off=on#contracts-results-table">
+                    Afficher les contrats concernés
+                </a>
+            {% endfragment %}
+        {% endcomponent_alert %}
+    {% endif %}
+</div>

--- a/itou/templates/geiq_assessments_views/includes/contracts_list_validate_button_form.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_list_validate_button_form.html
@@ -1,0 +1,9 @@
+{% load buttons_form %}
+<form method="post" class="js-prevent-multiple-submit" id="validate-contracts-selection-form"{% if hx_swap_oob %} hx-swap-oob="true"{% endif %}>
+    {% csrf_token %}
+    {% if request.from_employer %}
+        {% itou_buttons_form primary_label="Valider la sélection" primary_name="action" primary_value=ContractsAction.VALIDATE reset_url=back_url primary_disabled=False show_mandatory_fields_mention=False %}
+    {% elif request.from_institution %}
+        {% itou_buttons_form primary_label="Valider la sélection" primary_name="action" primary_value=ContractsAction.VALIDATE reset_url=back_url primary_disabled=contracts_awaiting_justification_nb show_mandatory_fields_mention=False %}
+    {% endif %}
+</form>

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -1,3 +1,6 @@
+{% load enums %}
+{% enums "geiq_assessments" "AssessmentContractDetailsTab" as AssessmentContractDetailsTab %}
+
 {% if value %}
     {% url "geiq_assessments_views:assessment_contracts_exclude" contract_pk=contract.pk as post_url %}
 {% else %}
@@ -12,7 +15,26 @@
       class="js-prevent-multiple-submit">
     {% csrf_token %}
     <div class="form-check form-switch{% if not from_list %} form-switch-lg{% endif %}">
-        <input type="checkbox" class="form-check-input" name="allowance" id="allowance_for_contract_{{ contract.pk }}" {% if value %}checked{% endif %} {% if not editable %}disabled{% endif %} />
+        <div class="d-flex align-items-center gap-2">
+            <input type="checkbox" class="form-check-input" name="allowance" id="allowance_for_contract_{{ contract.pk }}" {% if value %}checked{% endif %} {% if not editable %}disabled{% endif %} />
+            {% if request.from_institution and not contract.allowance_granted %}
+                {% if contract.allowance_refusal_reason %}
+                    <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+                       class="text-success text-decoration-none lh-1"
+                       data-bs-toggle="tooltip"
+                       data-bs-title="Voir le motif de refus pour contrat.">
+                        <i class="ri-check-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
+                    </a>
+                {% else %}
+                    <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+                       class="text-warning text-decoration-none lh-1"
+                       data-bs-toggle="tooltip"
+                       data-bs-title="Vous devez encore motiver le refus pour ce contrat.">
+                        <i class="ri-error-warning-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
+                    </a>
+                {% endif %}
+            {% endif %}
+        </div>
         <label class="form-check-label{% if from_list %} visually-hidden{% endif %}" for="allowance_for_contract_{{ contract.pk }}">
             {% if request.from_employer %}
                 Obtenir l’aide

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -50,5 +50,7 @@
 {% with disable_oob=disable_stats_oob|default:False %}
     {% if from_list and request.htmx and not disable_oob %}
         {% include "geiq_assessments_views/includes/contracts_list_stats.html" with stats=stats hx_swap_oob=True request=request only %}
+        {% include "geiq_assessments_views/includes/contracts_list_validate_button_form.html" with ContractsAction=ContractsAction back_url=back_url contracts_awaiting_justification_nb=stats.contracts_awaiting_justification_nb csrf_token=csrf_token request=request hx_swap_oob=True only %}
+        {% include "geiq_assessments_views/includes/contracts_list_justification_alert.html" with contracts_awaiting_justification_nb=stats.contracts_awaiting_justification_nb assessment=assessment request=request hx_swap_oob=True only %}
     {% endif %}
 {% endwith %}

--- a/itou/templates/geiq_assessments_views/includes/contracts_switch.html
+++ b/itou/templates/geiq_assessments_views/includes/contracts_switch.html
@@ -7,43 +7,46 @@
     {% url "geiq_assessments_views:assessment_contracts_include" contract_pk=contract.pk as post_url %}
 {% endif %}
 
-<form hx-post="{{ post_url }}{% if from_list %}?from_list=1{% endif %}"
-      hx-trigger="change"
-      id="toggle_allowance_for_contract_{{ contract.pk }}"
-      hx-target="this"
-      hx-swap="outerHTML"
-      class="js-prevent-multiple-submit">
-    {% csrf_token %}
-    <div class="form-check form-switch{% if not from_list %} form-switch-lg{% endif %}">
-        <div class="d-flex align-items-center gap-2">
+
+<div class="d-flex align-items-start" id="toggle_allowance_for_contract_{{ contract.pk }}">
+    <form hx-post="{{ post_url }}{% if from_list %}?from_list=1{% endif %}"
+          hx-trigger="change"
+          hx-target="#toggle_allowance_for_contract_{{ contract.pk }}"
+          hx-swap="outerHTML"
+          class="js-prevent-multiple-submit">
+        {% csrf_token %}
+        <div class="form-check form-switch mb-0{% if not from_list %} form-switch-lg{% endif %}">
             <input type="checkbox" class="form-check-input" name="allowance" id="allowance_for_contract_{{ contract.pk }}" {% if value %}checked{% endif %} {% if not editable %}disabled{% endif %} />
-            {% if request.from_institution and not contract.allowance_granted %}
-                {% if contract.allowance_refusal_reason %}
-                    <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
-                       class="text-success text-decoration-none lh-1"
-                       data-bs-toggle="tooltip"
-                       data-bs-title="Voir le motif de refus pour contrat.">
-                        <i class="ri-check-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
-                    </a>
-                {% else %}
-                    <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
-                       class="text-warning text-decoration-none lh-1"
-                       data-bs-toggle="tooltip"
-                       data-bs-title="Vous devez encore motiver le refus pour ce contrat.">
-                        <i class="ri-error-warning-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
-                    </a>
-                {% endif %}
-            {% endif %}
+            <label class="form-check-label" for="allowance_for_contract_{{ contract.pk }}">
+                <span {% if from_list %}class="visually-hidden"{% endif %}>
+                    {% if request.from_employer %}
+                        Obtenir l’aide
+                    {% elif request.from_institution %}
+                        Accorder l’aide
+                    {% endif %}
+                </span>
+            </label>
         </div>
-        <label class="form-check-label{% if from_list %} visually-hidden{% endif %}" for="allowance_for_contract_{{ contract.pk }}">
-            {% if request.from_employer %}
-                Obtenir l’aide
-            {% elif request.from_institution %}
-                Accorder l’aide
-            {% endif %}
-        </label>
-    </div>
-</form>
+    </form>
+
+    {% if request.from_institution and not contract.allowance_granted %}
+        {% if contract.allowance_refusal_reason %}
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+               class="text-success text-decoration-none lh-1"
+               data-bs-toggle="tooltip"
+               data-bs-title="Voir le motif de refus pour contrat.">
+                <i class="ri-check-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
+            </a>
+        {% else %}
+            <a href="{% url 'geiq_assessments_views:assessment_contracts_details' contract_pk=contract.pk tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value %}"
+               class="text-warning text-decoration-none lh-1"
+               data-bs-toggle="tooltip"
+               data-bs-title="Vous devez encore motiver le refus pour ce contrat.">
+                <i class="ri-error-warning-line ri-xl" aria-label="Se rendre au formulaire de justification de refus" role="button" tabindex="0"></i>
+            </a>
+        {% endif %}
+    {% endif %}
+</div>
 {% with disable_oob=disable_stats_oob|default:False %}
     {% if from_list and request.htmx and not disable_oob %}
         {% include "geiq_assessments_views/includes/contracts_list_stats.html" with stats=stats hx_swap_oob=True request=request only %}

--- a/itou/www/geiq_assessments_views/forms.py
+++ b/itou/www/geiq_assessments_views/forms.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django_select2.forms import Select2Widget
 
 from itou.files.forms import ItouFileField
+from itou.geiq_assessments.enums import AllowanceRefusalReason
 from itou.geiq_assessments.models import Assessment, Employee
 from itou.institutions.enums import InstitutionKind
 from itou.institutions.models import Institution
@@ -374,3 +375,19 @@ class AskForFixCommentForm(forms.Form):
     comment = forms.CharField(
         label="Précisez les corrections à apporter au dossier", widget=forms.Textarea(), strip=True
     )
+
+
+class AllowanceRefusalJustificationForm(forms.Form):
+    allowance_refusal_reason = forms.ChoiceField(
+        label="Sélectionnez le motif applicable",
+        required=True,
+        choices=AllowanceRefusalReason.choices,
+        widget=forms.RadioSelect,
+    )
+    allowance_refusal_details = forms.CharField(label="Précisions", widget=forms.Textarea(), strip=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for choice in self["allowance_refusal_reason"]:
+            choice.description = AllowanceRefusalReason.get_description(choice.data["value"])

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -653,6 +653,15 @@ class AssessmentContractDetailsTab(models.TextChoices):
     CONTRACT = "contract", "Contrat"
     SUPPORT_AND_TRAINING = "support-and-training", "Accompagnement et formation"
     EXIT = "exit", "Sortie"
+    ALLOWANCE_REFUSAL_JUSTIFICATION = "refusal-justification", "Motif de refus"
+
+    @classmethod
+    def get_common_tabs(cls):
+        return [cls.EMPLOYEE, cls.CONTRACT, cls.SUPPORT_AND_TRAINING, cls.EXIT]
+
+    @classmethod
+    def get_institution_tabs(cls):
+        return cls.get_common_tabs() + [cls.ALLOWANCE_REFUSAL_JUSTIFICATION]
 
 
 @check_request(lambda request: employer_has_access_to_assessments(request) or request.from_institution)
@@ -664,8 +673,12 @@ def assessment_contracts_details(
     except ValueError:
         raise Http404
     if request.from_employer:
+        if tab not in AssessmentContractDetailsTab.get_common_tabs():
+            raise Http404
         filter_kwargs = {"employee__assessment__companies": request.current_organization}
     elif request.from_institution:
+        if tab not in AssessmentContractDetailsTab.get_institution_tabs():
+            raise Http404
         filter_kwargs = {
             "employee__assessment__institutions": request.current_organization,
             "employee__assessment__submitted_at__isnull": False,
@@ -685,6 +698,9 @@ def assessment_contracts_details(
     elif request.from_institution:
         if not contract.employee.assessment.reviewed_at:
             editable = not contract.employee.assessment.grants_selection_validated_at
+        if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
+            if contract.allowance_granted:
+                raise Http404
     context = {
         "back_url": reverse(
             "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -22,7 +22,7 @@ from itou.companies.enums import CompanyKind
 from itou.companies.models import Company
 from itou.files.models import save_file
 from itou.geiq_assessments import sync
-from itou.geiq_assessments.enums import AssessmentTransition, InstitutionAction
+from itou.geiq_assessments.enums import AssessmentContractDetailsTab, AssessmentTransition, InstitutionAction
 from itou.geiq_assessments.models import (
     MIN_DAYS_IN_YEAR_FOR_ALLOWANCE,
     Assessment,
@@ -604,7 +604,6 @@ def assessment_contracts_list(request, pk, template_name="geiq_assessments_views
         "previous_campaign_year": assessment.campaign.year - 1,
         "can_validate": can_validate,
         "can_invalidate": can_invalidate,
-        "AssessmentContractDetailsTab": AssessmentContractDetailsTab,
         "ContractsAction": ContractsAction,
         "stats": stats,
         "filters_form": filters_form,
@@ -647,22 +646,6 @@ def assessment_contracts_export(request, pk):
         partial(serialize_employee_contract, export_format=export_format),
         columns=[column.export_format for column in export_format.values()],
     )
-
-
-class AssessmentContractDetailsTab(models.TextChoices):
-    EMPLOYEE = "employee", "Informations salarié"
-    CONTRACT = "contract", "Contrat"
-    SUPPORT_AND_TRAINING = "support-and-training", "Accompagnement et formation"
-    EXIT = "exit", "Sortie"
-    ALLOWANCE_REFUSAL_JUSTIFICATION = "refusal-justification", "Motif de refus"
-
-    @classmethod
-    def get_common_tabs(cls):
-        return [cls.EMPLOYEE, cls.CONTRACT, cls.SUPPORT_AND_TRAINING, cls.EXIT]
-
-    @classmethod
-    def get_institution_tabs(cls):
-        return cls.get_common_tabs() + [cls.ALLOWANCE_REFUSAL_JUSTIFICATION]
 
 
 @check_request(lambda request: employer_has_access_to_assessments(request) or request.from_institution)
@@ -783,7 +766,6 @@ def assessment_contracts_details(
         "editable": editable,
         "contract": contract,
         "matomo_custom_title": f"Bilan d’exécution - page de detail d’un contrat - {tab}",
-        "AssessmentContractDetailsTab": AssessmentContractDetailsTab,
         "active_tab": details_tab,
     }
     return render(request, template_name, context)

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -50,6 +50,7 @@ from itou.www.geiq_assessments_views.export import (
 )
 from itou.www.geiq_assessments_views.forms import (
     ActionFinancialAssessmentForm,
+    AllowanceRefusalJustificationForm,
     AskForFixCommentForm,
     ContractFilterForm,
     CreateForm,
@@ -692,6 +693,7 @@ def assessment_contracts_details(
     contract = get_object_or_404(contract_qs, pk=contract_pk)
 
     editable = False
+    context = {}
     if request.from_employer:
         if not contract.employee.assessment.submitted_at:
             editable = not contract.employee.assessment.contracts_selection_validated_at
@@ -701,7 +703,79 @@ def assessment_contracts_details(
         if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
             if contract.allowance_granted:
                 raise Http404
-    context = {
+            allowance_refusal_justification_form = AllowanceRefusalJustificationForm(
+                data=request.POST
+                if request.POST.get("action") == InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION
+                else None,
+                initial={
+                    "allowance_refusal_reason": contract.allowance_refusal_reason,
+                    "allowance_refusal_details": contract.allowance_refusal_details,
+                },
+            )
+            if contract.employee.assessment.grants_selection_validated_at:
+                for fieldname in allowance_refusal_justification_form.fields:
+                    allowance_refusal_justification_form.fields[fieldname].disabled = True
+            context |= {"allowance_refusal_justification_form": allowance_refusal_justification_form}
+
+        if request.method == "POST":
+            try:
+                action = InstitutionAction(request.POST.get("action"))
+            except ValueError:
+                raise Http404
+
+            if action in [InstitutionAction.REFUSE_ALLOWANCE, InstitutionAction.GRANT_ALLOWANCE]:
+                redirect_to_tab = None
+                if contract.employee.assessment.grants_selection_validated_at:
+                    messages.error(
+                        request,
+                        "La sélection des contrats a déjà été validée : "
+                        "vous ne pouvez plus accorder ou refuser l’aide pour ce contrat.",
+                    )
+                elif action is InstitutionAction.REFUSE_ALLOWANCE:
+                    contract.allowance_granted = False
+                    contract.save(update_fields=("allowance_granted",))
+                    redirect_to_tab = AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value
+                elif action is InstitutionAction.GRANT_ALLOWANCE:
+                    contract.allowance_granted = True
+                    contract.allowance_refusal_reason = ""
+                    contract.allowance_refusal_details = ""
+                    contract.save(
+                        update_fields=(
+                            "allowance_granted",
+                            "allowance_refusal_reason",
+                            "allowance_refusal_details",
+                        )
+                    )
+                    if details_tab == AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
+                        redirect_to_tab = AssessmentContractDetailsTab.EMPLOYEE.value
+                if redirect_to_tab:
+                    return HttpResponseRedirect(
+                        reverse(
+                            "geiq_assessments_views:assessment_contracts_details",
+                            kwargs={"contract_pk": str(contract.pk), "tab": redirect_to_tab},
+                        )
+                    )
+
+            elif action is InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION:
+                if details_tab != AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION:
+                    raise Http404
+                if allowance_refusal_justification_form.is_valid():
+                    if contract.employee.assessment.grants_selection_validated_at:
+                        messages.error(
+                            request,
+                            "La sélection des contrats a déjà été validée : "
+                            "vous ne pouvez plus modifier le motif de refus.",
+                        )
+                    else:
+                        contract.allowance_refusal_reason = allowance_refusal_justification_form.cleaned_data[
+                            "allowance_refusal_reason"
+                        ]
+                        contract.allowance_refusal_details = allowance_refusal_justification_form.cleaned_data[
+                            "allowance_refusal_details"
+                        ]
+                        contract.save(update_fields=("allowance_refusal_reason", "allowance_refusal_details"))
+
+    context |= {
         "back_url": reverse(
             "geiq_assessments_views:assessment_contracts_list", kwargs={"pk": contract.employee.assessment.pk}
         ),

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -128,6 +128,9 @@ def get_allowance_stats_for_institution(assessment, *, for_assessment_details=Fa
         else {
             "allowance_of_0_nb": Count("pk", filter=Q(employee__allowance_amount=0)),
             "allowance_of_0_selected_nb": Count("pk", filter=Q(employee__allowance_amount=0, allowance_granted=True)),
+            "contracts_awaiting_justification_nb": Count(
+                "pk", filter=Q(allowance_granted=False, allowance_refusal_reason="")
+            ),
         }
     )
     return EmployeeContract.objects.filter(employee__assessment=assessment, allowance_requested=True).aggregate(
@@ -510,22 +513,25 @@ def assessment_contracts_list(request, pk, template_name="geiq_assessments_views
 
     back_url, can_validate, can_invalidate, stats = None, False, False, None  # defined to please the linters
     if request.from_employer:
+        stats = get_allowance_stats_for_geiq(assessment, for_assessment_details=False)
         back_url = reverse("geiq_assessments_views:details_for_geiq", kwargs={"pk": assessment.pk})
         if not assessment.submitted_at:
             can_validate = not assessment.contracts_selection_validated_at
             can_invalidate = not can_validate
     elif request.from_institution:
+        stats = get_allowance_stats_for_institution(assessment, for_assessment_details=False)
         back_url = reverse("geiq_assessments_views:details_for_institution", kwargs={"pk": assessment.pk})
         if not assessment.reviewed_at:
             can_validate = not assessment.grants_selection_validated_at
             can_invalidate = not can_validate
+
     if request.method == "POST":
         try:
             action = ContractsAction(request.POST.get("action"))
         except ValueError:
             raise Http404
         if action == ContractsAction.VALIDATE:
-            if not can_validate:
+            if not can_validate or stats.get("contracts_awaiting_justification_nb", 0):
                 raise PermissionDenied
             if request.from_employer:
                 assessment.contracts_selection_validated_at = timezone.now()
@@ -574,11 +580,6 @@ def assessment_contracts_list(request, pk, template_name="geiq_assessments_views
             raise Http404
 
         return HttpResponseRedirect(next_url)
-
-    if request.from_employer:
-        stats = get_allowance_stats_for_geiq(assessment, for_assessment_details=False)
-    elif request.from_institution:
-        stats = get_allowance_stats_for_institution(assessment, for_assessment_details=False)
 
     contracts_qs = (
         EmployeeContract.objects.filter(employee__assessment=assessment, **contract_filter_kwargs)

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -97,12 +97,21 @@ def get_allowance_stats_for_geiq(assessment, *, for_assessment_details=False):
         if not for_assessment_details
         else {}
     )
-    return EmployeeContract.objects.filter(employee__assessment=assessment).aggregate(
-        allowance_of_814_selected_nb=Count("pk", filter=Q(allowance_requested=True, employee__allowance_amount=814)),
-        allowance_of_1400_selected_nb=Count("pk", filter=Q(allowance_requested=True, employee__allowance_amount=1400)),
-        potential_allowance_amount=Sum("employee__allowance_amount", filter=Q(allowance_requested=True)),
-        with_allowance_granted_previous_year_nb=Count("pk", filter=Q(employee__allowance_granted_previous_year=True)),
-        **extra_stats,
+    return (
+        EmployeeContract.objects.filter(employee__assessment=assessment).aggregate(
+            allowance_of_814_selected_nb=Count(
+                "pk", filter=Q(allowance_requested=True, employee__allowance_amount=814)
+            ),
+            allowance_of_1400_selected_nb=Count(
+                "pk", filter=Q(allowance_requested=True, employee__allowance_amount=1400)
+            ),
+            potential_allowance_amount=Sum("employee__allowance_amount", filter=Q(allowance_requested=True)),
+            with_allowance_granted_previous_year_nb=Count(
+                "pk", filter=Q(employee__allowance_granted_previous_year=True)
+            ),
+            **extra_stats,
+        )
+        | {"contracts_awaiting_justification_nb": None}  # FIXME(ewen/lgavalda): fill this variable with an aggregate)
     )
 
 
@@ -777,6 +786,8 @@ def assessment_contracts_details(
 def assessment_contracts_toggle(
     request, contract_pk, new_value, template_name="geiq_assessments_views/includes/contracts_switch.html"
 ):
+    back_url = None
+
     if request.from_employer:
         filter_kwargs = {"employee__assessment__companies": request.current_organization}
     elif request.from_institution:
@@ -807,14 +818,22 @@ def assessment_contracts_toggle(
         and contract.allowance_granted != new_value
     ):
         contract.allowance_granted = new_value
-        contract.save(update_fields=("allowance_granted",))
+        updated_fields = ["allowance_granted"]
+        if contract.allowance_granted and contract.allowance_refusal_reason:
+            contract.allowance_refusal_reason = ""
+            contract.allowance_refusal_details = ""
+            updated_fields += ["allowance_refusal_reason", "allowance_refusal_details"]
+        contract.save(update_fields=updated_fields)
     from_list = bool(request.GET.get("from_list"))
     stats = None
     if from_list:
         if request.from_employer:
             stats = get_allowance_stats_for_geiq(assessment, for_assessment_details=False)
+            back_url = reverse("geiq_assessments_views:details_for_geiq", kwargs={"pk": assessment.pk})
         elif request.from_institution:
             stats = get_allowance_stats_for_institution(assessment, for_assessment_details=False)
+            back_url = reverse("geiq_assessments_views:details_for_institution", kwargs={"pk": assessment.pk})
+
     context = {
         "assessment": assessment,
         "contract": contract,
@@ -822,6 +841,8 @@ def assessment_contracts_toggle(
         "editable": True,
         "value": new_value,
         "stats": stats,
+        "ContractsAction": ContractsAction,
+        "back_url": back_url,
     }
     return render(request, template_name, context)
 

--- a/itou/www/geiq_assessments_views/views.py
+++ b/itou/www/geiq_assessments_views/views.py
@@ -310,8 +310,8 @@ def assessment_details_for_geiq(request, pk, template_name="geiq_assessments_vie
             )
         else:
             assessment.submit(user=request.user)
-            # Preselect all contracts for institution validation
-            EmployeeContract.objects.filter(employee__assessment=assessment).update(
+            # Preselect contracts for institution validation, those that have not been already refused with a reason
+            EmployeeContract.objects.filter(employee__assessment=assessment, allowance_refusal_reason="").update(
                 allowance_granted=F("allowance_requested")
             )
             institution_members = {

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5491,7 +5491,7 @@
                           </table>
                       </div>
                   </div>
-                  <form class="js-prevent-multiple-submit" method="post">
+                  <form class="js-prevent-multiple-submit" id="validate-contracts-selection-form" method="post">
                       <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                       <div class="row">
                           <div class="col-12">
@@ -5634,7 +5634,7 @@
                           </p>
                       </div>
                   </div>
-                  <form class="js-prevent-multiple-submit" method="post">
+                  <form class="js-prevent-multiple-submit" id="validate-contracts-selection-form" method="post">
                       <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                       <div class="row">
                           <div class="col-12">
@@ -6124,6 +6124,8 @@
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
                               Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que le GEIQ souhaiterait vous soumettre.
                   </p>
+                  <div id="alert-contracts-awaiting-justification">
+                  </div>
               </div>
           </div>
           <div class="s-section__row row">
@@ -6376,6 +6378,8 @@
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
                               Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que le GEIQ souhaiterait vous soumettre.
                   </p>
+                  <div id="alert-contracts-awaiting-justification">
+                  </div>
               </div>
           </div>
           <div class="s-section__row row">
@@ -6566,7 +6570,7 @@
                           </table>
                       </div>
                   </div>
-                  <form class="js-prevent-multiple-submit" method="post">
+                  <form class="js-prevent-multiple-submit" id="validate-contracts-selection-form" method="post">
                       <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                       <div class="row">
                           <div class="col-12">
@@ -6654,6 +6658,31 @@
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
                               Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que le GEIQ souhaiterait vous soumettre.
                   </p>
+                  <div id="alert-contracts-awaiting-justification">
+                      <div class="alert alert-warning mt-3" role="status">
+                          <div class="row">
+                              <div class="col-auto pe-0">
+                                  <i aria-hidden="true" class="ri-error-warning-line ri-xl text-warning">
+                                  </i>
+                              </div>
+                              <div class="col">
+                                  <p class="mb-2">
+                                      <strong>
+                                          Refus à justifier
+                                      </strong>
+                                  </p>
+                                  <p class="mb-0">
+                                      Vous devez encore motiver le refus d’aide de 1 contrat.
+                                  </p>
+                              </div>
+                              <div class="col-12 col-md-auto mt-3 mt-md-0 d-flex align-items-center justify-content-center">
+                                  <a class="btn btn-sm btn-primary" href="/geiq-assessments/00000000-1111-2222-3333-444444444444/contracts?allowance_eligibility_off=on#contracts-results-table" type="button">
+                                      Afficher les contrats concernés
+                                  </a>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
               </div>
           </div>
           <div class="s-section__row row">
@@ -6844,7 +6873,7 @@
                           </table>
                       </div>
                   </div>
-                  <form class="js-prevent-multiple-submit" method="post">
+                  <form class="js-prevent-multiple-submit" id="validate-contracts-selection-form" method="post">
                       <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                       <div class="row">
                           <div class="col-12">
@@ -6860,7 +6889,7 @@
                                       </a>
                                   </div>
                                   <div class="form-group col col-lg-auto order-2 order-lg-3">
-                                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" name="action" type="submit" value="validate">
+                                      <button class="btn btn-block btn-primary disabled" type="button">
                                           <span>
                                               Valider la sélection
                                           </span>
@@ -6932,6 +6961,8 @@
                       L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
                               Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que le GEIQ souhaiterait vous soumettre.
                   </p>
+                  <div id="alert-contracts-awaiting-justification">
+                  </div>
               </div>
           </div>
           <div class="s-section__row row">
@@ -6980,7 +7011,7 @@
                           </p>
                       </div>
                   </div>
-                  <form class="js-prevent-multiple-submit" method="post">
+                  <form class="js-prevent-multiple-submit" id="validate-contracts-selection-form" method="post">
                       <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                       <div class="row">
                           <div class="col-12">

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -1,4 +1,274 @@
 # serializer version: 1
+# name: TestAssessmentContractsDetails.test_contract_details_access[SQL queries for tab=AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION as DDETS]
+  dict({
+    'num_queries': 8,
+    'queries': list([
+      dict({
+        'origin': list([
+          'SessionStore._get_session_from_db[<site-packages>/django/contrib/sessions/backends/db.py]',
+        ]),
+        'sql': '''
+          SELECT "django_session"."session_key",
+                 "django_session"."session_data",
+                 "django_session"."expire_date"
+          FROM "django_session"
+          WHERE ("django_session"."expire_date" > %s
+                 AND "django_session"."session_key" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "users_user"."id",
+                 "users_user"."password",
+                 "users_user"."last_login",
+                 "users_user"."is_superuser",
+                 "users_user"."username",
+                 "users_user"."first_name",
+                 "users_user"."last_name",
+                 "users_user"."is_staff",
+                 "users_user"."is_active",
+                 "users_user"."date_joined",
+                 "users_user"."fields_history",
+                 "users_user"."address_line_1",
+                 "users_user"."address_line_2",
+                 "users_user"."post_code",
+                 "users_user"."city",
+                 "users_user"."department",
+                 "users_user"."coords",
+                 "users_user"."geocoding_score",
+                 "users_user"."geocoding_updated_at",
+                 "users_user"."ban_api_resolved_address",
+                 "users_user"."insee_city_id",
+                 "users_user"."title",
+                 "users_user"."full_name_search_vector",
+                 "users_user"."email",
+                 "users_user"."phone",
+                 "users_user"."kind",
+                 "users_user"."identity_provider",
+                 "users_user"."has_completed_welcoming_tour",
+                 "users_user"."created_by_id",
+                 "users_user"."external_data_source_history",
+                 "users_user"."last_checked_at",
+                 "users_user"."terms_accepted_at",
+                 "users_user"."public_id",
+                 "users_user"."address_filled_at",
+                 "users_user"."first_login",
+                 "users_user"."upcoming_deletion_notified_at",
+                 "users_user"."allow_next_sso_sub_update"
+          FROM "users_user"
+          WHERE "users_user"."id" = %s
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_company_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "companies_companymembership"."id",
+                 "companies_companymembership"."user_id",
+                 "companies_companymembership"."joined_at",
+                 "companies_companymembership"."is_admin",
+                 "companies_companymembership"."is_active",
+                 "companies_companymembership"."created_at",
+                 "companies_companymembership"."updated_at",
+                 "companies_companymembership"."company_id",
+                 "companies_companymembership"."updated_by_id"
+          FROM "companies_companymembership"
+          WHERE ("companies_companymembership"."is_active"
+                 AND "companies_companymembership"."user_id" = %s)
+          ORDER BY RANDOM() ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_prescriber_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "prescribers_prescribermembership"."id",
+                 "prescribers_prescribermembership"."user_id",
+                 "prescribers_prescribermembership"."joined_at",
+                 "prescribers_prescribermembership"."is_admin",
+                 "prescribers_prescribermembership"."is_active",
+                 "prescribers_prescribermembership"."created_at",
+                 "prescribers_prescribermembership"."updated_at",
+                 "prescribers_prescribermembership"."organization_id",
+                 "prescribers_prescribermembership"."updated_by_id",
+                 "prescribers_prescriberorganization"."id",
+                 "prescribers_prescriberorganization"."address_line_1",
+                 "prescribers_prescriberorganization"."address_line_2",
+                 "prescribers_prescriberorganization"."post_code",
+                 "prescribers_prescriberorganization"."city",
+                 "prescribers_prescriberorganization"."department",
+                 "prescribers_prescriberorganization"."coords",
+                 "prescribers_prescriberorganization"."geocoding_score",
+                 "prescribers_prescriberorganization"."geocoding_updated_at",
+                 "prescribers_prescriberorganization"."ban_api_resolved_address",
+                 "prescribers_prescriberorganization"."insee_city_id",
+                 "prescribers_prescriberorganization"."name",
+                 "prescribers_prescriberorganization"."created_at",
+                 "prescribers_prescriberorganization"."updated_at",
+                 "prescribers_prescriberorganization"."uid",
+                 "prescribers_prescriberorganization"."active_members_email_reminder_last_sent_at",
+                 "prescribers_prescriberorganization"."automatic_geocoding_update",
+                 "prescribers_prescriberorganization"."siret",
+                 "prescribers_prescriberorganization"."kind",
+                 "prescribers_prescriberorganization"."is_brsa",
+                 "prescribers_prescriberorganization"."phone",
+                 "prescribers_prescriberorganization"."email",
+                 "prescribers_prescriberorganization"."website",
+                 "prescribers_prescriberorganization"."description",
+                 "prescribers_prescriberorganization"."code_safir_pole_emploi",
+                 "prescribers_prescriberorganization"."created_by_id",
+                 "prescribers_prescriberorganization"."authorization_status",
+                 "prescribers_prescriberorganization"."authorization_updated_at",
+                 "prescribers_prescriberorganization"."authorization_updated_by_id",
+                 "prescribers_prescriberorganization"."is_gps_authorized"
+          FROM "prescribers_prescribermembership"
+          INNER JOIN "prescribers_prescriberorganization" ON ("prescribers_prescribermembership"."organization_id" = "prescribers_prescriberorganization"."id")
+          WHERE ("prescribers_prescribermembership"."is_active"
+                 AND "prescribers_prescribermembership"."user_id" = %s)
+          ORDER BY "prescribers_prescribermembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'get_active_institution_memberships[utils/perms/middleware.py]',
+          'ItouCurrentOrganizationMiddleware.__call__[utils/perms/middleware.py]',
+        ]),
+        'sql': '''
+          SELECT "institutions_institutionmembership"."id",
+                 "institutions_institutionmembership"."user_id",
+                 "institutions_institutionmembership"."joined_at",
+                 "institutions_institutionmembership"."is_admin",
+                 "institutions_institutionmembership"."is_active",
+                 "institutions_institutionmembership"."created_at",
+                 "institutions_institutionmembership"."updated_at",
+                 "institutions_institutionmembership"."institution_id",
+                 "institutions_institutionmembership"."updated_by_id",
+                 "institutions_institution"."id",
+                 "institutions_institution"."address_line_1",
+                 "institutions_institution"."address_line_2",
+                 "institutions_institution"."post_code",
+                 "institutions_institution"."city",
+                 "institutions_institution"."department",
+                 "institutions_institution"."coords",
+                 "institutions_institution"."geocoding_score",
+                 "institutions_institution"."geocoding_updated_at",
+                 "institutions_institution"."ban_api_resolved_address",
+                 "institutions_institution"."insee_city_id",
+                 "institutions_institution"."name",
+                 "institutions_institution"."created_at",
+                 "institutions_institution"."updated_at",
+                 "institutions_institution"."uid",
+                 "institutions_institution"."active_members_email_reminder_last_sent_at",
+                 "institutions_institution"."automatic_geocoding_update",
+                 "institutions_institution"."kind"
+          FROM "institutions_institutionmembership"
+          INNER JOIN "institutions_institution" ON ("institutions_institutionmembership"."institution_id" = "institutions_institution"."id")
+          WHERE ("institutions_institutionmembership"."is_active"
+                 AND "institutions_institutionmembership"."user_id" = %s)
+          ORDER BY "institutions_institutionmembership"."joined_at" ASC
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__enter__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'SAVEPOINT "<snapshot>"',
+      }),
+      dict({
+        'origin': list([
+          'assessment_contracts_details[www/geiq_assessments_views/views.py]',
+          '_check_request_view_wrapper[utils/auth.py]',
+        ]),
+        'sql': '''
+          SELECT "geiq_assessments_employeecontract"."id",
+                 "geiq_assessments_employeecontract"."label_id",
+                 "geiq_assessments_employeecontract"."employee_id",
+                 "geiq_assessments_employeecontract"."start_at",
+                 "geiq_assessments_employeecontract"."planned_end_at",
+                 "geiq_assessments_employeecontract"."end_at",
+                 "geiq_assessments_employeecontract"."nb_days_in_campaign_year",
+                 "geiq_assessments_employeecontract"."allowance_requested",
+                 "geiq_assessments_employeecontract"."allowance_granted",
+                 "geiq_assessments_employeecontract"."allowance_refusal_reason",
+                 "geiq_assessments_employeecontract"."allowance_refusal_details",
+                 "geiq_assessments_employeecontract"."other_data",
+                 "geiq_assessments_employee"."id",
+                 "geiq_assessments_employee"."assessment_id",
+                 "geiq_assessments_employee"."allowance_granted_previous_year",
+                 "geiq_assessments_employee"."label_id",
+                 "geiq_assessments_employee"."last_name",
+                 "geiq_assessments_employee"."first_name",
+                 "geiq_assessments_employee"."birthdate",
+                 "geiq_assessments_employee"."title",
+                 "geiq_assessments_employee"."allowance_amount",
+                 "geiq_assessments_employee"."other_data",
+                 "geiq_assessments_assessment"."id",
+                 "geiq_assessments_assessment"."created_at",
+                 "geiq_assessments_assessment"."created_by_id",
+                 "geiq_assessments_assessment"."state",
+                 "geiq_assessments_assessment"."campaign_id",
+                 "geiq_assessments_assessment"."label_geiq_id",
+                 "geiq_assessments_assessment"."label_geiq_name",
+                 "geiq_assessments_assessment"."label_geiq_post_code",
+                 "geiq_assessments_assessment"."with_main_geiq",
+                 "geiq_assessments_assessment"."label_antennas",
+                 "geiq_assessments_assessment"."summary_document_file_id",
+                 "geiq_assessments_assessment"."structure_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."action_financial_assessment_file_id",
+                 "geiq_assessments_assessment"."label_rates",
+                 "geiq_assessments_assessment"."employee_nb",
+                 "geiq_assessments_assessment"."contracts_synced_at",
+                 "geiq_assessments_assessment"."contracts_selection_validated_at",
+                 "geiq_assessments_assessment"."geiq_comment",
+                 "geiq_assessments_assessment"."submitted_at",
+                 "geiq_assessments_assessment"."submitted_by_id",
+                 "geiq_assessments_assessment"."review_comment",
+                 "geiq_assessments_assessment"."convention_amount",
+                 "geiq_assessments_assessment"."granted_amount",
+                 "geiq_assessments_assessment"."advance_amount",
+                 "geiq_assessments_assessment"."decision_validated_at",
+                 "geiq_assessments_assessment"."grants_selection_validated_at",
+                 "geiq_assessments_assessment"."reviewed_at",
+                 "geiq_assessments_assessment"."reviewed_by_id",
+                 "geiq_assessments_assessment"."reviewed_by_institution_id",
+                 "geiq_assessments_assessment"."final_reviewed_at",
+                 "geiq_assessments_assessment"."final_reviewed_by_id",
+                 "geiq_assessments_assessment"."final_reviewed_by_institution_id",
+                 "geiq_assessments_assessmentcampaign"."id",
+                 "geiq_assessments_assessmentcampaign"."year",
+                 "geiq_assessments_assessmentcampaign"."opening_date",
+                 "geiq_assessments_assessmentcampaign"."submission_deadline",
+                 "geiq_assessments_assessmentcampaign"."review_deadline"
+          FROM "geiq_assessments_employeecontract"
+          INNER JOIN "geiq_assessments_employee" ON ("geiq_assessments_employeecontract"."employee_id" = "geiq_assessments_employee"."id")
+          INNER JOIN "geiq_assessments_assessment" ON ("geiq_assessments_employee"."assessment_id" = "geiq_assessments_assessment"."id")
+          INNER JOIN "geiq_assessments_assessmentinstitutionlink" ON ("geiq_assessments_assessment"."id" = "geiq_assessments_assessmentinstitutionlink"."assessment_id")
+          INNER JOIN "geiq_assessments_assessmentcampaign" ON ("geiq_assessments_assessment"."campaign_id" = "geiq_assessments_assessmentcampaign"."id")
+          WHERE ("geiq_assessments_employeecontract"."allowance_requested"
+                 AND "geiq_assessments_assessmentinstitutionlink"."institution_id" = %s
+                 AND "geiq_assessments_assessment"."submitted_at" IS NOT NULL
+                 AND "geiq_assessments_employeecontract"."id" = %s)
+          LIMIT 21
+        ''',
+      }),
+      dict({
+        'origin': list([
+          'Atomic.__exit__[<site-packages>/django/db/transaction.py]',
+        ]),
+        'sql': 'RELEASE SAVEPOINT "<snapshot>"',
+      }),
+    ]),
+  })
+# ---
 # name: TestAssessmentContractsDetails.test_contract_details_access[SQL queries for tab=AssessmentContractDetailsTab.CONTRACT as DDETS]
   dict({
     'num_queries': 8,

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5141,7 +5141,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input class="form-check-input" disabled="" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" disabled="" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_33333333-4444-4444-4444-444444444444">
                                                       Obtenir l’aide
                                                   </label>
@@ -5171,7 +5173,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                                       Obtenir l’aide
                                                   </label>
@@ -5201,7 +5205,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                                       Obtenir l’aide
                                                   </label>
@@ -5395,7 +5401,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input class="form-check-input" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_33333333-4444-4444-4444-444444444444">
                                                       Obtenir l’aide
                                                   </label>
@@ -5425,7 +5433,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input checked="" class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input checked="" class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                                       Obtenir l’aide
                                                   </label>
@@ -5455,7 +5465,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                                       Obtenir l’aide
                                                   </label>
@@ -5907,7 +5919,10 @@
                                                                          WHERE "geiq_assessments_employee"."allowance_amount" = %s) AS "allowance_of_0_nb",
                  COUNT("geiq_assessments_employeecontract"."id") FILTER (
                                                                          WHERE ("geiq_assessments_employeecontract"."allowance_granted"
-                                                                                AND "geiq_assessments_employee"."allowance_amount" = %s)) AS "allowance_of_0_selected_nb"
+                                                                                AND "geiq_assessments_employee"."allowance_amount" = %s)) AS "allowance_of_0_selected_nb",
+                 COUNT("geiq_assessments_employeecontract"."id") FILTER (
+                                                                         WHERE (NOT "geiq_assessments_employeecontract"."allowance_granted"
+                                                                                AND "geiq_assessments_employeecontract"."allowance_refusal_reason" = %s)) AS "contracts_awaiting_justification_nb"
           FROM "geiq_assessments_employeecontract"
           INNER JOIN "geiq_assessments_employee" ON ("geiq_assessments_employeecontract"."employee_id" = "geiq_assessments_employee"."id")
           WHERE ("geiq_assessments_employeecontract"."allowance_requested"
@@ -6030,7 +6045,7 @@
                  AND "geiq_assessments_employee"."assessment_id" = %s)
           ORDER BY "geiq_assessments_employee"."last_name" ASC,
                    "geiq_assessments_employee"."first_name" ASC
-          LIMIT 2
+          LIMIT 3
         ''',
       }),
       dict({
@@ -6052,7 +6067,7 @@
                       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
                           <div class="d-flex flex-column">
                               <strong>
-                                  1 / 2
+                                  1 / 3
                               </strong>
                               Contrats acceptés
                           </div>
@@ -6066,7 +6081,7 @@
                           <div class="d-flex flex-column">
                               <strong>
                                   0
-                  / 0
+                  / 1
                               </strong>
                               Aides à 1400€
                           </div>
@@ -6117,7 +6132,7 @@
                   <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
                       <div class="flex-md-grow-1">
                           <p class="mb-0" id="contract-list-count">
-                              2 résultats
+                              3 résultats
                           </p>
                       </div>
                       <div class="flex-column flex-md-row mt-3 mt-md-0">
@@ -6130,6 +6145,9 @@
                                   </option>
                                   <option value="">
                                       ---------
+                                  </option>
+                                  <option value="44444444-eeee-4444-8888-111111111111">
+                                      DUPONS Pean-Jierre
                                   </option>
                                   <option value="11111111-eeee-4444-8888-111111111111">
                                       DUPONT Jean
@@ -6172,6 +6190,42 @@
                               <tbody>
                                   <tr>
                                       <td>
+                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee">
+                                              DUPONS Pean-Jierre
+                                          </a>
+                                      </td>
+                                      <td>
+                                          01/06/2024
+                                      </td>
+                                      <td>
+                                          30/09/2024
+                                      </td>
+                                      <td>
+                                          Oui
+                                      </td>
+                                      <td>
+                                          1 400 €
+                                      </td>
+                                      <td>
+                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                              <div class="form-check form-switch">
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" disabled="" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                          </i>
+                                                      </a>
+                                                  </div>
+                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                                      Accorder l’aide
+                                                  </label>
+                                              </div>
+                                          </form>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
                                           <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
                                               DUPONT Jean
                                           </a>
@@ -6192,7 +6246,13 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                          </i>
+                                                      </a>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                                       Accorder l’aide
                                                   </label>
@@ -6222,7 +6282,9 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                                       Accorder l’aide
                                                   </label>
@@ -6241,7 +6303,7 @@
   
   '''
 # ---
-# name: TestAssessmentContractsListAndToggle.test_access_as_institution[assessments contracts list]
+# name: TestAssessmentContractsListAndToggle.test_access_as_institution[assessments contracts list with justified refusal]
   '''
   <section class="s-section">
       <div class="s-section__container container">
@@ -6251,7 +6313,7 @@
                       <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
                           <div class="d-flex flex-column">
                               <strong>
-                                  1 / 2
+                                  1 / 3
                               </strong>
                               Contrats acceptés
                           </div>
@@ -6265,7 +6327,7 @@
                           <div class="d-flex flex-column">
                               <strong>
                                   0
-                  / 0
+                  / 1
                               </strong>
                               Aides à 1400€
                           </div>
@@ -6316,7 +6378,7 @@
                   <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
                       <div class="flex-md-grow-1">
                           <p class="mb-0" id="contract-list-count">
-                              2 résultats
+                              3 résultats
                           </p>
                       </div>
                       <div class="flex-column flex-md-row mt-3 mt-md-0">
@@ -6329,6 +6391,9 @@
                                   </option>
                                   <option value="">
                                       ---------
+                                  </option>
+                                  <option value="44444444-eeee-4444-8888-111111111111">
+                                      DUPONS Pean-Jierre
                                   </option>
                                   <option value="11111111-eeee-4444-8888-111111111111">
                                       DUPONT Jean
@@ -6371,6 +6436,42 @@
                               <tbody>
                                   <tr>
                                       <td>
+                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee">
+                                              DUPONS Pean-Jierre
+                                          </a>
+                                      </td>
+                                      <td>
+                                          01/06/2024
+                                      </td>
+                                      <td>
+                                          30/09/2024
+                                      </td>
+                                      <td>
+                                          Oui
+                                      </td>
+                                      <td>
+                                          1 400 €
+                                      </td>
+                                      <td>
+                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                              <div class="form-check form-switch">
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                          </i>
+                                                      </a>
+                                                  </div>
+                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                                      Accorder l’aide
+                                                  </label>
+                                              </div>
+                                          </form>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
                                           <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
                                               DUPONT Jean
                                           </a>
@@ -6391,7 +6492,13 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                          </i>
+                                                      </a>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
                                                       Accorder l’aide
                                                   </label>
@@ -6421,7 +6528,281 @@
                                           <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                               <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
                                               <div class="form-check form-switch">
-                                                  <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
+                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                                      Accorder l’aide
+                                                  </label>
+                                              </div>
+                                          </form>
+                                      </td>
+                                  </tr>
+                              </tbody>
+                          </table>
+                      </div>
+                  </div>
+                  <form class="js-prevent-multiple-submit" method="post">
+                      <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                      <div class="row">
+                          <div class="col-12">
+                              <hr class="mb-3"/>
+                              <div class="form-row align-items-center justify-content-end gx-3">
+                                  <div class="form-group col-12 col-lg order-3 order-lg-1">
+                                      <a aria-label="Annuler la saisie de ce formulaire" class="btn btn-link btn-ico ps-lg-0 w-100 w-lg-auto" href="/geiq-assessments/institution/00000000-1111-2222-3333-444444444444">
+                                          <i aria-hidden="true" class="ri-close-line ri-lg">
+                                          </i>
+                                          <span>
+                                              Annuler
+                                          </span>
+                                      </a>
+                                  </div>
+                                  <div class="form-group col col-lg-auto order-2 order-lg-3">
+                                      <button aria-label="Passer à l’étape suivante" class="btn btn-block btn-primary" name="action" type="submit" value="validate">
+                                          <span>
+                                              Valider la sélection
+                                          </span>
+                                      </button>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </form>
+              </div>
+          </div>
+      </div>
+  </section>
+  
+  '''
+# ---
+# name: TestAssessmentContractsListAndToggle.test_access_as_institution[assessments contracts list with refusal to justify]
+  '''
+  <section class="s-section">
+      <div class="s-section__container container">
+          <div class="s-section__row row">
+              <div class="col-12 mb-3 mb-md-4">
+                  <div class="c-box mb-3" id="contracts-list-stats">
+                      <div class="d-flex flex-column flex-md-row gap-3 mb-3 justify-content-md-between">
+                          <div class="d-flex flex-column">
+                              <strong>
+                                  1 / 3
+                              </strong>
+                              Contrats acceptés
+                          </div>
+                          <div class="d-flex flex-column">
+                              <strong>
+                                  1
+                  / 1
+                              </strong>
+                              Aides à 814€
+                          </div>
+                          <div class="d-flex flex-column">
+                              <strong>
+                                  0
+                  / 1
+                              </strong>
+                              Aides à 1400€
+                          </div>
+                          <div class="d-flex flex-column">
+                              <strong>
+                                  0
+                  / 1
+                              </strong>
+                              Aides à 0€
+                          </div>
+                          <div class="d-flex flex-column">
+                              <strong>
+                                  814 €
+                              </strong>
+                              Montant total potentiel
+                          </div>
+                      </div>
+                      <div class="c-info c-info--borderless">
+                          <span class="c-info__summary">
+                              Sous réserve de la contractualisation initialement prévue et de l’enveloppe disponible
+                          </span>
+                      </div>
+                  </div>
+                  <h2>
+                      Sélectionnez les contrats pour lesquels vous souhaitez accorder l’aide
+                  </h2>
+                  <p class="mb-0">
+                      L’aide potentielle est calculée à partir de critères administratifs sélectionnés par le GEIQ.
+                              Elle ne prend pas en compte la durée d’accompagnement réellement effectuée, afin de ne pas exclure automatiquement certaines situations particulières que le GEIQ souhaiterait vous soumettre.
+                  </p>
+              </div>
+          </div>
+          <div class="s-section__row row">
+              <div class="col-12">
+                  <div class="btn-dropdown-filter-group mb-3 mb-md-4">
+                      <button aria-controls="offcanvasApplyFiltersContent" class="btn btn-ico btn-dropdown-filter" data-bs-target="#offcanvasApplyFiltersContent" data-bs-toggle="offcanvas" type="button">
+                          <i aria-hidden="true" class="ri-sound-module-fill fw-medium">
+                          </i>
+                          <span>
+                              Tous les filtres
+                              <span id="all-filters-btn">
+                              </span>
+                          </span>
+                      </button>
+                      <div class="ms-md-auto" id="reset-button-container">
+                      </div>
+                  </div>
+                  <div class="d-flex flex-column flex-md-row align-items-md-center mb-3 mb-md-4">
+                      <div class="flex-md-grow-1">
+                          <p class="mb-0" id="contract-list-count">
+                              3 résultats
+                          </p>
+                      </div>
+                      <div class="flex-column flex-md-row mt-3 mt-md-0">
+                          <div class="w-lg-400px">
+                              <label class="visually-hidden" for="id_employee">
+                                  Nom du salarié
+                              </label>
+                              <select class="form-select is-valid django-select2" data-allow-clear="true" data-minimum-input-length="0" data-placeholder="Nom du salarié" data-theme="bootstrap-5" id="id_employee" lang="fr" name="employee">
+                                  <option selected="" value="">
+                                  </option>
+                                  <option value="">
+                                      ---------
+                                  </option>
+                                  <option value="44444444-eeee-4444-8888-111111111111">
+                                      DUPONS Pean-Jierre
+                                  </option>
+                                  <option value="11111111-eeee-4444-8888-111111111111">
+                                      DUPONT Jean
+                                  </option>
+                                  <option value="22222222-eeee-4444-8888-222222222222">
+                                      MARTIN Cécile
+                                  </option>
+                              </select>
+                          </div>
+                      </div>
+                  </div>
+                  <div id="contracts-results-table">
+                      <div class="table-responsive mt-3 mt-md-4">
+                          <table class="table table-hover">
+                              <caption class="visually-hidden">
+                                  Liste des bilans d’exécution
+                              </caption>
+                              <thead>
+                                  <tr>
+                                      <th scope="col">
+                                          NOM Prénom
+                                      </th>
+                                      <th scope="col">
+                                          Date de début
+                                      </th>
+                                      <th scope="col">
+                                          Date de fin
+                                      </th>
+                                      <th scope="col">
+                                          ≥ 90 jours en 2024
+                                      </th>
+                                      <th scope="col">
+                                          Aide potentielle
+                                      </th>
+                                      <th scope="col">
+                                          Éligible à l’aide
+                                      </th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/employee">
+                                              DUPONS Pean-Jierre
+                                          </a>
+                                      </td>
+                                      <td>
+                                          01/06/2024
+                                      </td>
+                                      <td>
+                                          30/09/2024
+                                      </td>
+                                      <td>
+                                          Oui
+                                      </td>
+                                      <td>
+                                          1 400 €
+                                      </td>
+                                      <td>
+                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                              <div class="form-check form-switch">
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <a class="text-warning text-decoration-none lh-1" data-bs-title="Vous devez encore motiver le refus pour ce contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-error-warning-line ri-xl" role="button" tabindex="0">
+                                                          </i>
+                                                      </a>
+                                                  </div>
+                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                                      Accorder l’aide
+                                                  </label>
+                                              </div>
+                                          </form>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/employee">
+                                              DUPONT Jean
+                                          </a>
+                                      </td>
+                                      <td>
+                                          01/01/2024
+                                      </td>
+                                      <td>
+                                          30/04/2024
+                                      </td>
+                                      <td>
+                                          Oui
+                                      </td>
+                                      <td>
+                                          0 €
+                                      </td>
+                                      <td>
+                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                              <div class="form-check form-switch">
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                          </i>
+                                                      </a>
+                                                  </div>
+                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                                      Accorder l’aide
+                                                  </label>
+                                              </div>
+                                          </form>
+                                      </td>
+                                  </tr>
+                                  <tr>
+                                      <td>
+                                          <a class="btn-link" href="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/employee">
+                                              MARTIN Cécile
+                                          </a>
+                                      </td>
+                                      <td>
+                                          01/02/2024
+                                      </td>
+                                      <td>
+                                          30/03/2024
+                                      </td>
+                                      <td>
+                                          Non
+                                      </td>
+                                      <td>
+                                          814 €
+                                      </td>
+                                      <td>
+                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                              <div class="form-check form-switch">
+                                                  <div class="d-flex align-items-center gap-2">
+                                                      <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                  </div>
                                                   <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
                                                       Accorder l’aide
                                                   </label>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -5138,17 +5138,19 @@
                                           1 400 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_33333333-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Obtenir l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                                      Obtenir l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -5170,17 +5172,19 @@
                                           0 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Obtenir l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                                      Obtenir l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -5202,17 +5206,19 @@
                                           814 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Obtenir l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                                      Obtenir l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                               </tbody>
@@ -5398,17 +5404,19 @@
                                           1 400 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/33333333-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_33333333-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_33333333-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_33333333-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Obtenir l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_33333333-4444-4444-4444-444444444444">
-                                                      Obtenir l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -5430,17 +5438,19 @@
                                           0 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Obtenir l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                                      Obtenir l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -5462,17 +5472,19 @@
                                           814 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Obtenir l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                                      Obtenir l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                               </tbody>
@@ -6207,21 +6219,23 @@
                                           1 400 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
-                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
-                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
-                                                          </i>
-                                                      </a>
+                                                      <label class="form-check-label" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                              <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                                  <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                  </i>
+                                              </a>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -6243,21 +6257,23 @@
                                           0 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" disabled="" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
-                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
-                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
-                                                          </i>
-                                                      </a>
+                                                      <label class="form-check-label" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                              <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                                  <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                  </i>
+                                              </a>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -6279,17 +6295,19 @@
                                           814 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" disabled="" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                               </tbody>
@@ -6453,21 +6471,23 @@
                                           1 400 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
-                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
-                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
-                                                          </i>
-                                                      </a>
+                                                      <label class="form-check-label" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                              <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                                  <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                  </i>
+                                              </a>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -6489,21 +6509,23 @@
                                           0 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
-                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
-                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
-                                                          </i>
-                                                      </a>
+                                                      <label class="form-check-label" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                              <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                                  <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                  </i>
+                                              </a>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -6525,17 +6547,19 @@
                                           814 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                               </tbody>
@@ -6725,21 +6749,23 @@
                                           1 400 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_44444444-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_44444444-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
-                                                      <a class="text-warning text-decoration-none lh-1" data-bs-title="Vous devez encore motiver le refus pour ce contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
-                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-error-warning-line ri-xl" role="button" tabindex="0">
-                                                          </i>
-                                                      </a>
+                                                      <label class="form-check-label" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_44444444-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                              <a class="text-warning text-decoration-none lh-1" data-bs-title="Vous devez encore motiver le refus pour ce contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/44444444-4444-4444-4444-444444444444/refusal-justification">
+                                                  <i aria-label="Se rendre au formulaire de justification de refus" class="ri-error-warning-line ri-xl" role="button" tabindex="0">
+                                                  </i>
+                                              </a>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -6761,21 +6787,23 @@
                                           0 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/include?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_11111111-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input class="form-check-input" id="allowance_for_contract_11111111-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
-                                                      <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
-                                                          <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
-                                                          </i>
-                                                      </a>
+                                                      <label class="form-check-label" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_11111111-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                              <a class="text-success text-decoration-none lh-1" data-bs-title="Voir le motif de refus pour contrat." data-bs-toggle="tooltip" href="/geiq-assessments/contracts/11111111-4444-4444-4444-444444444444/refusal-justification">
+                                                  <i aria-label="Se rendre au formulaire de justification de refus" class="ri-check-line ri-xl" role="button" tabindex="0">
+                                                  </i>
+                                              </a>
+                                          </div>
                                       </td>
                                   </tr>
                                   <tr>
@@ -6797,17 +6825,19 @@
                                           814 €
                                       </td>
                                       <td>
-                                          <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="this" hx-trigger="change" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                              <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
-                                              <div class="form-check form-switch">
-                                                  <div class="d-flex align-items-center gap-2">
+                                          <div class="d-flex align-items-start" id="toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                              <form class="js-prevent-multiple-submit" hx-post="/geiq-assessments/contracts/22222222-4444-4444-4444-444444444444/exclude?from_list=1" hx-swap="outerHTML" hx-target="#toggle_allowance_for_contract_22222222-4444-4444-4444-444444444444" hx-trigger="change">
+                                                  <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+                                                  <div class="form-check form-switch mb-0">
                                                       <input checked="" class="form-check-input" id="allowance_for_contract_22222222-4444-4444-4444-444444444444" name="allowance" type="checkbox"/>
+                                                      <label class="form-check-label" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
+                                                          <span class="visually-hidden">
+                                                              Accorder l’aide
+                                                          </span>
+                                                      </label>
                                                   </div>
-                                                  <label class="form-check-label visually-hidden" for="allowance_for_contract_22222222-4444-4444-4444-444444444444">
-                                                      Accorder l’aide
-                                                  </label>
-                                              </div>
-                                          </form>
+                                              </form>
+                                          </div>
                                       </td>
                                   </tr>
                               </tbody>

--- a/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
+++ b/tests/www/geiq_assessments_views/__snapshots__/test_views_for_both.ambr
@@ -3477,6 +3477,169 @@
     ]),
   })
 # ---
+# name: TestAssessmentContractsDetails.test_contract_grant_or_refuse_allowance_as_institution[contract detail side box with granted allowance]
+  '''
+  <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
+      <h3>
+          L’aide financière est accordée
+      </h3>
+      <p>
+          La demande d’aide est approuvée.
+      </p>
+      <p>
+          Vous pouvez refuser la demande pour ce contrat tant que le bilan n’a pas été validé.
+      </p>
+      <form method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button class="btn btn-primary btn-block btn-lg btn-ico" name="action" type="submit" value="refuse_allowance">
+              <i aria-hidden="true" class="ri-close-line">
+              </i>
+              <span>
+                  Refuser l’aide
+              </span>
+          </button>
+      </form>
+  </div>
+  
+  '''
+# ---
+# name: TestAssessmentContractsDetails.test_contract_grant_or_refuse_allowance_as_institution[contract detail side box with refused allowance, filled reason, common tab]
+  '''
+  <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
+      <h3>
+          L’aide financière n’est pas accordée
+      </h3>
+      <p>
+          La demande d’obtention de l’aide est refusée.
+      </p>
+      <p>
+          Vous avez déjà motivé votre refus.
+      </p>
+      <p>
+          Vous avez la possibilité de modifier votre décision
+              ou le motif de refus
+              tant que le bilan n'a pas été validé.
+      </p>
+      <p>
+          Si vous décidez d’accorder l'aide, le motif et le commentaire de refus seront supprimés.
+      </p>
+      <a class="btn btn-outline-primary btn-block btn-lg mb-2" href="/geiq-assessments/contracts/[Pk of EmployeeContract]/refusal-justification">
+          <span>
+              Modifier le motif de refus
+          </span>
+      </a>
+      <form method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button class="btn btn-primary btn-block btn-lg" name="action" type="submit" value="grant_allowance">
+              <span>
+                  Accorder l’aide
+              </span>
+          </button>
+      </form>
+  </div>
+  
+  '''
+# ---
+# name: TestAssessmentContractsDetails.test_contract_grant_or_refuse_allowance_as_institution[contract detail side box with refused allowance, missing reason, common tab]
+  '''
+  <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
+      <h3>
+          L’aide financière n’est pas accordée
+      </h3>
+      <p>
+          La demande d’obtention de l’aide est refusée.
+      </p>
+      <p>
+          Vous devez obligatoirement justifier votre refus.
+      </p>
+      <p>
+          Vous avez la possibilité de modifier votre décision
+              
+              tant que le bilan n'a pas été validé.
+      </p>
+      <a class="btn btn-outline-primary btn-block btn-lg mb-2" href="/geiq-assessments/contracts/[Pk of EmployeeContract]/refusal-justification">
+          <span>
+              Justifier le refus
+          </span>
+      </a>
+      <form method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button class="btn btn-primary btn-block btn-lg" name="action" type="submit" value="grant_allowance">
+              <span>
+                  Accorder l’aide
+              </span>
+          </button>
+      </form>
+  </div>
+  
+  '''
+# ---
+# name: TestAssessmentContractsDetails.test_contract_grant_or_refuse_allowance_as_institution[contract detail side box with refused allowance, missing reason, justification tab]
+  '''
+  <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
+      <h3>
+          L’aide financière n’est pas accordée
+      </h3>
+      <p>
+          La demande d’obtention de l’aide est refusée.
+      </p>
+      <p>
+          Vous devez obligatoirement justifier votre refus.
+      </p>
+      <p>
+          Vous avez la possibilité de modifier votre décision
+              
+              tant que le bilan n'a pas été validé.
+      </p>
+      <form method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button class="btn btn-primary btn-block btn-lg" name="action" type="submit" value="grant_allowance">
+              <span>
+                  Accorder l’aide
+              </span>
+          </button>
+      </form>
+  </div>
+  
+  '''
+# ---
+# name: TestAssessmentContractsDetails.test_contract_grant_or_refuse_allowance_as_institution_after_selection_validation[contract detail side box with refused allowance and validated selection]
+  '''
+  <div class="c-box mb-3 mb-md-4 bg-info-lightest border-accent-02">
+      <h3>
+          L’aide financière n’est pas accordée
+      </h3>
+      <p>
+          La demande d’obtention de l’aide est refusée.
+      </p>
+      <p>
+          Vous avez déjà motivé votre refus.
+      </p>
+      <p>
+          Vous avez la possibilité de modifier votre décision
+              ou le motif de refus
+              tant que le bilan n'a pas été validé.
+      </p>
+      <p>
+          Si vous décidez d’accorder l'aide, le motif et le commentaire de refus seront supprimés.
+      </p>
+      <a class="btn btn-outline-primary btn-block btn-lg mb-2 disabled" href="/geiq-assessments/contracts/[Pk of EmployeeContract]/refusal-justification">
+          <span>
+              Modifier le motif de refus
+          </span>
+      </a>
+      <form method="post">
+          <input name="csrfmiddlewaretoken" type="hidden" value="NORMALIZED_CSRF_TOKEN"/>
+          <button class="btn btn-primary btn-block btn-lg" disabled="" name="action" type="submit" value="grant_allowance">
+              <span>
+                  Accorder l’aide
+              </span>
+          </button>
+      </form>
+  </div>
+  
+  '''
+# ---
 # name: TestAssessmentContractsExportView.test_export[SQL queries]
   dict({
     'num_queries': 17,

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -11,7 +11,7 @@ from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
 from itou.companies.enums import CompanyKind
-from itou.geiq_assessments.enums import AllowanceRefusalReason
+from itou.geiq_assessments.enums import AllowanceRefusalReason, InstitutionAction
 from itou.geiq_assessments.models import AssessmentInstitutionLink
 from itou.institutions.enums import InstitutionKind
 from itou.users.enums import Title
@@ -783,9 +783,223 @@ class TestAssessmentContractsDetails:
             fresh_page = parse_response_to_soup(response, selector="#main")
             assertSoupEqual(simulated_page, fresh_page)
 
-    def test_contract_grant_or_refuse_allowance_as_institution(self):
-        # FIXME: fill the test
-        pass
+    def test_contract_grant_or_refuse_allowance_as_institution(self, client, snapshot):
+        ddets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_GEIQ)
+        geiq_membership = CompanyMembershipFactory(
+            company__kind=CompanyKind.GEIQ,
+        )
+        assessment = AssessmentFactory(
+            companies=[geiq_membership.company],
+            campaign__year=2024,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(seconds=1),
+            submitted_by=geiq_membership.user,
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment,
+            institution=ddets_membership.institution,
+            with_convention=True,
+        )
+        contract = EmployeeContractFactory(
+            employee__assessment=assessment, allowance_requested=True, allowance_granted=True
+        )
+        details_url = reverse(
+            "geiq_assessments_views:assessment_contracts_details",
+            kwargs={
+                "contract_pk": str(contract.pk),
+                # all common tabs should behave the same
+                "tab": random.choice(AssessmentContractDetailsTab.get_common_tabs()).value,
+            },
+        )
+        details_justification_url = reverse(
+            "geiq_assessments_views:assessment_contracts_details",
+            kwargs={
+                "contract_pk": str(contract.pk),
+                "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
+            },
+        )
+        JUSTIFICATION_TAB_LI = f"""
+        <li class="nav-item">
+            <a class="nav-link" href="{details_justification_url}">
+                Motif de refus
+            </a>
+        </li>"""
+        JUSTIFICATION_TAB_WITH_ICON_LI = f"""
+        <li class="nav-item">
+            <a class="nav-link" href="{details_justification_url}">
+                Motif de refus <i class="ri-error-warning-line ri-xl text-warning ms-2"></i>
+            </a>
+        </li>"""
+
+        client.force_login(ddets_membership.user)
+        response = client.get(details_url)
+        assertNotContains(response, JUSTIFICATION_TAB_LI, html=True)
+        assertNotContains(response, JUSTIFICATION_TAB_WITH_ICON_LI, html=True)
+        assert pretty_indented(
+            parse_response_to_soup(response, selector="div.s-section__row > div.s-section__col.order-1 > div.c-box")
+        ) == snapshot(name="contract detail side box with granted allowance")
+
+        # User refuses the allowance and gets redirected to the justification form tab
+        response = client.post(details_url, data={"action": InstitutionAction.REFUSE_ALLOWANCE})
+        assertRedirects(response, details_justification_url)
+        contract.refresh_from_db()
+        assert contract.allowance_granted is False
+
+        response = client.get(details_url)
+        assertNotContains(response, JUSTIFICATION_TAB_LI, html=True)
+        assertContains(response, JUSTIFICATION_TAB_WITH_ICON_LI, html=True)
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
+                replace_in_attr=[("href", str(contract.pk), "[Pk of EmployeeContract]")],
+            )
+        ) == snapshot(name="contract detail side box with refused allowance, missing reason, common tab")
+
+        response = client.get(details_justification_url)
+        assert pretty_indented(
+            parse_response_to_soup(response, selector="div.s-section__row > div.s-section__col.order-1 > div.c-box")
+        ) == snapshot(name="contract detail side box with refused allowance, missing reason, justification tab")
+
+        # User fills the form with invalid values
+        response = client.post(details_justification_url, data={"allowance_refusal_reason": ""})
+        assert response.status_code == 404  # no action given leads to 404
+        response = client.post(
+            details_justification_url,
+            data={
+                "action": InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION,
+                "allowance_refusal_reason": "inexistant",
+            },
+        )
+        assertContains(
+            response, "<li>Sélectionnez un choix valide. inexistant n’en fait pas partie.</li>", html=True, count=1
+        )
+        assertContains(response, "<li>Ce champ est obligatoire.</li>", html=True, count=1)
+        response = client.post(
+            details_justification_url,
+            data={"action": InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION, "allowance_refusal_details": " "},
+        )
+        assertContains(
+            response, "<li>Ce champ est obligatoire.</li>", html=True, count=2
+        )  # both reason and details are empty
+
+        # User fills the form with valid values
+        response = client.post(
+            details_justification_url,
+            data={
+                "action": InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION,
+                "allowance_refusal_reason": random.choice(AllowanceRefusalReason.choices)[0],
+                "allowance_refusal_details": "C’est un refus.",
+            },
+        )
+        assert response.status_code == 200
+        contract.refresh_from_db()
+        assert contract.allowance_granted is False
+        assert contract.allowance_refusal_reason is not None
+        assert contract.allowance_refusal_details == "C’est un refus."
+
+        # Check content of the common tabs
+        response = client.get(details_url)
+        assertContains(response, JUSTIFICATION_TAB_LI, html=True)
+        assertNotContains(response, JUSTIFICATION_TAB_WITH_ICON_LI, html=True)
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
+                replace_in_attr=[("href", str(contract.pk), "[Pk of EmployeeContract]")],
+            )
+        ) == snapshot(name="contract detail side box with refused allowance, filled reason, common tab")
+
+        # User grants the allowance and gets redirected to employee tab
+        response = client.post(details_justification_url, data={"action": InstitutionAction.GRANT_ALLOWANCE})
+        assertRedirects(
+            response,
+            reverse(
+                "geiq_assessments_views:assessment_contracts_details",
+                kwargs={"contract_pk": contract.pk, "tab": AssessmentContractDetailsTab.EMPLOYEE},
+            ),
+        )
+        contract.refresh_from_db()
+        assert contract.allowance_granted is True
+        assert contract.allowance_refusal_reason == ""
+        assert contract.allowance_refusal_details == ""
+
+    def test_contract_grant_or_refuse_allowance_as_institution_after_selection_validation(self, client, snapshot):
+        ddets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_GEIQ)
+        geiq_membership = CompanyMembershipFactory(
+            company__kind=CompanyKind.GEIQ,
+        )
+        assessment = AssessmentFactory(
+            companies=[geiq_membership.company],
+            campaign__year=2024,
+            with_submission_requirements=True,
+            submitted_at=timezone.now() + datetime.timedelta(seconds=1),
+            submitted_by=geiq_membership.user,
+            grants_selection_validated_at=timezone.now() + datetime.timedelta(seconds=2),
+        )
+        AssessmentInstitutionLink.objects.create(
+            assessment=assessment,
+            institution=ddets_membership.institution,
+            with_convention=True,
+        )
+        contract = EmployeeContractFactory(
+            employee__assessment=assessment,
+            allowance_requested=True,
+            allowance_granted=False,
+            allowance_refusal_reason=AllowanceRefusalReason.UNCONFIRMED_ELIGIBILITY,
+            allowance_refusal_details="Incorrect.",
+        )
+        details_url = reverse(
+            "geiq_assessments_views:assessment_contracts_details",
+            kwargs={
+                "contract_pk": str(contract.pk),
+                # all common tabs should behave the same
+                "tab": random.choice(AssessmentContractDetailsTab.get_common_tabs()).value,
+            },
+        )
+        details_justification_url = reverse(
+            "geiq_assessments_views:assessment_contracts_details",
+            kwargs={
+                "contract_pk": str(contract.pk),
+                "tab": AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION.value,
+            },
+        )
+
+        client.force_login(ddets_membership.user)
+        response = client.get(details_url)
+        assert pretty_indented(
+            parse_response_to_soup(
+                response,
+                selector="div.s-section__row > div.s-section__col.order-1 > div.c-box",
+                replace_in_attr=[("href", str(contract.pk), "[Pk of EmployeeContract]")],
+            )
+        ) == snapshot(name="contract detail side box with refused allowance and validated selection")
+
+        # User tries to grant the allowance
+        response = client.post(details_url, data={"action": InstitutionAction.GRANT_ALLOWANCE})
+        assertContains(
+            response,
+            "La sélection des contrats a déjà été validée : vous ne pouvez plus accorder ou "
+            "refuser l’aide pour ce contrat.",
+        )
+        contract.refresh_from_db()
+        assert contract.allowance_granted is False
+
+        # User tries to update a refusal reason
+        response = client.post(
+            details_justification_url,
+            data={
+                "action": InstitutionAction.ALLOWANCE_REFUSAL_JUSTIFICATION,
+                "allowance_refusal_reason": random.choice(AllowanceRefusalReason.choices)[0],
+                "allowance_refusal_details": "C’est un refus.",
+            },
+        )
+        assertContains(
+            response, "La sélection des contrats a déjà été validée : vous ne pouvez plus modifier le motif de refus."
+        )
+        contract.refresh_from_db()
+        assert contract.allowance_refusal_reason == AllowanceRefusalReason.UNCONFIRMED_ELIGIBILITY
+        assert contract.allowance_refusal_details == "Incorrect."
 
 
 class TestEmployeeContractToggleView:

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -500,6 +500,8 @@ class TestAssessmentContractsListAndToggle:
             planned_end_at=datetime.date(2024, 6, 30),
             allowance_requested=True,
             allowance_granted=False,
+            allowance_refusal_reason=AllowanceRefusalReason.UNCONFIRMED_ELIGIBILITY,
+            allowance_refusal_details="Détails",
         )
         EmployeeContractFactory(
             id=uuid.UUID("33333333-4444-4444-4444-444444444444"),
@@ -543,6 +545,8 @@ class TestAssessmentContractsListAndToggle:
         assert response.status_code == 200
         contract_2.refresh_from_db()
         assert contract_2.allowance_granted is True
+        response = client.get(url)
+        assertSoupEqual(simulated_page, parse_response_to_soup(response, ".s-section"))
 
     def test_contract_selection_after_ask_for_geiq_fix(self, client):
         """Simulate back and forth exchanges between institution and GEIQ."""

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -765,47 +765,9 @@ class TestAssessmentContractsDetails:
             fresh_page = parse_response_to_soup(response, selector="#main")
             assertSoupEqual(simulated_page, fresh_page)
 
-    def test_contract_toggle_as_institution(self, client):
-        ddets_membership = InstitutionMembershipFactory(institution__kind=InstitutionKind.DDETS_GEIQ)
-        geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
-        assessment = AssessmentFactory(
-            id=uuid.UUID("00000000-1111-2222-3333-444444444444"),
-            campaign__year=2024,
-            companies=[geiq_membership.company],
-            with_submission_requirements=True,
-            submitted_at=timezone.now() + datetime.timedelta(seconds=1),
-            submitted_by=geiq_membership.user,
-        )
-        AssessmentInstitutionLink.objects.create(
-            assessment=assessment,
-            institution=ddets_membership.institution,
-            with_convention=True,
-        )
-        contract = EmployeeContractFactory(
-            employee__assessment=assessment,
-            allowance_requested=True,
-            allowance_granted=random.choice([True, False]),
-        )
-        client.force_login(ddets_membership.user)
-        for tab in AssessmentContractDetailsTab:
-            current_value = contract.allowance_granted
-            tab_url = reverse(
-                "geiq_assessments_views:assessment_contracts_details",
-                kwargs={"contract_pk": str(contract.pk), "tab": tab.value},
-            )
-            response = client.get(tab_url)
-            simulated_page = parse_response_to_soup(response, selector="#main")
-            view_name = "assessment_contracts_include" if not current_value else "assessment_contracts_exclude"
-            response = client.post(
-                reverse(f"geiq_assessments_views:{view_name}", kwargs={"contract_pk": str(contract.pk)}),
-                headers={"HX-Request": "true"},
-            )
-            contract.refresh_from_db()
-            assert contract.allowance_granted != current_value
-            update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract.pk}", response)
-            response = client.get(tab_url)
-            fresh_page = parse_response_to_soup(response, selector="#main")
-            assertSoupEqual(simulated_page, fresh_page)
+    def test_contract_grant_or_refuse_allowance_as_institution(self):
+        # FIXME: fill the test
+        pass
 
 
 class TestEmployeeContractToggleView:

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -432,7 +432,7 @@ class TestAssessmentContractsListAndToggle:
             + "?from_list=1",
             headers={"HX-Request": "true"},
         )
-        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_1.pk}", response)
+        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_1.pk} > form", response)
         assert response.status_code == 200
         contract_1.refresh_from_db()
         assert contract_1.allowance_requested is False
@@ -446,7 +446,7 @@ class TestAssessmentContractsListAndToggle:
             + "?from_list=1",
             headers={"HX-Request": "true"},
         )
-        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_2.pk}", response)
+        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_2.pk} > form", response)
         assert response.status_code == 200
         contract_2.refresh_from_db()
         assert contract_2.allowance_requested is True
@@ -525,7 +525,7 @@ class TestAssessmentContractsListAndToggle:
             + "?from_list=1",
             headers={"HX-Request": "true"},
         )
-        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_1.pk}", response)
+        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_1.pk} > form", response)
         assert response.status_code == 200
         contract_1.refresh_from_db()
         assert contract_1.allowance_granted is False
@@ -539,7 +539,7 @@ class TestAssessmentContractsListAndToggle:
             + "?from_list=1",
             headers={"HX-Request": "true"},
         )
-        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_2.pk}", response)
+        update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract_2.pk} > form", response)
         assert response.status_code == 200
         contract_2.refresh_from_db()
         assert contract_2.allowance_granted is True
@@ -804,7 +804,7 @@ class TestAssessmentContractsDetails:
             )
             contract.refresh_from_db()
             assert contract.allowance_requested != current_value
-            update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract.pk}", response)
+            update_page_with_htmx(simulated_page, f"#toggle_allowance_for_contract_{contract.pk} > form", response)
             response = client.get(tab_url)
             fresh_page = parse_response_to_soup(response, selector="#main")
             assertSoupEqual(simulated_page, fresh_page)

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -688,15 +688,23 @@ class TestAssessmentContractsDetails:
             "Ce salarié figurait déjà dans le bilan précédent, nous vous invitons à vérifier ce contrat."
         )
 
-        def check_user_access_to_all_tabs(user, *, access, with_previous_year_warning=False):
+        def check_user_access_to_tabs(
+            user, *, access, tabs=AssessmentContractDetailsTab, with_previous_year_warning=False
+        ):
             client.force_login(user)
             user_label = "GEIQ" if user == geiq_membership.user else "DDETS"
-            for tab in AssessmentContractDetailsTab:
+            if user == geiq_membership.user:
+                user_label = "GEIQ"
+                viewable_tabs_for_user = AssessmentContractDetailsTab.get_common_tabs()
+            else:
+                user_label = "DDETS"
+                viewable_tabs_for_user = AssessmentContractDetailsTab.get_institution_tabs()
+            for tab in tabs:
                 tab_url = reverse(
                     "geiq_assessments_views:assessment_contracts_details",
                     kwargs={"contract_pk": str(contract.pk), "tab": tab.value},
                 )
-                if access:
+                if access and tab in viewable_tabs_for_user:
                     with assertSnapshotQueries(snapshot(name=f"SQL queries for {tab=} as {user_label}")):
                         response = client.get(tab_url)
                     assertContains(response, "DUPONT Jean")
@@ -708,28 +716,38 @@ class TestAssessmentContractsDetails:
                     response = client.get(tab_url)
                     assert response.status_code == 404
 
-        check_user_access_to_all_tabs(geiq_membership.user, access=True)
+        check_user_access_to_tabs(geiq_membership.user, access=True)
 
         # DDETS user should not access the contract details before submission
-        check_user_access_to_all_tabs(ddets_membership.user, access=False)
+        check_user_access_to_tabs(ddets_membership.user, access=False)
 
         # Submit the assessment
         assessment.submit(user=geiq_membership.user)
-        check_user_access_to_all_tabs(ddets_membership.user, access=True)
+        check_user_access_to_tabs(ddets_membership.user, access=True)
 
         # Now for contract without allowance requested
         contract.allowance_requested = False
         contract.save()
-        check_user_access_to_all_tabs(geiq_membership.user, access=True)
-        check_user_access_to_all_tabs(ddets_membership.user, access=False)
+        check_user_access_to_tabs(geiq_membership.user, access=True)
+        check_user_access_to_tabs(ddets_membership.user, access=False)
 
         # Now for contract with previous year info
         contract.employee.allowance_granted_previous_year = True
         contract.employee.save()
         contract.allowance_requested = True
         contract.save()
-        check_user_access_to_all_tabs(ddets_membership.user, access=True, with_previous_year_warning=True)
-        check_user_access_to_all_tabs(geiq_membership.user, access=True, with_previous_year_warning=True)
+        check_user_access_to_tabs(ddets_membership.user, access=True, with_previous_year_warning=True)
+        check_user_access_to_tabs(geiq_membership.user, access=True, with_previous_year_warning=True)
+
+        # Now for contract with allowance_granted
+        contract.allowance_granted = True
+        contract.save()
+        check_user_access_to_tabs(
+            geiq_membership.user, access=False, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION]
+        )
+        check_user_access_to_tabs(
+            ddets_membership.user, access=False, tabs=[AssessmentContractDetailsTab.ALLOWANCE_REFUSAL_JUSTIFICATION]
+        )
 
     def test_contract_toggle_as_geiq(self, client):
         geiq_membership = CompanyMembershipFactory(company__kind=CompanyKind.GEIQ)
@@ -745,7 +763,7 @@ class TestAssessmentContractsDetails:
             allowance_requested=random.choice([True, False]),
         )
         client.force_login(geiq_membership.user)
-        for tab in AssessmentContractDetailsTab:
+        for tab in AssessmentContractDetailsTab.get_common_tabs():
             current_value = contract.allowance_requested
             tab_url = reverse(
                 "geiq_assessments_views:assessment_contracts_details",

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -11,6 +11,7 @@ from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
 from itou.companies.enums import CompanyKind
+from itou.geiq_assessments.enums import AllowanceRefusalReason
 from itou.geiq_assessments.models import AssessmentInstitutionLink
 from itou.institutions.enums import InstitutionKind
 from itou.users.enums import Title
@@ -560,14 +561,31 @@ class TestAssessmentContractsListAndToggle:
             allowance_requested=True,
             allowance_granted=True,
         )
+        contract_2 = EmployeeContractFactory(
+            id=uuid.UUID("22222222-4444-4444-4444-444444444444"),
+            employee__assessment=assessment,
+            employee__last_name="Dupont",
+            employee__first_name="Jean",
+            employee__allowance_amount=0,
+            start_at=datetime.date(2024, 1, 1),
+            end_at=datetime.date(2024, 4, 30),
+            planned_end_at=datetime.date(2024, 5, 31),
+            allowance_requested=True,
+            allowance_granted=False,
+            allowance_refusal_reason=AllowanceRefusalReason.ALLOWANCE_ALREADY_GRANTED,
+            allowance_refusal_details="Ce contrat n’aura pas d’aide.",
+        )
         assessment.ask_for_geiq_fix(
             user=ddets_membership.user, institution=ddets_membership.institution, comment="À revoir"
         )
 
         # Sending the assessment back to the GEIQ for correction unsets allowance_granted
         contract_1.refresh_from_db()
+        contract_2.refresh_from_db()
         assert contract_1.allowance_requested is True
         assert contract_1.allowance_granted is False
+        assert contract_2.allowance_requested is True
+        assert contract_2.allowance_granted is False
 
         client.force_login(geiq_membership.user)
 
@@ -586,6 +604,9 @@ class TestAssessmentContractsListAndToggle:
         assert contract_1.allowance_requested is False
         assert contract_1.allowance_granted is False
 
+        # The GEIQ submits a corrected assessment, the DDETS/DREETS preselection is updated
+        client.post(reverse("geiq_assessments_views:details_for_geiq", kwargs={"pk": assessment.pk}))
+
         # The work done by the institution was not lost
         assessment.refresh_from_db()
         assert assessment.review_comment == "Bon bilan."
@@ -593,8 +614,13 @@ class TestAssessmentContractsListAndToggle:
         assert assessment.granted_amount == 9_000
         assert assessment.advance_amount == 0
 
-        # FIXME(ewen): when refusal and refusal_reason are ready, update this test as we'll use these fields
-        # to automatically unselect the contracts in the institution's view.
+        # The contracts with allowance_refusal_reason are automatically unselected
+        contract_1.refresh_from_db()
+        contract_2.refresh_from_db()
+        assert contract_1.allowance_requested is False  # Was unselected by GEIQ
+        assert contract_1.allowance_granted is False
+        assert contract_2.allowance_requested is True
+        assert contract_2.allowance_granted is False  # Had non empty allowance_refusal_reason
 
 
 class TestAssessmentContractsDetails:

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -283,6 +283,8 @@ class TestAssessmentContractsListAndToggle:
             planned_end_at=datetime.date(2024, 5, 31),
             allowance_requested=True,
             allowance_granted=False,
+            allowance_refusal_reason=AllowanceRefusalReason.UNCONFIRMED_ELIGIBILITY,
+            allowance_refusal_details="Éligibilité non confirmée",
         )
         EmployeeContractFactory(
             id=uuid.UUID("22222222-4444-4444-4444-444444444444"),
@@ -310,11 +312,36 @@ class TestAssessmentContractsListAndToggle:
             allowance_requested=False,
             allowance_granted=False,
         )
+        refused_contract = EmployeeContractFactory(
+            id=uuid.UUID("44444444-4444-4444-4444-444444444444"),
+            employee__id=uuid.UUID("44444444-eeee-4444-8888-111111111111"),
+            employee__assessment=assessment,
+            employee__last_name="Dupons",
+            employee__first_name="Pean-Jierre",
+            employee__allowance_amount=1_400,
+            start_at=datetime.date(2024, 6, 1),
+            end_at=datetime.date(2024, 9, 30),
+            planned_end_at=datetime.date(2024, 10, 30),
+            allowance_requested=True,
+            allowance_granted=False,
+            allowance_refusal_reason="",
+            allowance_refusal_details="",
+        )
         with assertSnapshotQueries(snapshot(name="SQL queries")):
             response = client.get(contracts_list_url)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
-            name="assessments contracts list"
+            name="assessments contracts list with refusal to justify"
         )
+        # One contract's allowance is refused, the user cannot validate
+        response = client.post(contracts_list_url, data={"action": "validate"})
+        assert response.status_code == 403
+        assessment.refresh_from_db()
+        assert assessment.grants_selection_validated_at is None
+
+        # Fill allowance refusal reason and try again
+        refused_contract.allowance_refusal_reason = AllowanceRefusalReason.ALLOWANCE_ALREADY_GRANTED
+        refused_contract.allowance_refusal_details = "Aide déjà attribuée."
+        refused_contract.save()
         response = client.post(contracts_list_url, data={"action": "validate"})
         assertRedirects(
             response,
@@ -333,7 +360,7 @@ class TestAssessmentContractsListAndToggle:
         assert assessment.grants_selection_validated_at is None
         response = client.get(contracts_list_url)
         assert pretty_indented(parse_response_to_soup(response, ".s-section")) == snapshot(
-            name="assessments contracts list"
+            name="assessments contracts list with justified refusal"
         )
 
     def test_htmx_toggle_as_geiq(self, client):

--- a/tests/www/geiq_assessments_views/test_views_for_both.py
+++ b/tests/www/geiq_assessments_views/test_views_for_both.py
@@ -11,11 +11,10 @@ from itoutils.django.testing import assertSnapshotQueries
 from pytest_django.asserts import assertContains, assertNotContains, assertRedirects
 
 from itou.companies.enums import CompanyKind
-from itou.geiq_assessments.enums import AllowanceRefusalReason, InstitutionAction
+from itou.geiq_assessments.enums import AllowanceRefusalReason, AssessmentContractDetailsTab, InstitutionAction
 from itou.geiq_assessments.models import AssessmentInstitutionLink
 from itou.institutions.enums import InstitutionKind
 from itou.users.enums import Title
-from itou.www.geiq_assessments_views.views import AssessmentContractDetailsTab
 from tests.companies.factories import CompanyMembershipFactory
 from tests.geiq_assessments.factories import (
     AssessmentFactory,

--- a/tests/www/geiq_assessments_views/test_views_for_geiq.py
+++ b/tests/www/geiq_assessments_views/test_views_for_geiq.py
@@ -18,7 +18,7 @@ from pytest_django.asserts import (
 )
 
 from itou.companies.enums import CompanyKind
-from itou.geiq_assessments.enums import AssessmentState, AssessmentTransition
+from itou.geiq_assessments.enums import AllowanceRefusalReason, AssessmentState, AssessmentTransition
 from itou.geiq_assessments.models import Assessment, AssessmentInstitutionLink, AssessmentTransitionLog, LabelInfos
 from itou.institutions.enums import InstitutionKind
 from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
@@ -625,6 +625,16 @@ class TestAssessmentDetailsForGEIQView:
             planned_end_at=datetime.date(2024, 6, 30),
             allowance_requested=False,
         )
+        requested_contract_refused = EmployeeContractFactory(
+            employee__assessment=assessment,
+            employee__allowance_amount=0,
+            start_at=datetime.date(2024, 1, 1),
+            end_at=datetime.date(2024, 4, 30),
+            planned_end_at=datetime.date(2024, 5, 31),
+            allowance_requested=True,
+            allowance_refusal_reason=AllowanceRefusalReason.OTHER,
+            allowance_refusal_details="Ce contrat n’aura pas d’aide.",
+        )
         AssessmentInstitutionLink.objects.create(
             assessment=assessment,
             institution=ddets_membership.institution,
@@ -642,9 +652,11 @@ class TestAssessmentDetailsForGEIQView:
         assert transition.user == membership.user
         assert transition.timestamp == transition.assessment.submitted_at
         requested_contract.refresh_from_db()
-        # Requested allowance are automatically granted by default
+        # Requested allowance are automatically granted by default…
         assert requested_contract.allowance_granted is True
         assert not_requested_contract.allowance_granted is False
+        # …except for the ones that have a refusal reason
+        assert requested_contract_refused.allowance_granted is False
 
         assert len(mailoutbox) == 1
         email = mailoutbox[0]


### PR DESCRIPTION
## :thinking: Pourquoi ?

Actuellement la DDETS/DREETS peut juste refuser sans justifier.
La DDETS/DREET utilise l’espace commentaire global du dossier pour expliquer, ce n’est pas optimal car il faut penser à reporter chaque contrat concerné.
Au niveau règlementaire la DDETS doit être en capacité de justifier le refus de l’aide.

PR sœur : #7971

[Carte Notion](https://www.notion.so/gip-inclusion/URGENT-AVANT-01-06-ETQ-DDETS-DREETS-je-justifie-le-refus-d-attribution-d-une-aide-pour-un-contrat--3175f321b60480b192cefeae993be51b?v=2845f321b60480bd9ef6000c92a2d6ab&source=copy_link)


## :cake: Comment ? <!-- optionnel -->

- page de détail du contrat :
    - enlever l’interrupteur pour accorder/refuser l’aide
    - utiliser à la place des boutons dans une boîte latérale (*Ne pas accorder l’aide*…)
    - ajouter un onglet où se trouve le formulaire de justification du non accord de l’aide
- page liste :
    - sélectionner/désélectionner des contrats met à jour :
      - un petit tooltip à côté de l'interrupteur si besoin de justification pour ce contrat
      - le bouton de validation (désactivé si justification nécessaire)
 
