### PR TITLE
Candidatures : Correction d'un bug dans la mise à jour des infos candidat après une candidature

### DIFF
--- a/itou/www/apply/views/submit_views.py
+++ b/itou/www/apply/views/submit_views.py
@@ -2,6 +2,7 @@ import enum
 import logging
 from datetime import timedelta
 
+from allauth.account.views import method_decorator
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.contrib.auth.mixins import UserPassesTestMixin
@@ -30,6 +31,7 @@ from itou.utils.perms.utils import can_edit_personal_information, can_view_perso
 from itou.utils.session import SessionNamespace, SessionNamespaceException
 from itou.utils.templatetags.str_filters import mask_unless
 from itou.utils.urls import get_safe_url
+from itou.utils.views import with_triggers_context
 from itou.www.apply.forms import ApplicationJobsForm, SubmitJobApplicationForm
 from itou.www.apply.views import constants as apply_view_constants
 from itou.www.apply.views.common import previous_applications_queryset
@@ -715,6 +717,7 @@ class ApplicationResumeView(CheckApplySessionMixin, ApplicationBaseView):
         }
 
 
+@method_decorator(with_triggers_context, name="post")
 class ApplicationEndView(TemplateView):
     template_name = "apply/submit/application/end.html"
 

--- a/tests/www/apply/test_submit.py
+++ b/tests/www/apply/test_submit.py
@@ -3304,10 +3304,12 @@ class TestApplicationView:
 
 
 class TestApplicationEndView:
-    def test_update_job_seeker(self, client):
+    def test_update_job_seeker_forbidden_if_not_proxy(self, client):
         job_application = JobApplicationFactory(sent_by_prescriber=True, job_seeker__with_mocked_address=True)
         job_seeker = job_application.job_seeker
-        # Ensure sender cannot update job seeker infos
+        assert not job_seeker.is_handled_by_proxy
+        # Ensure sender cannot update infos, because the job seeker is
+        # the owner of their account.
         assert job_seeker.address_line_2 == ""
         url = reverse("apply:application_end", kwargs={"application_pk": job_application.pk})
         client.force_login(job_application.sender)
@@ -3323,7 +3325,33 @@ class TestApplicationEndView:
         )
         assert response.status_code == 403
         job_seeker.refresh_from_db()
-        assert job_seeker.address_line_2 == ""
+        assert job_seeker.address_line_2 == ""  # not updated
+
+    def test_update_job_seeker_allowed_if_proxy(self, client):
+        job_application = JobApplicationFactory(sent_by_prescriber=True, job_seeker__with_mocked_address=True)
+        job_seeker = job_application.job_seeker
+        job_seeker.created_by = job_application.sender
+        job_seeker.save()
+        assert job_seeker.is_handled_by_proxy
+        url = reverse(
+            "apply:application_end",
+            kwargs={"application_pk": job_application.pk},
+        )
+        client.force_login(job_application.sender)
+        response = client.post(
+            url,
+            data={
+                "address_line_1": job_seeker.address_line_1,
+                "address_line_2": "something new",
+                "post_code": job_seeker.post_code,
+                "city": job_seeker.city,
+                "phone": job_seeker.phone,
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        job_seeker.refresh_from_db()
+        assert job_seeker.address_line_2 == "something new"
 
     def test_wo_phone_number_as_job_seeker(self, client):
         application = JobApplicationFactory(sent_by_job_seeker=True, job_seeker__phone="")


### PR DESCRIPTION
Après la création d'une candidature par un prescripteur, le prescripteur a la possibilité de modifier les informations du candidat (adresse et téléphone seulement, apparemment), si le candidat n'a pas pris la main sur son compte. Une erreur survenait lors de la soumission de ce formulaire de modification, car il manquait un décorateur `with_triggers_context`.

Entrée Sentry : https://inclusion.sentry.io/issues/119226364/

La correction est similaire à [celle-ci](https://github.com/gip-inclusion/les-emplois/pull/8017).

J'en ai profité pour ajouter un test de cas passant sur le `POST` de cette vue (il n'y en avait pas). Mais le test ne permet pas de reproduire le bug (idem #8017 et cf. #8019 pour une tentative en cours de Xavier pour corriger ça).

## :desert_island: Comment tester ?

1. Se logger en tant que prescripteur.
2. Postuler pour un candidat **qui n'a pas pris la main sur son compte**.
3. Une fois la candidature créée, cliquer sur le bouton "Modifier" pour modifier les informations de l'utilisateur.
4. Modifier le numéro de téléphone (par exemple) puis cliquer sur "Enregistrer".
5. Il ne devrait y avoir aucune erreur (!) et la modification devrait être appliquée.