### PR TITLE
Pilotage : Résoudre un bug empêchant un employeur d'accéder à ses tableaux de bord s’il est également membre d’une organisation prescriptrice

### DIFF
--- a/itou/www/stats/views.py
+++ b/itou/www/stats/views.py
@@ -217,9 +217,8 @@ def render_stats_siae(request, page_title, *, filters_param=[mb.C1_SIAE_FILTER_K
             str(membership.company_id) for membership in request.user.active_or_in_grace_period_company_memberships()
         ]
     if mb.ASP_SIAE_FILTER_KEY_FLAVOR3 in filters_param:
-        params[mb.ASP_SIAE_FILTER_KEY_FLAVOR3] = [
-            org.convention.asp_id for org in request.organizations if org.convention is not None
-        ]
+        siaes = [org for org in request.organizations if isinstance(org, Company)]
+        params[mb.ASP_SIAE_FILTER_KEY_FLAVOR3] = [org.convention.asp_id for org in siaes if org.convention is not None]
     return render_stats(
         request=request,
         context=context,

--- a/tests/www/stats/test_views.py
+++ b/tests/www/stats/test_views.py
@@ -22,7 +22,7 @@ from itou.www.stats import urls as stats_urls, utils as stats_utils
 from itou.www.stats.views import get_params_aci_asp_ids_for_department
 from tests.companies.factories import CompanyFactory
 from tests.institutions.factories import InstitutionFactory
-from tests.prescribers.factories import PrescriberOrganizationFactory
+from tests.prescribers.factories import PrescriberMembershipFactory, PrescriberOrganizationFactory
 from tests.users.factories import ItouStaffFactory
 
 
@@ -147,6 +147,9 @@ def test_stats_cd_log_visit(client, settings, view_name):
 def test_stats_siae_log_visit(client, settings, view_name):
     company = CompanyFactory(name="El garaje de la esperanza", kind="ACI", with_membership=True)
     user = company.members.get()
+
+    # Add prescriber_organization membership to check we filter companies
+    PrescriberMembershipFactory(user=user)
 
     settings.STATS_SIAE_USER_PK_WHITELIST = [user.pk]
 


### PR DESCRIPTION
## :thinking: Pourquoi ?

Un utilisateur peut désormais avoir des entreprises et des organisations dans son
`request.organizations`. Les organisations prescriptrices ne disposent pas d'un
attribut `conventions`.

💥 Cela a donné lieu à un ticket : https://inclusion.sentry.io/issues/116524594


Note : il existe pas mal de cas où on regarde aveuglément le `request.organizations`. Une autre PR viendra pour corriger ces cas.

