### PR TITLE
Tech : Amélioration de l'accès au calendrier de la campagne de contrôle

### DIFF
--- a/itou/www/siae_evaluations_views/views.py
+++ b/itou/www/siae_evaluations_views/views.py
@@ -78,11 +78,18 @@ def samples_selection(request, template_name="siae_evaluations/samples_selection
 
 
 @readonly_view
+@check_request(lambda request: request.from_employer or request.from_institution or request.user.is_staff)
 def campaign_calendar(request, evaluation_campaign_pk, template_name="siae_evaluations/campaign_calendar.html"):
-    evaluation_campaign = get_object_or_404(
-        EvaluationCampaign,
-        pk=evaluation_campaign_pk,
-    )
+    if request.user.is_staff:
+        # Allow itou staff to inspect any campaign for support purposes (cf. PR #3216).
+        queryset = EvaluationCampaign.objects.all()
+    elif request.from_institution:
+        institution = get_current_institution_or_404(request)
+        queryset = EvaluationCampaign.objects.for_institution(institution)
+    else:
+        company = get_current_company_or_404(request)
+        queryset = EvaluationCampaign.objects.filter(evaluated_siaes__siae=company)
+    evaluation_campaign = get_object_or_404(queryset, pk=evaluation_campaign_pk)
 
     context = {
         "back_url": reverse("dashboard:index"),

--- a/tests/www/siae_evaluations_views/test_views.py
+++ b/tests/www/siae_evaluations_views/test_views.py
@@ -23,7 +23,7 @@ from tests.siae_evaluations.factories import (
     EvaluationCampaignFactory,
     SanctionsFactory,
 )
-from tests.users.factories import EmployerFactory
+from tests.users.factories import EmployerFactory, JobSeekerFactory, PrescriberFactory
 from tests.utils.testing import parse_response_to_soup, pretty_indented
 
 
@@ -477,6 +477,23 @@ class TestViewProof:
         client.force_login(membership.user)
         response = client.get(url)
         assert response.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "user_factory, expected_status",
+    [
+        (lambda: JobSeekerFactory(), 403),
+        (lambda: PrescriberFactory(membership=True), 403),
+        (lambda: CompanyMembershipFactory(company__evaluable_kind=True).user, 404),
+        (lambda: InstitutionMembershipFactory().user, 404),
+    ],
+    ids=["job_seeker", "prescriber", "unrelated_employer", "unrelated_inspector"],
+)
+def test_campaign_calendar_denies_unauthorized(client, user_factory, expected_status):
+    campaign = EvaluationCampaignFactory()
+    client.force_login(user_factory())
+    response = client.get(reverse("siae_evaluations_views:campaign_calendar", args=[campaign.pk]))
+    assert response.status_code == expected_status
 
 
 def test_active_campaign_calendar_for_admin_no_crash(admin_client):


### PR DESCRIPTION
## :thinking: Pourquoi ?

Par sécurité (mineure). Voir commit message
