### PR TITLE
Interface: Appliquer les nouvelles règles aux pages de formulaires "approvals"

### DIFF
--- a/itou/templates/approvals/contracts.html
+++ b/itou/templates/approvals/contracts.html
@@ -10,53 +10,56 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <h2>Suivi des contrats IAE</h2>
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    <h2>Suivi des contrats IAE</h2>
+                    {% component_alert title=title content=content variant="info" extra_classes="mb-3 mb-md-4" %}
+                        {% fragment as title %}
+                            Cette page affiche l’ensemble des contrats IAE déclarés dans l’Extranet IAE 2.0 de l’ASP.
+                        {% endfragment %}
+                        {% fragment as content %}
+                            <p class="mb-0">
+                                Il y a quelques jours de décalage entre la saisie de données dans l'ASP et leur mise à jour sur cette page.
+                            </p>
+                        {% endfragment %}
+                    {% endcomponent_alert %}
 
-            {% component_alert title=title content=content variant="info" extra_classes="mb-3 mb-md-4" %}
-                {% fragment as title %}
-                    Cette page affiche l’ensemble des contrats IAE déclarés dans l’Extranet IAE 2.0 de l’ASP.
-                {% endfragment %}
-                {% fragment as content %}
-                    <p class="mb-0">
-                        Il y a quelques jours de décalage entre la saisie de données dans l'ASP et leur mise à jour sur cette page.
-                    </p>
-                {% endfragment %}
-            {% endcomponent_alert %}
+                    {% for contract in contracts %}
+                        <div class="c-box c-box--results mb-3 mb-md-4">
+                            <div class="c-box--results__header">
+                                <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                                    <div class="c-box--results__summary flex-grow-1">
+                                        <i class="ri-home-smile-2-line" aria-hidden="true"></i>
+                                        <div>
+                                            <span>{{ contract.company.kind }}</span>
+                                            <h3>{{ contract.company.display_name }}</h3>
+                                        </div>
+                                    </div>
+                                    <div class="align-self-center">
+                                        <span>
+                                            <i class="ri-calendar-line ri-lg fw-normal" aria-hidden="true"></i>
 
-            {% for contract in contracts %}
-                <div class="c-box c-box--results mb-3 mb-md-4">
-                    <div class="c-box--results__header">
-                        <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-                            <div class="c-box--results__summary flex-grow-1">
-                                <i class="ri-home-smile-2-line" aria-hidden="true"></i>
-                                <div>
-                                    <span>{{ contract.company.kind }}</span>
-                                    <h3>{{ contract.company.display_name }}</h3>
+                                            {% if contract.end_date %}
+                                                Du {{ contract.start_date|date:"d/m/Y" }} au {{ contract.end_date|date:"d/m/Y" }}
+                                            {% else %}
+                                                Depuis le {{ contract.start_date|date:"d/m/Y" }}
+                                            {% endif %}
+                                        </span>
+                                    </div>
                                 </div>
                             </div>
-                            <div class="align-self-center">
-                                <span>
-                                    <i class="ri-calendar-line ri-lg fw-normal" aria-hidden="true"></i>
-
-                                    {% if contract.end_date %}
-                                        Du {{ contract.start_date|date:"d/m/Y" }} au {{ contract.end_date|date:"d/m/Y" }}
-                                    {% else %}
-                                        Depuis le {{ contract.start_date|date:"d/m/Y" }}
-                                    {% endif %}
-                                </span>
+                        </div>
+                    {% empty %}
+                        <div class="c-box c-box--results mb-3 mb-md-4">
+                            <div class="c-box--results__body">
+                                <p class="mb-0">
+                                    Aucun contrat IAE n’a été trouvé. Cela peut s’expliquer par l’absence d’enregistrement dans l’Extranet ou par une impossibilité de récupération des données.
+                                </p>
                             </div>
                         </div>
-                    </div>
+                    {% endfor %}
                 </div>
-            {% empty %}
-                <div class="c-box c-box--results mb-3 mb-md-4">
-                    <div class="c-box--results__body">
-                        <p class="mb-0">
-                            Aucun contrat IAE n’a été trouvé. Cela peut s’expliquer par l’absence d’enregistrement dans l’Extranet ou par une impossibilité de récupération des données.
-                        </p>
-                    </div>
-                </div>
-            {% endfor %}
+            </div>
         </div>
     </section>
 {% endblock %}

--- a/itou/templates/approvals/details.html
+++ b/itou/templates/approvals/details.html
@@ -9,13 +9,14 @@
 {% block content %}
     <section class="s-section">
         <div class="s-section__container container">
-            <div class="row">
-                <div class="col-12">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
+                    <h2>Vue d'ensemble</h2>
                     {% approval_details_box approval=approval version='details_view' extra_classes='mb-3 mb-md-4' %}
                 </div>
             </div>
-            <div class="row">
-                <div class="col-12">
+            <div class="s-section__row row">
+                <div class="s-section__col col-12">
                     <div class="c-box mb-3 mb-md-4">
                         <div class="d-flex flex-column flex-md-row gap-3 justify-content-md-between">
                             <h2 class="h3">Suspensions</h2>

--- a/itou/templates/approvals/prolongation_requests/deny.html
+++ b/itou/templates/approvals/prolongation_requests/deny.html
@@ -37,7 +37,7 @@
                         </p>
                     </div>
                     <div class="c-form mb-3 mb-md-4">
-                        <h2 class="h4">Réponse envoyée à l'employeur et au candidat</h2>
+                        <h2 class="h3">Réponse envoyée à l'employeur et au candidat</h2>
                         {% block form_content %}
                             <form method="post">
                                 {% csrf_token %}

--- a/itou/templates/approvals/suspend.html
+++ b/itou/templates/approvals/suspend.html
@@ -24,6 +24,7 @@
                         {# Edit mode. #}
 
                         <div class="c-form">
+                            <h2 class="h3">Déclarer une suspension de PASS IAE</h2>
                             <form method="post" class="js-prevent-multiple-submit">
 
                                 {% csrf_token %}
@@ -59,24 +60,27 @@
 
                         <div class="c-form">
                             <form method="post" class="js-prevent-multiple-submit">
-
                                 {% csrf_token %}
-
                                 {# Hide all form fields. #}
                                 {% for field in form %}<input type="hidden" name="{{ field.name }}" value="{{ field.value }}">{% endfor %}
 
                                 {# Show the user a summary of the info. #}
-                                <h5 class="h4 mb-3 card-title">Vous êtes sur le point de suspendre ce PASS IAE pour la raison suivante :</h5>
-                                <p class="card-text">{{ form.instance.get_reason_display }}</p>
-                                <p class="card-text text-success">
-                                    À partir du
-                                    <span class="badge rounded-pill bg-success">{{ form.instance.start_at|date:"d/m/Y" }}</span>
-                                    jusqu'au
-                                    <span class="badge rounded-pill bg-success">{{ form.instance.end_at|date:"d/m/Y" }}</span>
-                                </p>
+                                <h2 class="h3">Vous êtes sur le point de suspendre ce PASS IAE pour la raison suivante :</h2>
+                                <p class="mb-0">{{ form.instance.get_reason_display }}</p>
                                 <p>
-                                    En confirmant cette demande je certifie sur l'honneur que le motif de suspension choisi correspond à la situation du salarié.
+                                    À partir du
+                                    <strong class="text-success">{{ form.instance.start_at|date:"d/m/Y" }}</strong>
+                                    jusqu'au
+                                    <strong class="text-success">{{ form.instance.end_at|date:"d/m/Y" }}</strong>
                                 </p>
+                                {% component_alert content=content variant="warning" %}
+                                    {% fragment as content %}
+                                        <p class="mb-0">
+                                            En confirmant cette demande je certifie sur l'honneur que le motif de suspension choisi correspond à la situation du salarié.
+                                        </p>
+                                    {% endfragment %}
+                                {% endcomponent_alert %}
+
                                 {% itou_buttons_form primary_label="Confirmer la suspension" primary_aria_label="Confirmer la suspension du PASS IAE de "|add:approval.user.get_inverted_full_name primary_name="save" primary_value=1 secondary_name="edit" secondary_value="1" reset_url=back_url show_mandatory_fields_mention=False %}
 
                             </form>

--- a/itou/templates/approvals/suspension_action_choice.html
+++ b/itou/templates/approvals/suspension_action_choice.html
@@ -27,6 +27,7 @@
                     </div>
 
                     <div class="c-form">
+                        <h2 class="h3">Choix de l'action</h2>
                         <p class="fw-bold">Quelle action souhaitez-vous faire ?</p>
                         <form method="post">
                             {% csrf_token %}

--- a/itou/templates/approvals/suspension_delete.html
+++ b/itou/templates/approvals/suspension_delete.html
@@ -26,7 +26,9 @@
                             <strong>Étape 2/2</strong> : Confirmation
                         </p>
                     </div>
+
                     <div class="c-form">
+                        <h2 class="h3">Confirmation</h2>
                         <p>
                             <strong>Action choisie</strong> : Confirmer la <strong class="text-danger">suppression définitive</strong> de cette suspension.
                         </p>
@@ -36,9 +38,7 @@
                             {% endfragment %}
                             {% fragment as content %}
                                 <ul class="mb-0">
-                                    <li>
-                                        <strong>Réduire la durée restante de ce PASS IAE de {{ lost_days }} jour{{ lost_days|pluralizefr }}.</strong>
-                                    </li>
+                                    <li>Réduire la durée restante de ce PASS IAE de {{ lost_days }} jour{{ lost_days|pluralizefr }}.</li>
                                 </ul>
                             {% endfragment %}
                         {% endcomponent_alert %}

--- a/itou/templates/approvals/suspension_update.html
+++ b/itou/templates/approvals/suspension_update.html
@@ -20,6 +20,7 @@
             <div class="s-section__row row">
                 <div class="s-section__col col-12 col-xxl-8 col-xxxl-9 order-2 order-xxl-1">
                     <div class="c-form">
+                        <h2 class="h3">Modifier la suspension de PASS IAE</h2>
                         <form method="post" class="js-prevent-multiple-submit">
 
                             {% csrf_token %}

--- a/itou/templates/approvals/suspension_update_enddate.html
+++ b/itou/templates/approvals/suspension_update_enddate.html
@@ -25,7 +25,9 @@
                             <strong>Étape 2/2</strong> : Demande de précision
                         </p>
                     </div>
+
                     <div class="c-form">
+                        <h2 class="h3">Demande de précision</h2>
                         <p>
                             <strong>Action choisie</strong> : Lever la suspension pour <strong class="text-success">réintégrer ce candidat</strong>
                         </p>

--- a/tests/www/approvals_views/__snapshots__/test_detail.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_detail.ambr
@@ -5677,123 +5677,127 @@
       </section>
       <section class="s-section">
           <div class="s-section__container container">
-              <h2>
-                  Suivi des contrats IAE
-              </h2>
-              <div class="alert alert-info mb-3 mb-md-4" role="status">
-                  <div class="row">
-                      <div class="col-auto pe-0">
-                          <i aria-hidden="true" class="ri-information-line ri-xl text-info">
-                          </i>
-                      </div>
-                      <div class="col">
-                          <p class="mb-2">
-                              <strong>
-                                  Cette page affiche l’ensemble des contrats IAE déclarés dans l’Extranet IAE 2.0 de l’ASP.
-                              </strong>
-                          </p>
-                          <p class="mb-0">
-                              Il y a quelques jours de décalage entre la saisie de données dans l'ASP et leur mise à jour sur cette page.
-                          </p>
-                      </div>
-                  </div>
-              </div>
-              <div class="c-box c-box--results mb-3 mb-md-4">
-                  <div class="c-box--results__header">
-                      <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-                          <div class="c-box--results__summary flex-grow-1">
-                              <i aria-hidden="true" class="ri-home-smile-2-line">
-                              </i>
-                              <div>
-                                  <span>
-                                      EI
-                                  </span>
-                                  <h3>
-                                      Tralal’Hair
-                                  </h3>
+              <div class="s-section__row row">
+                  <div class="s-section__col col-12">
+                      <h2>
+                          Suivi des contrats IAE
+                      </h2>
+                      <div class="alert alert-info mb-3 mb-md-4" role="status">
+                          <div class="row">
+                              <div class="col-auto pe-0">
+                                  <i aria-hidden="true" class="ri-information-line ri-xl text-info">
+                                  </i>
+                              </div>
+                              <div class="col">
+                                  <p class="mb-2">
+                                      <strong>
+                                          Cette page affiche l’ensemble des contrats IAE déclarés dans l’Extranet IAE 2.0 de l’ASP.
+                                      </strong>
+                                  </p>
+                                  <p class="mb-0">
+                                      Il y a quelques jours de décalage entre la saisie de données dans l'ASP et leur mise à jour sur cette page.
+                                  </p>
                               </div>
                           </div>
-                          <div class="align-self-center">
-                              <span>
-                                  <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
-                                  </i>
-                                  Depuis le 01/02/2025
-                              </span>
-                          </div>
                       </div>
-                  </div>
-              </div>
-              <div class="c-box c-box--results mb-3 mb-md-4">
-                  <div class="c-box--results__header">
-                      <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-                          <div class="c-box--results__summary flex-grow-1">
-                              <i aria-hidden="true" class="ri-home-smile-2-line">
-                              </i>
-                              <div>
-                                  <span>
-                                      EI
-                                  </span>
-                                  <h3>
-                                      Tif'any
-                                  </h3>
+                      <div class="c-box c-box--results mb-3 mb-md-4">
+                          <div class="c-box--results__header">
+                              <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                                  <div class="c-box--results__summary flex-grow-1">
+                                      <i aria-hidden="true" class="ri-home-smile-2-line">
+                                      </i>
+                                      <div>
+                                          <span>
+                                              EI
+                                          </span>
+                                          <h3>
+                                              Tralal’Hair
+                                          </h3>
+                                      </div>
+                                  </div>
+                                  <div class="align-self-center">
+                                      <span>
+                                          <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
+                                          </i>
+                                          Depuis le 01/02/2025
+                                      </span>
+                                  </div>
                               </div>
                           </div>
-                          <div class="align-self-center">
-                              <span>
-                                  <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
-                                  </i>
-                                  Du 01/01/2025 au 07/08/2025
-                              </span>
-                          </div>
                       </div>
-                  </div>
-              </div>
-              <div class="c-box c-box--results mb-3 mb-md-4">
-                  <div class="c-box--results__header">
-                      <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-                          <div class="c-box--results__summary flex-grow-1">
-                              <i aria-hidden="true" class="ri-home-smile-2-line">
-                              </i>
-                              <div>
-                                  <span>
-                                      EI
-                                  </span>
-                                  <h3>
-                                      Faudra Tif Hair
-                                  </h3>
+                      <div class="c-box c-box--results mb-3 mb-md-4">
+                          <div class="c-box--results__header">
+                              <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                                  <div class="c-box--results__summary flex-grow-1">
+                                      <i aria-hidden="true" class="ri-home-smile-2-line">
+                                      </i>
+                                      <div>
+                                          <span>
+                                              EI
+                                          </span>
+                                          <h3>
+                                              Tif'any
+                                          </h3>
+                                      </div>
+                                  </div>
+                                  <div class="align-self-center">
+                                      <span>
+                                          <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
+                                          </i>
+                                          Du 01/01/2025 au 07/08/2025
+                                      </span>
+                                  </div>
                               </div>
                           </div>
-                          <div class="align-self-center">
-                              <span>
-                                  <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
-                                  </i>
-                                  Du 01/10/2024 au 10/01/2025
-                              </span>
-                          </div>
                       </div>
-                  </div>
-              </div>
-              <div class="c-box c-box--results mb-3 mb-md-4">
-                  <div class="c-box--results__header">
-                      <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
-                          <div class="c-box--results__summary flex-grow-1">
-                              <i aria-hidden="true" class="ri-home-smile-2-line">
-                              </i>
-                              <div>
-                                  <span>
-                                      EI
-                                  </span>
-                                  <h3>
-                                      Inter Planet Hair
-                                  </h3>
+                      <div class="c-box c-box--results mb-3 mb-md-4">
+                          <div class="c-box--results__header">
+                              <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                                  <div class="c-box--results__summary flex-grow-1">
+                                      <i aria-hidden="true" class="ri-home-smile-2-line">
+                                      </i>
+                                      <div>
+                                          <span>
+                                              EI
+                                          </span>
+                                          <h3>
+                                              Faudra Tif Hair
+                                          </h3>
+                                      </div>
+                                  </div>
+                                  <div class="align-self-center">
+                                      <span>
+                                          <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
+                                          </i>
+                                          Du 01/10/2024 au 10/01/2025
+                                      </span>
+                                  </div>
                               </div>
                           </div>
-                          <div class="align-self-center">
-                              <span>
-                                  <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
-                                  </i>
-                                  Du 01/10/2024 au 30/06/2025
-                              </span>
+                      </div>
+                      <div class="c-box c-box--results mb-3 mb-md-4">
+                          <div class="c-box--results__header">
+                              <div class="d-flex flex-column flex-lg-row gap-2 gap-lg-3">
+                                  <div class="c-box--results__summary flex-grow-1">
+                                      <i aria-hidden="true" class="ri-home-smile-2-line">
+                                      </i>
+                                      <div>
+                                          <span>
+                                              EI
+                                          </span>
+                                          <h3>
+                                              Inter Planet Hair
+                                          </h3>
+                                      </div>
+                                  </div>
+                                  <div class="align-self-center">
+                                      <span>
+                                          <i aria-hidden="true" class="ri-calendar-line ri-lg fw-normal">
+                                          </i>
+                                          Du 01/10/2024 au 30/06/2025
+                                      </span>
+                                  </div>
+                              </div>
                           </div>
                       </div>
                   </div>

--- a/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_prolongation_requests.ambr
@@ -18,7 +18,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -110,7 +110,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -182,7 +182,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -259,7 +259,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -351,7 +351,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -423,7 +423,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -515,7 +515,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -587,7 +587,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">
@@ -679,7 +679,7 @@
                       </p>
                   </div>
                   <div class="c-form mb-3 mb-md-4">
-                      <h2 class="h4">
+                      <h2 class="h3">
                           Réponse envoyée à l'employeur et au candidat
                       </h2>
                       <form method="post">

--- a/tests/www/approvals_views/__snapshots__/test_suspend.ambr
+++ b/tests/www/approvals_views/__snapshots__/test_suspend.ambr
@@ -1284,6 +1284,9 @@
 # name: TestApprovalSuspendView.test_delete_suspension[delete_suspension_form]
   '''
   <div class="c-form">
+      <h2 class="h3">
+          Confirmation
+      </h2>
       <p>
           <strong>
               Action choisie
@@ -1308,9 +1311,7 @@
                   </p>
                   <ul class="mb-0">
                       <li>
-                          <strong>
-                              Réduire la durée restante de ce PASS IAE de 1 jour.
-                          </strong>
+                          Réduire la durée restante de ce PASS IAE de 1 jour.
                       </li>
                   </ul>
               </div>


### PR DESCRIPTION
## :thinking: Pourquoi ?

Parcque qu'on a des [règles maintenant ](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-form-detail--docs) et de nombreux [exemples d'incohérences](https://www.notion.so/gip-inclusion/UX-UI-Lister-les-cas-red-finir-les-r-gles-ux-ui-des-titres-sous-titres-puis-harmoniser-dans-les-f-3025f321b60480e28782f1f1e7d84061) 
Aussi pour harmoniser avec les différentes tailles de titres des [pages details](https://gip-inclusion.github.io/itou-theme/doc/?path=/docs/pages-box-detail--docs)


## :cake: Comment ? <!-- optionnel -->

Principalement en corrigeant les tailles des titres de `c-form`.
A savoir, toujours au moins un titre (avec un look `.h3`) en intro de `c-form`.

Soit:
- en `<h3>` (mais dans ce cas il faut au moins un `<h2>` dans la page)
- en `<h2 class="h3">`
- ou idéalement en `<fieldset> + <legend class="h3">`

## :computer: Captures d'écran <!-- optionnel -->
Quelques avant/apres

**Avant**
<img width="956" height="444" alt="capture 2026-05-13 à 11 19 51" src="https://github.com/user-attachments/assets/da496558-f5a0-4605-a50d-fd872ad8d569" />

<img width="1160" height="457" alt="capture 2026-05-13 à 11 20 03" src="https://github.com/user-attachments/assets/b72b6f32-0f62-42cc-a3ed-08e34ceb9d4c" />

<img width="1225" height="521" alt="capture 2026-05-13 à 11 20 18" src="https://github.com/user-attachments/assets/b0515264-ac01-4fca-8068-a0a7ff948052" />


**Apres**
<img width="1016" height="553" alt="capture 2026-05-13 à 10 42 50" src="https://github.com/user-attachments/assets/f2ae0700-7f47-4d91-8b70-ecee1447a1f5" />

<img width="1015" height="487" alt="capture 2026-05-13 à 10 53 02" src="https://github.com/user-attachments/assets/cecdc1db-f9a2-4437-a8dd-a07e5400435a" />

<img width="1003" height="523" alt="capture 2026-05-13 à 10 55 17" src="https://github.com/user-attachments/assets/9f9141b4-9767-43de-a63e-20cbfbb3510f" />
