### PR TITLE
Interface: Appliquer les nouvelles règles aux pages de formulaires

### DIFF
--- a/itou/templates/apply/edit_contract_start_date.html
+++ b/itou/templates/apply/edit_contract_start_date.html
@@ -19,7 +19,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     <div class="c-form">
-                        <h2>Modification de la date de contrat</h2>
+                        <h2 class="h3">Modification de la date de contrat</h2>
                         <form method="post" class="js-prevent-multiple-submit">
 
                             {% csrf_token %}

--- a/itou/templates/apply/hire_step_check_prev_applications.html
+++ b/itou/templates/apply/hire_step_check_prev_applications.html
@@ -12,8 +12,7 @@
         {% csrf_token %}
 
         <div class="c-form">
-            <h2>Ce candidat a déjà postulé pour votre entreprise</h2>
-
+            <h2 class="h3">Ce candidat a déjà postulé pour votre entreprise</h2>
             <p>
                 Nous vous recommandons d'accepter une candidature existante plutôt que d'en créer une nouvelle avec la déclaration d'embauche.
             </p>

--- a/itou/templates/apply/includes/accept_confirmation.html
+++ b/itou/templates/apply/includes/accept_confirmation.html
@@ -4,10 +4,9 @@
 {% load str_filters %}
 
 {% enums "companies" "ContractType" as ContractType %}
-<h2>Vérifiez les informations avant de confirmer l’embauche</h2>
 <div class="c-form">
     <h3>Récapitulatif du contrat</h3>
-    <ul class="list-data mb-3">
+    <ul class="list-data">
         <li>
             <small>Entreprise</small>
             <span>

--- a/itou/templates/apply/includes/job_application_accept_form.html
+++ b/itou/templates/apply/includes/job_application_accept_form.html
@@ -19,7 +19,7 @@
 
         {% csrf_token %}
 
-        <h2>Contrat</h2>
+        <h2 class="h3">Contrat</h2>
         {% bootstrap_form_errors form_accept type="non_fields" %}
 
         {# reloadable contract type and options for GEIQ #}

--- a/itou/templates/apply/includes/job_application_fill_user_infos_form.html
+++ b/itou/templates/apply/includes/job_application_fill_user_infos_form.html
@@ -1,7 +1,7 @@
 {% load django_bootstrap5 %}
 {% load theme_inclusion %}
 
-<h2>Candidat</h2>
+<h2 class="h3">Candidat</h2>
 
 {% if form_personal_data %}
     {% if form_personal_data.nir_error %}{{ form_personal_data.nir_error|safe }}{% endif %}

--- a/itou/templates/apply/includes/profile_infos.html
+++ b/itou/templates/apply/includes/profile_infos.html
@@ -3,8 +3,6 @@
 {% load wording %}
 
 <div class="personal-infos">
-    <h2>Informations personnelles</h2>
-    <hr>
     <div class="row mb-3">
         <div class="col-12 col-sm">
             <h3 class="mb-0">État civil</h3>
@@ -20,8 +18,7 @@
             </div>
         {% endif %}
     </div>
-
-    <ul class="list-data mb-3">
+    <ul class="list-data">
         <li>
             <small>Civilité</small>
             {% if profile.user.title %}
@@ -71,15 +68,9 @@
             {% endif %}
         </li>
     </ul>
-
-    <hr>
-    <div class="row mb-3">
-        <div class="col-12 col-sm">
-            <h3 class="mb-0">Coordonnées</h3>
-        </div>
-    </div>
-
-    <ul class="list-data mb-3">
+    <hr class="my-4">
+    <h3>Coordonnées</h3>
+    <ul class="list-data">
         <li>
             <small>Adresse e-mail</small>
             {% if profile.user.email %}
@@ -109,15 +100,9 @@
             {% endif %}
         </li>
     </ul>
-
-    <hr>
-    <div class="row mb-3">
-        <div class="col-12 col-sm">
-            <h3 class="mb-0">Situation</h3>
-        </div>
-    </div>
-
-    <ul class="list-data mb-3">
+    <hr class="my-4">
+    <h3>Situation</h3>
+    <ul class="list-data mb-4">
         <li>
             <small>Inscrit à France Travail depuis</small>
             {% if profile.pole_emploi_since %}

--- a/itou/templates/apply/process_add_to_pool.html
+++ b/itou/templates/apply/process_add_to_pool.html
@@ -19,7 +19,7 @@
 
 {% block content_extend %}
     <div class="c-form mb-3 mb-md-4">
-        <h2>Réponse au candidat</h2>
+        <h2 class="h3">Réponse au candidat</h2>
         <p>
             En ajoutant cette candidature au vivier, elle ne sera pas automatiquement refusée après deux mois.
             Toutefois, nous vous invitons à la traiter dans un délai raisonnable afin d’informer le candidat de l’avancement de sa candidature.

--- a/itou/templates/apply/process_refuse.html
+++ b/itou/templates/apply/process_refuse.html
@@ -55,7 +55,7 @@
                             {% csrf_token %}
 
                             {% if wizard_steps.current == RefuseViewStep.REASON %}
-                                <h2 class="mb-3 mb-md-4">Choix du motif de refus</h2>
+                                <h2 class="h3">Choix du motif de refus</h2>
                                 <p class="mb-3 mb-md-4">
                                     {% if with_prescriber %}
                                         Dans le cadre d’un parcours IAE, la transparence sur les motifs de refus est importante pour {{ job_seeker_nb|pluralizefr:"le candidat,les candidats" }} comme pour {{ the_prescriber }}. Nous vous encourageons à répondre à chacune des parties.
@@ -64,7 +64,7 @@
                                     {% endif %}
                                 </p>
                             {% elif wizard_steps.current == RefuseViewStep.JOB_SEEKER_ANSWER %}
-                                <h2 class="mb-3 mb-md-4">Réponse {{ job_seeker_nb|pluralizefr:"au candidat,aux candidats" }}</h2>
+                                <h2 class="h3">Réponse {{ job_seeker_nb|pluralizefr:"au candidat,aux candidats" }}</h2>
                                 <p class="mb-3 mb-md-4">
                                     {% if with_prescriber %}
                                         Une copie de ce message sera adressée {{ to_prescriber }}.
@@ -80,7 +80,7 @@
                                     {% endif %}
                                 </p>
                             {% elif wizard_steps.current == RefuseViewStep.PRESCRIBER_ANSWER %}
-                                <h2 class="mb-3 mb-md-4">Réponse {{ to_prescriber }}</h2>
+                                <h2 class="h3">Réponse {{ to_prescriber }}</h2>
                                 <p class="mb-3 mb-md-4">
                                     Vous pouvez partager un message {{ to_prescriber }} uniquement, comme détailler ou évoquer d’autres motifs de refus.
                                 </p>

--- a/itou/templates/apply/submit/application/base.html
+++ b/itou/templates/apply/submit/application/base.html
@@ -81,7 +81,7 @@
                     <div class="c-form">
                         {% include "includes/organizations/_organization_info.html" with organization=company company_show_cta=True extra_box_class="mb-3 mb-md-4" open_in_tab=True only %}
                         {% block pre_step_title %}{% endblock %}
-                        <h2>
+                        <h2 class="h3">
                             {% block step_title %}{% endblock %}
                         </h2>
                         <hr class="mt-5">

--- a/itou/templates/apply/submit/application/end.html
+++ b/itou/templates/apply/submit/application/end.html
@@ -91,7 +91,7 @@
                         </div>
                         {% if not request.user.is_job_seeker %}
                             <div class="c-form c-card--noshadow border-bottom {% if not form.is_bound %}d-none{% endif %}" data-swap-element-with="#informations">
-                                <h2 class="mb-5">{{ job_application.job_seeker.get_inverted_full_name }}</h2>
+                                <h2 class="h3 mb-5">{{ job_application.job_seeker.get_inverted_full_name }}</h2>
 
                                 <form method="post">
                                     {% csrf_token %}

--- a/itou/templates/apply/submit/hire_confirmation_step.html
+++ b/itou/templates/apply/submit/hire_confirmation_step.html
@@ -18,6 +18,15 @@
     {% endcomponent_title %}
 {% endblock %}
 
+
+{% block content_subtitle %}
+    <div class="s-section__row row">
+        <div class="s-section__col col-12">
+            <h2>Vérifiez les informations avant de confirmer l’embauche</h2>
+        </div>
+    </div>
+{% endblock %}
+
 {% block content_extend %}
     {% include "apply/includes/accept_confirmation.html" with form_accept=form_accept job_seeker=job_seeker to_company=company csrf_token=csrf_token back_url=back_url reset_url=reset_url only %}
 {% endblock %}

--- a/itou/templates/apply/submit_base.html
+++ b/itou/templates/apply/submit_base.html
@@ -15,6 +15,7 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
+            {% block content_subtitle %}{% endblock %}
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 {% if is_subject_to_iae_rules and job_seeker.has_valid_approval %}order-2 order-xxl-1{% endif %}">
                     {% block content_extend %}{% endblock %}

--- a/itou/templates/apply/submit_step_check_prev_applications.html
+++ b/itou/templates/apply/submit_step_check_prev_applications.html
@@ -9,9 +9,9 @@
 
         <div class="c-form">
             {% if request.user == job_seeker %}
-                <h2>Vous avez déjà postulé pour cette entreprise</h2>
+                <h2 class="h3">Vous avez déjà postulé pour cette entreprise</h2>
             {% else %}
-                <h2>Ce candidat a déjà postulé pour cette entreprise</h2>
+                <h2 class="h3">Ce candidat a déjà postulé pour cette entreprise</h2>
             {% endif %}
 
             <p>

--- a/itou/templates/dashboard/edit_job_seeker_info.html
+++ b/itou/templates/dashboard/edit_job_seeker_info.html
@@ -33,6 +33,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     <div class="c-form">
+                        <h2 class="h3">Informations personnelles</h2>
                         {% include "dashboard/includes/edit_job_seeker_info_form.html" with prev_url=prev_url submit_label="Mettre à jour" %}
                     </div>
                 </div>

--- a/itou/templates/dashboard/edit_user_info.html
+++ b/itou/templates/dashboard/edit_user_info.html
@@ -33,7 +33,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9">
                     <div class="c-form">
-                        <h2>Informations personnelles</h2>
+                        <h2 class="h3">Informations personnelles</h2>
                         {% if request.user.is_job_seeker and not request.user.title %}
                             {% component_alert title=title content=content variant="warning" extra_id="missing-infos-warning" %}
                                 {% fragment as title %}

--- a/itou/templates/eligibility/includes/geiq/eligibility_section.html
+++ b/itou/templates/eligibility/includes/geiq/eligibility_section.html
@@ -15,7 +15,7 @@
                 <div class="c-box">
                     {% include "includes/organizations/_organization_info.html" with organization=company company_show_cta=True extra_box_class="mb-3 mb-md-4" only %}
 
-                    <h2>Souhaitez-vous préciser la situation administrative du candidat ?</h2>
+                    <h2 class="h3">Souhaitez-vous préciser la situation administrative du candidat ?</h2>
                     <p>
                         Si vous souhaitez bénéficier de l’aide à l’accompagnement, veuillez renseigner les critères du candidat ci-dessous et vous assurer de pouvoir fournir les justificatifs associés.
                     </p>

--- a/itou/templates/eligibility/includes/iae/eligibility_section.html
+++ b/itou/templates/eligibility/includes/iae/eligibility_section.html
@@ -1,9 +1,7 @@
 {# This template is shown only to SIAEs (*auto-prescription*). #}
-<div class="c-box mb-4">
-    <h2 class="h1">Valider l'éligibilité IAE</h2>
-
+<div class="c-box mb-3 mb-md-4">
+    <h2 class="h3">Valider l'éligibilité IAE</h2>
     <p>Pour valider l'éligibilité IAE du candidat il faut :</p>
-
     <ol>
         <li>
             Avoir réalisé un diagnostic socio-professionnel (dans le cadre d'un entretien, vous pouvez vous appuyer sur le <a href="{{ ITOU_DIAGNOSTIC_URL }}" target="_blank" rel="noreferrer noopener" class="has-external-link">document diagnostic socio-professionnel de référence</a>)
@@ -16,14 +14,11 @@
             </ul>
         </li>
     </ol>
-
     <p>
         Si le candidat ne remplit pas les conditions administratives, <a href="{{ ITOU_HELP_CENTER_URL }}/articles/14733565634705--Dérogation-aux-critères-administratifs-IAE/" target="_blank" rel="noreferrer noopener" class="has-external-link">orientez-le vers un prescripteur habilité</a>.
     </p>
-
-    <hr>
-
-    <h2 class="h1">Critères d'éligibilité</h2>
+    <hr class="my-4">
+    <h2 class="h3">Critères d'éligibilité</h2>
 
     {% if criteria_filled_from_job_seeker %}
         {% include "eligibility/includes/iae/criteria_filled_from_job_seeker.html" with criteria_filled_from_job_seeker=criteria_filled_from_job_seeker only %}
@@ -32,5 +27,4 @@
     {% endif %}
 
     {% include "eligibility/includes/iae/form.html" with cancel_url=cancel_url %}
-
 </div>

--- a/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
+++ b/itou/templates/job_seekers_views/check_job_seeker_info_for_hire.html
@@ -24,6 +24,7 @@
         <div class="s-section__container container">
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
+                    <h2 class="visually-hidden">Informations personnelles</h2>
                     <div class="c-box mb-3 mb-md-4">
                         {% include "apply/includes/profile_infos.html" %}
                         {% itou_buttons_form primary_url=next_url primary_label="Poursuivre l'embauche" secondary_url=back_url show_mandatory_fields_mention=False %}

--- a/tests/www/apply/__snapshots__/test_hire_views.ambr
+++ b/tests/www/apply/__snapshots__/test_hire_views.ambr
@@ -2,10 +2,6 @@
 # name: TestCheckJobSeekerInformationsForHire.test_company[job_seeker_not_born_in_france][personal-infos]
   '''
   <div class="personal-infos">
-      <h2>
-          Informations personnelles
-      </h2>
-      <hr/>
       <div class="row mb-3">
           <div class="col-12 col-sm">
               <h3 class="mb-0">
@@ -22,7 +18,7 @@
               </a>
           </div>
       </div>
-      <ul class="list-data mb-3">
+      <ul class="list-data">
           <li>
               <small>
                   Civilité
@@ -92,15 +88,11 @@
               </strong>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Coordonnées
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Coordonnées
+      </h3>
+      <ul class="list-data">
           <li>
               <small>
                   Adresse e-mail
@@ -140,15 +132,11 @@
               </address>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Situation
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Situation
+      </h3>
+      <ul class="list-data mb-4">
           <li>
               <small>
                   Inscrit à France Travail depuis
@@ -189,10 +177,6 @@
 # name: TestCheckJobSeekerInformationsForHire.test_company[job_seeker_with_all_datas][personal-infos]
   '''
   <div class="personal-infos">
-      <h2>
-          Informations personnelles
-      </h2>
-      <hr/>
       <div class="row mb-3">
           <div class="col-12 col-sm">
               <h3 class="mb-0">
@@ -209,7 +193,7 @@
               </a>
           </div>
       </div>
-      <ul class="list-data mb-3">
+      <ul class="list-data">
           <li>
               <small>
                   Civilité
@@ -287,15 +271,11 @@
               </strong>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Coordonnées
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Coordonnées
+      </h3>
+      <ul class="list-data">
           <li>
               <small>
                   Adresse e-mail
@@ -335,15 +315,11 @@
               </address>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Situation
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Situation
+      </h3>
+      <ul class="list-data mb-4">
           <li>
               <small>
                   Inscrit à France Travail depuis
@@ -432,10 +408,6 @@
 # name: TestCheckJobSeekerInformationsForHire.test_company[job_seeker_with_few_datas][personal-infos]
   '''
   <div class="personal-infos">
-      <h2>
-          Informations personnelles
-      </h2>
-      <hr/>
       <div class="row mb-3">
           <div class="col-12 col-sm">
               <h3 class="mb-0">
@@ -452,7 +424,7 @@
               </a>
           </div>
       </div>
-      <ul class="list-data mb-3">
+      <ul class="list-data">
           <li>
               <small>
                   Civilité
@@ -500,15 +472,11 @@
               </strong>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Coordonnées
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Coordonnées
+      </h3>
+      <ul class="list-data">
           <li>
               <small>
                   Adresse e-mail
@@ -534,15 +502,11 @@
               </i>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Situation
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Situation
+      </h3>
+      <ul class="list-data mb-4">
           <li>
               <small>
                   Inscrit à France Travail depuis
@@ -583,10 +547,6 @@
 # name: TestCheckJobSeekerInformationsForHire.test_company[job_seeker_with_single_other_data][personal-infos]
   '''
   <div class="personal-infos">
-      <h2>
-          Informations personnelles
-      </h2>
-      <hr/>
       <div class="row mb-3">
           <div class="col-12 col-sm">
               <h3 class="mb-0">
@@ -603,7 +563,7 @@
               </a>
           </div>
       </div>
-      <ul class="list-data mb-3">
+      <ul class="list-data">
           <li>
               <small>
                   Civilité
@@ -681,15 +641,11 @@
               </strong>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Coordonnées
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Coordonnées
+      </h3>
+      <ul class="list-data">
           <li>
               <small>
                   Adresse e-mail
@@ -729,15 +685,11 @@
               </address>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Situation
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Situation
+      </h3>
+      <ul class="list-data mb-4">
           <li>
               <small>
                   Inscrit à France Travail depuis
@@ -785,10 +737,6 @@
 # name: TestCheckJobSeekerInformationsForHire.test_geiq[personal-infos]
   '''
   <div class="personal-infos">
-      <h2>
-          Informations personnelles
-      </h2>
-      <hr/>
       <div class="row mb-3">
           <div class="col-12 col-sm">
               <h3 class="mb-0">
@@ -805,7 +753,7 @@
               </a>
           </div>
       </div>
-      <ul class="list-data mb-3">
+      <ul class="list-data">
           <li>
               <small>
                   Civilité
@@ -855,15 +803,11 @@
               </strong>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Coordonnées
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Coordonnées
+      </h3>
+      <ul class="list-data">
           <li>
               <small>
                   Adresse e-mail
@@ -903,15 +847,11 @@
               </address>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Situation
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Situation
+      </h3>
+      <ul class="list-data mb-4">
           <li>
               <small>
                   Inscrit à France Travail depuis
@@ -2077,10 +2017,6 @@
 # name: TestDirectHireFullProcess.test_hire_as_company[personal-infos]
   '''
   <div class="personal-infos">
-      <h2>
-          Informations personnelles
-      </h2>
-      <hr/>
       <div class="row mb-3">
           <div class="col-12 col-sm">
               <h3 class="mb-0">
@@ -2088,7 +2024,7 @@
               </h3>
           </div>
       </div>
-      <ul class="list-data mb-3">
+      <ul class="list-data">
           <li>
               <small>
                   Civilité
@@ -2166,15 +2102,11 @@
               </strong>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Coordonnées
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Coordonnées
+      </h3>
+      <ul class="list-data">
           <li>
               <small>
                   Adresse e-mail
@@ -2214,15 +2146,11 @@
               </address>
           </li>
       </ul>
-      <hr/>
-      <div class="row mb-3">
-          <div class="col-12 col-sm">
-              <h3 class="mb-0">
-                  Situation
-              </h3>
-          </div>
-      </div>
-      <ul class="list-data mb-3">
+      <hr class="my-4"/>
+      <h3>
+          Situation
+      </h3>
+      <ul class="list-data mb-4">
           <li>
               <small>
                   Inscrit à France Travail depuis

--- a/tests/www/apply/__snapshots__/test_submit.ambr
+++ b/tests/www/apply/__snapshots__/test_submit.ambr
@@ -155,7 +155,7 @@
                                   </a>
                               </div>
                           </div>
-                          <h2>
+                          <h2 class="h3">
                               Préciser la situation administrative du candidat (facultatif)
                           </h2>
                           <hr class="mt-5"/>
@@ -461,7 +461,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_another_employer[allowed]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -506,7 +506,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_another_employer[blocked]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -556,7 +556,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_authorized_prescriber[allowed update diagnosis]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -642,7 +642,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_authorized_prescriber[allowed validate diagnosis]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -728,7 +728,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_authorized_prescriber[blocked]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -788,7 +788,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_job_seeker[allowed]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Vous avez déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -833,7 +833,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_job_seeker[blocked]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Vous avez déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -883,7 +883,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_prescriber[allowed]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>
@@ -928,7 +928,7 @@
 # name: TestCheckPreviousApplicationsView.test_with_previous_as_prescriber[blocked]
   '''
   <div class="c-form">
-      <h2>
+      <h2 class="h3">
           Ce candidat a déjà postulé pour cette entreprise
       </h2>
       <p>

--- a/tests/www/apply/__snapshots__/test_submit_from_job_seekers_list.ambr
+++ b/tests/www/apply/__snapshots__/test_submit_from_job_seekers_list.ambr
@@ -116,7 +116,7 @@
                                   </a>
                               </div>
                           </div>
-                          <h2>
+                          <h2 class="h3">
                               Préciser la situation administrative du candidat (facultatif)
                           </h2>
                           <hr class="mt-5"/>

--- a/tests/www/apply/test_transfer.py
+++ b/tests/www/apply/test_transfer.py
@@ -520,7 +520,7 @@ def test_step_2(client, snapshot):
     response = client.get(transfer_step_2_url)
 
     assert pretty_indented(parse_response_to_soup(response, ".c-stepper")) == snapshot(name="progress")
-    assertContains(response, "<h2>Sélectionner les métiers recherchés</h2>", html=True)
+    assertContains(response, '<h2 class="h3">Sélectionner les métiers recherchés</h2>', html=True)
     assert response.context["form"].initial == {"selected_jobs": [], "spontaneous_application": True}
 
     response = client.post(transfer_step_2_url, data={"spontaneous_application": "on"})
@@ -544,7 +544,7 @@ def test_step_2(client, snapshot):
     response = client.get(transfer_step_2_url)
 
     assert pretty_indented(parse_response_to_soup(response, ".c-stepper")) == snapshot(name="progress")
-    assertContains(response, "<h2>Sélectionner les métiers recherchés</h2>", html=True)
+    assertContains(response, '<h2 class="h3">Sélectionner les métiers recherchés</h2>', html=True)
     assert response.context["form"].initial == {"selected_jobs": [str(job_id)]}
 
     response = client.post(transfer_step_2_url, data={"selected_jobs": [job_id]})
@@ -823,7 +823,7 @@ def test_full_process(client, pdf_file):
 
     # STEP 2
     response = client.get(transfer_step_2_url)
-    assertContains(response, "<h2>Sélectionner les métiers recherchés</h2>", html=True)
+    assertContains(response, '<h2 class="h3">Sélectionner les métiers recherchés</h2>', html=True)
     assert response.context["form"].initial == {"selected_jobs": [], "spontaneous_application": True}
     # Check back_url
     assertContains(response, transfer_step_1_url)
@@ -845,7 +845,7 @@ def test_full_process(client, pdf_file):
 
     # STEP 3
     response = client.get(transfer_step_3_url)
-    assertContains(response, "<h2>Finaliser la candidature</h2>", html=True)
+    assertContains(response, '<h2 class="h3">Finaliser la candidature</h2>', html=True)
     # CHeck back_url
     assertContains(response, transfer_step_2_url)
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcque qu'on a des [règles maintenant ](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-form-detail--docs) et de nombreux [exemples d'incohérences](https://www.notion.so/gip-inclusion/UX-UI-Lister-les-cas-red-finir-les-r-gles-ux-ui-des-titres-sous-titres-puis-harmoniser-dans-les-f-3025f321b60480e28782f1f1e7d84061) 
Aussi pour harmoniser avec les différentes tailles de titres des [pages details](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-box-detail--docs)



## :cake: Comment ? <!-- optionnel -->

Principalement en corrigeant les tailles des titres de `c-form`.
A savoir, toujours au moins un titre (avec un look `.h3`) en intro de `c-form`.

Soit:
- en `<h3>` (mais dans ce cas il faut au moins un `<h2>` dans la page)
- en `<h2 class="h3">`
- ou idéalement en `<fieldset> + <legend class="h3">`


## :computer: Captures d'écran <!-- optionnel -->
Quelques avant/apres
**Avant**
<img width="932" height="1065" alt="capture 2026-05-12 à 15 31 41" src="https://github.com/user-attachments/assets/59bf785b-a8f8-4133-ad89-79de663c8bdc" />

<img width="1312" height="823" alt="capture 2026-05-12 à 15 37 53" src="https://github.com/user-attachments/assets/99b5d90e-2c3d-4340-bd71-426de06a1833" />

**Apres**
<img width="971" height="1022" alt="capture 2026-05-12 à 15 33 13" src="https://github.com/user-attachments/assets/0d1f3b81-0de9-42de-81a7-5a3c2043ea41" />

<img width="1073" height="803" alt="capture 2026-05-12 à 16 13 22" src="https://github.com/user-attachments/assets/7f17d294-07f6-4bb0-9ab8-edc28bc4971b" />
