### PR TITLE
Tech : Désactivation de AUTO_TRIGGER_CONTEXT pour la commande `archive_job_applications`

### DIFF
--- a/itou/job_applications/management/commands/archive_job_applications.py
+++ b/itou/job_applications/management/commands/archive_job_applications.py
@@ -10,6 +10,9 @@ from itou.utils.command import BaseCommand
 
 
 class Command(BaseCommand):
+    ATOMIC_HANDLE = False
+    AUTO_TRIGGER_CONTEXT = False
+
     def add_arguments(self, parser):
         parser.add_argument("--wet-run", dest="wet_run", action="store_true")
 


### PR DESCRIPTION
The global transaction was already disabled (ATOMIC_HANDLE is False by default), but we needed to override `AUTO_TRIGGER_CONTEXT` (which is True by default).

---

C'est la même chose que dans #7982 (mais dans une autre commande)

