### PR TITLE
Connexion : désactivation des EA/EATT

### DIFF
--- a/itou/archive/anonymize.py
+++ b/itou/archive/anonymize.py
@@ -1,0 +1,96 @@
+from allauth.account.models import EmailAddress
+from django.contrib.auth.hashers import make_password
+from django.db.models import Exists, OuterRef, Prefetch
+from django.utils import timezone
+
+from itou.archive.models import AnonymizedProfessional
+from itou.archive.utils import get_year_month_or_none
+from itou.companies.models import CompanyMembership
+from itou.institutions.models import InstitutionMembership
+from itou.prescribers.enums import PrescriberAuthorizationStatus
+from itou.prescribers.models import PrescriberMembership
+from itou.users.models import JobSeekerAssignment, User
+from itou.utils.admin import bulk_add_support_remark_to_objs
+
+
+def annotate_and_prefetch_for_anonymization(users_qs):
+    has_membership_in_authorized_organization_sqs = PrescriberMembership.include_inactive.filter(
+        user_id=OuterRef("id"), organization__authorization_status=PrescriberAuthorizationStatus.VALIDATED
+    )
+    return users_qs.annotate(
+        has_membership_in_authorized_organization=Exists(has_membership_in_authorized_organization_sqs)
+    ).prefetch_related(
+        Prefetch(
+            "companymembership_set",
+            to_attr="prefetched_companymemberships",
+            queryset=CompanyMembership.include_inactive.all(),
+        ),
+        Prefetch(
+            "prescribermembership_set",
+            to_attr="prefetched_prescribermemberships",
+            queryset=PrescriberMembership.include_inactive.all(),
+        ),
+        Prefetch(
+            "institutionmembership_set",
+            to_attr="prefetched_institutionmemberships",
+            queryset=InstitutionMembership.include_inactive.all(),
+        ),
+    )
+
+
+def _make_anonymized_professional(user):
+    memberships = [
+        *user.prefetched_companymemberships,
+        *user.prefetched_institutionmemberships,
+        *user.prefetched_prescribermemberships,
+    ]
+    return AnonymizedProfessional(
+        date_joined=get_year_month_or_none(user.date_joined),
+        first_login=get_year_month_or_none(user.first_login),
+        last_login=get_year_month_or_none(user.last_login),
+        department=user.department,
+        title=user.title,
+        kind=user.kind,
+        number_of_memberships=len(memberships),
+        number_of_active_memberships=sum(m.is_active for m in memberships),
+        number_of_memberships_as_administrator=sum(m.is_admin for m in memberships),
+        had_memberships_in_authorized_organization=user.has_membership_in_authorized_organization,
+        identity_provider=user.identity_provider,
+    )
+
+
+def anonymize_and_delete_professionals(users):
+    AnonymizedProfessional.objects.bulk_create([_make_anonymized_professional(user) for user in users])
+    User.objects.filter(id__in=[user.id for user in users]).delete()
+
+
+def anonymize_professionals_without_deletion(users):
+    user_ids = [user.id for user in users]
+    for model in [CompanyMembership, InstitutionMembership, PrescriberMembership]:
+        model.objects.filter(user_id__in=user_ids).update(is_active=False)
+
+    EmailAddress.objects.filter(user_id__in=user_ids).delete()
+
+    # No need to keep assignments from professionals without organization or company.
+    # If a professional was anonymized without deletion just because of an assignment
+    # like these, he will be deleted on the next command run.
+    JobSeekerAssignment.objects.filter(
+        professional_id__in=user_ids,
+        prescriber_organization_id__isnull=True,
+        company_id__isnull=True,
+    ).delete()
+
+    User.objects.filter(id__in=user_ids).update(
+        is_active=False,
+        password=make_password(None),
+        email=None,
+        phone="",
+        address_line_1="",
+        address_line_2="",
+        post_code="",
+        city="",
+        coords=None,
+        insee_city=None,
+    )
+    text = f"{timezone.localtime().replace(microsecond=0)} - Désactivation/archivage de l'utilisateur"
+    bulk_add_support_remark_to_objs(users, text)

--- a/itou/archive/management/commands/anonymize_professionals.py
+++ b/itou/archive/management/commands/anonymize_professionals.py
@@ -1,22 +1,19 @@
-from allauth.account.models import EmailAddress
 from django.conf import settings
-from django.contrib.auth.hashers import make_password
-from django.db.models import Exists, F, OuterRef, Prefetch, Q
+from django.db.models import F, Q
 from django.utils import timezone
 from itoutils.django.commands import dry_runnable
 from sentry_sdk.crons import monitor
 
+from itou.archive.anonymize import (
+    annotate_and_prefetch_for_anonymization,
+    anonymize_and_delete_professionals,
+    anonymize_professionals_without_deletion,
+)
 from itou.archive.constants import GRACE_PERIOD
-from itou.archive.models import AnonymizedProfessional
 from itou.archive.tasks import async_delete_contact
-from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check, get_year_month_or_none
-from itou.companies.models import CompanyMembership
-from itou.institutions.models import InstitutionMembership
-from itou.prescribers.enums import PrescriberAuthorizationStatus
-from itou.prescribers.models import PrescriberMembership
-from itou.users.models import JobSeekerAssignment, User, UserKind
+from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check
+from itou.users.models import User, UserKind
 from itou.users.notifications import ArchiveUser
-from itou.utils.admin import add_support_remark_to_obj
 from itou.utils.command import BaseCommand
 
 
@@ -72,8 +69,8 @@ class Command(BaseCommand):
         for user in users:
             ArchiveUser(user).send()
 
-        self.anonymize_and_delete_professionals(users_to_delete)
-        self.anonymize_professionals_without_deletion(users_to_anonymize)
+        anonymize_and_delete_professionals(users_to_delete)
+        anonymize_professionals_without_deletion(users_to_anonymize)
         self.remove_from_contact(users_to_remove_from_contact)
 
         self.logger.info("Anonymized professionals after grace period, count: %d", len(users))
@@ -95,88 +92,11 @@ class Command(BaseCommand):
 
     def get_users_to_anonymize_and_delete(self, users):
         related_objects_to_check = get_filter_kwargs_on_user_for_related_objects_to_check()
-        has_membership_in_authorized_organization_sqs = PrescriberMembership.include_inactive.filter(
-            user_id=OuterRef("id"), organization__authorization_status=PrescriberAuthorizationStatus.VALIDATED
-        )
         return list(
-            User.objects.filter(id__in=[user.id for user in users])
-            .filter(**related_objects_to_check)
-            .annotate(has_membership_in_authorized_organization=Exists(has_membership_in_authorized_organization_sqs))
-            .prefetch_related(
-                Prefetch(
-                    "companymembership_set",
-                    to_attr="prefetched_companymemberships",
-                    queryset=CompanyMembership.include_inactive.all(),
-                ),
-                Prefetch(
-                    "prescribermembership_set",
-                    to_attr="prefetched_prescribermemberships",
-                    queryset=PrescriberMembership.include_inactive.all(),
-                ),
-                Prefetch(
-                    "institutionmembership_set",
-                    to_attr="prefetched_institutionmemberships",
-                    queryset=InstitutionMembership.include_inactive.all(),
-                ),
+            annotate_and_prefetch_for_anonymization(
+                User.objects.filter(id__in=[user.id for user in users]).filter(**related_objects_to_check)
             )
         )
-
-    def make_anonymized_professional(self, user):
-        memberships = [
-            *user.prefetched_companymemberships,
-            *user.prefetched_institutionmemberships,
-            *user.prefetched_prescribermemberships,
-        ]
-        return AnonymizedProfessional(
-            date_joined=get_year_month_or_none(user.date_joined),
-            first_login=get_year_month_or_none(user.first_login),
-            last_login=get_year_month_or_none(user.last_login),
-            department=user.department,
-            title=user.title,
-            kind=user.kind,
-            number_of_memberships=len(memberships),
-            number_of_active_memberships=sum(m.is_active for m in memberships),
-            number_of_memberships_as_administrator=sum(m.is_admin for m in memberships),
-            had_memberships_in_authorized_organization=user.has_membership_in_authorized_organization,
-            identity_provider=user.identity_provider,
-        )
-
-    def anonymize_and_delete_professionals(self, users):
-        AnonymizedProfessional.objects.bulk_create([self.make_anonymized_professional(user) for user in users])
-        User.objects.filter(id__in=[user.id for user in users]).delete()
-
-    def anonymize_professionals_without_deletion(self, users):
-        user_ids = [user.id for user in users]
-        for model in [CompanyMembership, InstitutionMembership, PrescriberMembership]:
-            model.objects.filter(user_id__in=user_ids).update(is_active=False)
-
-        EmailAddress.objects.filter(user_id__in=user_ids).delete()
-
-        # No need to keep assignments from professionals without organization or company. If a professional was
-        # anonymized without deletion just because of an assignment like these, he will be deleted on the next command
-        # run.
-        JobSeekerAssignment.objects.filter(
-            professional_id__in=[user.id for user in users],
-            prescriber_organization_id__isnull=True,
-            company_id__isnull=True,
-        ).delete()
-
-        User.objects.filter(id__in=user_ids).update(
-            is_active=False,
-            password=make_password(None),
-            email=None,
-            phone="",
-            address_line_1="",
-            address_line_2="",
-            post_code="",
-            city="",
-            coords=None,
-            insee_city=None,
-        )
-        for user in users:
-            add_support_remark_to_obj(
-                user, f"{timezone.localtime().replace(microsecond=0)} - Désactivation/archivage de l'utilisateur"
-            )
 
     def remove_from_contact(self, users):
         for user in users:

--- a/itou/archive/management/commands/cleanup_ea_eatt_members.py
+++ b/itou/archive/management/commands/cleanup_ea_eatt_members.py
@@ -1,0 +1,167 @@
+from django.db.models import Exists, OuterRef
+from django.utils import timezone
+from itoutils.django.commands import dry_runnable
+
+from itou.archive.anonymize import (
+    annotate_and_prefetch_for_anonymization,
+    anonymize_and_delete_professionals,
+    anonymize_professionals_without_deletion,
+)
+from itou.archive.tasks import async_delete_contact
+from itou.archive.utils import get_filter_kwargs_on_user_for_related_objects_to_check
+from itou.companies.enums import CompanyKind
+from itou.companies.models import Company, CompanyMembership
+from itou.institutions.models import InstitutionMembership
+from itou.prescribers.models import PrescriberMembership
+from itou.users.models import User, UserKind
+from itou.utils.admin import bulk_add_support_remark_to_objs
+from itou.utils.command import BaseCommand
+
+
+EA_EATT_KINDS = (CompanyKind.EA, CompanyKind.EATT)
+BATCH_SIZE = 500
+
+
+class Command(BaseCommand):
+    ATOMIC_HANDLE = True
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--wet-run",
+            action="store_true",
+            help="Perform the EA/EATT cleanup (otherwise dry-run: transaction is rolled back).",
+        )
+
+        parser.add_argument(
+            "--batch-size",
+            action="store",
+            type=int,
+            default=BATCH_SIZE,
+            help="Number of users to process in a batch",
+        )
+
+    @dry_runnable
+    def handle(self, *args, batch_size, **options):
+        self.batch_size = batch_size
+        self.logger.info("Start EA/EATT cleanup")
+
+        user_ids = CompanyMembership.include_inactive.filter(
+            company__kind__in=EA_EATT_KINDS,
+            user__kind__in=UserKind.professionals(),
+        ).values_list("user_id", flat=True)
+        user_ids_for_update = list(
+            User.objects.filter(id__in=user_ids).select_for_update().values_list("id", flat=True)
+        )
+        self.logger.info("Number of users with EA/EATT memberships: %d", len(user_ids_for_update))
+
+        users_to_anonymize_qs = (
+            User.objects.filter(id__in=user_ids_for_update)
+            .annotate(
+                has_non_ea_eatt_company_membership=Exists(
+                    CompanyMembership.include_inactive.filter(user_id=OuterRef("pk")).exclude(
+                        company__kind__in=EA_EATT_KINDS
+                    )
+                ),
+                has_prescriber_membership=Exists(PrescriberMembership.include_inactive.filter(user_id=OuterRef("pk"))),
+                has_institution_membership=Exists(
+                    InstitutionMembership.include_inactive.filter(user_id=OuterRef("pk"))
+                ),
+            )
+            .filter(
+                has_non_ea_eatt_company_membership=False,
+                has_prescriber_membership=False,
+                has_institution_membership=False,
+            )
+        )
+        users_to_anonymize_ids = list(users_to_anonymize_qs.values_list("id", flat=True))
+        users_to_detach_ids = [uid for uid in user_ids_for_update if uid not in users_to_anonymize_ids]
+
+        anonymized = self._anonymize_users(users_to_anonymize_ids)
+        detached = self._detach_users(users_to_detach_ids)
+        self._disable_companies()
+
+        self.logger.info("EA/EATT cleanup done: anonymized=%d detached=%d", anonymized, detached)
+
+        self._check_remaining_memberships()
+
+    def _batched(self, ids):
+        for start in range(0, len(ids), self.batch_size):
+            yield ids[start : start + self.batch_size]
+
+    def _anonymize_users(self, user_ids):
+        if not user_ids:
+            return 0
+
+        total_deleted = 0
+        total_anonymized = 0
+        total_removed_from_contact = 0
+        for batch_ids in self._batched(user_ids):
+            related_objects_to_check = get_filter_kwargs_on_user_for_related_objects_to_check()
+            deletable_ids = set(
+                User.objects.filter(id__in=batch_ids).filter(**related_objects_to_check).values_list("id", flat=True)
+            )
+
+            users = list(annotate_and_prefetch_for_anonymization(User.objects.filter(id__in=batch_ids)))
+            users_to_delete = [user for user in users if user.id in deletable_ids]
+            users_to_anonymize = [user for user in users if user.id not in deletable_ids and user.email]
+            users_to_remove_from_contact = [user for user in users if user.email]
+
+            anonymize_and_delete_professionals(users_to_delete)
+            anonymize_professionals_without_deletion(users_to_anonymize)
+            for user in users_to_remove_from_contact:
+                async_delete_contact(user.email)
+
+            total_deleted += len(users_to_delete)
+            total_anonymized += len(users_to_anonymize)
+            total_removed_from_contact += len(users_to_remove_from_contact)
+
+        self.logger.info(
+            "EA/EATT anonymization: %d deleted, %d anonymized without deletion, %d removed from contact",
+            total_deleted,
+            total_anonymized,
+            total_removed_from_contact,
+        )
+        return total_deleted + total_anonymized
+
+    def _detach_users(self, user_ids):
+        if not user_ids:
+            return 0
+
+        total_deleted = 0
+        # will look like: 2026-05-13 12:34:56+02:00
+        remark = f"{timezone.localtime().replace(microsecond=0)} - Détachement EA/EATT"
+        for batch_ids in self._batched(user_ids):
+            deleted, _ = CompanyMembership.include_inactive.filter(
+                user_id__in=batch_ids, company__kind__in=EA_EATT_KINDS
+            ).delete()
+            total_deleted += deleted
+            bulk_add_support_remark_to_objs(User.objects.filter(id__in=batch_ids), remark)
+
+        self.logger.info("EA/EATT cleanup: %d memberships removed for %d users", total_deleted, len(user_ids))
+        return len(user_ids)
+
+    def _disable_companies(self):
+        companies = Company.unfiltered_objects.filter(kind__in=EA_EATT_KINDS)
+        now = timezone.now()
+        updated = companies.filter(block_job_applications=False).update(
+            block_job_applications=True,
+            job_applications_blocked_at=now,
+        )
+        self.logger.info("EA/EATT cleanup: %d companies disabled", updated)
+
+    def _check_remaining_memberships(self):
+        """Safety net to check if there are still some EA/EATT memberships left after the cleanup.
+
+        If there are some, it could indicate that some users were missed by the anonymization/detachment
+        process: there is no DB constraint ensuring that all EA/EATT memberships correspond to professionals.
+        """
+        remaining_memberships = CompanyMembership.include_inactive.filter(company__kind__in=EA_EATT_KINDS)
+        remaining_ms_count = remaining_memberships.count()
+        if remaining_ms_count > 0:
+            remaining_users_count = remaining_memberships.values("user_id").distinct().count()
+            self.logger.warning(
+                "EA/EATT cleanup: %d remaining memberships left for %d distinct users.",
+                remaining_ms_count,
+                remaining_users_count,
+            )

--- a/itou/companies/admin.py
+++ b/itou/companies/admin.py
@@ -23,7 +23,7 @@ from itou.utils.admin import (
     ItouTabularInline,
     PkSupportRemarkInline,
     ReadonlyMixin,
-    add_support_remark_to_obj,
+    bulk_add_support_remark_to_objs,
     get_admin_view_link,
 )
 from itou.utils.apis.exceptions import GeocodingDataError
@@ -382,8 +382,7 @@ class CompanyAdmin(ItouGISMixin, CreatedOrUpdatedByMixin, OrganizationAdmin):
                                 summary_lines.extend([f"- {report_field.label}:"] + [f"  * {item}" for item in items])
                         summary_lines += ["-" * 20]
                         summary_text = "\n".join(summary_lines)
-                        add_support_remark_to_obj(from_company, summary_text)
-                        add_support_remark_to_obj(to_company, summary_text)
+                        bulk_add_support_remark_to_objs([from_company, to_company], summary_text)
                         message = format_html(
                             "Transfert effectué avec succès de l’entreprise {from_company} vers {to_company}.",
                             from_company=from_company,

--- a/itou/gps/management/commands/import_advisor_information.py
+++ b/itou/gps/management/commands/import_advisor_information.py
@@ -14,7 +14,7 @@ from itou.gps.models import FollowUpGroup, FollowUpGroupMembership
 from itou.prescribers.models import PrescriberMembership, PrescriberOrganization
 from itou.users.enums import UserKind
 from itou.users.models import JobSeekerProfile, User
-from itou.utils.admin import add_support_remark_to_obj
+from itou.utils.admin import bulk_add_support_remark_to_objs
 from itou.utils.command import BaseCommand
 
 
@@ -286,8 +286,8 @@ class Command(BaseCommand):
                     )
                     FollowUpGroupMembership.objects.bulk_create(follow_up_memberships_to_create)
                     PrescriberMembership.objects.bulk_create(prescriber_memberships_to_create)
-                    for prescriber in prescribers_to_create:
-                        add_support_remark_to_obj(prescriber, "Créé par l'import des référents FT pour GPS")
+                    text = "Créé par l'import des référents FT pour GPS"
+                    bulk_add_support_remark_to_objs(prescribers_to_create, text)
 
             created_prescriber_count += len(prescribers_to_create)
 

--- a/itou/users/admin.py
+++ b/itou/users/admin.py
@@ -52,6 +52,7 @@ from itou.utils.admin import (
     PkSupportRemarkInline,
     ReadonlyMixin,
     add_support_remark_to_obj,
+    bulk_add_support_remark_to_objs,
     get_admin_view_link,
     get_organization_view_link,
 )
@@ -834,8 +835,7 @@ class ItouUserAdmin(InconsistencyCheckMixin, CreatedOrUpdatedByMixin, ItouModelM
                         + [f"- {item_title} {item} transféré " for item_title, item in transferred_items]
                         + ["-" * 20]
                     )
-                    add_support_remark_to_obj(from_user, summary_text)
-                    add_support_remark_to_obj(to_user, summary_text)
+                    bulk_add_support_remark_to_objs([from_user, to_user], summary_text)
                     message = format_html(
                         "Transfert effectué avec succès de l'utilisateur {from_user} vers {to_user}.",
                         from_user=from_user,

--- a/itou/utils/admin.py
+++ b/itou/utils/admin.py
@@ -10,8 +10,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.forms import fields as gis_fields
 from django.contrib.messages import WARNING
 from django.core.exceptions import FieldDoesNotExist, ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.html import format_html, format_html_join
 from django.utils.text import capfirst
 
@@ -256,19 +257,54 @@ class ItouModelAdmin(ItouModelMixin, ModelAdmin):
     pass
 
 
-def add_support_remark_to_obj(obj, text):
-    if isinstance(obj._meta.pk, models.UUIDField):
+def bulk_add_support_remark_to_objs(objs, text):
+    """Add the same remark to multiple objects in a batch.
+
+    `objs` should be an iterable of instances of the same model. Mixing model types
+    would cause remarks to be written under the wrong content type.
+    """
+    objs_list = list(objs)
+    if not objs_list:
+        return 0
+
+    first_obj_class = objs_list[0].__class__
+    if any(not isinstance(obj, first_obj_class) for obj in objs_list):
+        raise ValueError("All objects must be instances of the same model")
+
+    if isinstance(objs_list[0]._meta.pk, models.UUIDField):
         remark_model = UUIDSupportRemark
     else:
         remark_model = PkSupportRemark
-    obj_content_type = ContentType.objects.get_for_model(obj)
-    try:
-        remark = remark_model.objects.filter(content_type=obj_content_type, object_id=obj.pk).get()
-    except remark_model.DoesNotExist:
-        remark_model.objects.create(content_type=obj_content_type, object_id=obj.pk, remark=text)
-    else:
-        remark.remark += "\n" + text
-        remark.save(update_fields=("remark", "updated_at"))
+    obj_content_type = ContentType.objects.get_for_model(objs_list[0])
+    obj_pks = [obj.pk for obj in objs_list]
+    now = timezone.now()
+
+    with transaction.atomic():
+        # silently keeps only one remark when there are multiple existing remarks for the same object
+        existing_remarks = {
+            remark.object_id: remark
+            for remark in remark_model.objects.select_for_update().filter(
+                content_type=obj_content_type, object_id__in=obj_pks
+            )
+        }
+
+        to_create, to_update = [], []
+        for pk in obj_pks:
+            if remark := existing_remarks.get(pk):
+                remark.remark += "\n" + text
+                remark.updated_at = now
+                to_update.append(remark)
+            else:
+                to_create.append(remark_model(content_type=obj_content_type, object_id=pk, remark=text))
+
+        created = remark_model.objects.bulk_create(to_create) if to_create else []
+        nb_updated = remark_model.objects.bulk_update(to_update, fields=["remark", "updated_at"]) if to_update else 0
+    return nb_updated + len(created)
+
+
+def add_support_remark_to_obj(obj, text):
+    """Add a remark to an object, or update the existing one if it already has a remark."""
+    bulk_add_support_remark_to_objs([obj], text)
 
 
 class ReadonlyMixin:

--- a/tests/archive/__snapshots__/tests_management_command.ambr
+++ b/tests/archive/__snapshots__/tests_management_command.ambr
@@ -1523,7 +1523,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1551,7 +1551,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1611,7 +1611,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1636,7 +1636,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1661,7 +1661,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1694,7 +1694,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1719,7 +1719,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1744,7 +1744,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1769,7 +1769,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1800,7 +1800,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1833,7 +1833,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1858,7 +1858,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1883,7 +1883,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1916,7 +1916,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1949,7 +1949,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1974,7 +1974,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -1999,7 +1999,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2024,7 +2024,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2049,7 +2049,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2074,7 +2074,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2099,7 +2099,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2131,7 +2131,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2161,7 +2161,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2186,7 +2186,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2211,7 +2211,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2246,7 +2246,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2281,7 +2281,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2306,7 +2306,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2331,7 +2331,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2356,7 +2356,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2381,7 +2381,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2406,7 +2406,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2449,7 +2449,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2492,7 +2492,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2535,7 +2535,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2578,7 +2578,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2603,7 +2603,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2628,7 +2628,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2653,7 +2653,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2678,7 +2678,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2703,7 +2703,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2740,7 +2740,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2765,7 +2765,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2790,7 +2790,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2815,7 +2815,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2840,7 +2840,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2873,7 +2873,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2898,7 +2898,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2923,7 +2923,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2962,7 +2962,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -2987,7 +2987,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3011,7 +3011,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3035,7 +3035,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3059,7 +3059,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3083,7 +3083,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3107,7 +3107,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3131,7 +3131,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3155,7 +3155,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3179,7 +3179,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3203,7 +3203,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3227,7 +3227,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3251,7 +3251,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3275,7 +3275,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3299,7 +3299,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3323,7 +3323,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3347,7 +3347,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3371,7 +3371,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3395,7 +3395,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',
@@ -3419,7 +3419,7 @@
       }),
       dict({
         'origin': list([
-          'Command.anonymize_and_delete_professionals[archive/management/commands/anonymize_professionals.py]',
+          'anonymize_and_delete_professionals[archive/anonymize.py]',
           'Command.anonymize_professionals_after_grace_period[archive/management/commands/anonymize_professionals.py]',
           'Command.handle[archive/management/commands/anonymize_professionals.py]',
           'wrapper[itoutils/django/commands.py]',

--- a/tests/archive/test_cleanup_ea_eatt_members.py
+++ b/tests/archive/test_cleanup_ea_eatt_members.py
@@ -1,0 +1,180 @@
+import re
+
+import httpx
+import pytest
+from django.core.management import call_command
+
+from itou.archive.models import AnonymizedProfessional
+from itou.companies.enums import CompanyKind
+from itou.companies.models import Company, CompanyMembership
+from itou.users.models import User
+from tests.companies.factories import CompanyFactory, CompanyMembershipFactory
+from tests.institutions.factories import InstitutionMembershipFactory
+from tests.job_applications.factories import JobApplicationFactory
+from tests.prescribers.factories import PrescriberMembershipFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def brevo_api_key_fixture(settings):
+    settings.BREVO_API_KEY = "BREVO_API_KEY"
+
+
+@pytest.fixture(autouse=True)
+def respx_delete_mock(respx_mock, settings):
+    respx_mock.delete(url__regex=re.compile(f"^{re.escape(settings.BREVO_API_URL)}/contacts/.*")).mock(
+        return_value=httpx.Response(status_code=204)
+    )
+
+
+class TestCleanupEaEattMembers:
+    def test_user_only_in_ea_is_anonymized_and_deleted(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA)
+        user_id = membership.user_id
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert not User.objects.filter(id=user_id).exists()
+        assert AnonymizedProfessional.objects.count() == 1
+        assert not CompanyMembership.include_inactive.filter(user_id=user_id).exists()
+
+    def test_user_only_in_inactive_eatt_is_anonymized(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EATT, is_active=False)
+        user_id = membership.user_id
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert not User.objects.filter(id=user_id).exists()
+        assert AnonymizedProfessional.objects.count() == 1
+
+    def test_user_with_other_company_is_only_detached(self):
+        user_membership = CompanyMembershipFactory(company__kind=CompanyKind.EA)
+        user = user_membership.user
+        other = CompanyMembershipFactory(user=user, company__kind=CompanyKind.ACI)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert User.objects.filter(id=user.id).exists()
+        assert AnonymizedProfessional.objects.count() == 0
+        assert not CompanyMembership.include_inactive.filter(user=user, company__kind=CompanyKind.EA).exists()
+        assert CompanyMembership.include_inactive.filter(id=other.id).exists()
+
+    def test_user_with_prescriber_membership_is_only_detached(self):
+        ea_membership = CompanyMembershipFactory(company__kind=CompanyKind.EA)
+        user = ea_membership.user
+        PrescriberMembershipFactory(user=user)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert User.objects.filter(id=user.id).exists()
+        assert AnonymizedProfessional.objects.count() == 0
+        assert not CompanyMembership.include_inactive.filter(user=user).exists()
+
+    def test_user_with_institution_membership_is_only_detached(self):
+        ea_membership = CompanyMembershipFactory(company__kind=CompanyKind.EA)
+        user = ea_membership.user
+        InstitutionMembershipFactory(user=user)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert User.objects.filter(id=user.id).exists()
+        assert AnonymizedProfessional.objects.count() == 0
+        assert not CompanyMembership.include_inactive.filter(user=user).exists()
+
+    def test_user_with_non_cascade_relation_is_anonymized_without_deletion(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA, user__email="pro@example.com")
+        user = membership.user
+        JobApplicationFactory(sender=user, sent_by_prescriber_alone=True)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        user.refresh_from_db()
+        assert user.is_active is False
+        assert user.email is None
+        assert user.phone == ""
+        assert AnonymizedProfessional.objects.count() == 0
+
+    def test_dry_run_makes_no_changes(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA)
+        user_id = membership.user_id
+
+        call_command("cleanup_ea_eatt_members")
+
+        assert User.objects.filter(id=user_id).exists()
+        assert AnonymizedProfessional.objects.count() == 0
+        assert CompanyMembership.include_inactive.filter(user_id=user_id).exists()
+
+    def test_ea_eatt_companies_are_blocked_and_memberships_removed(self):
+        ea = CompanyFactory(kind=CompanyKind.EA, block_job_applications=False)
+        eatt = CompanyFactory(kind=CompanyKind.EATT, block_job_applications=False)
+        # Memberships that will be cascaded by anonymization (user-only-EA).
+        CompanyMembershipFactory(company=ea)
+        CompanyMembershipFactory(company=eatt)
+        # Membership for a user who also has a non-EA membership: gets explicitly detached.
+        mixed = CompanyMembershipFactory(company=ea)
+        CompanyMembershipFactory(user=mixed.user, company__kind=CompanyKind.ACI)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        ea.refresh_from_db()
+        eatt.refresh_from_db()
+        assert ea.block_job_applications is True
+        assert ea.job_applications_blocked_at is not None
+        assert eatt.block_job_applications is True
+        assert not CompanyMembership.include_inactive.filter(
+            company__kind__in=[CompanyKind.EA, CompanyKind.EATT]
+        ).exists()
+        assert Company.unfiltered_objects.filter(kind__in=[CompanyKind.EA, CompanyKind.EATT]).count() == 2
+
+    def test_user_with_inactive_ea_and_active_non_ea_is_only_detached(self):
+        ea_membership = CompanyMembershipFactory(company__kind=CompanyKind.EA, is_active=False)
+        user = ea_membership.user
+        other = CompanyMembershipFactory(user=user, company__kind=CompanyKind.ACI, is_active=True)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert User.objects.filter(id=user.id).exists()
+        assert AnonymizedProfessional.objects.count() == 0
+        assert not CompanyMembership.include_inactive.filter(user=user, company__kind=CompanyKind.EA).exists()
+        assert CompanyMembership.include_inactive.filter(id=other.id).exists()
+
+    def test_non_ea_eatt_company_is_not_blocked(self):
+        aci = CompanyFactory(kind=CompanyKind.ACI, block_job_applications=False)
+        CompanyMembershipFactory(company=aci)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        aci.refresh_from_db()
+        assert aci.block_job_applications is False
+        assert aci.job_applications_blocked_at is None
+
+    def test_already_anonymized_user_rerun_is_idempotent(self):
+        membership = CompanyMembershipFactory(company__kind=CompanyKind.EA, user__email="pro@example.com")
+        user_id = membership.user_id
+        JobApplicationFactory(sender=membership.user, sent_by_prescriber_alone=True)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        user = User.objects.get(id=user_id)
+        assert user.is_active is False
+        assert user.email is None
+
+    def test_no_ea_eatt_users_is_noop(self, caplog):
+        CompanyMembershipFactory(company__kind=CompanyKind.ACI)
+
+        call_command("cleanup_ea_eatt_members", wet_run=True)
+
+        assert AnonymizedProfessional.objects.count() == 0
+        assert "EA/EATT cleanup done: anonymized=0 detached=0" in caplog.messages
+
+    def test_batches_process_all_users(self):
+        memberships = CompanyMembershipFactory.create_batch(5, company__kind=CompanyKind.EA)
+        user_ids = [m.user_id for m in memberships]
+
+        call_command("cleanup_ea_eatt_members", wet_run=True, batch_size=2)
+
+        assert not User.objects.filter(id__in=user_ids).exists()
+        assert AnonymizedProfessional.objects.count() == 5

--- a/tests/archive/tests_management_command.py
+++ b/tests/archive/tests_management_command.py
@@ -94,7 +94,7 @@ def respx_delete_mock(respx_mock):
 @pytest.fixture(autouse=True)
 def mock_make_password():
     with patch(
-        "itou.archive.management.commands.anonymize_professionals.make_password",
+        "itou.archive.anonymize.make_password",
         return_value="pbkdf2_sha256$test$hash",
     ):
         yield

--- a/tests/utils/tests.py
+++ b/tests/utils/tests.py
@@ -42,7 +42,7 @@ from itou.prescribers.enums import PrescriberOrganizationKind
 from itou.users.enums import IdentityProvider, UserKind
 from itou.users.models import User
 from itou.utils import constants as global_constants, pagination
-from itou.utils.admin import add_support_remark_to_obj
+from itou.utils.admin import add_support_remark_to_obj, bulk_add_support_remark_to_objs
 from itou.utils.emails import redact_email_address
 from itou.utils.models import PkSupportRemark, UUIDSupportRemark
 from itou.utils.password_validation import CnilCompositionPasswordValidator
@@ -1868,3 +1868,59 @@ def test_add_support_remark_to_obj(remark_model, obj_factory):
     assert updated_remark.remark == "A remark\nOther remark"
     assert remark.pk == updated_remark.pk
     assert updated_remark.updated_at != remark.updated_at
+
+
+@pytest.mark.parametrize(
+    "remark_model,obj_factory",
+    [
+        (PkSupportRemark, PrescriberFactory),
+        (UUIDSupportRemark, functools.partial(JobApplicationFactory, sent_by_prescriber_alone=True)),
+    ],
+)
+def test_bulk_add_support_remark_to_objs(remark_model, obj_factory):
+    def get_remarks_for(objs):
+        if not objs:
+            return {}
+        return (
+            remark_model.objects.filter(content_type=ContentType.objects.get_for_model(objs[0].__class__))
+            .distinct("object_id")
+            .in_bulk([o.pk for o in objs], field_name="object_id")
+        )
+
+    # Empty input is a no-op and issues no queries.
+    with assertNumQueries(0):
+        assert bulk_add_support_remark_to_objs([], "A remark") == 0
+    assert not remark_model.objects.exists()
+
+    # All-new objects: bulk_create path
+    # Queries: SAVEPOINT + SELECT FOR UPDATE + bulk_create INSERT + RELEASE SAVEPOINT
+    new_objs = [obj_factory(), obj_factory()]
+    with assertNumQueries(4):
+        assert bulk_add_support_remark_to_objs(new_objs, "First") == 2
+    remarks = get_remarks_for(new_objs)
+    assert len(remarks) == 2
+    for obj in new_objs:
+        assert remarks[obj.pk].remark == "First"
+
+    # All-existing objects: bulk_update path appends and bumps updated_at
+    # Queries: SAVEPOINT + SELECT FOR UPDATE + bulk_update UPDATE + RELEASE SAVEPOINT
+    prior_updates = {pk: r.updated_at for pk, r in remarks.items()}
+    with assertNumQueries(4):
+        assert bulk_add_support_remark_to_objs(new_objs, "Second") == 2
+    refreshed = get_remarks_for(new_objs)
+    for obj in new_objs:
+        assert refreshed[obj.pk].remark == "First\nSecond"
+        assert refreshed[obj.pk].pk == remarks[obj.pk].pk
+        assert refreshed[obj.pk].updated_at != prior_updates[obj.pk]
+
+    # Mixed new/existing objects: one bulk_create + one bulk_update in a single call
+    # Queries: SAVEPOINT + SELECT FOR UPDATE + INSERT + UPDATE + RELEASE SAVEPOINT
+    fresh_obj = obj_factory()
+    mixed_objs = [new_objs[0], fresh_obj]  # existing, new
+    with assertNumQueries(5):
+        assert bulk_add_support_remark_to_objs(mixed_objs, "Third") == 2
+    mixed_remarks = get_remarks_for(mixed_objs)
+    assert mixed_remarks[new_objs[0].pk].remark == "First\nSecond\nThird"
+    assert mixed_remarks[fresh_obj.pk].remark == "Third"
+    # The untouched object's remark is unchanged
+    assert get_remarks_for([new_objs[1]])[new_objs[1].pk].remark == "First\nSecond"


### PR DESCRIPTION
## :thinking: Pourquoi ?

Cette PR correspond à [cette carte](https://www.notion.so/gip-inclusion/MEP-le-11-05-G-rer-les-comptes-des-utilisateurs-EA-EATT-3545f321b60480d981e9df1c18d77c5d), elle regroupe 3 commits dont je vous invite à consulter les messages :
- Optimisation de l’ajout de remarques support en lot pour éviter des requêtes N+1 par la suite,
- Refactorisation de la logique d’anonymisation dans des services réutilisables,
- Ajout d’une commande de nettoyage dédiée aux membres EA/EATT.

## :cake: Comment ?

- Un helper `bulk_add_support_remark_to_objs` a été introduit et utilisé dans plusieurs endroits afin d’écrire les remarques pour plusieurs objets en une seule opération (encore une fois il s'agissait surtout d'éviter des N+1).
- La logique d’anonymisation a été déplacée hors des commandes vers des services dédiés dans un fichier `anonymize.py`, ce qui facilite sa réutilisation.
- Une nouvelle commande `cleanup_ea_eatt_members` est ajoutée pour désactiver les comptes EA/EATT.
